### PR TITLE
fix(Studio): Filter alias fields from CSV export field selection

### DIFF
--- a/.changeset/filter-alias-csv-export.md
+++ b/.changeset/filter-alias-csv-export.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Filter alias fields from CSV export field selection

--- a/app/src/views/private/components/export-sidebar-detail.vue
+++ b/app/src/views/private/components/export-sidebar-detail.vue
@@ -97,6 +97,14 @@ watch(
 	{ immediate: true },
 );
 
+function filterNonAliasFields(selectedFields: string[]) {
+	const aliasFieldKeys = new Set(
+		fields.value?.filter((field) => field.type === 'alias').map((field) => field.field) ?? [],
+	);
+
+	return selectedFields.filter((key) => !aliasFieldKeys.has(key));
+}
+
 watch(
 	() => props.layoutQuery,
 	() => {
@@ -635,7 +643,7 @@ async function exportDataFiles() {
 						:value="exportSettings.fields"
 						:collection-name="collection"
 						allow-select-all
-						@input="exportSettings.fields = $event"
+						@input="exportSettings.fields = filterNonAliasFields($event)"
 					/>
 				</div>
 			</div>

--- a/contributors.yml
+++ b/contributors.yml
@@ -57,6 +57,7 @@
 - stevefan1999-personal
 - sethkaufee
 - matt-rolley
+- mvanhorn
 - magnus-bb
 - ZeyarPaing
 - mrbarletta


### PR DESCRIPTION
## Summary

Filters out alias-type fields when the "Select All" button is used in the export dialog's field picker. Alias fields can't be fetched from the API and cause the export to fail.

## Why this matters

The initial field list (line 87) and the fields watcher (line 95) both filter `field.type !== 'alias'`, but the `@input` handler on `InterfaceSystemFields` passed the raw selection through without filtering. When "Select All" was clicked, alias fields were included, and the subsequent API call failed because these fields don't map to actual database columns.

## Changes

**File:** `app/src/views/private/components/export-sidebar-detail.vue`

- Added `filterNonAliasFields()` function that builds a set of alias field keys from the collection's field metadata and filters them from the selection
- Updated the `@input` handler to pass through this filter before setting `exportSettings.fields`

## Testing

- The filter uses the same `fields.value` source and `field.type === 'alias'` check as the existing initial value and watcher, so behavior is consistent
- Non-alias fields pass through unchanged

Closes #26766

This contribution was developed with AI assistance (Claude Code).