### PR TITLE
fix: show descriptive error on weak password validation

### DIFF
--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -103,16 +103,9 @@ export class UsersService extends ItemsService {
 
 		for (const password of passwords) {
 			if (!regex.test(password)) {
-				throw new FailedValidationError(
-					joiValidationErrorItemToErrorExtensions({
-						message: `Provided password doesn't match password policy`,
-						path: ['password'],
-						type: 'custom.pattern.base',
-						context: {
-							value: password,
-						},
-					}),
-				);
+				throw new InvalidPayloadError({
+					reason: `Provided password doesn't match the password policy`,
+				});
 			}
 		}
 	}

--- a/app/src/routes/accept-invite.vue
+++ b/app/src/routes/accept-invite.vue
@@ -8,8 +8,8 @@ import VButton from '@/components/v-button.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
 import VInput from '@/components/v-input.vue';
 import VNotice from '@/components/v-notice.vue';
-import { translateAPIError } from '@/lang';
 import { jwtPayload } from '@/utils/jwt-payload';
+import { getErrorReason } from '@/utils/get-error-reason';
 import PublicView from '@/views/public';
 
 const { t } = useI18n();
@@ -26,7 +26,7 @@ const done = ref(false);
 
 const errorFormatted = computed(() => {
 	if (error.value) {
-		return translateAPIError(error.value);
+		return getErrorReason(error.value);
 	}
 
 	return null;

--- a/app/src/routes/reset-password/reset.vue
+++ b/app/src/routes/reset-password/reset.vue
@@ -6,8 +6,8 @@ import api, { RequestError } from '@/api';
 import VButton from '@/components/v-button.vue';
 import VInput from '@/components/v-input.vue';
 import VNotice from '@/components/v-notice.vue';
-import { translateAPIError } from '@/lang';
 import { jwtPayload } from '@/utils/jwt-payload';
+import { getErrorReason } from '@/utils/get-error-reason';
 
 const props = defineProps<{
 	token: string;
@@ -23,7 +23,7 @@ const done = ref(false);
 
 const errorFormatted = computed(() => {
 	if (error.value) {
-		return translateAPIError(error.value);
+		return getErrorReason(error.value);
 	}
 
 	return null;

--- a/app/src/utils/get-error-reason.ts
+++ b/app/src/utils/get-error-reason.ts
@@ -1,0 +1,17 @@
+import type { RequestError } from '@/api';
+import { translateAPIError } from '@/lang';
+
+/**
+ * Extract the most descriptive error message from an API error response.
+ * Prefers `extensions.reason` (from InvalidPayloadError etc.) when available,
+ * falls back to `translateAPIError()` for generic error code translation.
+ */
+export function getErrorReason(error: RequestError): string {
+	const reason = error?.response?.data?.errors?.[0]?.extensions?.reason;
+
+	if (reason && typeof reason === 'string') {
+		return reason;
+	}
+
+	return translateAPIError(error);
+}


### PR DESCRIPTION
## Summary

Fixes #27016

When creating an account via invite or resetting a password with a password that doesn't match the configured `auth_password_policy`, the UI previously displayed a generic **"Validation failed"** message. This doesn't help users understand what went wrong.

## Changes

### Backend (`api/src/services/users.ts`)
- Replace `FailedValidationError` with `InvalidPayloadError` for password policy violations
- Provides a descriptive `reason` field: *"Provided password doesn't match the password policy"*
- This makes the error reason available via `extensions.reason` in the API response

### Frontend (`app/src/utils/get-error-reason.ts`) — **New utility**
- Extracts the most descriptive error message from API error responses
- Prefers `extensions.reason` when available (from `InvalidPayloadError` etc.)
- Falls back to `translateAPIError()` for errors without a `reason` field
- Follows the same pattern as the existing `extract-error-code.ts` utility

### Frontend (`accept-invite.vue`, `reset-password/reset.vue`)
- Switch from `translateAPIError()` to `getErrorReason()` for error display
- Both pages can now show descriptive password policy errors

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Weak password on invite accept | "Validation failed" | "Provided password doesn't match the password policy" |
| Weak password on reset | "Validation failed" | "Provided password doesn't match the password policy" |
| Other errors (token expired, etc.) | Unchanged | Unchanged (falls back to `translateAPIError`) |

## Related

- Follows the pattern established in #26971 for showing descriptive API error reasons
- The `getErrorReason()` utility is reusable for other pages that need better error messages