### PR TITLE
Add cleanup handlers for disconnected file streams

### DIFF
--- a/.changeset/wild-breads-relax.md
+++ b/.changeset/wild-breads-relax.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+---
+
+Add cleanup handlers to destroy archive and source streams when clients disconnect during file downloads to prevent
+socket/resource leaks.

--- a/.changeset/wild-breads-relax.md
+++ b/.changeset/wild-breads-relax.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Add cleanup handlers for disconnected file streams
+Added cleanup handlers for disconnected file streams

--- a/.changeset/wild-breads-relax.md
+++ b/.changeset/wild-breads-relax.md
@@ -2,5 +2,4 @@
 '@directus/api': patch
 ---
 
-Add cleanup handlers to destroy archive and source streams when clients disconnect during file downloads to prevent
-socket/resource leaks.
+Add cleanup handlers to destroy streams when clients disconnect during file downloads

--- a/.changeset/wild-breads-relax.md
+++ b/.changeset/wild-breads-relax.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Add cleanup handlers to destroy streams when clients disconnect during file downloads
+Add cleanup handlers for disconnected file streams

--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -41,6 +41,13 @@ router.post(
 		const folderName = `folder-${metadata['name'] ? metadata['name'] : 'unknown'}-${getDateTimeFormatted()}.zip`;
 		res.setHeader('Content-Disposition', contentDisposition(folderName, { type: 'attachment' }));
 
+		// Clean up the archive stream if the client disconnects
+		res.on('close', () => {
+			if (!res.writableEnded) {
+				archive.destroy();
+			}
+		});
+
 		archive.pipe(res);
 
 		await complete();
@@ -75,6 +82,13 @@ router.post(
 
 		res.setHeader('Content-Type', 'application/zip');
 		res.setHeader('Content-Disposition', `attachment; filename="files-${getDateTimeFormatted()}.zip"`);
+
+		// Clean up the archive stream if the client disconnects
+		res.on('close', () => {
+			if (!res.writableEnded) {
+				archive.destroy();
+			}
+		});
 
 		archive.pipe(res);
 
@@ -296,9 +310,19 @@ router.get(
 			return res.end();
 		}
 
-		(await stream())
+		const sourceStream = await stream();
+
+		// Clean up the source stream if the client disconnects
+		res.on('close', () => {
+			if (!res.writableEnded) {
+				sourceStream.destroy();
+			}
+		});
+
+		sourceStream
 			.on('error', (error) => {
 				logger.error(error, `Couldn't stream file ${file.id} to the client`);
+				sourceStream.destroy();
 
 				if (!res.headersSent) {
 					res.removeHeader('Content-Type');

--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -44,13 +44,37 @@ router.post(
 		// Clean up the archive stream if the client disconnects
 		res.on('close', () => {
 			if (!res.writableEnded) {
-				archive.destroy();
+				archive.abort();
 			}
 		});
 
 		archive.pipe(res);
 
-		await complete();
+		try {
+			await complete();
+		} catch (error) {
+			useLogger().error(error, `Couldn't archive folder ${req.params['pk']} to the client`);
+			archive.destroy();
+
+			if (!res.headersSent) {
+				res.removeHeader('Content-Type');
+				res.removeHeader('Content-Disposition');
+				res.removeHeader('Cache-Control');
+
+				res.status(500).json({
+					errors: [
+						{
+							message: 'An unexpected error occurred.',
+							extensions: {
+								code: 'INTERNAL_SERVER_ERROR',
+							},
+						},
+					],
+				});
+			} else {
+				res.end();
+			}
+		}
 	}),
 );
 
@@ -86,13 +110,37 @@ router.post(
 		// Clean up the archive stream if the client disconnects
 		res.on('close', () => {
 			if (!res.writableEnded) {
-				archive.destroy();
+				archive.abort();
 			}
 		});
 
 		archive.pipe(res);
 
-		await complete();
+		try {
+			await complete();
+		} catch (error) {
+			useLogger().error(error, `Couldn't archive files to the client`);
+			archive.destroy();
+
+			if (!res.headersSent) {
+				res.removeHeader('Content-Type');
+				res.removeHeader('Content-Disposition');
+				res.removeHeader('Cache-Control');
+
+				res.status(500).json({
+					errors: [
+						{
+							message: 'An unexpected error occurred.',
+							extensions: {
+								code: 'INTERNAL_SERVER_ERROR',
+							},
+						},
+					],
+				});
+			} else {
+				res.end();
+			}
+		}
 	}),
 );
 

--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -29,6 +29,8 @@ router.use(useCollection('directus_files'));
 router.post(
 	'/folder/:pk',
 	asyncHandler(async (req, res) => {
+		const logger = useLogger();
+
 		const service = new AssetsService({
 			accountability: req.accountability,
 			schema: req.schema,
@@ -53,7 +55,7 @@ router.post(
 		try {
 			await complete();
 		} catch (error) {
-			useLogger().error(error, `Couldn't archive folder ${req.params['pk']} to the client`);
+			logger.error(error, `Couldn't archive folder ${req.params['pk']} to the client`);
 			archive.destroy();
 
 			if (!res.headersSent) {
@@ -81,6 +83,8 @@ router.post(
 router.post(
 	'/files/',
 	asyncHandler(async (req, res) => {
+		const logger = useLogger();
+
 		const service = new AssetsService({
 			accountability: req.accountability,
 			schema: req.schema,
@@ -119,7 +123,7 @@ router.post(
 		try {
 			await complete();
 		} catch (error) {
-			useLogger().error(error, `Couldn't archive files to the client`);
+			logger.error(error, `Couldn't archive files to the client`);
 			archive.destroy();
 
 			if (!res.headersSent) {

--- a/api/src/controllers/assets.ts
+++ b/api/src/controllers/assets.ts
@@ -46,6 +46,7 @@ router.post(
 		// Clean up the archive stream if the client disconnects
 		res.on('close', () => {
 			if (!res.writableEnded) {
+				archive.destroy();
 				archive.abort();
 			}
 		});
@@ -114,6 +115,7 @@ router.post(
 		// Clean up the archive stream if the client disconnects
 		res.on('close', () => {
 			if (!res.writableEnded) {
+				archive.destroy();
 				archive.abort();
 			}
 		});

--- a/api/src/services/assets.test.ts
+++ b/api/src/services/assets.test.ts
@@ -381,22 +381,24 @@ describe('AssetsService', () => {
 	});
 
 	describe('zip (private)', () => {
-		const mockArchiver = {
-			append: vi.fn(),
-			finalize: vi.fn().mockResolvedValue(undefined),
-		};
-
 		const mockSchema = {
 			collections: {},
 			relations: [],
 		} as SchemaOverview;
 
 		let mockDriver: Partial<Driver>;
+		let mockArchiver: Partial<Archiver>;
 		let mockStorage: Partial<StorageManager>;
 
 		// Common setup
 		beforeEach(() => {
 			vi.resetAllMocks();
+
+			mockArchiver = {
+				append: vi.fn(),
+				finalize: vi.fn().mockResolvedValue(undefined),
+				destroyed: false,
+			};
 
 			mockDriver = {
 				read: vi.fn().mockResolvedValue(Readable.from(['stream'])),
@@ -595,22 +597,24 @@ describe('AssetsService', () => {
 	});
 
 	describe('zipFiles', () => {
-		const mockArchiver = {
-			append: vi.fn(),
-			finalize: vi.fn().mockResolvedValue(undefined),
-		};
-
 		const mockSchema = {
 			collections: {},
 			relations: [],
 		} as SchemaOverview;
 
 		let mockDriver: Partial<Driver>;
+		let mockArchiver: Partial<Archiver>;
 		let mockStorage: Partial<StorageManager>;
 
 		// Common setup
 		beforeEach(() => {
 			vi.resetAllMocks();
+
+			mockArchiver = {
+				append: vi.fn(),
+				finalize: vi.fn().mockResolvedValue(undefined),
+				destroyed: false,
+			};
 
 			mockDriver = {
 				read: vi.fn().mockResolvedValue(Readable.from(['stream'])),
@@ -657,25 +661,50 @@ describe('AssetsService', () => {
 				limit: -1,
 			});
 		});
+
+		test('should skip appends and call finalize (error) when archive is destroyed (aborted)', async () => {
+			vi.spyOn(FilesService.prototype, 'readByQuery').mockResolvedValue([
+				{ id: 'file1', folder: null, filename_download: 'file1.txt' },
+			] as File[]);
+
+			vi.spyOn(FilesService.prototype, 'readOne').mockImplementation(
+				async (key) => ({ id: key, folder: null, filename_download: `${key}.txt` }) as File,
+			);
+
+			const service = new AssetsService({
+				schema: mockSchema,
+			});
+
+			const result = await service.zipFiles(['file1']);
+
+			mockArchiver.destroyed = true;
+
+			await result.complete();
+
+			expect(mockArchiver.append).not.toHaveBeenCalled();
+			expect(mockArchiver.finalize).toHaveBeenCalled();
+		});
 	});
 
 	describe('zipFolder', () => {
-		const mockArchiver = {
-			append: vi.fn(),
-			finalize: vi.fn().mockResolvedValue(undefined),
-		};
-
 		const mockSchema = {
 			collections: {},
 			relations: [],
 		} as SchemaOverview;
 
 		let mockDriver: Partial<Driver>;
+		let mockArchiver: Partial<Archiver>;
 		let mockStorage: Partial<StorageManager>;
 
 		// Common setup
 		beforeEach(() => {
 			vi.resetAllMocks();
+
+			mockArchiver = {
+				append: vi.fn(),
+				finalize: vi.fn().mockResolvedValue(undefined),
+				destroyed: false,
+			};
 
 			mockDriver = {
 				read: vi.fn().mockResolvedValue(Readable.from(['stream'])),

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -85,6 +85,8 @@ export class AssetsService {
 			const storage = await getStorage();
 
 			for (const { id, folder, filename_download } of options.files) {
+				if (archive.destroyed) break;
+
 				const file = await this.sudoFilesService.readOne(id, {
 					fields: ['id', 'storage', 'filename_disk', 'filename_download', 'modified_on', 'type'],
 				});
@@ -109,6 +111,8 @@ export class AssetsService {
 			// add any empty folders, does not override already filled folder
 			if (options.folders) {
 				for (const [, folder] of options.folders) {
+					if (archive.destroyed) break;
+
 					archive.append('', { name: folder + '/' });
 				}
 			}

--- a/contributors.yml
+++ b/contributors.yml
@@ -261,3 +261,4 @@
 - costajohnt
 - AbdelhamidKhald
 - HattoriEnzo
+- Champ-Goblem


### PR DESCRIPTION
When streaming large objects from S3, if a client disconnects midway through the download, the stream may still have pending data that is not consumed. This leads to sockets being left open with pending receive data in the TCP queue, which will no longer be consumed by the client.

## Scope

What's changed:

- Added res.on('close') cleanup handlers to destroy archive streams when clients disconnect during folder/file zip downloads                                                                                                                                
- Added res.on('close') cleanup handler to destroy source streams when clients disconnect during file streaming from S3/MinIO                                                                                                                               
- Added explicit sourceStream.destroy() call in error handler to stop reading from MinIO when stream errors occur

## Potential Risks / Drawbacks

## Tested Scenarios

Tested streaming a large object (100MB) from Minio and cancelling the download part way through, that `netstat -tnp` shows no connections left open with data in the receive queue.

## Review Notes / Questions

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26991
