### PR TITLE
Fix missing nested overwriteDefaults timestamps during version promote

### DIFF
--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -119,11 +119,11 @@ export class PayloadService {
 			return value;
 		},
 		async 'user-created'({ action, value, accountability, overwriteDefaults }) {
-			if (action === 'create') return (overwriteDefaults ? overwriteDefaults._user : accountability?.user) ?? null;
+			if (action === 'create') return overwriteDefaults?._user ?? accountability?.user ?? null;
 			return value;
 		},
 		async 'user-updated'({ action, value, accountability, overwriteDefaults }) {
-			if (action === 'update') return (overwriteDefaults ? overwriteDefaults._user : accountability?.user) ?? null;
+			if (action === 'update') return overwriteDefaults?._user ?? accountability?.user ?? null;
 			return value;
 		},
 		async 'role-created'({ action, value, accountability }) {
@@ -136,16 +136,12 @@ export class PayloadService {
 		},
 		async 'date-created'({ action, value, helpers, overwriteDefaults }) {
 			if (action === 'create')
-				return new Date(
-					overwriteDefaults ? overwriteDefaults._date : helpers.date.writeTimestamp(new Date().toISOString()),
-				);
+				return new Date(overwriteDefaults?._date ?? helpers.date.writeTimestamp(new Date().toISOString()));
 			return value;
 		},
 		async 'date-updated'({ action, value, helpers, overwriteDefaults }) {
 			if (action === 'update')
-				return new Date(
-					overwriteDefaults ? overwriteDefaults._date : helpers.date.writeTimestamp(new Date().toISOString()),
-				);
+				return new Date(overwriteDefaults?._date ?? helpers.date.writeTimestamp(new Date().toISOString()));
 			return value;
 		},
 		async 'cast-csv'({ action, value }) {


### PR DESCRIPTION
Fix invalid date during version promote

## Scope

What's changed:

- Fixed an `Invalid time value` error during version promote
- Updated payload special field handling to fall back when `_date` or `_user` is missing in `overwriteDefaults`

## Potential Risks / Drawbacks

- Affects shared payload handling for special user/date fields
- Nested revision flows should be checked closely

## Tested Scenarios

- Promoted a version with nested relation deletes
- Confirmed the request no longer failed with a 500 error

## Review Notes / Questions

- The issue was caused by truthy but incomplete `overwriteDefaults` values such as `[]`
- Special attention should be paid to nested relation update/delete flows

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26084