### PR TITLE
Fix incorrect error message for already-activated user invites

### DIFF
--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -424,7 +424,15 @@ export class UsersService extends ItemsService {
 
 		const user = await this.getUserByEmail(email);
 
-		if (user?.status !== 'invited') {
+		if (!user) {
+			throw new InvalidPayloadError({ reason: `Email address ${email} hasn't been invited` });
+		}
+
+		if (user.status === 'active') {
+			throw new InvalidPayloadError({ reason: `Email address ${email} is already active` });
+		}
+
+		if (user.status !== 'invited') {
 			throw new InvalidPayloadError({ reason: `Email address ${email} hasn't been invited` });
 		}
 


### PR DESCRIPTION
## Problem

When a user is invited to Directus and then manually activated before accepting the invite, the error message incorrectly states "Email address has not been invited" instead of indicating the user is already activated.

## Solution

Updated the authentication error handling to distinguish between:
- User not invited (correct "not invited" message)
- User already activated (new "already activated" message)

## Validation

```bash
# Invite user, then activate manually
# Before: "Email hasn't been invited" (confusing)
# After: "Email is already activated" (accurate)
```

Fixes #26699