### PR TITLE
Fix filtered modules on settings page

### DIFF
--- a/.changeset/empty-gifts-dance.md
+++ b/.changeset/empty-gifts-dance.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed filtering out `preRegisterCheck === false` modules from settings module bar config

--- a/app/src/extensions.ts
+++ b/app/src/extensions.ts
@@ -1,5 +1,5 @@
-import type { AppExtensionConfigs, RefRecord } from '@directus/types';
-import { App, shallowRef, watch } from 'vue';
+import type { AppExtensionConfigs, ModuleConfig, RefRecord } from '@directus/types';
+import { App, shallowRef, type ShallowRef, watch } from 'vue';
 import { getInternalDisplays, registerDisplays } from './displays';
 import { getInternalInterfaces, registerInterfaces } from './interfaces';
 import { i18n } from './lang';
@@ -25,6 +25,8 @@ const extensions: RefRecord<AppExtensionConfigs> = {
 
 const onHydrateCallbacks: (() => Promise<void>)[] = [];
 const onDehydrateCallbacks: (() => Promise<void>)[] = [];
+
+const allModules = shallowRef<ModuleConfig[]>([]);
 
 export async function loadExtensions(): Promise<void> {
 	try {
@@ -83,6 +85,7 @@ export function registerExtensions(app: App): void {
 		[i18n.global.locale, registeredModules],
 		() => {
 			extensions.modules.value = translate(registeredModules.value);
+			allModules.value = translate(modules);
 		},
 		{ immediate: true },
 	);
@@ -101,4 +104,8 @@ export async function onDehydrateExtensions() {
 
 export function useExtensions(): RefRecord<AppExtensionConfigs> {
 	return extensions;
+}
+
+export function useAllModules(): ShallowRef<ModuleConfig[]> {
+	return allModules;
 }

--- a/app/src/interfaces/_system/system-modules/system-modules.vue
+++ b/app/src/interfaces/_system/system-modules/system-modules.vue
@@ -119,30 +119,16 @@ const isSaveDisabled = computed(() => {
 });
 
 function valueToPreview(value: Settings['module_bar']): PreviewValue[] {
-	return value
-		.filter((part) => {
-			if (part.type === 'link') return true;
-			return !!allModules.value.find((module) => module.id === part.id);
-		})
-		.map((part) => {
-			if (part.type === 'link') {
-				return {
-					...part,
-					to: part.url,
-					icon: part.icon,
-					name: translate(part.name),
-				};
-			}
+	return value.flatMap((part): PreviewValue[] => {
+		if (part.type === 'link') {
+			return [{ ...part, to: part.url, icon: part.icon, name: translate(part.name) }];
+		}
 
-			const module = allModules.value.find((module) => module.id === part.id)!;
+		const module = allModules.value.find((module) => module.id === part.id);
+		if (!module) return [];
 
-			return {
-				...part,
-				to: `/${module.id}`,
-				name: module.name,
-				icon: module.icon,
-			};
-		});
+		return [{ ...part, to: `/${module.id}`, name: module.name, icon: module.icon }];
+	});
 }
 
 function previewToValue(preview: PreviewValue[]): Settings['module_bar'] {

--- a/app/src/interfaces/_system/system-modules/system-modules.vue
+++ b/app/src/interfaces/_system/system-modules/system-modules.vue
@@ -10,7 +10,7 @@ import VForm from '@/components/v-form/v-form.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
 import VListItem from '@/components/v-list-item.vue';
 import { MODULE_BAR_DEFAULT } from '@/constants';
-import { useExtensions } from '@/extensions';
+import { useAllModules } from '@/extensions';
 import { hideDragImage } from '@/utils/hide-drag-image';
 import { translate } from '@/utils/translate-object-values';
 import { PrivateViewHeaderBarActionButton } from '@/views/private';
@@ -75,10 +75,10 @@ const editing = ref<string | null>();
 const values = ref<SettingsModuleBarLink | null>();
 const initialValues = ref<SettingsModuleBarLink | null>();
 
-const { modules: registeredModules } = useExtensions();
+const allModules = useAllModules();
 
 const availableModulesAsBarModule = computed<SettingsModuleBarModule[]>(() => {
-	return registeredModules.value
+	return allModules.value
 		.filter((module) => module.hidden !== true)
 		.map(
 			(module): SettingsModuleBarModule => ({
@@ -122,7 +122,7 @@ function valueToPreview(value: Settings['module_bar']): PreviewValue[] {
 	return value
 		.filter((part) => {
 			if (part.type === 'link') return true;
-			return !!registeredModules.value.find((module) => module.id === part.id);
+			return !!allModules.value.find((module) => module.id === part.id);
 		})
 		.map((part) => {
 			if (part.type === 'link') {
@@ -134,7 +134,7 @@ function valueToPreview(value: Settings['module_bar']): PreviewValue[] {
 				};
 			}
 
-			const module = registeredModules.value.find((module) => module.id === part.id)!;
+			const module = allModules.value.find((module) => module.id === part.id)!;
 
 			return {
 				...part,


### PR DESCRIPTION
## Scope

What's changed:

- Modules that fail the `preRegisterCheck` call are filtered out on the module bar, but at some point they were also filtered out of the modules section of the settings page
- This PR adds a new `useAllModules` function to `extension.ts` that returns all modules unfiltered
- This is then used on the settings page to ensure admins can still enable, disable and re-order modules that even they are not able to see in the sidebar

## Potential Risks / Drawbacks

- Some modules that are meant to be filtered from the settings page will now show up there

## Tested Scenarios

- Tested with a module that has `preRegisterCheck: (user) => user.admin_access === false;` and hence does not show in the module bar
- Module still shows in the settings page, is able to be deactivated, reactivated and re-ordered

## Review Notes / Questions

- This was a regression, is there some reason we started filtering these modules out on the settings page that I'm not aware of?

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes CMS-1277
