### PR TITLE
Release 11.17.1

### DIFF
--- a/.changeset/fast-webs-run.md
+++ b/.changeset/fast-webs-run.md
@@ -1,5 +1,0 @@
----
-'@directus/api': patch
----
-
-Fixed file replacement returning Forbidden

--- a/.changeset/fix-calendar-dynamic-variable.md
+++ b/.changeset/fix-calendar-dynamic-variable.md
@@ -1,6 +1,0 @@
----
-'@directus/app': patch
-'@directus/utils': patch
----
-
-Fixed calendar picker crash when using dynamic variables (e.g. $NOW)

--- a/.changeset/fix-mysql-foreignkeys-join.md
+++ b/.changeset/fix-mysql-foreignkeys-join.md
@@ -1,5 +1,0 @@
----
-"@directus/schema": patch
----
-
-Fixed MySQL foreignKeys query to include TABLE_NAME in the JOIN condition, preventing a cartesian product when InnoDB statistics on system tables are degraded.

--- a/.changeset/fix-relation-permission-warning.md
+++ b/.changeset/fix-relation-permission-warning.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Updated `relationship_not_setup` wording to clarify it may also result from missing permissions

--- a/.changeset/fix-sdk-date-time-filter-operators.md
+++ b/.changeset/fix-sdk-date-time-filter-operators.md
@@ -1,5 +1,0 @@
----
-'@directus/sdk': patch
----
-
-Fixed filter operator typing for `date` and `time` fields to support comparison and range operators.

--- a/.changeset/floppy-tigers-punch.md
+++ b/.changeset/floppy-tigers-punch.md
@@ -1,5 +1,0 @@
----
-'@directus/api': patch
----
-
-Updated `happy-dom`, `path-to-regexp`, `picomatch`, `node-forge`, and `brace-expansion` to address CVEs

--- a/.changeset/green-kiwis-camp.md
+++ b/.changeset/green-kiwis-camp.md
@@ -1,5 +1,0 @@
----
-'@directus/app': minor
----
-
-Added keyboard navigation to the cards layout

--- a/.changeset/many-symbols-decide.md
+++ b/.changeset/many-symbols-decide.md
@@ -1,9 +1,0 @@
----
-'@directus/app': minor
----
-
-Added native Tabs group interface.
-
-::: notice
-This new interface is a drop-in replacement for the `directus-extension-group-tabs-interface` extension. Uninstall the extension if currently using it to avoid unintended side effects.
-:::

--- a/.changeset/polite-hounds-type.md
+++ b/.changeset/polite-hounds-type.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Restored `useItem` support for custom query options like `fields` and `deep` by adding an optional extra query parameter and updating affected call sites.

--- a/.changeset/slow-cougars-cough.md
+++ b/.changeset/slow-cougars-cough.md
@@ -1,5 +1,0 @@
----
-'@directus/api': patch
----
-
-Fixed extension auto reload not triggering

--- a/.changeset/strict-rules-follow.md
+++ b/.changeset/strict-rules-follow.md
@@ -1,5 +1,0 @@
----
-'@directus/app': minor
----
-
-Added bulk folder deletion from the files grid with move-up or delete-all options

--- a/.changeset/tender-boats-greet.md
+++ b/.changeset/tender-boats-greet.md
@@ -1,5 +1,0 @@
----
-'@directus/app': minor
----
-
-Used shorter tooltip delay for disabled elements

