### PR TITLE
fix(api,app): show descriptive error for password policy violations

### DIFF
--- a/.changeset/fix-password-policy-error.md
+++ b/.changeset/fix-password-policy-error.md
@@ -1,0 +1,7 @@
+---
+"@directus/api": patch
+"@directus/app": patch
+"@directus/errors": patch
+---
+
+Show descriptive error message when password doesn't meet password policy requirements

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError, InvalidInviteError, InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
+import { ForbiddenError, InvalidInviteError, InvalidPasswordError, InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import type { Accountability, MutationOptions } from '@directus/types';
 import { UserIntegrityCheckFlag } from '@directus/types';
@@ -7,7 +7,7 @@ import { createTracker, MockClient } from 'knex-mock-client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { validateRemainingAdminUsers } from '../permissions/modules/validate-remaining-admin/validate-remaining-admin-users.js';
 import { verifyJWT } from '../utils/jwt.js';
-import { ItemsService, MailService, UsersService } from './index.js';
+import { ItemsService, MailService, SettingsService, UsersService } from './index.js';
 
 vi.mock('../../src/database/index', () => ({
 	default: vi.fn(),
@@ -479,6 +479,59 @@ describe('Integration Tests', () => {
 				});
 
 				await expect(service.acceptInvite('fake-token', 'Password123!')).rejects.toThrow(ForbiddenError);
+			});
+		});
+
+		describe('checkPasswordPolicy', () => {
+			it('should throw InvalidPasswordError when password does not match policy', async () => {
+				const settingsReadSpy = vi
+					.spyOn(SettingsService.prototype, 'readSingleton')
+					.mockResolvedValueOnce({ auth_password_policy: '/^(?=.*[A-Z])(?=.*[0-9]).{8,}$/' });
+
+				const service = new UsersService({
+					knex: db,
+					schema,
+				});
+
+				await expect(
+					(service as any).checkPasswordPolicy(['weak']),
+				).rejects.toThrow(InvalidPasswordError);
+
+				settingsReadSpy.mockRestore();
+			});
+
+			it('should not throw when password matches policy', async () => {
+				const settingsReadSpy = vi
+					.spyOn(SettingsService.prototype, 'readSingleton')
+					.mockResolvedValueOnce({ auth_password_policy: '/^(?=.*[A-Z])(?=.*[0-9]).{8,}$/' });
+
+				const service = new UsersService({
+					knex: db,
+					schema,
+				});
+
+				await expect(
+					(service as any).checkPasswordPolicy(['StrongPass1']),
+				).resolves.not.toThrow();
+
+				settingsReadSpy.mockRestore();
+			});
+
+			it('should not throw when no password policy is set', async () => {
+				const settingsReadSpy = vi
+					.spyOn(SettingsService.prototype, 'readSingleton')
+					.mockResolvedValueOnce({ auth_password_policy: null });
+
+				const service = new UsersService({
+					knex: db,
+					schema,
+				});
+
+				await expect(
+					(service as any).checkPasswordPolicy(['anything']),
+				).resolves.not.toThrow();
+
+				settingsReadSpy.mockRestore();
 			});
 		});
 	});

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -1,4 +1,10 @@
-import { ForbiddenError, InvalidInviteError, InvalidPasswordError, InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
+import {
+	ForbiddenError,
+	InvalidInviteError,
+	InvalidPasswordError,
+	InvalidPayloadError,
+	RecordNotUniqueError,
+} from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import type { Accountability, MutationOptions } from '@directus/types';
 import { UserIntegrityCheckFlag } from '@directus/types';
@@ -493,9 +499,7 @@ describe('Integration Tests', () => {
 					schema,
 				});
 
-				await expect(
-					(service as any).checkPasswordPolicy(['weak']),
-				).rejects.toThrow(InvalidPasswordError);
+				await expect((service as any).checkPasswordPolicy(['weak'])).rejects.toThrow(InvalidPasswordError);
 
 				settingsReadSpy.mockRestore();
 			});
@@ -510,9 +514,7 @@ describe('Integration Tests', () => {
 					schema,
 				});
 
-				await expect(
-					(service as any).checkPasswordPolicy(['StrongPass1']),
-				).resolves.not.toThrow();
+				await expect((service as any).checkPasswordPolicy(['StrongPass1'])).resolves.not.toThrow();
 
 				settingsReadSpy.mockRestore();
 			});
@@ -527,9 +529,7 @@ describe('Integration Tests', () => {
 					schema,
 				});
 
-				await expect(
-					(service as any).checkPasswordPolicy(['anything']),
-				).resolves.not.toThrow();
+				await expect((service as any).checkPasswordPolicy(['anything'])).resolves.not.toThrow();
 
 				settingsReadSpy.mockRestore();
 			});

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -1,6 +1,12 @@
 import { performance } from 'perf_hooks';
 import { useEnv } from '@directus/env';
