### PR TITLE
xiiui ← Update type system, borders, and theme variables

### DIFF
--- a/.changeset/flat-years-start.md
+++ b/.changeset/flat-years-start.md
@@ -1,0 +1,16 @@
+---
+'@directus/composables': minor
+'@directus/themes': minor
+'@directus/types': minor
+'@directus/app': minor
+---
+
+Updated type system, borders, and theme variables
+
+::: notice
+
+- @directus/types: headerShadow and sidebarShadow removed from LayoutConfig interface
+- @directus/types: boxShadow removed from header theme rules schema
+- @directus/composables: sidebarShadow no longer exposed in layout wrapper state
+
+:::

--- a/app/src/ai/components/ai-context-card.vue
+++ b/app/src/ai/components/ai-context-card.vue
@@ -155,8 +155,6 @@ const icon = computed(() => {
 
 	&:focus-visible {
 		opacity: 1;
-		outline: 2px solid var(--theme--primary);
-		outline-offset: 1px;
 	}
 }
 </style>

--- a/app/src/ai/components/ai-conversation.vue
+++ b/app/src/ai/components/ai-conversation.vue
@@ -243,7 +243,7 @@ function scrollToBottom(behavior: ScrollBehavior = 'smooth') {
 	inset: 0;
 	z-index: 100;
 	background-color: var(--theme--primary-background);
-	border: 2px dashed var(--theme--primary);
+	border: var(--theme--border-width) dashed var(--theme--primary);
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/app/src/ai/components/parts/ai-message-text.vue
+++ b/app/src/ai/components/parts/ai-message-text.vue
@@ -257,7 +257,7 @@ useResizeObserver(contentRef, (entries) => {
 	vertical-align: top;
 	appearance: none;
 	background-color: transparent;
-	border: 2px solid var(--theme--foreground-subdued);
+	border: var(--theme--border-width) solid var(--theme--foreground-subdued);
 	border-radius: 2px;
 	cursor: pointer;
 	transition: all var(--fast) var(--transition);
@@ -277,7 +277,7 @@ useResizeObserver(contentRef, (entries) => {
 			inline-size: 0.3125rem;
 			block-size: 0.5625rem;
 			border: solid var(--theme--primary);
-			border-width: 0 2px 2px 0;
+			border-width: 0 var(--theme--border-width) var(--theme--border-width) 0;
 			transform: rotate(45deg);
 		}
 	}

--- a/app/src/components/v-banner.vue
+++ b/app/src/components/v-banner.vue
@@ -159,7 +159,9 @@ defineProps<{
 	</div>
 </template>
 
-<style scoped>
+<style scoped lang="scss">
+@use '@/styles/mixins';
+
 .v-banner {
 	container-type: inline-size;
 	inline-size: 100%;
@@ -203,11 +205,12 @@ defineProps<{
 		}
 
 		.title {
+			@include mixins.type-display;
+
 			--theme--foreground: var(--theme--banner--foreground);
 			color: var(--theme--banner--title--foreground);
 			font-family: var(--theme--banner--title--font-family);
 			font-weight: var(--theme--banner--title--font-weight);
-			font-size: 1.375rem;
 			line-height: 1.4091;
 		}
 

--- a/app/src/components/v-card-title.vue
+++ b/app/src/components/v-card-title.vue
@@ -9,7 +9,5 @@
 	align-items: center;
 	margin-block-start: 0.25rem;
 	padding: var(--v-card-padding, 0.875rem);
-	font-weight: 600;
-	line-height: 1.6;
 }
 </style>

--- a/app/src/components/v-checkbox.vue
+++ b/app/src/components/v-checkbox.vue
@@ -175,7 +175,7 @@ function onClickIcon(e: MouseEvent): void {
 			inline-size: 100%;
 			background-color: transparent;
 			border: none;
-			border-block-end: 2px solid var(--theme--form--field--input--border-color);
+			border-block-end: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
 			border-radius: 0;
 		}
 	}

--- a/app/src/components/v-date-picker/v-date-picker.vue
+++ b/app/src/components/v-date-picker/v-date-picker.vue
@@ -434,7 +434,7 @@ function setToNow() {
 		position: relative;
 		justify-content: center;
 		align-items: center;
-		border-width: 2px;
+		border-width: var(--theme--border-width);
 		border-style: solid;
 		border-color: transparent;
 		font-size: 0.8125rem;
@@ -521,7 +521,6 @@ function setToNow() {
 		align-items: center;
 		border-radius: 0.1875rem;
 		gap: 0.1875rem;
-		border-width: 1px;
 		text-align: center;
 		user-select: none;
 	}

--- a/app/src/components/v-divider.vue
+++ b/app/src/components/v-divider.vue
@@ -19,7 +19,7 @@ withDefaults(defineProps<Props>(), {
 	<div class="v-divider" :class="{ vertical, inlineTitle, large }">
 		<span v-if="$slots.icon || $slots.default" class="wrapper">
 			<slot name="icon" class="icon" />
-			<span v-if="!vertical && $slots.default" class="type-text"><slot /></span>
+			<span v-if="!vertical && $slots.default" class="text" :class="{ 'type-display': large }"><slot /></span>
 		</span>
 		<hr :aria-orientation="vertical ? 'vertical' : 'horizontal'" />
 	</div>
@@ -62,18 +62,14 @@ withDefaults(defineProps<Props>(), {
 		}
 	}
 
-	.type-text {
+	.text {
 		inline-size: 100%;
-		line-height: 1;
-		font-weight: 600;
 		color: var(--v-divider-label-color, var(--theme--foreground-accent));
 		transition: color var(--fast) var(--transition);
-	}
 
-	&.large .type-text {
-		font-size: 1.375rem;
-		font-weight: var(--theme--fonts--display--font-weight);
-		font-family: var(--theme--fonts--display--font-family);
+		&:not(.type-display) {
+			font-weight: 600;
+		}
 	}
 
 	&.inlineTitle {

--- a/app/src/components/v-drawer-header.vue
+++ b/app/src/components/v-drawer-header.vue
@@ -6,17 +6,11 @@ import { translateShortcut } from '@/utils/translate-shortcut';
 import PrivateViewHeaderBarActions from '@/views/private/private-view/components/private-view-header-bar-actions.vue';
 import PrivateViewHeaderBarIcon from '@/views/private/private-view/components/private-view-header-bar-icon.vue';
 
-withDefaults(
-	defineProps<{
-		title?: string;
-		shadow?: boolean;
-		icon?: string;
-		iconColor?: string;
-	}>(),
-	{
-		shadow: false,
-	},
-);
+defineProps<{
+	title?: string;
+	icon?: string;
+	iconColor?: string;
+}>();
 
 defineEmits<{
 	cancel: [];
@@ -24,7 +18,7 @@ defineEmits<{
 </script>
 
 <template>
-	<header class="header-bar" :class="{ shadow }">
+	<header class="header-bar">
 		<div class="primary">
 			<VButton
 				v-tooltip.bottom="`${$t('cancel')} (${translateShortcut(['esc'])})`"
@@ -88,15 +82,9 @@ defineEmits<{
 	background-color: var(--theme--header--background);
 	inline-size: 100%;
 	padding-inline: var(--content-padding);
-	box-shadow: none;
 	border-block-end: var(--theme--header--border-width) solid var(--theme--header--border-color);
 	block-size: var(--header-bar-height);
 	grid-template-rows: repeat(2, 1fr);
-
-	&.shadow {
-		box-shadow: var(--theme--header--box-shadow);
-		transition: box-shadow var(--fast) var(--transition);
-	}
 
 	@media (width > 22.5rem) {
 		display: flex;

--- a/app/src/components/v-drawer-header.vue
+++ b/app/src/components/v-drawer-header.vue
@@ -125,7 +125,9 @@ defineEmits<{
 	display: flex;
 
 	&:deep(.type-title) {
-		line-height: 1.2;
+		font-family: var(--theme--header--title--font-family);
+		font-weight: var(--theme--header--title--font-weight);
+		color: var(--theme--header--title--foreground);
 		max-inline-size: 100%;
 		block-size: 1.375rem;
 	}

--- a/app/src/components/v-drawer.vue
+++ b/app/src/components/v-drawer.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useScroll } from '@vueuse/core';
 import { computed, provide, ref, useTemplateRef } from 'vue';
 import { type ApplyShortcut } from './v-dialog.vue';
 import VResizeable from './v-resizeable.vue';
@@ -56,10 +55,6 @@ const internalActive = computed({
 		emit('update:modelValue', newActive);
 	},
 });
-
-const { y } = useScroll(scrollContainer);
-
-const showHeaderShadow = computed(() => y.value > 0);
 </script>
 
 <template>
@@ -106,7 +101,7 @@ const showHeaderShadow = computed(() => y.value > 0);
 				</VResizeable>
 
 				<main ref="scroll-container" :class="{ main: true, 'small-search-input': $slots.sidebar }">
-					<VDrawerHeader :title :shadow="showHeaderShadow" :icon :icon-color @cancel="$emit('cancel')">
+					<VDrawerHeader :title :icon :icon-color @cancel="$emit('cancel')">
 						<template #title><slot name="title" /></template>
 						<template #headline>
 							<slot name="subtitle">

--- a/app/src/components/v-field-template/v-field-template.vue
+++ b/app/src/components/v-field-template/v-field-template.vue
@@ -312,8 +312,6 @@ function setContent() {
 .content {
 	display: block;
 	flex-grow: 1;
-	block-size: 100%;
-	padding: var(--theme--form--field--input--padding) 0;
 	overflow: hidden;
 	font-size: 0.8125rem;
 	font-family: var(--theme--fonts--monospace--font-family);

--- a/app/src/components/v-form/components/form-field-label.vue
+++ b/app/src/components/v-form/components/form-field-label.vue
@@ -139,7 +139,7 @@ const isPromotableField = computed(() => {
 	}
 
 	.v-checkbox {
-		block-size: 1rem; // Don't push down label with normal icon height (1.375rem)
+		block-size: var(--label-height); /* Prevent label from increasing height */
 		margin-inline-end: 0.25rem;
 		display: inline-flex;
 		align-self: baseline;
@@ -182,7 +182,9 @@ const isPromotableField = computed(() => {
 	}
 
 	.ctx-arrow {
-		margin-block-start: -0.1875rem;
+		--v-icon-size: 1.375rem;
+
+		margin-block-start: calc(var(--label-height) - var(--v-icon-size)); /* Prevent label from increasing height */
 		color: var(--theme--foreground-subdued);
 		opacity: 0;
 		transition: opacity var(--fast) var(--transition);
@@ -205,13 +207,18 @@ const isPromotableField = computed(() => {
 	}
 
 	.raw-editor-toggle {
+		--raw-editor-toggle-size: 1.375rem;
+
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
-		block-size: 1.375rem;
-		inline-size: 1.375rem;
-		margin-block-start: -0.125rem;
+		block-size: var(--raw-editor-toggle-size);
+		inline-size: var(--raw-editor-toggle-size);
 		margin-inline-start: 0.3125rem;
+		margin-block-start: calc(
+			var(--label-height) - var(--raw-editor-toggle-size) /* Prevent label from increasing height */
+		);
+		transform: translateY(0.0625rem); /* Visually align element */
 		color: var(--theme--foreground-subdued);
 		transition: color var(--fast) var(--transition);
 
@@ -229,8 +236,9 @@ const isPromotableField = computed(() => {
 	&.edited {
 		.edit-dot {
 			position: absolute;
-			inset-block-start: 0.375rem;
-			inset-inline-start: -0.375rem;
+			inset-inline-end: 100%;
+			inset-block-start: 50%;
+			transform: translate(-0.1875rem, -50%);
 			display: block;
 			inline-size: 0.25rem;
 			block-size: 0.25rem;
@@ -249,16 +257,16 @@ const isPromotableField = computed(() => {
 	}
 }
 
-.type-label {
-	font-family: var(--theme--form--field--label--font-family);
-}
-
 .spacer {
 	flex-grow: 1;
 }
 
 .avatars {
-	margin-block-start: -0.1875rem;
+	--collab-indicator-height: 1.375rem;
+
+	margin-block-start: calc(
+		var(--label-height) - var(--collab-indicator-height) /* Prevent label from increasing height */
+	);
 	align-self: start;
 	flex-shrink: 0;
 }

--- a/app/src/components/v-form/components/form-field.vue
+++ b/app/src/components/v-form/components/form-field.vue
@@ -312,6 +312,7 @@ function useComputedValues() {
 
 	:deep(a) {
 		color: var(--theme--primary);
+		text-decoration: underline;
 
 		&:hover {
 			color: var(--theme--primary-accent);

--- a/app/src/components/v-info.vue
+++ b/app/src/components/v-info.vue
@@ -24,7 +24,7 @@ withDefaults(defineProps<Props>(), {
 		<div v-if="icon !== false" class="icon">
 			<VIcon large :name="icon" />
 		</div>
-		<h2 class="title type-title">{{ title }}</h2>
+		<h2 class="title type-display">{{ title }}</h2>
 		<p class="content"><slot /></p>
 		<slot name="append" />
 	</div>
@@ -80,7 +80,6 @@ withDefaults(defineProps<Props>(), {
 .content {
 	max-inline-size: 16.875rem;
 	color: var(--theme--foreground-subdued);
-	line-height: 1.25rem;
 
 	&:not(:last-child) {
 		margin-block-end: 1.375rem;

--- a/app/src/components/v-text-overflow.vue
+++ b/app/src/components/v-text-overflow.vue
@@ -43,7 +43,6 @@ watch(
 <style lang="scss" scoped>
 .v-text-overflow {
 	overflow: hidden;
-	line-height: normal;
 	white-space: nowrap;
 	text-overflow: ellipsis;
 }

--- a/app/src/components/v-workspace-tile.vue
+++ b/app/src/components/v-workspace-tile.vue
@@ -451,7 +451,7 @@ function useDragDrop() {
 
 .footer {
 	padding: 0 0.6875rem;
-	border-block-start: 2px solid var(--theme--border-color-subdued);
+	border-block-start: var(--theme--border-width) solid var(--theme--border-color-subdued);
 	margin-block-start: auto;
 	padding-block-start: 0.4375rem;
 }

--- a/app/src/interfaces/group-accordion/accordion-section.vue
+++ b/app/src/interfaces/group-accordion/accordion-section.vue
@@ -110,7 +110,7 @@ function useComparisonIndicator() {
 			>
 				<button
 					type="button"
-					class="label type-title"
+					class="label type-display"
 					:class="{ active, edited }"
 					@click="handleModifier($event, toggle)"
 				>

--- a/app/src/interfaces/presentation-header/header.vue
+++ b/app/src/interfaces/presentation-header/header.vue
@@ -227,7 +227,7 @@ const { runManualFlow, runningFlows } = useInjectRunManualFlow();
 			:style="{ '--header-color': color }"
 		>
 			<div class="text-content">
-				<p v-if="title" class="text-title">
+				<p v-if="title" class="text-title type-display">
 					<VIcon v-if="icon" :name="icon" />
 					<RenderTemplate :collection="collection" :fields="fields" :item="combinedItemData" :template="title" />
 				</p>
@@ -371,13 +371,10 @@ const { runManualFlow, runningFlows } = useInjectRunManualFlow();
 
 		.text-title {
 			display: flex;
-			color: var(--theme--foreground-accent);
 			overflow: hidden;
 			gap: 0.4375rem;
 			text-overflow: ellipsis;
 			white-space: nowrap;
-			font-size: 1.375rem;
-			font-weight: 600;
 			align-items: center;
 
 			.v-icon {

--- a/app/src/layouts/cards/index.ts
+++ b/app/src/layouts/cards/index.ts
@@ -21,7 +21,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 	name: '$t:layouts.cards.cards',
 	icon: 'grid_view',
 	component: CardsLayout,
-	headerShadow: false,
 	slots: {
 		options: CardsOptions,
 		sidebar: () => undefined,

--- a/app/src/layouts/kanban/index.ts
+++ b/app/src/layouts/kanban/index.ts
@@ -26,8 +26,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 	name: '$t:layouts.kanban.name',
 	icon: 'view_week',
 	component: KanbanLayout,
-	headerShadow: false,
-	sidebarShadow: false,
 	slots: {
 		options: KanbanOptions,
 		sidebar: () => undefined,

--- a/app/src/layouts/kanban/kanban.vue
+++ b/app/src/layouts/kanban/kanban.vue
@@ -402,7 +402,8 @@ const reorderGroupsDisabled = computed(() => !props.canReorderGroups || props.se
 					}
 
 					&.selected {
-						outline: 2px solid var(--theme--primary);
+						/* Not a focus ring, so using --theme--border-width for outline width */
+						outline: var(--theme--border-width) solid var(--theme--primary);
 					}
 				}
 

--- a/app/src/layouts/map/index.ts
+++ b/app/src/layouts/map/index.ts
@@ -23,7 +23,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 	name: '$t:layouts.map.map',
 	icon: 'map',
 	smallHeader: true,
-	sidebarShadow: true,
 	component: MapLayout,
 	slots: {
 		options: MapOptions,

--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -30,7 +30,6 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 		sidebar: () => undefined,
 		actions: TabularActions,
 	},
-	headerShadow: false,
 	setup(props, { emit }) {
 		const { t, n } = useI18n();
 		const fieldsStore = useFieldsStore();

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -325,7 +325,6 @@ function clearFilters() {
 			:title="bookmark ? bookmarkTitle : currentCollection.name"
 			:icon="archive ? 'archive' : currentCollection.icon"
 			:icon-color="currentCollection.color"
-			:sidebar-shadow="layoutState.sidebarShadow"
 		>
 			<template #headline>
 				<VBreadcrumb v-if="bookmark" :items="breadcrumb" />

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -3,7 +3,7 @@ import { useCollection } from '@directus/composables';
 import type { PrimaryKey } from '@directus/types';
 import { SplitPanel } from '@directus/vue-split-panel';
 import { useHead } from '@unhead/vue';
-import { useBreakpoints, useEventListener, useLocalStorage, useScroll } from '@vueuse/core';
+import { useBreakpoints, useEventListener, useLocalStorage } from '@vueuse/core';
 import { type ComponentPublicInstance, computed, onBeforeUnmount, provide, ref, toRefs, unref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
@@ -75,10 +75,6 @@ const { collectionRoute, backRoute } = useItemNavigation();
 const userStore = useUserStore();
 
 const form = ref<ComponentPublicInstance>();
-
-const scrollParent = computed(() => form.value?.$el?.parentElement);
-const { y: formScrollY } = useScroll(scrollParent);
-const showHeaderShadow = computed(() => formScrollY.value > 0);
 
 const { collection, primaryKey } = toRefs(props);
 const { breadcrumb } = useBreadcrumb();
@@ -652,7 +648,6 @@ function useItemNavigation() {
 		:title
 		:show-back="!collectionInfo.meta?.singleton"
 		:back-to="backRoute"
-		:show-header-shadow="showHeaderShadow"
 		:icon="collectionInfo.meta?.singleton ? collectionInfo.icon : undefined"
 	>
 		<template v-if="collectionInfo.meta && collectionInfo.meta.singleton === true" #title>

--- a/app/src/modules/settings/routes/data-model/fields/components/FieldSelect.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/FieldSelect.vue
@@ -572,8 +572,9 @@ const tFieldType = (type: string) => t(type === 'geometry' ? 'geometry.All' : ty
 }
 
 .sortable-ghost {
+	/* Not a focus ring, so using --theme--border-width for outline width */
+	outline: var(--theme--border-width) dashed var(--theme--primary);
 	border-radius: var(--theme--border-radius);
-	outline: 2px dashed var(--theme--primary);
 
 	> * {
 		opacity: 0;

--- a/app/src/modules/settings/routes/system-logs/components/logs-display.vue
+++ b/app/src/modules/settings/routes/system-logs/components/logs-display.vue
@@ -323,7 +323,7 @@ function selectLog(index: number) {
 	--v-chip-close-color: var(--theme--primary);
 
 	cursor: pointer;
-	box-shadow: var(--sidebar-shadow);
+	box-shadow: -4px 0 7px -4px var(--shadow-color);
 
 	.v-icon {
 		margin-inline-end: 0.4375rem;

--- a/app/src/modules/settings/routes/system-logs/logs.vue
+++ b/app/src/modules/settings/routes/system-logs/logs.vue
@@ -580,7 +580,7 @@ onUnmounted(() => {
 	background-color: var(--theme--background-subdued);
 	border-block-start: var(--theme--border-width) solid
 		var(--v-input-border-color, var(--theme--form--field--input--border-color));
-	box-shadow: var(--sidebar-shadow);
+	box-shadow: -4px 0 7px -4px var(--shadow-color);
 	z-index: 1;
 }
 

--- a/app/src/panels/label/panel-label.vue
+++ b/app/src/panels/label/panel-label.vue
@@ -99,12 +99,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-	<div
-		ref="labelContainer"
-		class="label type-title"
-		:class="[font, { 'has-header': showHeader }]"
-		:style="{ color: color }"
-	>
+	<div ref="labelContainer" class="label" :class="[font, { 'has-header': showHeader }]" :style="{ color: color }">
 		<p
 			ref="labelText"
 			class="label-text"

--- a/app/src/panels/metric/panel-metric.vue
+++ b/app/src/panels/metric/panel-metric.vue
@@ -204,7 +204,7 @@ const color = computed(() => {
 </script>
 
 <template>
-	<div ref="labelContainer" class="metric type-title" :class="[font, { 'has-header': showHeader }]">
+	<div ref="labelContainer" class="metric" :class="[font, { 'has-header': showHeader }]">
 		<p
 			ref="labelText"
 			class="metric-text"

--- a/app/src/routes/accept-invite.vue
+++ b/app/src/routes/accept-invite.vue
@@ -61,7 +61,7 @@ useHead({
 
 <template>
 	<PublicView>
-		<h1 class="type-title">{{ $t('create_account') }}</h1>
+		<h1 class="type-display type-display-public">{{ $t('create_account') }}</h1>
 
 		<form @submit.prevent="onSubmit">
 			<VInput :model-value="email" disabled />

--- a/app/src/routes/login/components/sso-links.vue
+++ b/app/src/routes/login/components/sso-links.vue
@@ -233,13 +233,11 @@ watch(selectedProviderName, (val) => {
 }
 
 .sso-link {
-	$sso-link-border-width: 2px; /* stylelint-disable-line unit-disallowed-list -- SCSS variable for border calc */
-
 	display: flex;
 	inline-size: 100%;
 	block-size: var(--theme--form--field--input--height);
 	background-color: var(--theme--background-normal);
-	border: $sso-link-border-width var(--theme--background-normal) solid;
+	border: var(--theme--border-width) var(--theme--background-normal) solid;
 	border-radius: var(--theme--border-radius);
 	transition: border-color var(--fast) var(--transition);
 	cursor: pointer;
@@ -251,7 +249,7 @@ watch(selectedProviderName, (val) => {
 		align-items: center;
 		justify-content: center;
 		inline-size: var(--theme--form--field--input--height);
-		margin: -$sso-link-border-width;
+		margin: calc(-1 * var(--theme--border-width));
 		background-color: var(--theme--background-accent);
 		border-radius: var(--theme--border-radius);
 	}

--- a/app/src/routes/login/login.vue
+++ b/app/src/routes/login/login.vue
@@ -53,7 +53,7 @@ useHead({
 <template>
 	<PublicView>
 		<div class="header">
-			<h1 class="type-title"><VTextOverflow :text="$t('sign_in')" /></h1>
+			<h1 class="type-display type-display-public"><VTextOverflow :text="$t('sign_in')" /></h1>
 			<div v-if="!authenticated && providerOptions.length > 1" class="provider-select">
 				<VSelect v-model="providerSelect" inline :items="providerOptions" label />
 			</div>
@@ -116,7 +116,7 @@ h1 {
 	justify-content: space-between;
 	margin-block-end: 1.125rem;
 
-	.type-title {
+	.type-display {
 		margin-block-end: 0;
 	}
 

--- a/app/src/routes/register/register.vue
+++ b/app/src/routes/register/register.vue
@@ -34,7 +34,9 @@ useHead({
 <template>
 	<PublicView>
 		<div class="header">
-			<h1 class="type-title">{{ wasSuccessful ? $t('registration_successful_headline') : $t('register') }}</h1>
+			<h1 class="type-display type-display-public">
+				{{ wasSuccessful ? $t('registration_successful_headline') : $t('register') }}
+			</h1>
 		</div>
 
 		<div v-if="wasSuccessful" class="after-success">
@@ -93,7 +95,7 @@ h1 {
 	justify-content: space-between;
 	margin-block-end: 1.125rem;
 
-	.type-title {
+	.type-display {
 		margin-block-end: 0;
 	}
 

--- a/app/src/routes/reset-password/reset-password.vue
+++ b/app/src/routes/reset-password/reset-password.vue
@@ -21,7 +21,7 @@ useHead({
 
 <template>
 	<PublicView>
-		<h1 class="type-title">{{ $t('reset_password') }}</h1>
+		<h1 class="type-display type-display-public">{{ $t('reset_password') }}</h1>
 
 		<RequestForm v-if="!resetToken" />
 		<ResetForm v-else :token="resetToken" />

--- a/app/src/routes/tfa-setup.vue
+++ b/app/src/routes/tfa-setup.vue
@@ -131,7 +131,7 @@ useHead({
 <template>
 	<PublicView>
 		<div class="header">
-			<h1 class="type-title">{{ $t('tfa_setup') }}</h1>
+			<h1 class="type-display type-display-public">{{ $t('tfa_setup') }}</h1>
 		</div>
 
 		<form v-if="tfaEnabled === false && tfaGenerated === false && loading === false" @submit.prevent="generate">

--- a/app/src/styles/_base.scss
+++ b/app/src/styles/_base.scss
@@ -29,12 +29,8 @@ html {
 }
 
 body {
-	color: var(--theme--foreground);
-	font-weight: 500;
-	font-size: 0.8125rem;
-	font-family: var(--theme--fonts--sans--font-family);
-	font-style: normal;
-	line-height: 1.5385;
+	@include mixins.type-text;
+
 	background-color: var(--theme--background);
 	-webkit-font-smoothing: antialiased;
 	text-rendering: optimizeLegibility;

--- a/app/src/styles/_type-styles.scss
+++ b/app/src/styles/_type-styles.scss
@@ -1,5 +1,9 @@
 @use 'mixins';
 
+.type-display {
+	@include mixins.type-display;
+}
+
 .type-title {
 	@include mixins.type-title;
 }

--- a/app/src/styles/lib/_emoji-picker.scss
+++ b/app/src/styles/lib/_emoji-picker.scss
@@ -71,12 +71,12 @@
 		}
 
 		.emoji-picker__emojis {
-			border-block-start: 2px solid var(--theme--form--field--input--border-color);
+			border-block-start: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
 		}
 	}
 
 	.emoji-picker__preview {
-		border-block-start: 2px solid var(--theme--form--field--input--border-color);
+		border-block-start: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
 	}
 
 	.emoji-picker__emoji {

--- a/app/src/styles/lib/_fullcalendar.scss
+++ b/app/src/styles/lib/_fullcalendar.scss
@@ -128,8 +128,8 @@
 			font-weight: inherit !important;
 			font-size: inherit !important;
 			background-color: var(--theme--background);
-			border-block-start: 2px solid var(--theme--border-color-subdued);
-			border-block-end: 2px solid var(--theme--border-color-subdued);
+			border-block-start: var(--theme--border-width) solid var(--theme--border-color-subdued);
+			border-block-end: var(--theme--border-width) solid var(--theme--border-color-subdued);
 			box-shadow: 0 0 0 2px var(--theme--background);
 		}
 	}

--- a/app/src/styles/mixins/_type-styles.scss
+++ b/app/src/styles/mixins/_type-styles.scss
@@ -1,35 +1,46 @@
-@mixin type-title {
+@mixin type-display {
 	color: var(--theme--foreground-accent);
-	font-size: 1rem;
-	font-weight: var(--theme--fonts--display--font-weight);
 	font-family: var(--theme--fonts--display--font-family);
+	font-weight: var(--theme--fonts--display--font-weight);
 	font-style: normal;
-	line-height: 1.375;
+	font-size: 1.375rem;
+	line-height: 1.1818;
+}
+
+@mixin type-title {
+	color: var(--theme--foreground);
+	font-family: var(--theme--fonts--title--font-family);
+	font-weight: var(--theme--fonts--title--font-weight);
+	font-style: normal;
+	font-size: 0.8125rem;
+	line-height: 1.5385;
 }
 
 @mixin type-label {
+	--label-height: 1.25rem; /* = 0.875rem (fs) * 1.4286 (lh) */
+
 	color: var(--theme--foreground-accent);
-	font-size: 0.875rem;
-	font-weight: var(--theme--form--field--label--font-weight);
 	font-family: var(--theme--form--field--label--font-family);
+	font-weight: var(--theme--form--field--label--font-weight);
 	font-style: normal;
-	line-height: 1.2143;
+	font-size: 0.875rem;
+	line-height: 1.4286;
 }
 
 @mixin type-text {
 	color: var(--theme--foreground);
-	font-weight: var(--theme--fonts--sans--font-weight);
-	font-size: 0.8125rem;
 	font-family: var(--theme--fonts--sans--font-family);
+	font-weight: var(--theme--fonts--sans--font-weight);
 	font-style: normal;
-	line-height: 1.5385;
+	font-size: 0.8125rem;
+	line-height: 1.4615;
 }
 
 @mixin type-note {
 	color: var(--theme--foreground-subdued);
-	font-weight: var(--theme--fonts--sans--font-weight);
-	font-size: 0.75rem;
 	font-family: var(--theme--fonts--sans--font-family);
+	font-weight: var(--theme--fonts--sans--font-weight);
 	font-style: italic;
-	line-height: 1.3333;
+	font-size: 0.6875rem;
+	line-height: 1.4545;
 }

--- a/app/src/styles/themes/_dark.scss
+++ b/app/src/styles/themes/_dark.scss
@@ -9,7 +9,7 @@
 		colors.$color-mapping,
 		(
 			'primary': $purple,
-			'secondary': colors.$pink,
+			'secondary': colors.$pink
 		)
 	);
 
@@ -24,7 +24,6 @@
 	--background-inverted: #fff;
 	--background-mark: var(--theme--primary-subdued);
 	--overlay-color: rgb(0 0 0 / 0.9);
-	--sidebar-shadow: 4px 0 7px -4px var(--black); /* stylelint-disable-line unit-disallowed-list -- custom property with box-shadow value */
 	--shadow-color: var(--black);
 
 	// Generate color variations

--- a/app/src/styles/themes/_light.scss
+++ b/app/src/styles/themes/_light.scss
@@ -13,8 +13,7 @@
 	--background-inverted: #263238;
 	--background-mark: var(--theme--primary-subdued);
 	--overlay-color: rgb(38 50 56 / 0.8);
-	--sidebar-shadow: -4px 0 7px -4px rgb(0 0 0 / 0.2); /* stylelint-disable-line unit-disallowed-list -- custom property with box-shadow value */
-	--shadow-color: rgb(0 0 0 / 0.1);
+	--shadow-color: rgb(0 0 0 / 0.2);
 
 	// Generate color variations
 	@include mixins.generate-colors(colors.$color-mapping, colors.$light-theme-tint, colors.$light-theme-shade);

--- a/app/src/views/private/components/comment-item.vue
+++ b/app/src/views/private/components/comment-item.vue
@@ -134,7 +134,7 @@ function useEdits() {
 	block-size: 0.125rem;
 	margin: 0.6875rem 0;
 	border: 0;
-	border-block-start: 2px solid var(--theme--form--field--input--border-color);
+	border-block-start: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
 }
 
 .comment-item .content :deep(mark) {

--- a/app/src/views/private/components/comparison/comparison-header.vue
+++ b/app/src/views/private/components/comparison/comparison-header.vue
@@ -266,7 +266,7 @@ function getDeltaOptionUser(deltaOption: any) {
 				align-items: center;
 				justify-content: space-between;
 				cursor: pointer;
-				border: 2px solid var(--theme--border-color);
+				border: var(--theme--border-width) solid var(--theme--border-color);
 				border-radius: var(--theme--border-radius);
 				padding-inline: 0.875rem;
 				padding-block: 0.4375rem;

--- a/app/src/views/private/components/comparison/comparison-modal.vue
+++ b/app/src/views/private/components/comparison/comparison-modal.vue
@@ -433,7 +433,6 @@ function onIncomingSelectionChange(newDeltaId: PrimaryKey) {
 
 	background: var(--theme--background);
 	border-radius: var(--comparison-modal--border-radius);
-	box-shadow: var(--theme--shadow);
 	display: flex;
 	flex-direction: column;
 	block-size: var(--comparison-modal--height);

--- a/app/src/views/private/components/comparison/comparison-modal.vue
+++ b/app/src/views/private/components/comparison/comparison-modal.vue
@@ -460,7 +460,7 @@ function onIncomingSelectionChange(newDeltaId: PrimaryKey) {
 	}
 
 	.comparison-content-divider {
-		border-block-start: 2px solid var(--theme--border-color-subdued);
+		border-block-start: var(--theme--border-width) solid var(--theme--border-color-subdued);
 	}
 
 	.columns {
@@ -522,7 +522,7 @@ function onIncomingSelectionChange(newDeltaId: PrimaryKey) {
 		justify-content: space-between;
 		padding-inline: var(--comparison-modal--padding-x);
 		padding-block: 1rem;
-		border-block-start: 2px solid var(--theme--border-color-subdued);
+		border-block-start: var(--theme--border-width) solid var(--theme--border-color-subdued);
 
 		.columns {
 			flex-direction: row;

--- a/app/src/views/private/components/user-popover.vue
+++ b/app/src/views/private/components/user-popover.vue
@@ -96,7 +96,7 @@ function navigateToUser() {
 				<VIcon v-else name="person" />
 			</VAvatar>
 			<div class="data">
-				<div class="name type-title">{{ userName(data) }}</div>
+				<div class="name type-label">{{ userName(data) }}</div>
 				<VChip class="status" :class="data.status" small>
 					{{ $t(`fields.directus_users.status_${data.status}`) }}
 				</VChip>
@@ -123,7 +123,8 @@ function navigateToUser() {
 	}
 
 	.status {
-		margin-inline-end: 0.25rem;
+		margin-block: 0.25rem;
+		margin-inline-end: 0.1875rem;
 
 		&.active {
 			--v-chip-color: var(--theme--success);

--- a/app/src/views/private/private-view/components/private-view-header-bar.test.ts
+++ b/app/src/views/private/private-view/components/private-view-header-bar.test.ts
@@ -58,7 +58,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: false,
 			},
 		});
@@ -66,36 +65,11 @@ describe('PrivateViewHeaderBar', () => {
 		expect(wrapper.find('.header-bar').exists()).toBe(true);
 	});
 
-	test('applies shadow class when shadow prop is true', () => {
-		const wrapper = mount(PrivateViewHeaderBar, {
-			...mountOptions,
-			props: {
-				shadow: true,
-				inlineNav: false,
-			},
-		});
-
-		expect(wrapper.find('.header-bar.shadow').exists()).toBe(true);
-	});
-
-	test('does not apply shadow class when shadow prop is false', () => {
-		const wrapper = mount(PrivateViewHeaderBar, {
-			...mountOptions,
-			props: {
-				shadow: false,
-				inlineNav: false,
-			},
-		});
-
-		expect(wrapper.find('.header-bar.shadow').exists()).toBe(false);
-	});
-
 	test('renders title when provided', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
 				title: 'Test Title',
-				shadow: false,
 				inlineNav: false,
 			},
 		});
@@ -107,7 +81,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: false,
 			},
 		});
@@ -120,7 +93,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: true,
 			},
 		});
@@ -136,7 +108,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: false,
 			},
 		});
@@ -152,7 +123,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: false,
 			},
 		});
@@ -165,7 +135,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: false,
 			},
 		});
@@ -181,7 +150,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: false,
 				showBack: true,
 			},
@@ -196,7 +164,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: false,
 				icon: 'edit',
 				iconColor: 'blue',
@@ -213,7 +180,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: false,
 			},
 			slots: {
@@ -229,7 +195,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: false,
 			},
 			slots: {
@@ -245,7 +210,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: false,
 			},
 			slots: {
@@ -260,7 +224,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: false,
 			},
 			slots: {
@@ -275,7 +238,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: false,
 			},
 			slots: {
@@ -290,7 +252,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: false,
 				title: 'Test Title',
 			},
@@ -306,7 +267,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: false,
 				title: 'Test Title',
 			},
@@ -322,7 +282,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: false,
 				showBack: true,
 				icon: 'edit',
@@ -339,7 +298,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: false,
 				showBack: true,
 			},
@@ -358,7 +316,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: false,
 				icon: 'edit',
 			},
@@ -377,7 +334,6 @@ describe('PrivateViewHeaderBar', () => {
 		const wrapper = mount(PrivateViewHeaderBar, {
 			...mountOptions,
 			props: {
-				shadow: false,
 				inlineNav: false,
 				showBack: true,
 				icon: 'edit',

--- a/app/src/views/private/private-view/components/private-view-header-bar.vue
+++ b/app/src/views/private/private-view/components/private-view-header-bar.vue
@@ -155,7 +155,9 @@ const showSidebarToggle = computed(() => {
 	display: flex;
 
 	&:deep(.type-title) {
-		line-height: 1.2;
+		font-family: var(--theme--header--title--font-family);
+		font-weight: var(--theme--header--title--font-weight);
+		color: var(--theme--header--title--foreground);
 		max-inline-size: 100%;
 
 		.render-template img,

--- a/app/src/views/private/private-view/components/private-view-header-bar.vue
+++ b/app/src/views/private/private-view/components/private-view-header-bar.vue
@@ -11,7 +11,6 @@ import { BREAKPOINTS } from '@/constants';
 
 const props = defineProps<{
 	title?: string;
-	shadow: boolean;
 	inlineNav: boolean;
 	icon?: string;
 	iconColor?: string;
@@ -39,7 +38,7 @@ const showSidebarToggle = computed(() => {
 </script>
 
 <template>
-	<header class="header-bar" :class="{ shadow }">
+	<header class="header-bar">
 		<div class="primary">
 			<VIcon
 				v-if="showNavToggle"
@@ -113,16 +112,9 @@ const showSidebarToggle = computed(() => {
 	background-color: var(--theme--header--background);
 	inline-size: 100%;
 	padding-inline: var(--content-padding);
-	box-shadow: none;
 	border-block-end: var(--theme--header--border-width) solid var(--theme--header--border-color);
 	block-size: var(--header-bar-height);
 	grid-template-rows: repeat(2, 1fr);
-
-	&.shadow {
-		z-index: 7;
-		box-shadow: var(--theme--header--box-shadow);
-		transition: box-shadow var(--fast) var(--transition);
-	}
 
 	@media (width > 22.5rem) {
 		display: flex;

--- a/app/src/views/private/private-view/components/private-view-main.test.ts
+++ b/app/src/views/private/private-view/components/private-view-main.test.ts
@@ -16,8 +16,6 @@ vi.mock('@vueuse/core', async () => {
 			smallerOrEqual: vi.fn(() => isMobileRef),
 		})),
 		useLocalStorage: vi.fn((_key: string, defaultValue: unknown) => ref(defaultValue)),
-		useResizeObserver: vi.fn(),
-		useScroll: vi.fn(() => ({ x: ref(0), y: ref(0) })),
 	};
 });
 

--- a/app/src/views/private/private-view/components/private-view-main.vue
+++ b/app/src/views/private/private-view/components/private-view-main.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { SplitPanel } from '@directus/vue-split-panel';
-import { useBreakpoints, useResizeObserver, useScroll } from '@vueuse/core';
-import { computed, type ComputedRef, inject, provide, ref, unref, useTemplateRef, watch } from 'vue';
+import { useBreakpoints } from '@vueuse/core';
+import { computed, type ComputedRef, inject, provide, useTemplateRef, watch } from 'vue';
 import NotificationsGroup from '../../components/notifications-group.vue';
 import SkipMenu from '../../components/skip-menu.vue';
 import { useSidebarStore } from '../stores/sidebar';
@@ -23,45 +23,9 @@ provide('main-element', contentEl);
 const userStore = useUserStore();
 const sidebarStore = useSidebarStore();
 
-const scrollContainerRef = useTemplateRef('scroll-container');
-
-const { y, x } = useScroll(scrollContainerRef);
-
-const containerWidth = ref(0);
-const scrollableWidth = ref(0);
-
-useResizeObserver(scrollContainerRef, ([entry]) => {
-	const el = entry?.target as HTMLElement | undefined;
-	if (!el) return;
-	containerWidth.value = el.clientWidth;
-	scrollableWidth.value = el.scrollWidth;
-});
-
-const enforceShadows = computed(() => props.sidebarShadow || false);
-
-const contentPadding = computed(() => {
-	const el = contentEl.value;
-	if (!el) return 11;
-	return parseFloat(getComputedStyle(el).paddingInlineStart) || 11;
-});
-
-const showStartShadow = computed(() => {
-	if (enforceShadows.value) return true;
-	return x.value >= contentPadding.value;
-});
-
-const showEndShadow = computed(() => {
-	if (enforceShadows.value) return true;
-	return scrollableWidth.value - containerWidth.value - x.value >= contentPadding.value;
-});
-
 const livePreviewActive = inject<ComputedRef<boolean>>(
 	'live-preview-active',
 	computed(() => false),
-);
-
-const showHeaderShadow = computed(
-	() => enforceShadows.value || props.showHeaderShadow || y.value > 0 || unref(livePreviewActive),
 );
 
 const breakpoints = useBreakpoints(BREAKPOINTS);
@@ -106,18 +70,8 @@ const teleportTarget = computed(() => (isMobile.value ? '#sidebar-mobile-outlet'
 			:disabled="isMobile"
 		>
 			<template #start>
-				<div class="scroll-shadow start" :class="{ visible: showStartShadow }" />
-				<div class="scroll-shadow end" :class="{ visible: showEndShadow }" />
 				<div ref="scroll-container" class="scrolling-container" :class="{ 'flex-layout': livePreviewActive }">
-					<PrivateViewHeaderBar
-						:title="props.title"
-						:shadow="showHeaderShadow"
-						:inline-nav
-						:icon
-						:icon-color
-						:show-back
-						:back-to
-					>
+					<PrivateViewHeaderBar :title="props.title" :inline-nav :icon :icon-color :show-back :back-to>
 						<template #actions:append><slot name="actions:append" /></template>
 						<template #actions:prepend><slot name="actions:prepend" /></template>
 						<template #actions><slot name="actions" /></template>
@@ -174,38 +128,6 @@ const teleportTarget = computed(() => (isMobile.value ? '#sidebar-mobile-outlet'
 	&:deep(.sp-divider) {
 		z-index: 8;
 	}
-}
-
-.scroll-shadow {
-	position: absolute;
-	inset-block: 0;
-	inline-size: 0.375rem;
-	pointer-events: none;
-	z-index: 6;
-	opacity: 0;
-	transition: opacity var(--medium) var(--transition);
-}
-
-.scroll-shadow.visible {
-	opacity: 1;
-}
-
-.scroll-shadow.start {
-	inset-inline-start: 0;
-	background: linear-gradient(to right, var(--shadow-color, transparent), transparent);
-}
-
-.scroll-shadow.end {
-	inset-inline-end: 0;
-	background: linear-gradient(to left, var(--shadow-color, transparent), transparent);
-}
-
-:dir(rtl) .scroll-shadow.start {
-	background: linear-gradient(to left, var(--shadow-color, transparent), transparent);
-}
-
-:dir(rtl) .scroll-shadow.end {
-	background: linear-gradient(to right, var(--shadow-color, transparent), transparent);
 }
 
 .main-split {

--- a/app/src/views/private/private-view/components/private-view.vue
+++ b/app/src/views/private/private-view/components/private-view.vue
@@ -14,12 +14,6 @@ export interface PrivateViewProps {
 
 	/** Where to navigate to on back button click. Defaults to last page in the browser history */
 	backTo?: string;
-
-	/** Whether to always show sidebar shadows regardless of scroll state (true) or only when horizontally scrolled (false). */
-	sidebarShadow?: boolean;
-
-	/** Override header shadow state. When provided, bypasses internal scroll-based calculation. */
-	showHeaderShadow?: boolean;
 }
 </script>
 

--- a/app/src/views/public/public-view.vue
+++ b/app/src/views/public/public-view.vue
@@ -55,7 +55,7 @@ const logoURL = computed<string | null>(() => {
 					class="logo"
 					:style="info?.project.project_color ? { backgroundColor: info.project.project_color } : {}"
 				>
-					<VImage :src="logoURL" :alt="info?.project.project_name || 'Logo'" />
+					<VImage :src="logoURL!" :alt="info?.project.project_name || 'Logo'" />
 				</div>
 				<div
 					v-else
@@ -65,7 +65,7 @@ const logoURL = computed<string | null>(() => {
 					<img src="./logo-light.svg" alt="Directus" class="directus-logo" />
 				</div>
 				<div class="title">
-					<h1 class="title-heading"><VTextOverflow :text="info?.project?.project_name" placement="bottom" /></h1>
+					<h1 class="title-heading"><VTextOverflow :text="info?.project?.project_name ?? ''" placement="bottom" /></h1>
 					<VTextOverflow
 						class="subtitle"
 						:text="info?.project?.project_descriptor ?? $t('application')"
@@ -131,14 +131,17 @@ const logoURL = computed<string | null>(() => {
 		--theme--form--field--input--padding: var(--theme--public--form--field--input--padding);
 		--theme--form--field--label--font-family: var(--theme--public--form--field--label--font-family);
 		--theme--form--field--label--foreground: var(--theme--public--form--field--label--foreground);
+		--public-view--container--max-width: 28.125rem;
+		--public-view--container--content--width: 19.125rem;
 
 		z-index: 2;
 		display: flex;
 		flex-shrink: 0;
 		flex-direction: column;
 		justify-content: space-between;
+		align-items: center;
 		inline-size: 100%;
-		max-inline-size: 28.125rem;
+		max-inline-size: var(--public-view--container--max-width);
 		block-size: 100%;
 		padding: 1.125rem;
 		overflow: hidden auto;
@@ -158,16 +161,13 @@ const logoURL = computed<string | null>(() => {
 		}
 
 		.content {
-			inline-size: 19.125rem;
-			max-inline-size: 100%;
+			inline-size: 100%;
+			max-inline-size: var(--public-view--container--content--width);
 		}
 
 		&.wide {
-			max-inline-size: 49.0625rem;
-
-			.content {
-				inline-size: 40.0625rem;
-			}
+			--public-view--container--max-width: 49.0625rem;
+			--public-view--container--content--width: 40.0625rem;
 		}
 
 		@media (width >= 28.125rem) {
@@ -185,6 +185,7 @@ const logoURL = computed<string | null>(() => {
 		block-size: 100%;
 		background-position: center center;
 		background-size: cover;
+		container-type: inline-size;
 
 		video {
 			inline-size: 100%;
@@ -359,10 +360,14 @@ const logoURL = computed<string | null>(() => {
 			position: absolute;
 			inset-inline: 0;
 			inset-block-end: 1.9375rem;
-			display: flex;
+			display: none;
 			align-items: flex-end;
 			justify-content: center;
 			block-size: 0.5625rem;
+
+			@container (inline-size >= 20.5rem) {
+				display: flex;
+			}
 
 			.note {
 				max-inline-size: 19.125rem;
@@ -385,15 +390,16 @@ const logoURL = computed<string | null>(() => {
 
 	.notice {
 		display: flex;
+		inline-size: 100%;
+		max-inline-size: var(--public-view--container--content--width);
 		color: var(--theme--foreground-subdued);
 	}
 
 	.title-box {
 		display: flex;
 		align-items: center;
-		inline-size: max-content;
-		max-inline-size: 100%;
-		block-size: 3.625rem;
+		inline-size: 100%;
+		max-inline-size: var(--public-view--container--content--width);
 
 		.title {
 			margin-block-start: 0.125rem;
@@ -444,4 +450,3 @@ const logoURL = computed<string | null>(() => {
 	opacity: 0;
 }
 </style>
-@/utils/get-appearance

--- a/app/src/views/public/public-view.vue
+++ b/app/src/views/public/public-view.vue
@@ -65,7 +65,7 @@ const logoURL = computed<string | null>(() => {
 					<img src="./logo-light.svg" alt="Directus" class="directus-logo" />
 				</div>
 				<div class="title">
-					<h1 class="type-title"><VTextOverflow :text="info?.project?.project_name" placement="bottom" /></h1>
+					<h1 class="title-heading"><VTextOverflow :text="info?.project?.project_name" placement="bottom" /></h1>
 					<VTextOverflow
 						class="subtitle"
 						:text="info?.project?.project_descriptor ?? $t('application')"
@@ -101,6 +101,8 @@ const logoURL = computed<string | null>(() => {
 </template>
 
 <style lang="scss" scoped>
+@use '@/styles/mixins';
+
 .public-view {
 	display: flex;
 	inline-size: 100%;
@@ -149,7 +151,7 @@ const logoURL = computed<string | null>(() => {
 		box-shadow: 0 0 40px 0 rgb(38 50 56 / 0.1);
 		transition: max-inline-size var(--medium) var(--transition);
 
-		:slotted(.type-title) {
+		:slotted(.type-display.type-display-public) {
 			font-size: 2.375rem;
 			line-height: 1.2368;
 			color: var(--theme--public--foreground-accent);
@@ -398,10 +400,11 @@ const logoURL = computed<string | null>(() => {
 			margin-inline-start: 0.875rem;
 			overflow: hidden;
 
-			h1 {
-				font-weight: 700;
+			.title-heading {
+				color: var(--theme--foreground-accent);
 				font-size: 1rem;
 				line-height: 1;
+				font-weight: 700;
 			}
 
 			.subtitle {

--- a/app/src/views/shared/shared-view.vue
+++ b/app/src/views/shared/shared-view.vue
@@ -42,7 +42,7 @@ const logoURL = computed<string | null>(() => {
 						<div class="title">
 							<p class="subtitle">{{ serverInfo?.project?.project_name }}</p>
 							<slot name="title">
-								<h1 class="type-title">{{ title ?? $t('share_access_page') }}</h1>
+								<h1 class="title-heading">{{ title ?? $t('share_access_page') }}</h1>
 							</slot>
 						</div>
 					</div>
@@ -59,6 +59,8 @@ const logoURL = computed<string | null>(() => {
 </template>
 
 <style scoped lang="scss">
+@use '@/styles/mixins';
+
 .shared {
 	inline-size: 100%;
 	block-size: 100%;
@@ -94,11 +96,10 @@ header {
 	.title {
 		margin-inline-start: 0.875rem;
 
-		h1 {
+		.title-heading {
+			@include mixins.type-display;
+
 			color: var(--theme--foreground);
-			font-weight: 700;
-			font-size: 1.375rem;
-			line-height: 1;
 		}
 
 		.subtitle {

--- a/packages/composables/src/use-layout.ts
+++ b/packages/composables/src/use-layout.ts
@@ -129,7 +129,6 @@ export function createLayoutWrapper<Options, Query>(layout: LayoutConfig): Compo
 			const state: Record<string, unknown> = reactive({
 				...layout.setup(props, { emit }),
 				...toRefs(props),
-				sidebarShadow: layout.sidebarShadow ?? false,
 			});
 
 			for (const key in state) {

--- a/packages/themes/src/themes/dark/default.ts
+++ b/packages/themes/src/themes/dark/default.ts
@@ -51,6 +51,10 @@ export default defineTheme({
 				fontFamily: '"Inter", system-ui',
 				fontWeight: '700',
 			},
+			title: {
+				fontFamily: '"Inter", system-ui',
+				fontWeight: '600',
+			},
 			sans: {
 				fontFamily: '"Inter", system-ui',
 				fontWeight: '500',
@@ -129,9 +133,9 @@ export default defineTheme({
 				fontFamily: 'var(--theme--fonts--sans--font-family)',
 			},
 			title: {
-				foreground: 'var(--theme--foreground-accent)',
-				fontFamily: 'var(--theme--fonts--display--font-family)',
-				fontWeight: 'var(--theme--fonts--display--font-weight)',
+				foreground: 'var(--theme--foreground)',
+				fontFamily: 'var(--theme--fonts--title--font-family)',
+				fontWeight: 'var(--theme--fonts--title--font-weight)',
 			},
 		},
 

--- a/packages/themes/src/themes/dark/default.ts
+++ b/packages/themes/src/themes/dark/default.ts
@@ -124,7 +124,6 @@ export default defineTheme({
 			background: 'var(--theme--background)',
 			borderColor: 'transparent',
 			borderWidth: '0px',
-			boxShadow: '0 4px 7px -4px black',
 			headline: {
 				foreground: 'var(--theme--foreground-subdued)',
 				fontFamily: 'var(--theme--fonts--sans--font-family)',

--- a/packages/themes/src/themes/dark/default.ts
+++ b/packages/themes/src/themes/dark/default.ts
@@ -6,7 +6,7 @@ export default defineTheme({
 	appearance: 'dark',
 	rules: {
 		borderRadius: '0.3125rem',
-		borderWidth: '2px',
+		borderWidth: '1px',
 
 		foreground: '#c9d1d9',
 		foregroundAccent: '#f0f6fc',

--- a/packages/themes/src/themes/light/color-match.ts
+++ b/packages/themes/src/themes/light/color-match.ts
@@ -54,7 +54,6 @@ export default defineTheme({
 			background: '#FFFFFF',
 			borderWidth: '1px',
 			borderColor: 'var(--theme--border-color-subdued)',
-			boxShadow: '0 4px 7px -4px rgba(0,102,102, 0.2)',
 		},
 		sidebar: {
 			background: '#FFFFFF',

--- a/packages/themes/src/themes/light/default.ts
+++ b/packages/themes/src/themes/light/default.ts
@@ -51,6 +51,10 @@ export default defineTheme({
 				fontFamily: '"Inter", system-ui',
 				fontWeight: '700',
 			},
+			title: {
+				fontFamily: '"Inter", system-ui',
+				fontWeight: '600',
+			},
 			sans: {
 				fontFamily: '"Inter", system-ui',
 				fontWeight: '500',
@@ -129,9 +133,9 @@ export default defineTheme({
 				fontFamily: 'var(--theme--fonts--sans--font-family)',
 			},
 			title: {
-				foreground: 'var(--theme--foreground-accent)',
-				fontFamily: 'var(--theme--fonts--display--font-family)',
-				fontWeight: 'var(--theme--fonts--display--font-weight)',
+				foreground: 'var(--theme--foreground)',
+				fontFamily: 'var(--theme--fonts--title--font-family)',
+				fontWeight: 'var(--theme--fonts--title--font-weight)',
 			},
 		},
 

--- a/packages/themes/src/themes/light/default.ts
+++ b/packages/themes/src/themes/light/default.ts
@@ -124,7 +124,6 @@ export default defineTheme({
 			background: 'var(--theme--background)',
 			borderColor: 'transparent',
 			borderWidth: '0px',
-			boxShadow: '0 4px 7px -4px rgb(0 0 0 / 0.2)',
 			headline: {
 				foreground: 'var(--theme--foreground-subdued)',
 				fontFamily: 'var(--theme--fonts--sans--font-family)',

--- a/packages/themes/src/themes/light/default.ts
+++ b/packages/themes/src/themes/light/default.ts
@@ -6,7 +6,7 @@ export default defineTheme({
 	appearance: 'light',
 	rules: {
 		borderRadius: '0.3125rem',
-		borderWidth: '2px',
+		borderWidth: '1px',
 
 		foreground: '#4f5464',
 		foregroundAccent: '#172940',

--- a/packages/themes/src/themes/light/minimal.ts
+++ b/packages/themes/src/themes/light/minimal.ts
@@ -43,7 +43,6 @@ export default defineTheme({
 			background: '#FFFFFF',
 			borderWidth: '1px',
 			borderColor: 'var(--theme--border-color)',
-			boxShadow: '0 4px 7px -4px rgba(0,102,102, 0.1)',
 		},
 		backgroundAccent: '#E2E8F0',
 		backgroundSubdued: '#F8FAFC',

--- a/packages/types/src/extensions/layouts.ts
+++ b/packages/types/src/extensions/layouts.ts
@@ -12,8 +12,6 @@ export interface LayoutConfig<Options = any, Query = any> {
 		actions: Component;
 	};
 	smallHeader?: boolean;
-	headerShadow?: boolean;
-	sidebarShadow?: boolean;
 	setup: (props: LayoutProps<Options, Query>, ctx: LayoutContext) => Record<string, unknown>;
 }
 

--- a/packages/types/src/extensions/themes.ts
+++ b/packages/types/src/extensions/themes.ts
@@ -204,7 +204,6 @@ const Rules = Type.Object({
 			background: Type.Optional(Type.Ref(Color)),
 			borderWidth: Type.Optional(Type.Ref(LineWidth)),
 			borderColor: Type.Optional(Type.Ref(Color)),
-			boxShadow: Type.Optional(Type.Ref(BoxShadow)),
 			headline: Type.Optional(
 				Type.Object({
 					foreground: Type.Optional(Type.Ref(Color)),

--- a/packages/types/src/extensions/themes.ts
+++ b/packages/types/src/extensions/themes.ts
@@ -109,6 +109,12 @@ const Rules = Type.Object({
 					fontWeight: Type.Optional(Type.Ref(FontWeight)),
 				}),
 			),
+			title: Type.Optional(
+				Type.Object({
+					fontFamily: Type.Optional(Type.Ref(FamilyName)),
+					fontWeight: Type.Optional(Type.Ref(FontWeight)),
+				}),
+			),
 			sans: Type.Optional(
 				Type.Object({
 					fontFamily: Type.Optional(Type.Ref(FamilyName)),


### PR DESCRIPTION
## Scope

What's changed:

- Refactored outline and border styles across components to use theme CSS variables instead of hard-coded values; set default border width to `1px` in both light and dark themes
- Removed shadow from header bar and sidebar (including `sidebarShadow` / `headerShadow` layout props)
- Overhauled the type scale system: introduced a `fonts.title` tier and a `type-display` mixin, redefined `type-title`, adjusted line-heights and font sizes across `type-label`,
`type-text`, `type-note`
- Migrated display-level elements (`v-info`, `v-divider`, `v-banner`, accordion sections, presentation headers) from `type-title` to `type-display`
- Wired header/drawer titles to `--theme--header--title--*` variables; removed `type-title` from panel components
- Cleaned up redundant typography overrides in `v-text-overflow`, `v-card-title`, `form-field-label`
- Minor visual fixes: link underline in form field notes, status chip spacing in user popover, public view centering, VFieldTemplate alignment

## Potential Risks / Drawbacks

- The body line-height reduction (1.5385 → 1.4615) is a global cascade change — any component relying on inherited line-height without its own override will render slightly tighter
- `type-title` is now semantically different (body-text-sized, weight 600). Used in page and drawer header — custom themes or extensions that relied on the old definition (1rem / 700 / display font / accent) will see a visual break (edge case)

## Tested Scenarios

- Verified header bar and drawer title rendering with new `--theme--header--title--*` variables
- Checked panel label/metric display after removing `type-title` class
- Confirmed public view headings (login, register, accept-invite, reset-password, tfa-setup) render at 2.375rem
- Verified VFieldTemplate alignment in data model settings > collection > display template
- Validated centered public view layout and responsive styles

## Review Notes / Questions

- Note that this PR lays the foundational work for more upcoming design changes.
- **Review commit-by-commit**: each commit is self-contained and messages include context
- Rebuild: `pnpm --filter composables --filter themes --filter types build`
- VFieldTemplate fix (ac80936): test alignment e.g. in data model settings > `collection` > display template
- All design decisions in this PR were discussed with and approved by the design team
  <details>
  <summary>Full list of visual/type-scale changes</summary>
  
  1. **Body line-height:** 1.5385 → 1.4615 (`_base.scss`) — effective line-height drops from ~20px to ~19px; affects all inheriting elements
  2. **`type-title` redefined** (`_type-styles.scss`) — was 1rem / 700 / display font / accent; now 0.8125rem / 600 / title font / foreground. Distinguished from body text only by weight (600 vs 500) and font-family
  3. **`type-label`** — line-height 1.2143 → 1.4286 (~17px → ~20px at 14px font); uses `--theme--form--field--label--font-family`
  4. **`type-text`** — line-height 1.5385 → 1.4615 (matches body change)
  5. **`type-note`** — font-size 0.75rem → 0.6875rem (12px → 11px); line-height 1.3333 → 1.4545
  6. **New `type-display` tier** — 1.375rem / 700 / display font / foreground-accent / line-height 1.1818. Visually replaces the old `type-title` role at a larger font-size
  7. **New `fonts.title` token** — 600 weight, Inter. Distinct from `fonts.display` (700)
  8. **`header.title.foreground`** — foreground-accent → foreground
  9. **Page header-bar / drawer titles** — now use new `type-title` + `--theme--header--title--*` vars; removed `line-height: 1.2` override
  10. **`v-info` title** — type-title → type-display (larger); `.content` inherits body line-height 1.4615
  11. **`v-divider`** — non-large inherits ~1.4615 line-height; large uses `type-display` class
  12. **`v-banner` title** — now includes `type-display` base with banner-specific theme overrides
  13. **Accordion section labels** — type-title → type-display (larger)
  14. **Presentation header title** — font-weight changed 600 → 700 via `type-display`
  15. **Public view headings** — use `type-display` + `.type-display-public` override at 2.375rem
  16. **Public view project name** — explicit `.title-heading` class (color/size/weight), visually identical
  17. **Shared view title** — `type-display` mixin, line-height 1 → 1.1818
  18. **Panel label** — removed `type-title` class; relies on own scoped styles (weight 500, line-height 1.2)
  19. **Panel metric** — removed `type-title` class; own styles (weight 800, line-height 1.2)
  20. **`v-text-overflow`** — removed `line-height: normal`; now inherits from parent
  21. **`v-card-title`** — removed explicit `font-weight: 600` / `line-height: 1.6`; inherits from `type-label` (line-height tightened to 1.4286)
  22. **Form field links** — added `text-decoration: underline` on `<a>` in notes/descriptions
  23. **Form field label spacing** — edit dot, raw editor toggle, checkbox, ctx-arrow, collab avatars use `--label-height` calc instead of magic px offsets
  24. **User popover status chip** — added `margin-block: 0.125rem`
  
  </details>

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Addresses CMS-1921