### PR TITLE
fix: disable readonly and required for presentation fields

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
@@ -19,6 +19,7 @@ const translations = syncFieldDetailStoreProperty('field.meta.translations');
 const { loading, field, localType } = storeToRefs(fieldDetailStore);
 const type = computed(() => field.value.type);
 const isGenerated = computed(() => field.value.schema?.is_generated);
+const supportsReadonlyOrRequired = computed(() => !isGenerated.value && localType.value !== 'presentation');
 const userStore = useUserStore();
 const searchable = syncFieldDetailStoreProperty('field.meta.searchable', true);
 
@@ -35,17 +36,17 @@ const isSearchableType = computed(() => {
 
 <template>
 	<div class="form">
-		<div v-if="!isGenerated" class="field half-left">
+		<div v-if="supportsReadonlyOrRequired" class="field half-left">
 			<div class="label type-label">{{ $t('readonly') }}</div>
 			<VCheckbox v-model="readonly" :label="$t('readonly_field_label')" block />
 		</div>
 
-		<div v-if="!isGenerated" class="field half-right">
+		<div v-if="supportsReadonlyOrRequired" class="field half-right">
 			<div class="label type-label">{{ $t('required') }}</div>
 			<VCheckbox v-model="required" :label="$t('require_value_to_be_set')" block />
 		</div>
 
-		<VNotice v-if="readonly && required" type="warning" class="full no-margin">
+		<VNotice v-if="supportsReadonlyOrRequired && readonly && required" type="warning" class="full no-margin">
 			{{ $t('required_readonly_field_warning') }}
 		</VNotice>
 

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/presentation.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/presentation.ts
@@ -4,6 +4,9 @@ import { HelperFunctions, State, StateUpdates } from '../types';
 export function applyChanges(updates: StateUpdates, state: State, helperFn: HelperFunctions) {
 	const { hasChanged } = helperFn;
 
+	clearReadonly(updates);
+	clearRequired(updates);
+
 	if (hasChanged('localType')) {
 		removeSchema(updates);
 		setTypeToAlias(updates);
@@ -21,4 +24,12 @@ export function setTypeToAlias(updates: StateUpdates) {
 
 export function setSpecialToNoData(updates: StateUpdates) {
 	set(updates, 'field.meta.special', ['alias', 'no-data']);
+}
+
+export function clearReadonly(updates: StateUpdates) {
+	set(updates, 'field.meta.readonly', false);
+}
+
+export function clearRequired(updates: StateUpdates) {
+	set(updates, 'field.meta.required', false);
 }

--- a/app/src/modules/settings/routes/data-model/field-detail/store/index.test.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/index.test.ts
@@ -112,6 +112,30 @@ describe('Actions', () => {
 });
 
 describe('Alterations', () => {
+	describe('presentation', () => {
+		it('clears readonly and required flags for presentation fields', () => {
+			const fieldDetailStore = useFieldDetailStore();
+
+			fieldDetailStore.startEditing('collection_a', '+', 'presentation');
+			fieldDetailStore.field.meta.readonly = true;
+			fieldDetailStore.field.meta.required = true;
+
+			fieldDetailStore.update({
+				field: {
+					meta: {
+						note: 'Divider note',
+					},
+				},
+			});
+
+			expect(fieldDetailStore.field.meta.readonly).toBe(false);
+			expect(fieldDetailStore.field.meta.required).toBe(false);
+			expect(fieldDetailStore.field.meta.note).toBe('Divider note');
+			expect(fieldDetailStore.fieldUpdates.meta?.readonly).toBe(false);
+			expect(fieldDetailStore.fieldUpdates.meta?.required).toBe(false);
+		});
+	});
+
 	describe('files', () => {
 		it('autoGenerateJunctionRelation has changed', () => {
 			const fieldDetailStore = useFieldDetailStore();

--- a/contributors.yml
+++ b/contributors.yml
@@ -238,6 +238,7 @@
 - mobml
 - tydung26
 - aderugy
+- a77ming
 - thomas-svrts
 - kekekuli
 - DanielRubianes


### PR DESCRIPTION
## Summary
- hide the readonly and required controls for presentation fields in the field detail UI
- normalize presentation field updates so those flags are always saved as `false`
- add a regression test covering presentation fields with stale validation flags

## Testing
- PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter @directus/app exec vitest run --config ../app/vite.config.js app/src/modules/settings/routes/data-model/field-detail/store/index.test.ts
- PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec prettier --check app/src/modules/settings/routes/data-model/field-detail/store/alterations/presentation.ts app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue app/src/modules/settings/routes/data-model/field-detail/store/index.test.ts

Closes #26961