### PR TITLE
Fix search area not closing on keyboard focus out

### DIFF
--- a/.changeset/sharp-toys-taste.md
+++ b/.changeset/sharp-toys-taste.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed search input so the search area closed when focus left the input via keyboard.
+Fixed search input not closing when focus changes on keyboard navigation

--- a/.changeset/sharp-toys-taste.md
+++ b/.changeset/sharp-toys-taste.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed search input so the search area closed when focus left the input via keyboard.

--- a/app/src/views/private/components/search-input.test.ts
+++ b/app/src/views/private/components/search-input.test.ts
@@ -76,12 +76,44 @@ describe('Component', () => {
 		const outside = document.createElement('button');
 		document.body.appendChild(outside);
 
-		input.element.dispatchEvent(new FocusEvent('focusout', { relatedTarget: outside }));
+		input.element.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: outside }));
 		await wrapper.vm.$nextTick();
 
 		expect(search.classes()).not.toContain('active');
 		expect(search.classes()).not.toContain('filter-active');
 
+		document.body.removeChild(outside);
+	});
+
+	it('should close when focus leaves a descendant element of search area', async () => {
+		const wrapper = mount(SearchInput, {
+			props: {
+				modelValue: 'test',
+			},
+			global,
+		});
+
+		const search = wrapper.find('.search-input');
+
+		await search.trigger('click');
+		await wrapper.find('v-icon-stub.icon-filter').trigger('click');
+
+		expect(search.classes()).toContain('active');
+		expect(search.classes()).toContain('filter-active');
+
+		const descendant = document.createElement('button');
+		search.element.appendChild(descendant);
+
+		const outside = document.createElement('button');
+		document.body.appendChild(outside);
+
+		descendant.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: outside }));
+		await wrapper.vm.$nextTick();
+
+		expect(search.classes()).not.toContain('active');
+		expect(search.classes()).not.toContain('filter-active');
+
+		search.element.removeChild(descendant);
 		document.body.removeChild(outside);
 	});
 });

--- a/app/src/views/private/components/search-input.test.ts
+++ b/app/src/views/private/components/search-input.test.ts
@@ -116,4 +116,38 @@ describe('Component', () => {
 		search.element.removeChild(descendant);
 		document.body.removeChild(outside);
 	});
+
+	it('should stay open when focus moves into v-menu-content', async () => {
+		const wrapper = mount(SearchInput, {
+			props: {
+				modelValue: 'test',
+			},
+			global,
+		});
+
+		const search = wrapper.find('.search-input');
+		const input = wrapper.find('input');
+
+		await search.trigger('click');
+		await wrapper.find('v-icon-stub.icon-filter').trigger('click');
+
+		expect(search.classes()).toContain('active');
+		expect(search.classes()).toContain('filter-active');
+
+		const menuContent = document.createElement('div');
+		menuContent.className = 'v-menu-content';
+		document.body.appendChild(menuContent);
+
+		const menuTarget = document.createElement('button');
+		menuContent.appendChild(menuTarget);
+
+		input.element.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: menuTarget }));
+		await wrapper.vm.$nextTick();
+
+		expect(search.classes()).toContain('active');
+		expect(search.classes()).toContain('filter-active');
+
+		menuContent.removeChild(menuTarget);
+		document.body.removeChild(menuContent);
+	});
 });

--- a/app/src/views/private/components/search-input.test.ts
+++ b/app/src/views/private/components/search-input.test.ts
@@ -55,4 +55,33 @@ describe('Component', () => {
 
 		expect(wrapper.find('input').attributes('disabled')).toBe('');
 	});
+
+	it('should close on keyboard focusout even when filter is active', async () => {
+		const wrapper = mount(SearchInput, {
+			props: {
+				modelValue: 'test',
+			},
+			global,
+		});
+
+		const search = wrapper.find('.search-input');
+		const input = wrapper.find('input');
+
+		await search.trigger('click');
+		await wrapper.find('v-icon-stub.icon-filter').trigger('click');
+
+		expect(search.classes()).toContain('active');
+		expect(search.classes()).toContain('filter-active');
+
+		const outside = document.createElement('button');
+		document.body.appendChild(outside);
+
+		input.element.dispatchEvent(new FocusEvent('focusout', { relatedTarget: outside }));
+		await wrapper.vm.$nextTick();
+
+		expect(search.classes()).not.toContain('active');
+		expect(search.classes()).not.toContain('filter-active');
+
+		document.body.removeChild(outside);
+	});
 });

