### PR TITLE
Fix Role not showing on user details page

### DIFF
--- a/.changeset/polite-hounds-type.md
+++ b/.changeset/polite-hounds-type.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Restored `useItem` support for custom query options like `fields` and `deep` by adding an optional extra query parameter and updating affected call sites.

--- a/app/src/composables/use-item/index.test.ts
+++ b/app/src/composables/use-item/index.test.ts
@@ -218,6 +218,70 @@ describe('Save As Copy', () => {
 	});
 });
 
+describe('Query merging', () => {
+	const mockCollection = {
+		collection: 'test',
+	} as AppCollection;
+
+	const mockPrimaryKeyField = {
+		field: 'id',
+	} as Field;
+
+	const mockFields = [mockPrimaryKeyField] as Field[];
+
+	beforeEach(() => {
+		vi.mocked(useCollection).mockReturnValue({
+			info: computed(() => mockCollection),
+			primaryKeyField: computed(() => mockPrimaryKeyField),
+			fields: computed(() => mockFields),
+		} as any);
+	});
+
+	test('should include extra query params when no content version is provided', async () => {
+		const sdkSpy = vi.spyOn(sdk, 'request');
+
+		useItem(ref('test'), ref(1), null, { fields: ['*', 'role.*'] });
+
+		await Promise.resolve();
+
+		const request = sdkSpy.mock.calls[0]?.[0]();
+
+		expect(request).toEqual(
+			expect.objectContaining({
+				path: '/items/test/1',
+				params: expect.objectContaining({
+					fields: ['*', 'role.*'],
+				}),
+			}),
+		);
+
+		expect(request?.params).not.toHaveProperty('version');
+		expect(request?.params).not.toHaveProperty('versionRaw');
+	});
+
+	test('should merge extra query params with content version params', async () => {
+		const sdkSpy = vi.spyOn(sdk, 'request');
+		const currentVersion = ref({ id: 'version-id', key: 'v1' } as any);
+
+		useItem(ref('test'), ref(1), currentVersion, { deep: { users: { _limit: 0 } } });
+
+		await Promise.resolve();
+
+		const request = sdkSpy.mock.calls[0]?.[0]();
+
+		expect(request).toEqual(
+			expect.objectContaining({
+				path: '/items/test/1',
+				params: expect.objectContaining({
+					deep: { users: { _limit: 0 } },
+					version: 'v1',
+					versionRaw: true,
+				}),
+			}),
+		);
+	});
+});
+
 describe('Clear Hidden Fields Condition', () => {
 	const mockCollection = {
 		collection: 'test',

--- a/app/src/composables/use-item/index.ts
+++ b/app/src/composables/use-item/index.ts
@@ -4,7 +4,7 @@ import { Alterations, Field, Item, PrimaryKey, Query, Relation } from '@directus
 import { getEndpoint, isObject } from '@directus/utils';
 import { jsonToGraphQLQuery } from 'json-to-graphql-query';
 import { cloneDeep, mergeWith } from 'lodash';
-import { computed, ComputedRef, ref, Ref, unref, watch } from 'vue';
+import { computed, ComputedRef, MaybeRef, ref, Ref, unref, watch } from 'vue';
 import { UsablePermissions, usePermissions } from '../use-permissions';
 import { getGraphqlQueryFields } from './lib/get-graphql-query-fields';
 import { transformM2AAliases } from './lib/transform-m2a-aliases';
@@ -53,6 +53,7 @@ export function useItem<T extends Item>(
 	collection: Ref<string>,
 	primaryKey: Ref<PrimaryKey | null>,
 	currentVersion: Ref<ContentVersionMaybeNew | null> | null = null,
+	extraQuery: MaybeRef<Omit<Query, 'version' | 'versionRaw'>> = {},
 ): UsableItem<T> {
 	const { info: collectionInfo, primaryKeyField } = useCollection(collection);
 	const item: Ref<T | null> = ref(null);
@@ -79,8 +80,9 @@ export function useItem<T extends Item>(
 
 	const query = computed<Query>(() => {
 		const version = unref(currentVersion);
-		if (!version || version.id === '+') return {};
-		return { version: version.key, versionRaw: true };
+		const extra = unref(extraQuery);
+		if (!version || version.id === '+') return { ...extra };
+		return { ...extra, version: version.key, versionRaw: true };
 	});
 
 	const isVersion = computed(() => unref(currentVersion) !== null);

--- a/app/src/modules/settings/routes/roles/item.vue
+++ b/app/src/modules/settings/routes/roles/item.vue
@@ -40,9 +40,8 @@ const revisionsSidebarDetailRef = ref<InstanceType<typeof RevisionsSidebarDetail
 const { edits, hasEdits, item, saving, loading, save, remove, deleting, validationErrors } = useItem<Role>(
 	ref('directus_roles'),
 	primaryKey,
-	{
-		deep: { users: { _limit: 0 } },
-	},
+	null,
+	{ deep: { users: { _limit: 0 } } },
 );
 
 const canInviteUsers = computed(() => !serverStore.auth.disableDefault);

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -80,11 +80,8 @@ const {
 } = useItem<User>(
 	ref('directus_users'),
 	primaryKey,
-	props.primaryKey !== '+'
-		? {
-				fields: ['*', 'role.*', 'avatar.id', 'avatar.modified_on'],
-			}
-		: undefined,
+	null,
+	{ fields: ['*', 'role.*', 'avatar.id', 'avatar.modified_on'] },
 );
 
 const {

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -77,12 +77,9 @@ const {
 	validationErrors,
 	refresh,
 	getItem,
-} = useItem<User>(
-	ref('directus_users'),
-	primaryKey,
-	null,
-	{ fields: ['*', 'role.*', 'avatar.id', 'avatar.modified_on'] },
-);
+} = useItem<User>(ref('directus_users'), primaryKey, null, {
+	fields: ['*', 'role.*', 'avatar.id', 'avatar.modified_on'],
+});
 
 const {
 	users: collabUsers,


### PR DESCRIPTION
## Scope

What's changed:

- Added an optional extraQuery parameter to useItem so callers can pass fields, deep, etc. alongside the existing version handling
- Updated users/routes/item.vue to pass fields through the new param (restores role + avatar field expansion)
- Updated settings/routes/roles/item.vue to pass deep: { users: { _limit: 0 } } through the new param (restores user count suppression on role detail page)

## Potential Risks / Drawbacks

The Omit<Query, 'version' | 'versionRaw'> type prevents callers from accidentally overriding version params at the type level, but this is additive, no existing behavior changes for callers that don't use the new param

## Tested Scenarios

- Role dropdown on user profile pages now correctly shows the assigned role

<img width="742" height="215" alt="image" src="https://github.com/user-attachments/assets/ed68c34d-45d4-4a64-b37e-cf1ebdf6cfcd" />


## Review Notes / Questions

Would be good to get eyes on whether any other useItem call sites should be passing extraQuery that we may have missed

## Checklist

- [x] Added or updated tests
- [] Documentation PR created [here](https://github.com/directus/docs) or not required
- [] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26980 
