### PR TITLE
Fix extension auto reload not triggering

### DIFF
--- a/.changeset/slow-cougars-cough.md
+++ b/.changeset/slow-cougars-cough.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed extension auto reload not triggering

--- a/api/src/extensions/manager.ts
+++ b/api/src/extensions/manager.ts
@@ -480,7 +480,7 @@ export class ExtensionManager {
 
 		this.watcher = chokidar.watch([path.resolve('package.json'), extensionDirPath], {
 			ignoreInitial: true,
-			depth: 2,
+			depth: 1,
 			ignored: (val: string, stats?: Stats) => {
 				if (val.includes('node_modules')) return true;
 

--- a/api/src/extensions/manager.ts
+++ b/api/src/extensions/manager.ts
@@ -456,16 +456,16 @@ export class ExtensionManager {
 
 		if (!extension) return false;
 
-		// Uses `includes` for comparison because chokidar emits watched change events as relative paths,
-		// while paths added via updateWatchedExtensions are emitted as absolute paths.
+		const resolvedPath = path.resolve(filePath);
+
 		if (isTypeIn(extension, HYBRID_EXTENSION_TYPES) || extension.type === 'bundle') {
 			return (
-				path.resolve(extension.path, extension.entrypoint.app).includes(filePath) ||
-				path.resolve(extension.path, extension.entrypoint.api).includes(filePath)
+				path.resolve(extension.path, extension.entrypoint.app) === resolvedPath ||
+				path.resolve(extension.path, extension.entrypoint.api) === resolvedPath
 			);
 		}
 
-		return path.resolve(extension.path, extension.entrypoint).includes(filePath);
+		return path.resolve(extension.path, extension.entrypoint) === resolvedPath;
 	}
 
 	/**
@@ -478,19 +478,30 @@ export class ExtensionManager {
 
 		const extensionDirPath = pathToRelativeUrl(getExtensionsPath());
 
+		const resolvedExtDir = path.resolve(extensionDirPath);
+
 		this.watcher = chokidar.watch([path.resolve('package.json'), extensionDirPath], {
 			ignoreInitial: true,
+			// Only top level watch inside extensions folder is necessary, "dist" paths are added via updateWatchedExtensions
 			depth: 1,
 			ignored: (val: string, stats?: Stats) => {
 				if (val.includes('node_modules')) return true;
 
-				// allow directory traversal so chokidar can reach extensions package.json
+				// allow directory traversal so chokidar can reach nested package.json files
 				if (!stats || stats.isDirectory()) return false;
 
-				// with depth:2, this only matches the extensions dir package.json
-				if (val.endsWith('package.json')) return false;
+				// allow root package.json and package.json in direct extension dirs (extensionsDir/*/package.json)
+				if (val.endsWith('package.json')) {
+					const resolvedVal = path.resolve(val);
 
-				// "dist" entrypoints are added via updateWatchedExtensions, not the watch paths above
+					// root package.json
+					if (!resolvedVal.startsWith(resolvedExtDir + path.sep)) return false;
+
+					// allow if within an extension folder dir
+					return path.dirname(resolvedVal) === resolvedExtDir;
+				}
+
+				// allow "dist" entrypoints added via updateWatchedExtensions
 				if (this.isWatchedExtensionPath(val)) return false;
 
 				return true;

--- a/api/src/extensions/manager.ts
+++ b/api/src/extensions/manager.ts
@@ -1,4 +1,4 @@
-import type { ReadStream } from 'node:fs';
+import type { ReadStream, Stats } from 'node:fs';
 import { readdir, readFile } from 'node:fs/promises';
 import os from 'node:os';
 import { dirname, join, relative, resolve, sep } from 'node:path';
@@ -442,6 +442,33 @@ export class ExtensionManager {
 	}
 
 	/**
+	 * Check if a file path matches a watched extension's dist entrypoint
+	 * by looking up the folder name in the existing extension maps
+	 */
+	private isWatchedExtensionPath(filePath: string): boolean {
+		const extensionDir = path.resolve(getExtensionsPath());
+
+		const folderName = path.relative(extensionDir, filePath).split(path.sep).shift();
+
+		if (!folderName) return false;
+
+		const extension = this.localExtensions.get(folderName);
+
+		if (!extension) return false;
+
+		// Uses `includes` for comparison because chokidar emits watched change events as relative paths,
+		// while paths added via updateWatchedExtensions are emitted as absolute paths.
+		if (isTypeIn(extension, HYBRID_EXTENSION_TYPES) || extension.type === 'bundle') {
+			return (
+				path.resolve(extension.path, extension.entrypoint.app).includes(filePath) ||
+				path.resolve(extension.path, extension.entrypoint.api).includes(filePath)
+			);
+		}
+
+		return path.resolve(extension.path, extension.entrypoint).includes(filePath);
+	}
+
+	/**
 	 * Start the chokidar watcher for extensions on the local filesystem
 	 */
 	private initializeWatcher(): void {
@@ -449,18 +476,28 @@ export class ExtensionManager {
 
 		logger.info('Watching extensions for changes...');
 
-		const extensionDirUrl = pathToRelativeUrl(getExtensionsPath());
+		const extensionDirPath = pathToRelativeUrl(getExtensionsPath());
 
-		this.watcher = chokidar.watch(
-			[path.resolve('package.json'), path.posix.join(extensionDirUrl, '*', 'package.json')],
-			{
-				ignoreInitial: true,
-				// dotdirs are watched by default and frequently found in 'node_modules'
-				ignored: `${extensionDirUrl}/**/node_modules/**`,
-				// on macOS dotdirs in linked extensions are watched too
-				followSymlinks: os.platform() === 'darwin' ? false : true,
+		this.watcher = chokidar.watch([path.resolve('package.json'), extensionDirPath], {
+			ignoreInitial: true,
+			depth: 2,
+			ignored: (val: string, stats?: Stats) => {
+				if (val.includes('node_modules')) return true;
+
+				// allow directory traversal so chokidar can reach extensions package.json
+				if (!stats || stats.isDirectory()) return false;
+
+				// with depth:2, this only matches the extensions dir package.json
+				if (val.endsWith('package.json')) return false;
+
+				// "dist" entrypoints are added via updateWatchedExtensions, not the watch paths above
+				if (this.isWatchedExtensionPath(val)) return false;
+
+				return true;
 			},
-		);
+			// on macOS dotdirs in linked extensions are watched too
+			followSymlinks: os.platform() === 'darwin' ? false : true,
+		});
 
 		this.watcher
 			.on(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,8 +451,8 @@ catalogs:
       specifier: 5.6.2
       version: 5.6.2
     chokidar:
-      specifier: 4.0.3
-      version: 4.0.3
+      specifier: 5.0.0
+      version: 5.0.0
     chroma-js:
       specifier: 3.1.2
       version: 3.1.2
@@ -1161,7 +1161,7 @@ importers:
         version: 5.6.2
       chokidar:
         specifier: 'catalog:'
-        version: 4.0.3
+        version: 5.0.0
       commander:
         specifier: 'catalog:'
         version: 14.0.2
@@ -8403,6 +8403,10 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
@@ -12815,6 +12819,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
@@ -21408,6 +21416,10 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   chownr@1.1.4: {}
 
   chownr@2.0.0:
@@ -26139,6 +26151,8 @@ snapshots:
       picomatch: 2.3.1
 
   readdirp@4.1.2: {}
+
+  readdirp@5.0.0: {}
 
   real-require@0.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -159,7 +159,7 @@ catalog:
   camelcase: 8.0.0
   caret-pos: 2.0.0
   chalk: 5.6.2
-  chokidar: 4.0.3
+  chokidar: 5.0.0
   chroma-js: 3.1.2
   codemirror: 5.65.18
   color: 5.0.2


### PR DESCRIPTION
## Scope

What's changed:

- Extension reload logic updated to chokidar v5

## Potential Risks / Drawbacks

- Should be none as this has not been working since chokidar v4 update

## Tested Scenarios

- Editing package.json under extension folder triggers reload
- Editing a dist folder file triggers reload
- Editing root package.json triggers a reload
- Aside from the above no remaining files trigger reload

## Review Notes / Questions

- To test `EXTENSIONS_AUTO_RELOAD` must be enabled

## Checklist

- [ ] Added or updated tests - **not relevant**
- [ ] Documentation PR created [here](https://github.com/directus/docs) or **not required** 
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or **not required**

---

Fixes #26631
