### PR TITLE
fix(api,app): show descriptive error on weak password validation

### DIFF
--- a/.changeset/fix-password-validation-error.md
+++ b/.changeset/fix-password-validation-error.md
@@ -1,0 +1,7 @@
+---
+"@directus/api": patch
+"@directus/app": patch
+"@directus/errors": patch
+---
+
+Fixed weak password validation error to display a descriptive message instead of generic "Validation failed"

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -1,6 +1,12 @@
 import { performance } from 'perf_hooks';
 import { useEnv } from '@directus/env';
-import { ForbiddenError, InvalidInviteError, InvalidPasswordError, InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
+import {
+	ForbiddenError,
+	InvalidInviteError,
+	InvalidPasswordError,
+	InvalidPayloadError,
+	RecordNotUniqueError,
+} from '@directus/errors';
 import type {
 	AbstractServiceOptions,
 	Item,

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -1,6 +1,6 @@
 import { performance } from 'perf_hooks';
 import { useEnv } from '@directus/env';
-import { ForbiddenError, InvalidInviteError, InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
+import { ForbiddenError, InvalidInviteError, InvalidPasswordError, InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
 import type {
 	AbstractServiceOptions,
 	Item,
@@ -103,16 +103,7 @@ export class UsersService extends ItemsService {
 
 		for (const password of passwords) {
 			if (!regex.test(password)) {
-				throw new FailedValidationError(
-					joiValidationErrorItemToErrorExtensions({
-						message: `Provided password doesn't match password policy`,
-						path: ['password'],
-						type: 'custom.pattern.base',
-						context: {
-							value: password,
-						},
-					}),
-				);
+				throw new InvalidPasswordError();
 			}
 		}
 	}

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -859,6 +859,7 @@ errors:
   INVALID_FOREIGN_KEY: Invalid foreign key
   INVALID_INVITE: This invite is no longer valid
   INVALID_IP: IP Address not allowed
+  INVALID_PASSWORD: "Provided password doesn't match the password policy"
   INVALID_OTP: Wrong one-time password
   INVALID_PAYLOAD: Invalid payload
   INVALID_PROVIDER: User belongs to a different auth provider

--- a/contributors.yml
+++ b/contributors.yml
@@ -264,3 +264,4 @@
 - Ikromjon1998
 - Zhey-on
 - faizkhairi
+- nielskaspers

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -9,6 +9,7 @@ export enum ErrorCode {
 	InvalidForeignKey = 'INVALID_FOREIGN_KEY',
 	InvalidInvite = 'INVALID_INVITE',
 	InvalidIp = 'INVALID_IP',
+	InvalidPassword = 'INVALID_PASSWORD',
 	InvalidOtp = 'INVALID_OTP',
 	InvalidPayload = 'INVALID_PAYLOAD',
 	InvalidPathParameter = 'INVALID_PATH_PARAMETER',

--- a/packages/errors/src/errors/index.ts
+++ b/packages/errors/src/errors/index.ts
@@ -9,6 +9,7 @@ export { InvalidCredentialsError } from './invalid-credentials.js';
 export { InvalidForeignKeyError } from './invalid-foreign-key.js';
 export { InvalidInviteError } from './invalid-invite.js';
 export { InvalidIpError } from './invalid-ip.js';
+export { InvalidPasswordError } from './invalid-password.js';
 export { InvalidOtpError } from './invalid-otp.js';
 export { InvalidPayloadError } from './invalid-payload.js';
 export { InvalidPathParameterError } from './invalid-path-parameter.js';

--- a/packages/errors/src/errors/invalid-password.ts
+++ b/packages/errors/src/errors/invalid-password.ts
@@ -1,0 +1,7 @@
+import { createError, type DirectusErrorConstructor, ErrorCode } from '../index.js';
+
+export const InvalidPasswordError: DirectusErrorConstructor = createError(
+	ErrorCode.InvalidPassword,
+	() => `Provided password doesn't match the password policy.`,
+	400,
+);


### PR DESCRIPTION
## Summary
When creating an account via invite or resetting a password with a password that doesn't match the configured `auth_password_policy`, the UI displays a generic "Validation failed" message. This PR introduces a dedicated error code following the pattern from #26971 to show a descriptive message instead.

## Issue
Fixes #27016

## Changes
- Add new `INVALID_PASSWORD` error code in `packages/errors/`
- Use the new error in `api/src/services/users.ts` for password policy violations
- Add translation string in `en-US.yaml`

## Testing
- Set Auth Password Policy to "strong" in settings
- Invite a user and attempt to set a weak password
- Verify the error message is now descriptive instead of "Validation failed"