### PR TITLE
fix(app): prevent Save as Copy from moving nested M2M relations

### DIFF
--- a/.changeset/full-flowers-join.md
+++ b/.changeset/full-flowers-join.md
@@ -1,0 +1,6 @@
+---
+'@directus/app': patch
+---
+
+Fixes a bug where duplicating an item (“Save as Copy”) could move M2M relations defined inside a translations collection
+(eg foo_translations) to the new copy, leaving the original empty.

--- a/app/src/composables/use-item/index.test.ts
+++ b/app/src/composables/use-item/index.test.ts
@@ -216,6 +216,126 @@ describe('Save As Copy', () => {
 
 		expect(sdkSpy.mock.lastCall?.[0]()).toEqual(expect.objectContaining({ body: {} }));
 	});
+
+	test('should omit nested m2m junction ids inside translations', async () => {
+		const sdkSpy = vi.spyOn(sdk, 'request');
+
+		const mockCollectionWithDupFields = {
+			collection: 'test',
+			meta: {
+				item_duplication_fields: ['translations.*', 'translations.tags.*', 'translations.tags.tag.*'],
+			},
+		} as unknown as AppCollection;
+
+		const mockPrimaryKeyField = {
+			field: 'id',
+			schema: { has_auto_increment: true },
+		} as Field;
+
+		vi.mocked(useCollection).mockReturnValue({
+			info: computed(() => mockCollectionWithDupFields),
+			primaryKeyField: computed(() => mockPrimaryKeyField),
+			fields: computed(() => [mockPrimaryKeyField]),
+		} as any);
+
+		const fieldsStore = useFieldsStore();
+		const relationsStore = useRelationsStore();
+
+		// Primary keys: all auto-increment so they should be removed during duplication
+		vi.mocked(fieldsStore.getPrimaryKeyFieldForCollection).mockImplementation((collection) => {
+			if (collection === 'test') return mockPrimaryKeyField;
+			if (collection === 'test_translations') return { field: 'id', schema: { has_auto_increment: true } } as Field;
+			if (collection === 'test_translations_tags')
+				return { field: 'id', schema: { has_auto_increment: true } } as Field;
+			if (collection === 'tags') return { field: 'id', schema: { has_auto_increment: true } } as Field;
+			return { field: 'id', schema: { has_auto_increment: true } } as Field;
+		});
+
+		vi.mocked(relationsStore.getRelationsForCollection).mockImplementation((collection) => {
+			if (collection === 'test') {
+				return [
+					{
+						collection: 'test_translations',
+						field: 'test_id',
+						related_collection: 'test',
+						meta: {
+							one_field: 'translations',
+							junction_field: null,
+						},
+					} as unknown as Relation,
+				];
+			}
+
+			if (collection === 'test_translations') {
+				// M2M: translations.tags -> junction collection test_translations_tags, with junction_field "tag"
+				return [
+					{
+						collection: 'test_translations_tags',
+						field: 'translation_id',
+						related_collection: 'test_translations',
+						meta: {
+							one_field: 'tags',
+							junction_field: 'tag',
+						},
+					} as unknown as Relation,
+				];
+			}
+
+			return [];
+		});
+
+		// This is used by clearJunctionRelatedKey to find the relation that describes the junction's related item.
+		vi.mocked(relationsStore).relations = [
+			{
+				collection: 'test_translations_tags',
+				field: 'tag',
+				related_collection: 'tags',
+				meta: {
+					many_field: 'tag',
+				},
+			} as unknown as Relation,
+		] as any;
+
+		// Sequence:
+		// 1) initial getItem (triggered by useItem() setup)
+		// 2) graphql fetch for saveAsCopy
+		// 3) POST /items/test with the new payload
+		sdkSpy
+			.mockResolvedValueOnce({ id: 1 })
+			.mockResolvedValueOnce({
+				item: {
+					id: 1,
+					translations: [
+						{
+							id: 100,
+							tags: [
+								{
+									id: 500, // junction row id -> must be removed
+									tag: { id: 9, name: 'Tag 9' }, // related id can be removed too, but must not break
+								},
+							],
+						},
+					],
+				},
+			})
+			.mockResolvedValueOnce({ id: 2 });
+
+		const { saveAsCopy } = useItem(ref('test'), ref(1));
+		await saveAsCopy();
+
+		const postCall = sdkSpy.mock.lastCall?.[0]();
+
+		expect(postCall).toEqual(
+			expect.objectContaining({
+				path: '/items/test',
+				method: 'POST',
+			}),
+		);
+
+		const body = (postCall as any).body;
+		expect(body).toHaveProperty('translations');
+		expect(body.translations[0].tags[0]).not.toHaveProperty('id');
+	});
 });
 
 describe('Query merging', () => {

--- a/app/src/composables/use-item/index.ts
+++ b/app/src/composables/use-item/index.ts
@@ -250,6 +250,73 @@ export function useItem<T extends Item>(
 		const relationsStore = useRelationsStore();
 		const relations = relationsStore.getRelationsForCollection(collection.value);
 
+		const visited = new Set<string>();
+
+		function scrubNestedRelationalIds(currentCollection: string, currentItem: Item, depth = 0) {
+			if (depth > 10) return;
+
+			const visitedKey = `${currentCollection}:${depth}`;
+			if (visited.has(visitedKey)) return;
+			visited.add(visitedKey);
+
+			const currentRelations = relationsStore.getRelationsForCollection(currentCollection);
+
+			for (const relation of currentRelations) {
+				const oneField = relation.meta?.one_field;
+				if (!oneField || !(oneField in currentItem)) continue;
+
+				const relatedPrimaryKeyField = fieldsStore.getPrimaryKeyFieldForCollection(relation.collection);
+				if (!relatedPrimaryKeyField) continue;
+
+				const existsJunctionRelated = relationsStore.relations.find(
+					(r) => r.collection === relation.collection && r.meta?.many_field === relation.meta?.junction_field,
+				);
+
+				const scrubRelatedObject = (obj: Item) => {
+					clearPrimaryKey(relatedPrimaryKeyField, obj);
+					clearJunctionRelatedKey(relation, existsJunctionRelated, obj);
+
+					scrubNestedRelationalIds(relation.collection, obj, depth + 1);
+
+					const junctionField = relation.meta?.junction_field;
+					if (!junctionField || !isObject(obj[junctionField]) || !existsJunctionRelated) return;
+
+					let junctionRelatedCollection: string | null = null;
+
+					if (existsJunctionRelated.related_collection) {
+						junctionRelatedCollection = existsJunctionRelated.related_collection;
+					} else if (
+						existsJunctionRelated.meta?.one_collection_field &&
+						obj[existsJunctionRelated.meta.one_collection_field]
+					) {
+						junctionRelatedCollection = obj[existsJunctionRelated.meta.one_collection_field] as string;
+					}
+
+					if (!junctionRelatedCollection) return;
+
+					scrubNestedRelationalIds(junctionRelatedCollection, obj[junctionField] as Item, depth + 1);
+				};
+
+				if (Array.isArray(currentItem[oneField])) {
+					currentItem[oneField] = currentItem[oneField].map((relatedItem: Item | PrimaryKey) => {
+						if (!isObject(relatedItem)) return relatedItem;
+						scrubRelatedObject(relatedItem);
+						return relatedItem;
+					});
+				} else if (isObject(currentItem[oneField])) {
+					const alterations = currentItem[oneField] as Alterations;
+
+					for (const item of alterations.create) {
+						if (isObject(item)) scrubRelatedObject(item as Item);
+					}
+
+					for (const item of alterations.update) {
+						if (isObject(item)) scrubRelatedObject(item as Item);
+					}
+				}
+			}
+		}
+
 		for (const relation of relations) {
 			const oneField = relation.meta?.one_field;
 			if (!oneField || !(oneField in newItem)) continue;
@@ -276,11 +343,18 @@ export function useItem<T extends Item>(
 						if (existingItem) {
 							clearPrimaryKey(primaryKeyField.value, existingItem);
 							clearJunctionRelatedKey(relation, existsJunctionRelated, existingItem);
+							scrubNestedRelationalIds(relation.collection, existingItem);
 							relatedItem = existingItem;
+						} else if (isObject(relatedItem)) {
+							scrubNestedRelationalIds(relation.collection, relatedItem as Item);
 						}
 
 						return relatedItem;
 					});
+				} else {
+					for (const relatedItem of newItem[oneField]) {
+						if (isObject(relatedItem)) scrubNestedRelationalIds(relation.collection, relatedItem as Item);
+					}
 				}
 			} else if (isObject(newItem[oneField])) {
 				const newRelatedItem = newItem[oneField] as Alterations;
@@ -309,12 +383,14 @@ export function useItem<T extends Item>(
 
 					clearPrimaryKey(relatedPrimaryKeyField, data);
 					clearJunctionRelatedKey(relation, existsJunctionRelated, data);
+					scrubNestedRelationalIds(relation.collection, data);
 
 					newRelatedItem.create.push(data);
 				}
 
 				for (const item of existingItems) {
 					clearPrimaryKey(relatedPrimaryKeyField, item);
+					scrubNestedRelationalIds(relation.collection, item);
 
 					newRelatedItem.create.push(item);
 				}
@@ -322,6 +398,8 @@ export function useItem<T extends Item>(
 				newRelatedItem.update.length = 0;
 			}
 		}
+
+		scrubNestedRelationalIds(collection.value, newItem);
 
 		const errors = validateItem(newItem, fieldsWithPermissions.value, isNew.value);
 		if (nestedValidationErrors.value?.length) errors.push(...nestedValidationErrors.value);

--- a/contributors.yml
+++ b/contributors.yml
@@ -264,3 +264,4 @@
 - Ikromjon1998
 - Zhey-on
 - faizkhairi
+- Iheanacho-ai


### PR DESCRIPTION
## Scope

Fixes a bug where duplicating an item (“Save as Copy”) could move M2M relations defined inside a translations collection (eg foo_translations) to the new copy, leaving the original empty.

Change: Ensure nested relational payloads have junction/PK ids stripped recursively so junction rows are recreated instead of repointed.

Test: Added a regression test covering translations -> m2m duplication.

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26841 
