### PR TITLE
Fix file replacement returning Forbidden

### DIFF
--- a/.changeset/fast-webs-run.md
+++ b/.changeset/fast-webs-run.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed file replacement returning Forbidden

--- a/api/src/services/files.test.ts
+++ b/api/src/services/files.test.ts
@@ -448,6 +448,31 @@ describe('Service / Files', () => {
 			);
 		});
 
+		test('should exclude updated file from uniqueness check', async () => {
+			const recordUpdatePayload = {
+				id: 1,
+				filename_disk: 'existing-file.jpg',
+			};
+
+			tracker.on
+				.select(`select "filename_disk" from "directus_files" where "filename_disk" = ? and not "id" = ?`)
+				.response([]);
+
+			vi.spyOn(ItemsService.prototype, 'readMany').mockResolvedValue([
+				{ id: 1, storage: 'local', filename_disk: 'old-file.jpg' },
+			]);
+
+			await service.updateMany([recordUpdatePayload.id], {
+				filename_disk: recordUpdatePayload.filename_disk,
+			});
+
+			expect(ItemsService.prototype.updateMany).toHaveBeenCalledWith(
+				[1],
+				{ filename_disk: recordUpdatePayload.filename_disk },
+				{},
+			);
+		});
+
 		test('should normalize filename_disk path', async () => {
 			tracker.on.select('select "filename_disk" from "directus_files" where "filename_disk" = ?').response([]);
 

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -343,14 +343,14 @@ export class FilesService extends ItemsService<File> {
 		}
 
 		if (data.filename_disk) {
+			data.filename_disk = this.generateFilenamePath(data.filename_disk);
+
 			try {
 				await this.checkUniqueFilename(data.filename_disk);
 			} catch (err: any) {
 				// Defer the error to be thrown until after permission checks
 				opts.preMutationError = err;
 			}
-
-			data.filename_disk = this.generateFilenamePath(data.filename_disk);
 		}
 
 		const key = await super.createOne(data, opts);
@@ -366,14 +366,14 @@ export class FilesService extends ItemsService<File> {
 		opts: MutationOptions = {},
 	): Promise<PrimaryKey[]> {
 		if (keys.length === 1 && data.filename_disk) {
+			data.filename_disk = this.generateFilenamePath(data.filename_disk);
+
 			try {
 				await this.checkUniqueFilename(data.filename_disk, keys[0]);
 			} catch (err: any) {
 				// Defer the error to be thrown until after permission checks
 				opts.preMutationError = err;
 			}
-
-			data.filename_disk = this.generateFilenamePath(data.filename_disk);
 
 			// Fetch existing records to have data prior to change, dont require read permissions.
 			const sudoFilesItemsService = new FilesService({

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -58,14 +58,17 @@ export class FilesService extends ItemsService<File> {
 	 * Check whether a filename is unique.
 	 *
 	 * @param filename - The filename
+	 * @param excludeId - The id of the existing file to exclude from the check
 	 * @throws ForbiddenError if a match is found
 	 */
-	private async checkUniqueFilename(filename: string) {
-		const existingFile = await this.knex
-			.select('filename_disk')
-			.from('directus_files')
-			.where({ filename_disk: filename })
-			.first();
+	private async checkUniqueFilename(filename: string, excludeId?: PrimaryKey) {
+		const query = this.knex.select('filename_disk').from('directus_files').where({ filename_disk: filename });
+
+		if (excludeId) {
+			query.whereNot('id', excludeId);
+		}
+
+		const existingFile = await query.first();
 
 		if (existingFile) {
 			throw new ForbiddenError();
@@ -364,7 +367,7 @@ export class FilesService extends ItemsService<File> {
 	): Promise<PrimaryKey[]> {
 		if (keys.length === 1 && data.filename_disk) {
 			try {
-				await this.checkUniqueFilename(data.filename_disk);
+				await this.checkUniqueFilename(data.filename_disk, keys[0]);
 			} catch (err: any) {
 				// Defer the error to be thrown until after permission checks
 				opts.preMutationError = err;

--- a/tests/blackbox/tests/db/routes/files/storage.test.ts
+++ b/tests/blackbox/tests/db/routes/files/storage.test.ts
@@ -62,7 +62,7 @@ describe('/files', () => {
 					.get('/files')
 					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`)
 					.query({
-						filter: { filename_download: { _eq: imageFile.name } },
+						filter: { filename_download: { _eq: imageFile.name }, storage: { _eq: storage } },
 						fields: ['id'],
 						limit: 1,
 					});
@@ -78,12 +78,12 @@ describe('/files', () => {
 				expect(response.statusCode).toBe(200);
 
 				// Normalize filesize to string as bigint returns as a string
-				response.body.data[0].filesize = String(response.body.data[0].filesize);
+				response.body.data.filesize = String(response.body.data.filesize);
 
 				// Assert
 				expect(response.statusCode).toBe(200);
 
-				expect(response.body.data[0]).toEqual(
+				expect(response.body.data).toEqual(
 					expect.objectContaining({
 						filesize: imageFile.filesize,
 						type: imageFile.type,

--- a/tests/blackbox/tests/db/routes/files/storage.test.ts
+++ b/tests/blackbox/tests/db/routes/files/storage.test.ts
@@ -78,12 +78,12 @@ describe('/files', () => {
 				expect(response.statusCode).toBe(200);
 
 				// Normalize filesize to string as bigint returns as a string
-				response.body.data.filesize = String(response.body.data.filesize);
+				response.body.data[0].filesize = String(response.body.data[0].filesize);
 
 				// Assert
 				expect(response.statusCode).toBe(200);
 
-				expect(response.body.data).toEqual(
+				expect(response.body.data[0]).toEqual(
 					expect.objectContaining({
 						filesize: imageFile.filesize,
 						type: imageFile.type,

--- a/tests/blackbox/tests/db/routes/files/storage.test.ts
+++ b/tests/blackbox/tests/db/routes/files/storage.test.ts
@@ -54,6 +54,51 @@ describe('/files', () => {
 		});
 	});
 
+	describe('PATCH /files/:id', () => {
+		describe.each(storages)('Storage: %s', (storage) => {
+			it.each(vendors)('%s', async (vendor) => {
+				// Setup
+				const readResponse = await request(getUrl(vendor))
+					.get('/files')
+					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`)
+					.query({
+						filter: { filename_download: { _eq: imageFile.name } },
+						fields: ['id'],
+						limit: 1,
+					});
+
+				expect(readResponse.statusCode).toBe(200);
+
+				// Action
+				const response = await request(getUrl(vendor))
+					.patch(`/files/${readResponse.body.data[0].id}`)
+					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`)
+					.attach('file', createReadStream(imageFilePath));
+
+				expect(response.statusCode).toBe(200);
+
+				// Normalize filesize to string as bigint returns as a string
+				response.body.data.filesize = String(response.body.data.filesize);
+
+				// Assert
+				expect(response.statusCode).toBe(200);
+
+				expect(response.body.data).toEqual(
+					expect.objectContaining({
+						filesize: imageFile.filesize,
+						type: imageFile.type,
+						filename_download: imageFile.name,
+						filename_disk: expect.any(String),
+						storage: storage,
+						title: imageFile.title,
+						description: imageFile.description,
+						id: expect.any(String),
+					}),
+				);
+			});
+		});
+	});
+
 	describe('DELETE /files/:id', () => {
 		describe.each(storages)('Storage: %s', (storage) => {
 			it.each(vendors)('%s', async (vendor) => {


### PR DESCRIPTION
## Scope

What's changed:

- We now exclude the current file from uniqueness check on update
- We check uniqueness against resolved path

## Potential Risks / Drawbacks

- N/A

## Tested Scenarios

- Replacing a file with the same filename_disk succeeds
- Replacing a file with a filename_disk duplicate of another file errors
- Editing file (e.g. rotate) succeeds
- Uploading a file succeeds

## Review Notes / Questions

- TBD

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or **not required**
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or **not required**

---

Fixes #26997
