### PR TITLE
Set minimum-release-age to 7d in pnpm settings

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -328,6 +328,9 @@ catalog:
 
 catalogMode: strict
 
+settings:
+  minimum-release-age: 7d
+
 onlyBuiltDependencies:
   - '@fortawesome/fontawesome-common-types'
   - '@fortawesome/fontawesome-svg-core'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -329,7 +329,7 @@ catalog:
 catalogMode: strict
 
 settings:
-  minimum-release-age: 7d
+  minimum-release-age: 10080 # 7 days
 
 onlyBuiltDependencies:
   - '@fortawesome/fontawesome-common-types'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -328,8 +328,7 @@ catalog:
 
 catalogMode: strict
 
-settings:
-  minimum-release-age: 10080 # 7 days
+minimumReleaseAge: 10080 # 7 days
 
 onlyBuiltDependencies:
   - '@fortawesome/fontawesome-common-types'


### PR DESCRIPTION
## Scope

What's changed:

- Add `minimum-release-age: 7d` setting to `pnpm-workspace.yaml`
- pnpm will only resolve package versions published at least 7 days ago, reducing supply chain attack surface from newly published malicious packages

## Potential Risks / Drawbacks

- Dependency updates will lag by 7 days — newly published security patches won't be available immediately
- Could block urgent upgrades; override with `--ignore-minimum-release-age` if needed

## Tested Scenarios

- N/A — configuration-only change

## Review Notes / Questions

- See https://pnpm.io/settings#minimumreleaseage for reference

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required