### PR TITLE
Add comparison modal checkbox to allow viewing only modified fields

### DIFF
--- a/.changeset/wicked-spoons-mate.md
+++ b/.changeset/wicked-spoons-mate.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Added comparison modal checkbox to allow viewing only modified fields

--- a/app/src/components/v-form/types.ts
+++ b/app/src/components/v-form/types.ts
@@ -14,7 +14,7 @@ export interface ComparisonContext {
 	revisionFields?: Set<string>;
 	selectedFields: string[];
 	onToggleField: ((field: string) => void) | null;
-	viewOnlyModifiedFields?: boolean;
+	showDifferencesOnly?: boolean;
 }
 
 export type FieldValues = {

--- a/app/src/components/v-form/types.ts
+++ b/app/src/components/v-form/types.ts
@@ -14,6 +14,7 @@ export interface ComparisonContext {
 	revisionFields?: Set<string>;
 	selectedFields: string[];
 	onToggleField: ((field: string) => void) | null;
+	viewOnlyModifiedFields?: boolean;
 }
 
 export type FieldValues = {

--- a/app/src/components/v-form/v-form.test.ts
+++ b/app/src/components/v-form/v-form.test.ts
@@ -146,6 +146,51 @@ describe('VForm', () => {
 			expect(renderedFields).toContain('modified_field');
 			expect(renderedFields).toContain('unmodified_field');
 		});
+
+		it('shows only modified fields for fields inside a group (nested group form)', async () => {
+			const modifiedInGroup = createField({
+				field: 'inner_modified',
+				name: 'Inner Modified',
+				meta: {
+					...createField().meta!,
+					field: 'inner_modified',
+					group: 'my_group',
+				},
+			});
+
+			const unmodifiedInGroup = createField({
+				field: 'inner_unmodified',
+				name: 'Inner Unmodified',
+				meta: {
+					...createField().meta!,
+					field: 'inner_unmodified',
+					group: 'my_group',
+				},
+			});
+
+			const wrapper = mount(VForm, {
+				props: {
+					fields: [modifiedInGroup, unmodifiedInGroup],
+					primaryKey: '+',
+					group: 'my_group',
+					comparison: {
+						side: 'incoming',
+						fields: new Set(['inner_modified']),
+						selectedFields: [],
+						onToggleField: null,
+						viewOnlyModifiedFields: true,
+					},
+				},
+				global,
+			});
+
+			await nextTick();
+
+			const renderedFields = wrapper.findAllComponents(FormField).map((c) => c.props('field').field);
+
+			expect(renderedFields).toContain('inner_modified');
+			expect(renderedFields).not.toContain('inner_unmodified');
+		});
 	});
 
 	describe('apply function', () => {

--- a/app/src/components/v-form/v-form.test.ts
+++ b/app/src/components/v-form/v-form.test.ts
@@ -3,6 +3,7 @@ import { createTestingPinia } from '@pinia/testing';
 import { mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { nextTick } from 'vue';
+import FormField from './components/form-field.vue';
 import VForm from './v-form.vue';
 import { ClickOutside } from '@/__utils__/click-outside';
 import { Md } from '@/__utils__/md';
@@ -95,6 +96,58 @@ function createField(overrides: Partial<Field> = {}): Field {
 }
 
 describe('VForm', () => {
+	describe('comparison mode with viewOnlyModifiedFields', () => {
+		it('shows only fields that are in comparison.fields when viewOnlyModifiedFields is true', async () => {
+			const modifiedField = createField({ field: 'modified_field', name: 'Modified Field' });
+			const unmodifiedField = createField({ field: 'unmodified_field', name: 'Unmodified Field' });
+
+			const wrapper = mount(VForm, {
+				props: {
+					fields: [modifiedField, unmodifiedField],
+					primaryKey: '+',
+					comparison: {
+						side: 'incoming',
+						fields: new Set(['modified_field']),
+						selectedFields: [],
+						onToggleField: null,
+						viewOnlyModifiedFields: true,
+					},
+				},
+				global,
+			});
+
+			const renderedFields = wrapper.findAllComponents(FormField).map((c) => c.props('field').field);
+
+			expect(renderedFields).toContain('modified_field');
+			expect(renderedFields).not.toContain('unmodified_field');
+		});
+
+		it('shows all fields when viewOnlyModifiedFields is false', async () => {
+			const modifiedField = createField({ field: 'modified_field', name: 'Modified Field' });
+			const unmodifiedField = createField({ field: 'unmodified_field', name: 'Unmodified Field' });
+
+			const wrapper = mount(VForm, {
+				props: {
+					fields: [modifiedField, unmodifiedField],
+					primaryKey: '+',
+					comparison: {
+						side: 'incoming',
+						fields: new Set(['modified_field']),
+						selectedFields: [],
+						onToggleField: null,
+						viewOnlyModifiedFields: false,
+					},
+				},
+				global,
+			});
+
+			const renderedFields = wrapper.findAllComponents(FormField).map((c) => c.props('field').field);
+
+			expect(renderedFields).toContain('modified_field');
+			expect(renderedFields).toContain('unmodified_field');
+		});
+	});
+
 	describe('apply function', () => {
 		it('preserves grouped readonly field values during nested form updates', async () => {
 			const checkboxField = createField({

--- a/app/src/components/v-form/v-form.test.ts
+++ b/app/src/components/v-form/v-form.test.ts
@@ -97,57 +97,50 @@ function createField(overrides: Partial<Field> = {}): Field {
 
 describe('VForm', () => {
 	describe('comparison mode with viewOnlyModifiedFields', () => {
-		it('shows only fields that are in comparison.fields when viewOnlyModifiedFields is true', async () => {
+		it('updates visible fields when viewOnlyModifiedFields toggles', async () => {
 			const modifiedField = createField({ field: 'modified_field', name: 'Modified Field' });
 			const unmodifiedField = createField({ field: 'unmodified_field', name: 'Unmodified Field' });
+			const comparisonFields = new Set(['modified_field']);
+
+			const comparison = {
+				side: 'incoming' as const,
+				fields: comparisonFields,
+				selectedFields: [],
+				onToggleField: null,
+				viewOnlyModifiedFields: false,
+			};
 
 			const wrapper = mount(VForm, {
 				props: {
 					fields: [modifiedField, unmodifiedField],
 					primaryKey: '+',
-					comparison: {
-						side: 'incoming',
-						fields: new Set(['modified_field']),
-						selectedFields: [],
-						onToggleField: null,
-						viewOnlyModifiedFields: true,
-					},
+					comparison,
 				},
 				global,
 			});
 
-			const renderedFields = wrapper.findAllComponents(FormField).map((c) => c.props('field').field);
+			let renderedFields = wrapper.findAllComponents(FormField).map((c) => c.props('field').field);
+			expect(renderedFields).toContain('modified_field');
+			expect(renderedFields).toContain('unmodified_field');
 
+			await wrapper.setProps({
+				comparison: { ...comparison, viewOnlyModifiedFields: true },
+			});
+
+			renderedFields = wrapper.findAllComponents(FormField).map((c) => c.props('field').field);
 			expect(renderedFields).toContain('modified_field');
 			expect(renderedFields).not.toContain('unmodified_field');
-		});
 
-		it('shows all fields when viewOnlyModifiedFields is false', async () => {
-			const modifiedField = createField({ field: 'modified_field', name: 'Modified Field' });
-			const unmodifiedField = createField({ field: 'unmodified_field', name: 'Unmodified Field' });
-
-			const wrapper = mount(VForm, {
-				props: {
-					fields: [modifiedField, unmodifiedField],
-					primaryKey: '+',
-					comparison: {
-						side: 'incoming',
-						fields: new Set(['modified_field']),
-						selectedFields: [],
-						onToggleField: null,
-						viewOnlyModifiedFields: false,
-					},
-				},
-				global,
+			await wrapper.setProps({
+				comparison: { ...comparison, viewOnlyModifiedFields: false },
 			});
 
-			const renderedFields = wrapper.findAllComponents(FormField).map((c) => c.props('field').field);
-
+			renderedFields = wrapper.findAllComponents(FormField).map((c) => c.props('field').field);
 			expect(renderedFields).toContain('modified_field');
 			expect(renderedFields).toContain('unmodified_field');
 		});
 
-		it('shows only modified fields for fields inside a group (nested group form)', async () => {
+		it('updates visible fields inside a group when viewOnlyModifiedFields toggles', async () => {
 			const modifiedInGroup = createField({
 				field: 'inner_modified',
 				name: 'Inner Modified',
@@ -168,28 +161,45 @@ describe('VForm', () => {
 				},
 			});
 
+			const comparisonFields = new Set(['inner_modified']);
+
+			const comparison = {
+				side: 'incoming' as const,
+				fields: comparisonFields,
+				selectedFields: [],
+				onToggleField: null,
+				viewOnlyModifiedFields: false,
+			};
+
 			const wrapper = mount(VForm, {
 				props: {
 					fields: [modifiedInGroup, unmodifiedInGroup],
 					primaryKey: '+',
 					group: 'my_group',
-					comparison: {
-						side: 'incoming',
-						fields: new Set(['inner_modified']),
-						selectedFields: [],
-						onToggleField: null,
-						viewOnlyModifiedFields: true,
-					},
+					comparison,
 				},
 				global,
 			});
 
-			await nextTick();
+			let renderedFields = wrapper.findAllComponents(FormField).map((c) => c.props('field').field);
+			expect(renderedFields).toContain('inner_modified');
+			expect(renderedFields).toContain('inner_unmodified');
 
-			const renderedFields = wrapper.findAllComponents(FormField).map((c) => c.props('field').field);
+			await wrapper.setProps({
+				comparison: { ...comparison, viewOnlyModifiedFields: true },
+			});
 
+			renderedFields = wrapper.findAllComponents(FormField).map((c) => c.props('field').field);
 			expect(renderedFields).toContain('inner_modified');
 			expect(renderedFields).not.toContain('inner_unmodified');
+
+			await wrapper.setProps({
+				comparison: { ...comparison, viewOnlyModifiedFields: false },
+			});
+
+			renderedFields = wrapper.findAllComponents(FormField).map((c) => c.props('field').field);
+			expect(renderedFields).toContain('inner_modified');
+			expect(renderedFields).toContain('inner_unmodified');
 		});
 	});
 

--- a/app/src/components/v-form/v-form.test.ts
+++ b/app/src/components/v-form/v-form.test.ts
@@ -96,8 +96,8 @@ function createField(overrides: Partial<Field> = {}): Field {
 }
 
 describe('VForm', () => {
-	describe('comparison mode with viewOnlyModifiedFields', () => {
-		it('updates visible fields when viewOnlyModifiedFields toggles', async () => {
+	describe('comparison mode with showDifferencesOnly', () => {
+		it('updates visible fields when showDifferencesOnly toggles', async () => {
 			const modifiedField = createField({ field: 'modified_field', name: 'Modified Field' });
 			const unmodifiedField = createField({ field: 'unmodified_field', name: 'Unmodified Field' });
 			const comparisonFields = new Set(['modified_field']);
@@ -107,7 +107,7 @@ describe('VForm', () => {
 				fields: comparisonFields,
 				selectedFields: [],
 				onToggleField: null,
-				viewOnlyModifiedFields: false,
+				showDifferencesOnly: false,
 			};
 
 			const wrapper = mount(VForm, {
@@ -124,7 +124,7 @@ describe('VForm', () => {
 			expect(renderedFields).toContain('unmodified_field');
 
 			await wrapper.setProps({
-				comparison: { ...comparison, viewOnlyModifiedFields: true },
+				comparison: { ...comparison, showDifferencesOnly: true },
 			});
 
 			renderedFields = wrapper.findAllComponents(FormField).map((c) => c.props('field').field);
@@ -132,7 +132,7 @@ describe('VForm', () => {
 			expect(renderedFields).not.toContain('unmodified_field');
 
 			await wrapper.setProps({
-				comparison: { ...comparison, viewOnlyModifiedFields: false },
+				comparison: { ...comparison, showDifferencesOnly: false },
 			});
 
 			renderedFields = wrapper.findAllComponents(FormField).map((c) => c.props('field').field);
@@ -140,7 +140,7 @@ describe('VForm', () => {
 			expect(renderedFields).toContain('unmodified_field');
 		});
 
-		it('updates visible fields inside a group when viewOnlyModifiedFields toggles', async () => {
+		it('updates visible fields inside a group when showDifferencesOnly toggles', async () => {
 			const modifiedInGroup = createField({
 				field: 'inner_modified',
 				name: 'Inner Modified',
@@ -168,7 +168,7 @@ describe('VForm', () => {
 				fields: comparisonFields,
 				selectedFields: [],
 				onToggleField: null,
-				viewOnlyModifiedFields: false,
+				showDifferencesOnly: false,
 			};
 
 			const wrapper = mount(VForm, {
@@ -186,7 +186,7 @@ describe('VForm', () => {
 			expect(renderedFields).toContain('inner_unmodified');
 
 			await wrapper.setProps({
-				comparison: { ...comparison, viewOnlyModifiedFields: true },
+				comparison: { ...comparison, showDifferencesOnly: true },
 			});
 
 			renderedFields = wrapper.findAllComponents(FormField).map((c) => c.props('field').field);
@@ -194,7 +194,7 @@ describe('VForm', () => {
 			expect(renderedFields).not.toContain('inner_unmodified');
 
 			await wrapper.setProps({
-				comparison: { ...comparison, viewOnlyModifiedFields: false },
+				comparison: { ...comparison, showDifferencesOnly: false },
 			});
 
 			renderedFields = wrapper.findAllComponents(FormField).map((c) => c.props('field').field);

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -281,7 +281,7 @@ function useForm() {
 
 	function isFieldVisible(field: Field | TFormField): boolean {
 		if (props.comparison?.viewOnlyModifiedFields) {
-			return !!props.comparison.fields?.has(field.field);
+			return !!props.comparison.fields.has(field.field);
 		}
 
 		return (

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -280,7 +280,7 @@ function useForm() {
 	}
 
 	function isFieldVisible(field: Field | TFormField): boolean {
-		if (props.comparison?.viewOnlyModifiedFields) {
+		if (props.comparison?.showDifferencesOnly) {
 			return !!props.comparison.fields.has(field.field);
 		}
 
@@ -419,7 +419,7 @@ function getFirstVisibleFieldClass(index: number) {
 }
 
 function isGroupFieldVisible(field: TFormField, groupFields: Field[]): boolean {
-	if (props.comparison?.viewOnlyModifiedFields) {
+	if (props.comparison?.showDifferencesOnly) {
 		return groupFields.some((f) => props.comparison!.fields.has(f.field));
 	}
 

--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -280,6 +280,10 @@ function useForm() {
 	}
 
 	function isFieldVisible(field: Field | TFormField): boolean {
+		if (props.comparison?.viewOnlyModifiedFields) {
+			return !!props.comparison.fields?.has(field.field);
+		}
+
 		return (
 			field.meta?.hidden !== true ||
 			!!props.comparison?.fields?.has(field.field) ||
@@ -414,6 +418,14 @@ function getFirstVisibleFieldClass(index: number) {
 	return index === firstVisibleFieldIndex.value ? 'first-visible-field' : '';
 }
 
+function isGroupFieldVisible(field: TFormField, groupFields: Field[]): boolean {
+	if (props.comparison?.viewOnlyModifiedFields) {
+		return groupFields.some((f) => props.comparison!.fields.has(f.field));
+	}
+
+	return isFieldVisible(field);
+}
+
 function getComparisonIndicatorClasses(field: TFormField, isGroup = false) {
 	if (isComparisonDiff()) {
 		if (field.indicatorStyle === 'active') return 'indicator-active';
@@ -456,7 +468,10 @@ function getComparisonIndicatorClasses(field: TFormField, isGroup = false) {
 			<template v-if="fieldsMap[fieldName]">
 				<component
 					:is="`interface-${fieldsMap[fieldName]!.meta?.interface || 'group-standard'}`"
-					v-if="fieldsMap[fieldName]!.meta?.special?.includes('group') && isFieldVisible(fieldsMap[fieldName])"
+					v-if="
+						fieldsMap[fieldName]!.meta?.special?.includes('group') &&
+						isGroupFieldVisible(fieldsMap[fieldName]!, fieldsForGroup[index] || [])
+					"
 					:ref="
 						(el: Element) => {
 							formFieldEls[fieldName] = el;

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -233,7 +233,7 @@ promote_version: Promote Version
 apply: Apply
 discard: Discard
 select_all_differences: Select All Differences
-view_only_modified_fields: View Only Modified Fields
+show_differences_only: Show Differences Only
 main_updated_notice: The main item has been updated since this version was created.
 delete_version: Delete Version
 delete_version_copy: >-

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -233,6 +233,7 @@ promote_version: Promote Version
 apply: Apply
 discard: Discard
 select_all_differences: Select All Differences
+view_only_modified_fields: View Only Modified Fields
 main_updated_notice: The main item has been updated since this version was created.
 delete_version: Delete Version
 delete_version_copy: >-

--- a/app/src/views/private/components/comparison/comparison-modal.vue
+++ b/app/src/views/private/components/comparison/comparison-modal.vue
@@ -48,7 +48,7 @@ const { t } = useI18n();
 const { deleteVersionsAllowed, collection, primaryKey, mode, currentVersion, revisions, currentCollab } = toRefs(props);
 
 const compareToOption = ref<'Previous' | 'Latest'>('Previous');
-const viewOnlyModifiedFields = ref(false);
+const showDifferencesOnly = ref(false);
 
 const {
 	comparisonData,
@@ -137,7 +137,7 @@ watch(
 
 		if (wasActive === undefined || wasActive === false) {
 			compareToOption.value = isFirstRevision.value ? 'Latest' : 'Previous';
-			viewOnlyModifiedFields.value = false;
+			showDifferencesOnly.value = false;
 		}
 
 		await loadComparisonData();
@@ -291,7 +291,7 @@ function onIncomingSelectionChange(newDeltaId: PrimaryKey) {
 										revisionFields: comparisonData?.revisionFields,
 										selectedFields: [],
 										onToggleField: null,
-										viewOnlyModifiedFields,
+										showDifferencesOnly,
 									}"
 									non-editable
 									class="comparison-form--base"
@@ -334,7 +334,7 @@ function onIncomingSelectionChange(newDeltaId: PrimaryKey) {
 										revisionFields: comparisonData?.revisionFields,
 										selectedFields: selectedComparisonFields,
 										onToggleField: mode !== 'revision' || compareToOption !== 'Previous' ? toggleComparisonField : null,
-										viewOnlyModifiedFields,
+										showDifferencesOnly,
 									}"
 									non-editable
 									class="comparison-form--incoming"
@@ -362,7 +362,7 @@ function onIncomingSelectionChange(newDeltaId: PrimaryKey) {
 						</div>
 						<div class="footer-actions">
 							<div v-if="availableFieldsCount > 0" class="view-only-modified-container">
-								<VCheckbox v-model="viewOnlyModifiedFields">
+								<VCheckbox v-model="showDifferencesOnly">
 									{{ $t('show_differences_only') }}
 								</VCheckbox>
 							</div>

--- a/app/src/views/private/components/comparison/comparison-modal.vue
+++ b/app/src/views/private/components/comparison/comparison-modal.vue
@@ -48,6 +48,7 @@ const { t } = useI18n();
 const { deleteVersionsAllowed, collection, primaryKey, mode, currentVersion, revisions, currentCollab } = toRefs(props);
 
 const compareToOption = ref<'Previous' | 'Latest'>('Previous');
+const viewOnlyModifiedFields = ref(false);
 
 const {
 	comparisonData,
@@ -289,6 +290,7 @@ function onIncomingSelectionChange(newDeltaId: PrimaryKey) {
 										revisionFields: comparisonData?.revisionFields,
 										selectedFields: [],
 										onToggleField: null,
+										viewOnlyModifiedFields,
 									}"
 									non-editable
 									class="comparison-form--base"
@@ -331,6 +333,7 @@ function onIncomingSelectionChange(newDeltaId: PrimaryKey) {
 										revisionFields: comparisonData?.revisionFields,
 										selectedFields: selectedComparisonFields,
 										onToggleField: mode !== 'revision' || compareToOption !== 'Previous' ? toggleComparisonField : null,
+										viewOnlyModifiedFields,
 									}"
 									non-editable
 									class="comparison-form--incoming"
@@ -357,6 +360,11 @@ function onIncomingSelectionChange(newDeltaId: PrimaryKey) {
 							<ComparisonToggle v-model="compareToOption" :disable-previous="isFirstRevision" />
 						</div>
 						<div class="footer-actions">
+							<div v-if="availableFieldsCount > 0" class="view-only-modified-container">
+								<VCheckbox v-model="viewOnlyModifiedFields">
+									{{ $t('view_only_modified_fields') }}
+								</VCheckbox>
+							</div>
 							<div v-if="mode !== 'revision' || compareToOption !== 'Previous'" class="select-all-container">
 								<VCheckbox
 									v-if="availableFieldsCount > 0"
@@ -584,6 +592,7 @@ function onIncomingSelectionChange(newDeltaId: PrimaryKey) {
 					}
 				}
 
+				.view-only-modified-container,
 				.select-all-container {
 					display: flex;
 					min-inline-size: auto;
@@ -683,6 +692,7 @@ function onIncomingSelectionChange(newDeltaId: PrimaryKey) {
 	}
 }
 
+.view-only-modified-container,
 .select-all-container {
 	:deep(.v-checkbox .type-text) {
 		font-weight: 600;

--- a/app/src/views/private/components/comparison/comparison-modal.vue
+++ b/app/src/views/private/components/comparison/comparison-modal.vue
@@ -362,7 +362,7 @@ function onIncomingSelectionChange(newDeltaId: PrimaryKey) {
 						<div class="footer-actions">
 							<div v-if="availableFieldsCount > 0" class="view-only-modified-container">
 								<VCheckbox v-model="viewOnlyModifiedFields">
-									{{ $t('view_only_modified_fields') }}
+									{{ $t('show_differences_only') }}
 								</VCheckbox>
 							</div>
 							<div v-if="mode !== 'revision' || compareToOption !== 'Previous'" class="select-all-container">

--- a/app/src/views/private/components/comparison/comparison-modal.vue
+++ b/app/src/views/private/components/comparison/comparison-modal.vue
@@ -137,6 +137,7 @@ watch(
 
 		if (wasActive === undefined || wasActive === false) {
 			compareToOption.value = isFirstRevision.value ? 'Latest' : 'Previous';
+			viewOnlyModifiedFields.value = false;
 		}
 
 		await loadComparisonData();


### PR DESCRIPTION
## Scope                                                                                               
                                                                                                         
  What's changed:                                                                                        
   
  - Added "Show Differences Only" checkbox to the comparison modal footer                            
  - Extended `ComparisonContext` interface with an optional `showDifferencesOnly` flag
  - Updated `isFieldVisible` in `v-form.vue` to hide unmodified fields when the flag is active                     
                                                                                                         
  ## Potential Risks / Drawbacks                                                                         
                                                                                                         
  - None I can think of
                                                            
  ## Tested Scenarios                                                                                    
                                                            
  - Toggling the checkbox hides/shows unmodified fields in both the base and incoming panels
  - Checkbox only appears when there are available (modified) fields to filter on
  - Normal comparison mode (checkbox unchecked) is unaffected                                            
                                                                                                         
  ## Review Notes / Questions                                                                                                                           
  
  ## Checklist                                                                                           
                                                            
  - [x] Added or updated tests
  - [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
  - [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required           
  
  ---                                                                                                    
                                                            
  Fixes [cms-2026](https://linear.app/directus/issue/CMS-2026/add-toggle-in-comparison-modal-so-only-show-modified-fields)