### PR TITLE
Fix field config collapsing when selecting directus_files in basic setup

### DIFF
--- a/.changeset/fix-basic-field-setup-directus-files.md
+++ b/.changeset/fix-basic-field-setup-directus-files.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed field configuration panel collapsing when selecting `directus_files` as related collection in basic field setup

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-detail-simple.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-detail-simple.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Collection } from '@directus/types';
 import { orderBy } from 'lodash';
-import { computed, toRefs, watch } from 'vue';
+import { computed, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { syncFieldDetailStoreProperty, useFieldDetailStore } from '../store/';
 import FieldConfiguration from './field-configuration.vue';
@@ -91,6 +91,8 @@ const groups = computed(() => {
 
 const chosenInterface = syncFieldDetailStoreProperty('field.meta.interface');
 
+const selectedGroupKey = ref<string | null>(null);
+
 const configRow = computed(() => {
 	if (!chosenInterface.value) return null;
 
@@ -126,11 +128,27 @@ function isSVG(path: string) {
 	return path.startsWith('<svg');
 }
 
+function shouldShowConfig(group: { key: string; interfaces: { id: string }[] }) {
+	if (!chosenInterface.value) return false;
+
+	if (group.interfaces.some((inter) => inter.id === chosenInterface.value)) return true;
+
+	return selectedGroupKey.value === group.key;
+}
+
 function toggleInterface(id: string) {
 	if (chosenInterface.value === id) {
 		chosenInterface.value = null;
+		selectedGroupKey.value = null;
 	} else {
 		chosenInterface.value = id;
+
+		for (const group of groups.value) {
+			if (group.interfaces.some((inter) => inter.id === id)) {
+				selectedGroupKey.value = group.key;
+				break;
+			}
+		}
 	}
 }
 </script>
@@ -164,7 +182,7 @@ function toggleInterface(id: string) {
 
 				<TransitionExpand>
 					<FieldConfiguration
-						v-if="chosenInterface && !!group.interfaces.some((inter) => inter.id === chosenInterface)"
+						v-if="shouldShowConfig(group)"
 						:row="configRow"
 						@save="$emit('save')"
 						@toggle-advanced="$emit('toggleAdvanced')"

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/relationship-configuration.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/relationship-configuration.vue
@@ -38,7 +38,7 @@ const availableCollections = computed(() => {
 
 <template>
 	<div class="relationship">
-		<div v-if="localType === 'm2o'" class="field full">
+		<div v-if="localType === 'm2o' || localType === 'file'" class="field full">
 			<div class="label type-label">
 				{{ $t('related_collection') }}
 				<VIcon v-tooltip="$t('required')" class="required-mark" sup name="star" filled />
@@ -67,7 +67,7 @@ const availableCollections = computed(() => {
 			</div>
 		</template>
 
-		<div v-if="localType === 'm2m'" class="field full">
+		<div v-if="localType === 'm2m' || localType === 'files'" class="field full">
 			<div class="label type-label">
 				{{ $t('related_collection') }}
 				<VIcon v-tooltip="$t('required')" class="required-mark" sup name="star" filled />

--- a/contributors.yml
+++ b/contributors.yml
@@ -262,3 +262,4 @@
 - AbdelhamidKhald
 - HattoriEnzo
 - Ikromjon1998
+- vipulcha


### PR DESCRIPTION
## Scope

What's changed:

- Tracked the user-selected interface group in the basic field creation view so the configuration panel stays open when the store programmatically switches the interface (e.g. `list-m2m` to `files`)
- Added `file` and `files` to the `v-if` conditions in `relationship-configuration.vue` so the related collection dropdown remains visible after the `localType` switch

## Potential Risks / Drawbacks

- The fallback logic (`selectedGroupKey`) only activates when the store changes the interface to one outside the current group. In practice, `list-m2m` and `files` are both in the `relational` group, so the primary `group.interfaces.some(...)` check handles it. The fallback is a safety net for any future interface that might land in a different group.
- No store logic was changed. The `m2m` to `files` localType switch and the `m2o` to `file` switch remain intact.

## Tested Scenarios

- Reproduced the original bug: created a collection, clicked Create Field > Many to Many > selected `directus_files` as related collection. Config panel collapsed. Confirmed fix resolves this.
- Verified selecting other collections (non `directus_files`) for M2M still works as before
- Verified deselecting an interface (clicking the same one again) still closes the config panel
- Verified switching between interfaces in different groups moves the config panel correctly
- Verified the M2O to `file` switch also keeps the config panel open
- Ran the full app test suite (`pnpm test`), all field detail store tests pass. One pre-existing unrelated failure in `v-date-picker.test.ts`.
- Ran `pnpm lint`, `pnpm lint:style`, and `pnpm format` with no errors.

## Review Notes / Questions

- The root cause is that selecting `directus_files` triggers a `localType` switch (e.g. `m2m` to `files`) in the field detail store, which also changes `field.meta.interface`. The basic/simple field creation UI was not accounting for this programmatic interface change, and the `relationship-configuration.vue` template had no conditions for the `file`/`files` local types.
- The fix is entirely in the UI layer (two components in `field-detail-simple/`). No store or data logic was modified.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---
Fixes #26973
cc: @ComfortablyCoding @bellahadid27211-lab