-import { ForbiddenError, InvalidInviteError, InvalidPasswordError, InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
+import {
+	ForbiddenError,
+	InvalidInviteError,
+	InvalidPasswordError,
+	InvalidPayloadError,
+	RecordNotUniqueError,
+} from '@directus/errors';
 import type {
 	AbstractServiceOptions,
 	Item,

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -1,6 +1,6 @@
 import { performance } from 'perf_hooks';
 import { useEnv } from '@directus/env';
-import { ForbiddenError, InvalidInviteError, InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
+import { ForbiddenError, InvalidInviteError, InvalidPasswordError, InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
 import type {
 	AbstractServiceOptions,
 	Item,
@@ -11,7 +11,7 @@ import type {
 } from '@directus/types';
 import { UserIntegrityCheckFlag } from '@directus/types';
 import { getSimpleHash, toArray, validatePayload } from '@directus/utils';
-import { FailedValidationError, joiValidationErrorItemToErrorExtensions } from '@directus/validation';
+import { FailedValidationError } from '@directus/validation';
 import Joi from 'joi';
 import jwt from 'jsonwebtoken';
 import { isEmpty } from 'lodash-es';
@@ -103,16 +103,7 @@ export class UsersService extends ItemsService {
 
 		for (const password of passwords) {
 			if (!regex.test(password)) {
-				throw new FailedValidationError(
-					joiValidationErrorItemToErrorExtensions({
-						message: `Provided password doesn't match password policy`,
-						path: ['password'],
-						type: 'custom.pattern.base',
-						context: {
-							value: password,
-						},
-					}),
-				);
+				throw new InvalidPasswordError();
 			}
 		}
 	}

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -859,6 +859,7 @@ errors:
   INVALID_FOREIGN_KEY: Invalid foreign key
   INVALID_INVITE: This invite is no longer valid
   INVALID_IP: IP Address not allowed
+  INVALID_PASSWORD: The provided password does not meet the password policy requirements
   INVALID_OTP: Wrong one-time password
   INVALID_PAYLOAD: Invalid payload
   INVALID_PROVIDER: User belongs to a different auth provider

--- a/contributors.yml
+++ b/contributors.yml
@@ -264,3 +264,4 @@
 - Ikromjon1998
 - Zhey-on
 - faizkhairi
+- claw-explorer

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -10,6 +10,7 @@ export enum ErrorCode {
 	InvalidInvite = 'INVALID_INVITE',
 	InvalidIp = 'INVALID_IP',
 	InvalidOtp = 'INVALID_OTP',
+	InvalidPassword = 'INVALID_PASSWORD',
 	InvalidPayload = 'INVALID_PAYLOAD',
 	InvalidPathParameter = 'INVALID_PATH_PARAMETER',
 	InvalidProvider = 'INVALID_PROVIDER',

--- a/packages/errors/src/errors/index.ts
+++ b/packages/errors/src/errors/index.ts
@@ -8,6 +8,7 @@ export { InternalServerError } from './internal.js';
 export { InvalidCredentialsError } from './invalid-credentials.js';
 export { InvalidForeignKeyError } from './invalid-foreign-key.js';
 export { InvalidInviteError } from './invalid-invite.js';
+export { InvalidPasswordError } from './invalid-password.js';
 export { InvalidIpError } from './invalid-ip.js';
 export { InvalidOtpError } from './invalid-otp.js';
 export { InvalidPayloadError } from './invalid-payload.js';

--- a/packages/errors/src/errors/invalid-password.ts
+++ b/packages/errors/src/errors/invalid-password.ts
@@ -1,0 +1,7 @@
+import { createError, type DirectusErrorConstructor, ErrorCode } from '../index.js';
+
+export const InvalidPasswordError: DirectusErrorConstructor = createError(
+	ErrorCode.InvalidPassword,
+	() => `Provided password does not meet the password policy requirements.`,
+	400,
+);


### PR DESCRIPTION
## Summary

Replaces the generic "Validation failed" error with a descriptive "The provided password does not meet the password policy requirements" message when a password fails the configured password policy check.

### Problem

When a password doesn't meet the configured password policy (e.g., on the invite acceptance page), users see only "Validation failed" — which gives no indication of what went wrong.

<img width="419" alt="Current error" src="https://github.com/user-attachments/assets/93d8077a-e6cd-4758-888c-92fce03e7196" />

### Solution

Following the pattern established in #26971, this PR introduces a dedicated `InvalidPasswordError` (error code `INVALID_PASSWORD`) that provides a clear, translatable error message.

### Changes

| Package | Change |
|---------|--------|
| `@directus/errors` | Added `InvalidPassword` error code and `InvalidPasswordError` class |
| `@directus/api` | Use `InvalidPasswordError` in `checkPasswordPolicy` instead of `FailedValidationError` |
| `@directus/app` | Added `INVALID_PASSWORD` translation to en-US locale |
| Tests | Added 3 new tests for `checkPasswordPolicy` behavior |

### Checklist

- [x] Changes follow the existing error handling pattern (see #26971)
- [x] New error code added to `packages/errors/src/codes.ts`
- [x] New error class in `packages/errors/src/errors/`
- [x] Translation added to `en-US.yaml`
- [x] Changeset added
- [x] Tests added for password policy validation

Closes #27016