--- a/app/src/views/private/components/search-input.test.ts
+++ b/app/src/views/private/components/search-input.test.ts
@@ -1,6 +1,6 @@
 import { createTestingPinia } from '@pinia/testing';
-import { mount } from '@vue/test-utils';
-import { describe, expect, it, vi } from 'vitest';
+import { DOMWrapper, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import SearchInput from './search-input.vue';
 import { ClickOutside } from '@/__utils__/click-outside';
 import { Tooltip } from '@/__utils__/tooltip';
@@ -56,98 +56,95 @@ describe('Component', () => {
 		expect(wrapper.find('input').attributes('disabled')).toBe('');
 	});
 
-	it('should close on keyboard focusout even when filter is active', async () => {
-		const wrapper = mount(SearchInput, {
-			props: {
-				modelValue: 'test',
-			},
-			global,
+	describe('focusout behavior', () => {
+		let wrapper: VueWrapper;
+		let search: DOMWrapper<Element>;
+
+		beforeEach(async () => {
+			wrapper = mount(SearchInput, {
+				props: {
+					modelValue: 'test',
+				},
+				global,
+			});
+
+			search = wrapper.find('.search-input');
+
+			await search.trigger('click');
+			await wrapper.find('v-icon-stub.icon-filter').trigger('click');
+
+			expect(search.classes()).toContain('active');
+			expect(search.classes()).toContain('filter-active');
 		});
 
-		const search = wrapper.find('.search-input');
-		const input = wrapper.find('input');
-
-		await search.trigger('click');
-		await wrapper.find('v-icon-stub.icon-filter').trigger('click');
-
-		expect(search.classes()).toContain('active');
-		expect(search.classes()).toContain('filter-active');
-
-		const outside = document.createElement('button');
-		document.body.appendChild(outside);
-
-		input.element.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: outside }));
-		await wrapper.vm.$nextTick();
-
-		expect(search.classes()).not.toContain('active');
-		expect(search.classes()).not.toContain('filter-active');
-
-		document.body.removeChild(outside);
-	});
-
-	it('should close when focus leaves a descendant element of search area', async () => {
-		const wrapper = mount(SearchInput, {
-			props: {
-				modelValue: 'test',
-			},
-			global,
+		afterEach(() => {
+			wrapper.unmount();
 		});
 
-		const search = wrapper.find('.search-input');
+		describe('when focus moves outside the search area', () => {
+			let outside: HTMLButtonElement;
+			let descendant: HTMLButtonElement;
 
-		await search.trigger('click');
-		await wrapper.find('v-icon-stub.icon-filter').trigger('click');
+			beforeEach(() => {
+				outside = document.createElement('button');
+				document.body.appendChild(outside);
 
-		expect(search.classes()).toContain('active');
-		expect(search.classes()).toContain('filter-active');
+				descendant = document.createElement('button');
+				search.element.appendChild(descendant);
+			});
 
-		const descendant = document.createElement('button');
-		search.element.appendChild(descendant);
+			afterEach(() => {
+				document.body.removeChild(outside);
+				search.element.removeChild(descendant);
+			});
 
-		const outside = document.createElement('button');
-		document.body.appendChild(outside);
+			it('should close on keyboard focusout even when filter is active', async () => {
+				wrapper
+					.find('input')
+					.element.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: outside }));
 
-		descendant.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: outside }));
-		await wrapper.vm.$nextTick();
+				await wrapper.vm.$nextTick();
 
-		expect(search.classes()).not.toContain('active');
-		expect(search.classes()).not.toContain('filter-active');
+				expect(search.classes()).not.toContain('active');
+				expect(search.classes()).not.toContain('filter-active');
+			});
 
-		search.element.removeChild(descendant);
-		document.body.removeChild(outside);
-	});
+			it('should close when focusout target is outside the search area', async () => {
+				descendant.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: outside }));
+				await wrapper.vm.$nextTick();
 