--- a/.changeset/tough-bugs-enter.md
+++ b/.changeset/tough-bugs-enter.md
@@ -1,5 +1,0 @@
----
-'@directus/utils': minor
----
-
-Added `parseNow` utility to resolve the `$NOW` dynamic variable

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/api",
-	"version": "35.0.0",
+	"version": "35.0.1",
 	"description": "Directus is a real-time API and App dashboard for managing SQL database content",
 	"keywords": [
 		"directus",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/app",
-	"version": "15.6.0",
+	"version": "15.7.0",
 	"description": "App dashboard for Directus",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/directus/package.json
+++ b/directus/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "directus",
-	"version": "11.17.0",
+	"version": "11.17.1",
 	"description": "Directus is a real-time API and App dashboard for managing SQL database content",
 	"keywords": [
 		"directus",

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/composables",
-	"version": "11.2.16",
+	"version": "11.2.17",
 	"description": "Shared Vue composables for Directus use",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/create-directus-extension/package.json
+++ b/packages/create-directus-extension/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "create-directus-extension",
-	"version": "11.0.32",
+	"version": "11.0.33",
 	"description": "A small util that will scaffold a Directus extension",
 	"keywords": [
 		"directus",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/env",
-	"version": "5.7.0",
+	"version": "5.7.1",
 	"description": "Utilities around using global env configuration",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/extensions-registry/package.json
+++ b/packages/extensions-registry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/extensions-registry",
-	"version": "3.0.22",
+	"version": "3.0.23",
 	"description": "Abstraction for exploring Directus extensions on a package registry",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/extensions-sdk/package.json
+++ b/packages/extensions-sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/extensions-sdk",
-	"version": "17.1.0",
+	"version": "17.1.1",
 	"description": "A toolkit to develop extensions to extend Directus",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/extensions",
-	"version": "3.0.22",
+	"version": "3.0.23",
 	"description": "Utilities and types for Directus extensions",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/memory",
-	"version": "3.1.5",
+	"version": "3.1.6",
 	"description": "Memory / Redis abstraction for Directus",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/pressure/package.json
+++ b/packages/pressure/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/pressure",
-	"version": "3.0.20",
+	"version": "3.0.21",
 	"description": "Pressure based rate limiter",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/schema-builder/package.json
+++ b/packages/schema-builder/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/schema-builder",
-	"version": "0.0.17",
+	"version": "0.0.18",
 	"description": "Directus SchemaBuilder for mocking/constructing a database schema based on code.",
 	"keywords": [
 		"sql",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/schema",
-	"version": "13.0.6",
+	"version": "13.0.7",
 	"description": "Utility for extracting information about existing DB schema",
 	"keywords": [
 		"sql",

--- a/packages/storage-driver-azure/package.json
+++ b/packages/storage-driver-azure/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-azure",
-	"version": "12.0.20",
+	"version": "12.0.21",
 	"description": "Azure file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/storage-driver-cloudinary/package.json
+++ b/packages/storage-driver-cloudinary/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-cloudinary",
-	"version": "12.0.20",
+	"version": "12.0.21",
 	"description": "Cloudinary file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/storage-driver-gcs/package.json
+++ b/packages/storage-driver-gcs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-gcs",
-	"version": "12.0.20",
+	"version": "12.0.21",
 	"description": "GCS file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/storage-driver-s3/package.json
+++ b/packages/storage-driver-s3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-s3",
-	"version": "12.1.6",
+	"version": "12.1.7",
 	"description": "S3 file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/storage-driver-supabase/package.json
+++ b/packages/storage-driver-supabase/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-supabase",
-	"version": "3.0.20",
+	"version": "3.0.21",
 	"description": "Supabase file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/themes",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "Themes for Directus",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/types",
-	"version": "15.0.0",
+	"version": "15.0.1",
 	"description": "Shared types for Directus",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/utils",
-	"version": "13.3.2",
+	"version": "13.4.0",
 	"description": "Utilities shared between the Directus packages",
 	"homepage": "https://directus.io",
 	"repository": {

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/validation",
-	"version": "2.0.20",
+	"version": "2.0.21",
 	"type": "module",
 	"sideEffects": false,
 	"scripts": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/sdk",
-	"version": "21.2.1",
+	"version": "21.2.2",
 	"description": "Directus JavaScript SDK",
 	"homepage": "https://directus.io",
 	"repository": {


### PR DESCRIPTION
### ✅ Release Checklist
- [x] Changesets processed and cleared
- [x] Package versions updated
- [x] Release notes generated
- [x] Merge Crowdin PR: https://github.com/directus/directus/pull/26975
- [x] PR reviewed and approved
- [x] Blackbox tests passed

### 🚀 Release Notes
```md

### ✨ New Features & Improvements

- **@directus/app**
  - Added keyboard navigation to the cards layout ([#26976](https://github.com/directus/directus/pull/26976) by @HZooly)
  - Added native Tabs group interface. Uninstall the extension if currently using it to avoid unintended side effects. ([#26836](https://github.com/directus/directus/pull/26836) by @bryantgillespie)
  - Added bulk folder deletion from the files grid with move-up or delete-all options ([#26886](https://github.com/directus/directus/pull/26886) by @HZooly)
  - Used shorter tooltip delay for disabled elements ([#26965](https://github.com/directus/directus/pull/26965) by @HZooly)
- **@directus/utils**
  - Added `parseNow` utility to resolve the `$NOW` dynamic variable ([#26954](https://github.com/directus/directus/pull/26954) by @costajohnt)

### 🐛 Bug Fixes & Optimizations

- **@directus/app**
  - Fixed calendar picker crash when using dynamic variables (e.g. $NOW) ([#26954](https://github.com/directus/directus/pull/26954) by @costajohnt)
  - Updated `relationship_not_setup` wording to clarify it may also result from missing permissions ([#26918](https://github.com/directus/directus/pull/26918) by @Ikromjon1998)
  - Restored `useItem` support for custom query options like `fields` and `deep` by adding an optional extra query parameter and updating affected call sites. ([#26985](https://github.com/directus/directus/pull/26985) by @LZylstra)
- **@directus/api**
  - Fixed file replacement returning Forbidden ([#27001](https://github.com/directus/directus/pull/27001) by @ComfortablyCoding)
  - Updated `happy-dom`, `path-to-regexp`, `picomatch`, `node-forge`, and `brace-expansion` to address CVEs ([#27006](https://github.com/directus/directus/pull/27006) by @br41nslug)
  - Fixed extension auto reload not triggering ([#26986](https://github.com/directus/directus/pull/26986) by @ComfortablyCoding)
- **@directus/utils**
  - Fixed calendar picker crash when using dynamic variables (e.g. $NOW) ([#26954](https://github.com/directus/directus/pull/26954) by @costajohnt)
- **@directus/schema**
  - Fixed MySQL foreignKeys query to include TABLE_NAME in the JOIN condition, preventing a cartesian product when InnoDB statistics on system tables are degraded. ([#26964](https://github.com/directus/directus/pull/26964) by @HattoriEnzo)
- **@directus/sdk**
  - Fixed filter operator typing for `date` and `time` fields to support comparison and range operators. ([#26957](https://github.com/directus/directus/pull/26957) by @costajohnt)

### 📦 Published Versions

- `@directus/app@15.7.0`
- `@directus/api@35.0.1`
- `@directus/composables@11.2.17`
- `create-directus-extension@11.0.33`
- `@directus/env@5.7.1`
- `@directus/extensions@3.0.23`
- `@directus/extensions-registry@3.0.23`
- `@directus/extensions-sdk@17.1.1`
- `@directus/memory@3.1.6`
- `@directus/pressure@3.0.21`
- `@directus/schema@13.0.7`
- `@directus/schema-builder@0.0.18`
- `@directus/storage-driver-azure@12.0.21`
- `@directus/storage-driver-cloudinary@12.0.21`
- `@directus/storage-driver-gcs@12.0.21`
- `@directus/storage-driver-s3@12.1.7`
- `@directus/storage-driver-supabase@3.0.21`
- `@directus/themes@1.3.1`
- `@directus/types@15.0.1`
- `@directus/utils@13.4.0`
- `@directus/validation@2.0.21`
- `@directus/sdk@21.2.2`
```