### PR TITLE
Use shorter tooltip delay for disabled elements

### DIFF
--- a/.changeset/tender-boats-greet.md
+++ b/.changeset/tender-boats-greet.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Used shorter tooltip delay for disabled elements

--- a/app/src/directives/tooltip.test.ts
+++ b/app/src/directives/tooltip.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { isDisabled } from './tooltip';
+
+function createElement(html: string): HTMLElement {
+	const div = document.createElement('div');
+	div.innerHTML = html;
+	return div.firstElementChild as HTMLElement;
+}
+
+describe('isDisabled', () => {
+	describe('when the element itself is disabled', () => {
+		it('returns true for disabled attribute', () => {
+			const element = createElement('<button disabled>Click</button>');
+			expect(isDisabled(element)).toBe(true);
+		});
+
+		it('returns true for aria-disabled="true"', () => {
+			const element = createElement('<div aria-disabled="true">Click</div>');
+			expect(isDisabled(element)).toBe(true);
+		});
+	});
+
+	describe('when a direct child is disabled', () => {
+		it('returns true for a direct child with disabled attribute', () => {
+			const element = createElement('<span><button disabled>Click</button></span>');
+			expect(isDisabled(element)).toBe(true);
+		});
+
+		it('returns true for a direct child with aria-disabled="true"', () => {
+			const element = createElement('<span><div aria-disabled="true">Click</div></span>');
+			expect(isDisabled(element)).toBe(true);
+		});
+	});
+
+	describe('when the element is not disabled', () => {
+		it('returns false for an enabled element', () => {
+			const element = createElement('<button>Click</button>');
+			expect(isDisabled(element)).toBe(false);
+		});
+
+		it('returns false when aria-disabled is not "true"', () => {
+			const element = createElement('<div aria-disabled="false">Click</div>');
+			expect(isDisabled(element)).toBe(false);
+		});
+
+		it('returns false when only a deeply nested descendant is disabled', () => {
+			const element = createElement('<span><span><button disabled>Click</button></span></span>');
+			expect(isDisabled(element)).toBe(false);
+		});
+	});
+});

--- a/app/src/directives/tooltip.ts
+++ b/app/src/directives/tooltip.ts
@@ -2,7 +2,18 @@ import { nanoid } from 'nanoid';
 import { Directive, DirectiveBinding } from 'vue';
 import { useUserStore } from '@/stores/user';
 
-const tooltipDelay = 500;
+const DELAYS = {
+	tooltip: 500,
+	tooltipDisabled: 125,
+};
+
+function isDisabled(element: HTMLElement): boolean {
+	return (
+		element.hasAttribute('disabled') ||
+		element.getAttribute('aria-disabled') === 'true' ||
+		element.querySelector(':disabled, [aria-disabled="true"]') !== null
+	);
+}
 
 const handlers: Record<string, () => void> = {};
 
@@ -53,10 +64,13 @@ export function createEnterHandler(element: HTMLElement, binding: DirectiveBindi
 		} else {
 			clearTimeout(tooltipTimer);
 
-			tooltipTimer = window.setTimeout(() => {
-				animateIn(tooltip);
-				updateTooltip(element, binding, tooltip);
-			}, tooltipDelay);
+			tooltipTimer = window.setTimeout(
+				() => {
+					animateIn(tooltip);
+					updateTooltip(element, binding, tooltip);
+				},
+				isDisabled(element) ? DELAYS.tooltipDisabled : DELAYS.tooltip,
+			);
 		}
 	};
 }

--- a/app/src/directives/tooltip.ts
+++ b/app/src/directives/tooltip.ts
@@ -7,11 +7,11 @@ const DELAYS = {
 	tooltipDisabled: 125,
 };
 
-function isDisabled(element: HTMLElement): boolean {
+export function isDisabled(element: HTMLElement): boolean {
 	return (
 		element.hasAttribute('disabled') ||
 		element.getAttribute('aria-disabled') === 'true' ||
-		element.querySelector(':disabled, [aria-disabled="true"]') !== null
+		element.querySelector(':scope > :disabled, :scope > [aria-disabled="true"]') !== null
 	);
 }
 


### PR DESCRIPTION
## Scope

What's changed:

- Reduce tooltip delay for disabled elements from `500ms` to `125ms` to provide faster feedback when hovering over non-interactive controls
- Add `isDisabled()` helper to detect disabled state via native `disabled` attribute, `aria-disabled="true"`, or disabled descendants

## Potential Risks / Drawbacks

- The descendant check (`querySelector(':disabled, [aria-disabled="true"]')`) could produce false positives if a tooltip is placed on a generic container that happens to contain an unrelated disabled input

## Tested Scenarios

- Hover over a disabled button and confirm the tooltip appears after ~125ms
- Hover over an enabled button and confirm the tooltip still appears after the default 500ms delay


## Review Notes / Questions

- Pay attention to the `isDisabled` scope — it intentionally checks only direct children (`:scope >`) to avoid false positives from deeply nested disabled descendants

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #[CMS-2050](https://linear.app/directus/issue/CMS-2050/reduce-tooltip-delay-for-disabled-elements)