### PR TITLE
Fix coercion of stringified JSON in AI assistant tool arguments

### DIFF
--- a/.changeset/sour-cobras-kiss.md
+++ b/.changeset/sour-cobras-kiss.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed coercion of stringified JSON in AI assistant tool arguments

--- a/api/src/ai/chat/utils/chat-request-tool-to-ai-sdk-tool.test.ts
+++ b/api/src/ai/chat/utils/chat-request-tool-to-ai-sdk-tool.test.ts
@@ -176,8 +176,6 @@ describe('chatRequestToolToAiSdkTool', () => {
 		const { execute } = result.config;
 		await execute({ data: '[{"name":"Test"}]' });
 
-		expect(mockValidate.safeParse).toHaveBeenCalledWith(
-			expect.objectContaining({ data: [{ name: 'Test' }] }),
-		);
+		expect(mockValidate.safeParse).toHaveBeenCalledWith(expect.objectContaining({ data: [{ name: 'Test' }] }));
 	});
 });

--- a/api/src/ai/chat/utils/chat-request-tool-to-ai-sdk-tool.test.ts
+++ b/api/src/ai/chat/utils/chat-request-tool-to-ai-sdk-tool.test.ts
@@ -163,4 +163,21 @@ describe('chatRequestToolToAiSdkTool', () => {
 		const config = result.config;
 		expect(config.needsApproval).toBe(true);
 	});
+
+	it('coerces stringified JSON fields before validation', async () => {
+		(mockValidate.safeParse as any).mockReturnValue({ data: { data: [{ name: 'Test' }] }, error: undefined });
+
+		const result: any = chatRequestToolToAiSdkTool({
+			chatRequestTool: 'directus.test',
+			accountability,
+			schema,
+		});
+
+		const { execute } = result.config;
+		await execute({ data: '[{"name":"Test"}]' });
+
+		expect(mockValidate.safeParse).toHaveBeenCalledWith(
+			expect.objectContaining({ data: [{ name: 'Test' }] }),
+		);
+	});
 });

--- a/api/src/ai/chat/utils/chat-request-tool-to-ai-sdk-tool.ts
+++ b/api/src/ai/chat/utils/chat-request-tool-to-ai-sdk-tool.ts
@@ -4,6 +4,7 @@ import type { Tool } from 'ai';
 import { jsonSchema, tool, zodSchema } from 'ai';
 import { fromZodError } from 'zod-validation-error';
 import { ALL_TOOLS } from '../../tools/index.js';