-	it('should stay open when focus moves into v-menu-content', async () => {
-		const wrapper = mount(SearchInput, {
-			props: {
-				modelValue: 'test',
-			},
-			global,
+				expect(search.classes()).not.toContain('active');
+				expect(search.classes()).not.toContain('filter-active');
+			});
 		});
 
-		const search = wrapper.find('.search-input');
-		const input = wrapper.find('input');
+		describe('when focus moves into v-menu-content', () => {
+			let menuContent: HTMLDivElement;
+			let menuTarget: HTMLButtonElement;
 
-		await search.trigger('click');
-		await wrapper.find('v-icon-stub.icon-filter').trigger('click');
+			beforeEach(() => {
+				menuContent = document.createElement('div');
+				menuContent.className = 'v-menu-content';
+				document.body.appendChild(menuContent);
 
-		expect(search.classes()).toContain('active');
-		expect(search.classes()).toContain('filter-active');
+				menuTarget = document.createElement('button');
+				menuContent.appendChild(menuTarget);
+			});
 
-		const menuContent = document.createElement('div');
-		menuContent.className = 'v-menu-content';
-		document.body.appendChild(menuContent);
+			afterEach(() => {
+				document.body.removeChild(menuContent);
+			});
 
-		const menuTarget = document.createElement('button');
-		menuContent.appendChild(menuTarget);
+			it('should stay open when focus moves into v-menu-content', async () => {
+				wrapper
+					.find('input')
+					.element.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: menuTarget }));
 
-		input.element.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: menuTarget }));
-		await wrapper.vm.$nextTick();
+				await wrapper.vm.$nextTick();
 
-		expect(search.classes()).toContain('active');
-		expect(search.classes()).toContain('filter-active');
-
-		menuContent.removeChild(menuTarget);
-		document.body.removeChild(menuContent);
+				expect(search.classes()).toContain('active');
+				expect(search.classes()).toContain('filter-active');
+			});
+		});
 	});
 });

--- a/app/src/views/private/components/search-input.vue
+++ b/app/src/views/private/components/search-input.vue
@@ -162,6 +162,7 @@ function emitValue() {
 			}"
 			role="search"
 			@click="activate"
+			@focusout="onFocusOut"
 		>
 			<VIcon small name="search" class="icon-search" :disabled :clickable="!active" @click="input?.focus()" />
 			<input
@@ -179,7 +180,6 @@ function emitValue() {
 				@paste="emitValue"
 				@keydown.esc="disable"
 				@focusin="activate"
-				@focusout="onFocusOut"
 			/>
 			<div class="spacer" />
 			<VIcon

--- a/app/src/views/private/components/search-input.vue
+++ b/app/src/views/private/components/search-input.vue
@@ -118,11 +118,11 @@ function disable() {
 }
 
 function onFocusOut(event: FocusEvent) {
-	if (filterActive.value) return;
-
 	// Check if focus is moving to another element inside the search component -- prevents race condition on touch vs click events
 	const searchElement = (event.currentTarget as HTMLElement)?.closest('.search-input');
 	const relatedTarget = event.relatedTarget as HTMLElement | null;
+
+	if (relatedTarget?.closest('.v-menu-content')) return;
 
 	if (relatedTarget && searchElement?.contains(relatedTarget)) return;
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -260,3 +260,4 @@
 - Mugesh13102001
 - costajohnt
 - AbdelhamidKhald
+- Zhey-on


### PR DESCRIPTION
## Scope

What's changed:

- Updated search input focus-out behavior to close the search area when focus leaves via keyboard navigation
- Kept search area open when focus moves within the search component or into filter menu content
- Added a regression test for keyboard focus-out while the filter is active

## Potential Risks / Drawbacks

- Focus behavior changed in a shared private view component, so keyboard interaction around filter popovers should be reviewed
- Test relies on focusout relatedTarget behavior in the test environment

## Tested Scenarios

- Activated search and filter, then moved focus out via focusout with an external relatedTarget
- Verified search area active and filter-active classes were removed after focus left input
- Confirmed existing behavior still keeps search open when focus remains inside component/menu

## Review Notes / Questions

- The fix intentionally treats keyboard focus-out similarly to click-outside close behavior
- Please confirm expected UX when moving from input into filter menu content remains open

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26944
