### PR TITLE
fix: avoid date picker crashes for dynamic variable values

### DIFF
--- a/app/src/components/v-date-picker/v-date-picker.test.ts
+++ b/app/src/components/v-date-picker/v-date-picker.test.ts
@@ -1142,6 +1142,30 @@ describe('v-date-picker', () => {
 	});
 
 	describe('edge cases', () => {
+		it.each(['date', 'time', 'dateTime', 'timestamp'] as const)(
+			'does not throw when modelValue is a dynamic variable for %s',
+			async (type) => {
+				vi.mocked(formatDatePickerModelValue).mockReturnValue('2024-01-15');
+
+				const mountPicker = () =>
+					createWrapper({
+						type,
+						modelValue: '$NOW',
+					});
+
+				expect(mountPicker).not.toThrow();
+
+				const wrapper = mountPicker();
+				await nextTick();
+
+				const nowButton = wrapper.find('.calendar-today-button');
+				await nowButton.trigger('click');
+				await nextTick();
+
+				expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+			},
+		);
+
 		it('handles rapid prop changes without errors', async () => {
 			let lastCapturedValue: unknown;
 

--- a/app/src/components/v-date-picker/v-date-picker.vue
+++ b/app/src/components/v-date-picker/v-date-picker.vue
@@ -80,6 +80,11 @@ function getDefaultTimeValue(): Time {
 	return new Time(12, 0, 0);
 }
 
+function resetInternalValues(): void {
+	calendarValue.value = undefined;
+	internalTimeValue.value = hasTime.value ? getDefaultTimeValue() : undefined;
+}
+
 /**
  * Internal time value state.
  * Initialized with a default time (12:00) when the picker type supports time.
@@ -124,38 +129,38 @@ watch(
 	() => props.modelValue,
 	(newValue) => {
 		if (!newValue) {
-			calendarValue.value = undefined;
-
-			// Reset time to a sensible default when the picker supports time.
-			internalTimeValue.value = hasTime.value ? getDefaultTimeValue() : undefined;
-
+			resetInternalValues();
 			return;
 		}
 
-		// Parse based on type
-		switch (props.type) {
-			case 'date':
-				calendarValue.value = parseDate(newValue);
-				break;
-			case 'time':
-				internalTimeValue.value = parseTime(newValue);
-				break;
+		try {
+			// Parse based on type
+			switch (props.type) {
+				case 'date':
+					calendarValue.value = parseDate(newValue);
+					break;
+				case 'time':
+					internalTimeValue.value = parseTime(newValue);
+					break;
 
-			case 'dateTime': {
-				// Matches legacy Flatpickr format: "yyyy-MM-dd'T'HH:mm:ss"
-				const dt = parseDateTime(newValue);
-				calendarValue.value = new CalendarDate(dt.year, dt.month, dt.day);
-				internalTimeValue.value = new Time(dt.hour, dt.minute, dt.second);
-				break;
-			}
+				case 'dateTime': {
+					// Matches legacy Flatpickr format: "yyyy-MM-dd'T'HH:mm:ss"
+					const dt = parseDateTime(newValue);
+					calendarValue.value = new CalendarDate(dt.year, dt.month, dt.day);
+					internalTimeValue.value = new Time(dt.hour, dt.minute, dt.second);
+					break;
+				}
 
-			case 'timestamp': {
-				// Matches legacy Flatpickr format: Date.toISOString() (absolute timestamp)
-				const dt = parseAbsoluteToLocal(newValue);
-				calendarValue.value = new CalendarDate(dt.year, dt.month, dt.day);
-				internalTimeValue.value = new Time(dt.hour, dt.minute, dt.second);
-				break;
+				case 'timestamp': {
+					// Matches legacy Flatpickr format: Date.toISOString() (absolute timestamp)
+					const dt = parseAbsoluteToLocal(newValue);
+					calendarValue.value = new CalendarDate(dt.year, dt.month, dt.day);
+					internalTimeValue.value = new Time(dt.hour, dt.minute, dt.second);
+					break;
+				}
 			}
+		} catch {
+			resetInternalValues();
 		}
 	},
 	{ immediate: true },

--- a/contributors.yml
+++ b/contributors.yml
@@ -238,6 +238,7 @@
 - mobml
 - tydung26
 - aderugy
+- a77ming
 - thomas-svrts
 - kekekuli
 - DanielRubianes


### PR DESCRIPTION
## Summary
- guard `v-date-picker` model parsing so invalid values like `$NOW` do not throw during sync
- reset the internal calendar/time state when parsing fails instead of crashing the picker
- add a regression test covering dynamic variables across date, time, datetime, and timestamp modes

## Testing
- PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter @directus/app exec vitest run --config ../app/vite.config.js app/src/components/v-date-picker/v-date-picker.test.ts
- PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec prettier --check app/src/components/v-date-picker/v-date-picker.vue app/src/components/v-date-picker/v-date-picker.test.ts

Closes #26828