+import { coerceJsonFields } from '../../tools/utils.js';
 import type { ChatRequestTool, ToolApprovalMode } from '../models/chat-request.js';
 
 export const chatRequestToolToAiSdkTool = ({
@@ -36,8 +37,10 @@ export const chatRequestToolToAiSdkTool = ({
 			inputSchema,
 			needsApproval,
 			execute: async (rawArgs) => {
-				const { error, data: args } = directusTool.validateSchema?.safeParse(rawArgs) ?? {
-					data: rawArgs,
+				const coercedArgs = coerceJsonFields(rawArgs as Record<string, unknown>);
+
+				const { error, data: args } = directusTool.validateSchema?.safeParse(coercedArgs) ?? {
+					data: coercedArgs,
 				};
 
 				if (error) {

--- a/api/src/ai/mcp/server.test.ts
+++ b/api/src/ai/mcp/server.test.ts
@@ -286,6 +286,41 @@ describe('mcp server', () => {
 			);
 		});
 
+		test('should coerce stringified JSON arguments before validation', async () => {
+			const safeParseSpy = vi.fn(() => ({ data: { data: [{ name: 'Test' }] } }));
+
+			vi.mocked(findMcpTool).mockReturnValueOnce({
+				name: 'test-tool',
+				description: 'A test tool',
+				validateSchema: { safeParse: safeParseSpy },
+				admin: false,
+				handler: vi.fn(() => Promise.resolve({ type: 'text', data: 'created' })),
+			} as unknown as ToolConfig<unknown>);
+
+			const mockReq = {
+				accepts: vi.fn(() => 'application/json'),
+				body: {
+					jsonrpc: '2.0',
+					id: 1,
+					method: 'tools/call',
+					params: {
+						name: 'test-tool',
+						arguments: { data: '[{"name":"Test"}]', collection: 'brands' },
+					},
+				},
+				accountability: { user: 'user', admin: false },
+				schema: {},
+			} as unknown as Request;
+
+			directusMCP.handleRequest(mockReq, mockRes as Response);
+
+			await awaitJsonResponse(directusMCP);
+
+			expect(safeParseSpy).toHaveBeenCalledWith(
+				expect.objectContaining({ data: [{ name: 'Test' }], collection: 'brands' }),
+			);
+		});
+
 		test('should return error for non-existent tool', async () => {
 			vi.mocked(findMcpTool).mockReturnValueOnce(undefined);
 

--- a/api/src/ai/mcp/server.ts
+++ b/api/src/ai/mcp/server.ts
@@ -1,6 +1,6 @@
 import { useEnv } from '@directus/env';
 import { ForbiddenError, InvalidPayloadError, isDirectusError } from '@directus/errors';
-import { isObject, parseJSON, toArray } from '@directus/utils';
+import { isObject, toArray } from '@directus/utils';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
 	type CallToolRequest,
@@ -25,6 +25,7 @@ import { ItemsService } from '../../services/index.js';
 import { Url } from '../../utils/url.js';
 import { findMcpTool, getAllMcpTools } from '../tools/index.js';
 import type { ToolConfig, ToolResult } from '../tools/types.js';
+import { coerceJsonFields } from '../tools/utils.js';
 import { DirectusTransport } from './transport.js';
 import type { MCPOptions, Prompt } from './types.js';
 
@@ -227,19 +228,12 @@ export class DirectusMCP {
 					request.params.arguments = { promptOverride: this.systemPrompt };
 				}
 
-				// ensure json expected fields are not stringified
-				if (request.params.arguments) {
-					for (const field of ['data', 'keys', 'query']) {
-						const arg = request.params.arguments[field];
+				const coercedArgs = request.params.arguments
+					? coerceJsonFields(request.params.arguments as Record<string, unknown>)
+					: request.params.arguments;
 
-						if (typeof arg === 'string') {
-							request.params.arguments[field] = parseJSON(arg);
-						}
-					}
-				}
-
-				const { error, data: args } = tool.validateSchema?.safeParse(request.params.arguments) ?? {
-					data: request.params.arguments,
+				const { error, data: args } = tool.validateSchema?.safeParse(coercedArgs) ?? {
+					data: coercedArgs,
 				};
 
 				if (error) {

--- a/api/src/ai/tools/utils.test.ts
+++ b/api/src/ai/tools/utils.test.ts
@@ -1,9 +1,49 @@
 import type { Accountability, Query, SchemaOverview } from '@directus/types';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { sanitizeQuery } from '../../utils/sanitize-query.js';
-import { buildSanitizedQueryFromArgs } from './utils.js';
+import { buildSanitizedQueryFromArgs, coerceJsonFields } from './utils.js';
 
 vi.mock('../../utils/sanitize-query.js');
+
+describe('coerceJsonFields', () => {
+	test('parses stringified data field', () => {
+		const result = coerceJsonFields({ data: '[{"name":"Test"}]', action: 'create' });
+		expect(result.data).toEqual([{ name: 'Test' }]);
+		expect(result.action).toBe('create');
+	});
+
+	test('parses stringified keys field', () => {
+		const result = coerceJsonFields({ keys: '["id1","id2"]' });
+		expect(result.keys).toEqual(['id1', 'id2']);
+	});
+
+	test('parses stringified query field', () => {
+		const result = coerceJsonFields({ query: '{"limit":10}' });
+		expect(result.query).toEqual({ limit: 10 });
+	});
+
+	test('leaves non-string fields untouched', () => {
+		const data = [{ name: 'Test' }];
+		const result = coerceJsonFields({ data, action: 'create' });
+		expect(result.data).toBe(data);
+	});
+
+	test('leaves non-coerced string fields untouched', () => {
+		const result = coerceJsonFields({ collection: 'brands', action: 'create' });
+		expect(result.collection).toBe('brands');
+	});
+
+	test('handles invalid JSON string gracefully', () => {
+		const result = coerceJsonFields({ data: 'not json' });
+		expect(result.data).toBe('not json');
+	});
+
+	test('does not mutate original args', () => {
+		const original = { data: '{"name":"Test"}' };
+		coerceJsonFields(original);
+		expect(typeof original.data).toBe('string');
+	});
+});
 
 describe('buildSanitizedQueryFromArgs', () => {
 	let mockSchema: SchemaOverview;

--- a/api/src/ai/tools/utils.test.ts
+++ b/api/src/ai/tools/utils.test.ts
@@ -22,6 +22,11 @@ describe('coerceJsonFields', () => {
 		expect(result.query).toEqual({ limit: 10 });
 	});
 
+	test('parses stringified headers field', () => {
+		const result = coerceJsonFields({ headers: '{"Authorization":"Bearer token"}' });
+		expect(result.headers).toEqual({ Authorization: 'Bearer token' });
+	});
+
 	test('leaves non-string fields untouched', () => {
 		const data = [{ name: 'Test' }];
 		const result = coerceJsonFields({ data, action: 'create' });

--- a/api/src/ai/tools/utils.test.ts
+++ b/api/src/ai/tools/utils.test.ts
@@ -6,39 +6,19 @@ import { buildSanitizedQueryFromArgs, coerceJsonFields } from './utils.js';
 vi.mock('../../utils/sanitize-query.js');
 
 describe('coerceJsonFields', () => {
-	test('parses stringified data field', () => {
-		const result = coerceJsonFields({ data: '[{"name":"Test"}]', action: 'create' });
+	test('parses stringified JSON in known fields', () => {
+		const result = coerceJsonFields({ data: '[{"name":"Test"}]', collection: 'brands' });
 		expect(result.data).toEqual([{ name: 'Test' }]);
-		expect(result.action).toBe('create');
-	});
-
-	test('parses stringified keys field', () => {
-		const result = coerceJsonFields({ keys: '["id1","id2"]' });
-		expect(result.keys).toEqual(['id1', 'id2']);
-	});
-
-	test('parses stringified query field', () => {
-		const result = coerceJsonFields({ query: '{"limit":10}' });
-		expect(result.query).toEqual({ limit: 10 });
-	});
-
-	test('parses stringified headers field', () => {
-		const result = coerceJsonFields({ headers: '{"Authorization":"Bearer token"}' });
-		expect(result.headers).toEqual({ Authorization: 'Bearer token' });
-	});
-
-	test('leaves non-string fields untouched', () => {
-		const data = [{ name: 'Test' }];
-		const result = coerceJsonFields({ data, action: 'create' });
-		expect(result.data).toBe(data);
-	});
-
-	test('leaves non-coerced string fields untouched', () => {
-		const result = coerceJsonFields({ collection: 'brands', action: 'create' });
 		expect(result.collection).toBe('brands');
 	});
 
-	test('handles invalid JSON string gracefully', () => {
+	test('leaves already-parsed fields untouched', () => {
+		const data = [{ name: 'Test' }];
+		const result = coerceJsonFields({ data });
+		expect(result.data).toBe(data);
+	});
+
+	test('leaves invalid JSON as-is', () => {
 		const result = coerceJsonFields({ data: 'not json' });
 		expect(result.data).toBe('not json');
 	});

--- a/api/src/ai/tools/utils.ts
+++ b/api/src/ai/tools/utils.ts
@@ -2,7 +2,7 @@ import type { Accountability, SchemaOverview } from '@directus/types';
 import { parseJSON } from '@directus/utils';
 import { sanitizeQuery } from '../../utils/sanitize-query.js';
 
-const JSON_COERCE_FIELDS = ['data', 'keys', 'query'];
+const JSON_COERCE_FIELDS = ['data', 'keys', 'query', 'headers'];
 
 /**
  * LLMs sometimes return object/array arguments as stringified JSON.

--- a/api/src/ai/tools/utils.ts
+++ b/api/src/ai/tools/utils.ts
@@ -1,5 +1,28 @@
 import type { Accountability, SchemaOverview } from '@directus/types';
+import { parseJSON } from '@directus/utils';
 import { sanitizeQuery } from '../../utils/sanitize-query.js';
+
+const JSON_COERCE_FIELDS = ['data', 'keys', 'query'];
+
+/**
+ * LLMs sometimes return object/array arguments as stringified JSON.
+ * Coerce known fields back to native values before validation.
+ */
+export function coerceJsonFields(args: Record<string, unknown>): Record<string, unknown> {
+	const coerced = { ...args };
+
+	for (const field of JSON_COERCE_FIELDS) {
+		if (typeof coerced[field] === 'string') {
+			try {
+				coerced[field] = parseJSON(coerced[field] as string);
+			} catch {
+				// Leave as-is if not valid JSON
+			}
+		}
+	}
+
+	return coerced;
+}
 
 /**
  * Build a sanitized query object from a tool's args payload.


### PR DESCRIPTION
## Scope
This PR adds coercion of specific fields that LLMs tend to stringify when calling tools through the AI Assistant. We previously had this coercion in the MCP server to improve reliability. This PR extracts that to a utility and reuses it in the in app AI Assistant as well.

What's changed:
- Extract shared coerceJsonFields() utility that parses stringified data, keys, query, and headers fields back to native objects before Zod
validation
- Wire coercion into the AI chat tool execution path — previously only MCP had this handling, so the AI Assistant chat would fail on
create/update operations
- Refactor MCP server to use the same shared utility instead of inline logic


## Potential Risks / Drawbacks
- Coercion only targets known field names (data, keys, query, headers) — if LLMs stringify other object fields, those would still fail. Can
expand the list as needed.
- Invalid JSON strings in coerced fields are silently left as-is (validation still catches them downstream)

## Tested Scenarios
- Stringified data array is parsed before validation (the reported bug case)
- Already-parsed object fields pass through unchanged
- Invalid JSON strings are left as-is and fail at validation as expected
- Original args object is not mutated
- MCP regression: stringified arguments are coerced before reaching safeParse
- Full AI test suite passes (456 tests across 35 files)

## Review Notes / Questions
- The AI SDK's zodSchema() also clobbers additionalProperties on z.record() schemas, which may increase the frequency of LLMs producing bad
output. That's a separate fix (switching to jsonSchema() with z.toJSONSchema()) — not included here to keep the PR focused.

## Checklist
- [x] Added or updated tests
- [x] ~~Documentation PR created here or not required~~
- [x] ~~OpenAPI package PR created here or not required~~

Fixes #26891 