### PR TITLE
Fix presentation fields allowing required and readonly options

### DIFF
--- a/app/src/components/v-form/components/form-field-label.vue
+++ b/app/src/components/v-form/components/form-field-label.vue
@@ -50,6 +50,10 @@ const showHiddenIndicator = computed(
 		props.field.meta?.hidden,
 );
 
+const isPresentationField = computed(
+	() => props.field.type === 'alias' && !props.field.meta?.special?.includes('group'),
+);
+
 const isPromotableField = computed(() => {
 	if (!props.comparison) return false;
 	return props.comparison.onToggleField !== null && props.comparison.fields.has(props.field.field);
@@ -85,7 +89,7 @@ const isPromotableField = computed(() => {
 				<span v-if="showHiddenIndicator" class="hidden-indicator">({{ $t('hidden') }})</span>
 
 				<VIcon
-					v-if="field.meta?.required === true"
+					v-if="field.meta?.required === true && !isPresentationField"
 					class="required"
 					:class="{ 'has-badge': badge }"
 					sup

--- a/app/src/components/v-form/components/form-field.vue
+++ b/app/src/components/v-form/components/form-field.vue
@@ -64,9 +64,13 @@ const { t } = useI18n();
 
 const { focusedBy, onFieldUnset, onFieldUpdate, onBlur, onFocus } = props.collabFieldContext;
 
+const isPresentationField = computed(
+	() => props.field.type === 'alias' && !props.field.meta?.special?.includes('group'),
+);
+
 const isDisabled = computed(() => {
 	if (props.disabled) return true;
-	if (props.field?.meta?.readonly === true) return true;
+	if (props.field?.meta?.readonly === true && !isPresentationField.value) return true;
 	if (props.batchMode && props.batchActive === false) return true;
 	if (focusedBy.value) return true;
 	return false;

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
@@ -35,12 +35,12 @@ const isSearchableType = computed(() => {
 
 <template>
 	<div class="form">
-		<div v-if="!isGenerated" class="field half-left">
+		<div v-if="!isGenerated && localType !== 'presentation'" class="field half-left">
 			<div class="label type-label">{{ $t('readonly') }}</div>
 			<VCheckbox v-model="readonly" :label="$t('readonly_field_label')" block />
 		</div>
 
-		<div v-if="!isGenerated" class="field half-right">
+		<div v-if="!isGenerated && localType !== 'presentation'" class="field half-right">
 			<div class="label type-label">{{ $t('required') }}</div>
 			<VCheckbox v-model="required" :label="$t('require_value_to_be_set')" block />
 		</div>

--- a/contributors.yml
+++ b/contributors.yml
@@ -260,3 +260,4 @@
 - Mugesh13102001
 - costajohnt
 - AbdelhamidKhald
+- nielskaspers


### PR DESCRIPTION
## Summary
- Presentation fields (divider, notice, button-links) are display-only with no user input, but the advanced field configuration allowed setting `required` and `readonly` on them
- Setting a presentation field as required caused errors when creating records, since the field cannot be filled in
- Hide the required and readonly checkboxes when the field's local type is `presentation`

## Issue
Fixes #26961

## Changes
- In `field-detail-advanced-field.vue`, added `localType !== 'presentation'` condition to the readonly and required checkbox visibility (the `localType` ref was already available in the component from the field detail store)
- The simple field creation mode already correctly hides these options for presentation fields (via the `autoKey` guard), so only the advanced mode needed fixing

## Testing
1. Create a collection
2. Add a presentation field (divider, notice, or button-links)
3. Open the advanced field configuration
4. Verify the required and readonly checkboxes are no longer shown
5. Verify non-presentation fields still show required and readonly as before