### PR TITLE
Fix cards keyboard behavior: Space should open item

### DIFF
--- a/.changeset/soft-cups-wave.md
+++ b/.changeset/soft-cups-wave.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed cards keyboard navigation so pressing Space on a focused card opened the item detail view.

--- a/app/src/layouts/cards/components/card.vue
+++ b/app/src/layouts/cards/components/card.vue
@@ -100,13 +100,24 @@ function handleClick() {
 		router.push(props.to);
 	}
 }
+
+function handleKeydown(event: KeyboardEvent) {
+	if (event.key === 'Enter') {
+		if (props.to) router.push(props.to);
+	} else if (event.key === ' ') {
+		event.preventDefault();
+		if (props.to) router.push(props.to);
+	}
+}
 </script>
 
 <template>
 	<div
 		class="card"
 		:class="{ loading, readonly, selected: item && modelValue.includes(item[itemKey]), 'select-mode': selectMode }"
+		tabindex="0"
 		@click="handleClick"
+		@keydown="handleKeydown"
 	>
 		<VIcon class="selector" :name="selectionIcon" clickable @click.stop="toggleSelection" />
 		<div class="header">
@@ -295,6 +306,22 @@ function handleClick() {
 	}
 
 	&:hover {
+		.selector {
+			opacity: 0.5;
+		}
+
+		.header {
+			.selection-fade {
+				opacity: 1;
+			}
+		}
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--theme--primary);
+		outline-offset: 2px;
+		border-radius: var(--theme--border-radius);
+
 		.selector {
 			opacity: 0.5;
 		}

--- a/contributors.yml
+++ b/contributors.yml
@@ -260,3 +260,4 @@
 - Mugesh13102001
 - costajohnt
 - AbdelhamidKhald
+- Zhey-on


### PR DESCRIPTION
## Scope

What's changed:

- Made cards keyboard-focusable in the cards layout
- Added keyboard handling on card: Enter opens the item and Space opens the item
- Added focus-visible styling for keyboard users to make focused cards visually identifiable

## Potential Risks / Drawbacks

- Space now opens item details from a focused card instead of toggling selection on the card body
- Existing selection behavior is still available through the selector icon

## Tested Scenarios

- Opened Content -> Users in cards layout and navigated cards with Tab
- Pressed Enter on a focused card and confirmed navigation to item detail
- Pressed Space on a focused card and confirmed navigation to item detail
- Verified selector icon still toggles selection when activated

## Review Notes / Questions

- This change is intentionally scoped to cards keyboard interaction only
- Please confirm this expected behavior should apply consistently across all collections using cards layout

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26945
