### PR TITLE
Add keyboard navigation to the cards layout

### DIFF
--- a/.changeset/green-kiwis-camp.md
+++ b/.changeset/green-kiwis-camp.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Added keyboard navigation to the cards layout

--- a/app/src/layouts/cards/components/card.vue
+++ b/app/src/layouts/cards/components/card.vue
@@ -94,7 +94,7 @@ function toggleSelection() {
 }
 
 function handleClick() {
-	if (props.selectMode === true) {
+	if (props.selectMode === true || props.modelValue.length > 0) {
 		toggleSelection();
 	} else {
 		router.push(props.to);
@@ -106,7 +106,10 @@ function handleClick() {
 	<div
 		class="card"
 		:class="{ loading, readonly, selected: item && modelValue.includes(item[itemKey]), 'select-mode': selectMode }"
+		:tabindex="readonly || loading || modelValue.length > 0 ? -1 : 0"
 		@click="handleClick"
+		@keydown.self.enter.prevent="handleClick"
+		@keydown.self.space.prevent="handleClick"
 	>
 		<VIcon class="selector" :name="selectionIcon" clickable @click.stop="toggleSelection" />
 		<div class="header">
@@ -145,6 +148,15 @@ function handleClick() {
 .card {
 	position: relative;
 	cursor: pointer;
+
+	&:focus-visible {
+		outline: none;
+
+		.header {
+			outline: var(--focus-ring-width) solid var(--focus-ring-color);
+			outline-offset: var(--focus-ring-offset);
+		}
+	}
 
 	.header {
 		position: relative;


### PR DESCRIPTION
## Scope

What's changed:

- Add keyboard navigation to the cards layout — cards are now focusable via `Tab` and activate on `Enter` or `Space`
- Skip Tab focus (`tabindex="-1"`) on cards when a selection is active, keeping the selector icon as the only keyboard target in that mode
- Prevent navigation when items are already selected — `handleClick` now toggles selection whenever `modelValue` is non-empty, regardless of `selectMode`

## Potential Risks / Drawbacks

- Cards become unreachable via Tab while any selection is active; keyboard users must clear the selection before they can Tab-navigate to an item
- The `@keydown.self` modifier scopes Enter/Space to the card root only — child elements (e.g. selector icon) handle their own keyboard events independently, which is intentional but worth verifying in edge cases

## Tested Scenarios

- Tab to a card and press Enter — confirm navigation to the item
- Tab to a card and press Space — confirm navigation to the item
- Select one or more items, then Tab — confirm cards are skipped and only selector icons receive focus
- With items selected, focus a selector icon and press Enter/Space — confirm selection toggles without navigating
- Verify the focus ring appears around the card header only, respects the header's border-radius, and matches the project focus ring style

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26945