### PR TITLE
Remove date-dependent assertions in v-date-picker clamping tests

### DIFF
--- a/app/src/components/v-date-picker/v-date-picker.test.ts
+++ b/app/src/components/v-date-picker/v-date-picker.test.ts
@@ -865,12 +865,7 @@ describe('v-date-picker', () => {
 			await monthSelect.setValue('2');
 			await nextTick();
 
-			// Trigger emission to capture the clamped value
-			const nowButton = wrapper.find('.calendar-today-button');
-			await nowButton.trigger('click');
-			await nextTick();
-
-			// Day should be clamped to 29 (max for Feb 2024)
+			// setCalendarMonth now calls emitValue() directly, so the clamped value is captured
 			expect(capturedDay).toBeDefined();
 			expect(capturedDay).toBeLessThanOrEqual(29);
 		});
@@ -899,12 +894,7 @@ describe('v-date-picker', () => {
 			await yearInput.setValue('2023');
 			await nextTick();
 
-			// Trigger emission to capture the clamped value
-			const nowButton = wrapper.find('.calendar-today-button');
-			await nowButton.trigger('click');
-			await nextTick();
-
-			// Day should be clamped to 28 (max for Feb 2023)
+			// setCalendarYear now calls emitValue() directly, so the clamped value is captured
 			expect(capturedDay).toBeDefined();
 			expect(capturedDay).toBeLessThanOrEqual(28);
 		});


### PR DESCRIPTION
## Scope

What's changed:

- Remove "set to now" button clicks from two clamping tests that were producing date-dependent failures
- Tests now assert the clamped value directly after month/year change, since `setCalendarMonth`/`setCalendarYear` already call `emitValue()` (added in #26880)

## Potential Risks / Drawbacks

- None — tests now verify the same clamping behavior without depending on the current date

## Tested Scenarios

- `clamps day when changing to month with fewer days` — passes regardless of current date
- `clamps day when changing year affects leap year` — passes regardless of current date
- Full test suite (234 files, 106k+ tests) passes

## Review Notes / Questions

- Root cause: #26880 added `emitValue()` calls inside `setCalendarMonth`/`setCalendarYear`, but the clamping tests still clicked the "set to now" button (which resets to today's date, overwriting the clamped value). On days where `today.day > max days in target month`, the assertion failed.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required