### PR TITLE
fix(api): return generic error for invalid invite acceptance

### DIFF
--- a/.changeset/fix-generic-invite-error.md
+++ b/.changeset/fix-generic-invite-error.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed invite acceptance error message leaking email address and account state. The error now returns a generic "invite is no longer valid" message for all failure cases.

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError, InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
+import { ForbiddenError, InvalidPayloadError, RecordNotUniqueError, TokenExpiredError } from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import type { Accountability, MutationOptions } from '@directus/types';
 import { UserIntegrityCheckFlag } from '@directus/types';
@@ -437,6 +437,41 @@ describe('Integration Tests', () => {
 
 				expect(superUpdateManySpy.mock.lastCall![0]).toEqual([mockUser.id]);
 				expect(superUpdateManySpy.mock.lastCall![1]).toEqual({ role: 'invite-role' });
+			});
+		});
+
+		describe('acceptInvite', () => {
+			it('should throw generic error when user status is not invited', async () => {
+				vi.mock('../utils/jwt.js', () => ({
+					verifyJWT: vi.fn().mockReturnValue({ email: 'user@example.com', scope: 'invite' }),
+				}));
+
+				vi.mock('../utils/get-secret.js', () => ({
+					getSecret: vi.fn().mockReturnValue('test-secret'),
+				}));
+
+				const service = new UsersService({
+					knex: db,
+					schema,
+				});
+
+				// mock an active user (not 'invited')
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+					status: 'active',
+				});
+
+				const promise = service.acceptInvite('test-token', 'password123');
+
+				await expect(promise).rejects.toThrow(InvalidPayloadError);
+
+				// Verify the error does NOT contain the email address (security)
+				await expect(promise).rejects.toThrow(
+					expect.not.objectContaining({
+						extensions: expect.objectContaining({
+							reason: expect.stringContaining('user@example.com'),
+						}),
+					}),
+				);
 			});
 		});
 	});

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -425,7 +425,7 @@ export class UsersService extends ItemsService {
 		const user = await this.getUserByEmail(email);
 
 		if (user?.status !== 'invited') {
-			throw new InvalidPayloadError({ reason: `Email address ${email} hasn't been invited` });
+			throw new InvalidPayloadError({ reason: `This invite is no longer valid` });
 		}
 
 		// Allow unauthenticated update

--- a/contributors.yml
+++ b/contributors.yml
@@ -260,3 +260,4 @@
 - Mugesh13102001
 - costajohnt
 - AbdelhamidKhald
+- faizkhairi


### PR DESCRIPTION
## Description

Replace the email-leaking error message in `acceptInvite` with a generic message that does not reveal account state.

### The Problem

When a user is invited, then manually activated in the CMS, the invite acceptance page shows:

> Email address test@test.com hasn't been invited

This reveals:
1. The email address (confirming the account exists)
2. The account's current state (not in `invited` status)

### Why Previous PRs Were Rejected

Four previous PRs (#26950, #26846, #26769, #26708) all attempted to make the error more descriptive (e.g., "user is already active") — each one was correctly rejected because they still leaked account existence information.

### The Fix

Replace the specific error with a generic message:

```
This invite is no longer valid
```

This single message covers **all** failure states:
- User doesn't exist → "invite is no longer valid"
- User is already active → "invite is no longer valid"
- User has a different status → "invite is no longer valid"

No information about account existence is revealed. The `INVALID_PAYLOAD` error code is preserved, and the frontend's `translateAPIError` handles it appropriately.

### Security

The fix follows the principle of **information minimization** — returning the same response regardless of internal state prevents account enumeration attacks.

### Changes

| File | Change |
|------|--------|
| `api/src/services/users.ts` | Replace email-leaking error reason with generic message (1 line) |

Fixes #26699