### PR TITLE
fix: handle pre-existing tables in schema diff/apply

### DIFF
--- a/.changeset/fix-schema-apply-existing-tables.md
+++ b/.changeset/fix-schema-apply-existing-tables.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed schema apply failing with "Collection already exists" when tables were pre-created by external migrations (e.g. Supabase, Prisma, Flyway)

--- a/api/src/cli/commands/schema/apply.ts
+++ b/api/src/cli/commands/schema/apply.ts
@@ -61,7 +61,9 @@ export async function apply(
 			snapshot = parseJSON(fileContents) as Snapshot;
 		}
 
-		const currentSnapshot = await getSnapshot({ database });
+		// Include untracked (db-only) tables so the diff produces "edit" instead of "new"
+		// for tables that already exist in the database but lack Directus metadata.
+		const currentSnapshot = await getSnapshot({ database, includeUntracked: true });
 		let snapshotDiff = getSnapshotDiff(currentSnapshot, snapshot);
 
 		if (options?.ignoreRules) {

--- a/api/src/controllers/schema.ts
+++ b/api/src/controllers/schema.ts
@@ -111,9 +111,7 @@ router.post(
 		if (!snapshotDiff) return next();
 
 		// The hash must match what service.apply() will compute (also with includeUntracked)
-		const currentSnapshotHash = service.getHashedSnapshot(
-			await getSnapshot({ includeUntracked: true }),
-		).hash;
+		const currentSnapshotHash = service.getHashedSnapshot(await getSnapshot({ includeUntracked: true })).hash;
 
 		res.locals['payload'] = { data: { hash: currentSnapshotHash, diff: snapshotDiff } };
 		return next();

--- a/api/src/controllers/schema.ts
+++ b/api/src/controllers/schema.ts
@@ -9,7 +9,7 @@ import { useLogger } from '../logger/index.js';
 import { respond } from '../middleware/respond.js';
 import { SchemaService } from '../services/schema.js';
 import asyncHandler from '../utils/async-handler.js';
-import { getVersionedHash } from '../utils/get-versioned-hash.js';
+import { getSnapshot } from '../utils/get-snapshot.js';
 
 const router = express.Router();
 
@@ -105,11 +105,16 @@ router.post(
 	asyncHandler(async (req, res, next) => {
 		const service = new SchemaService({ accountability: req.accountability });
 		const snapshot: Snapshot = res.locals['upload'];
-		const currentSnapshot = await service.snapshot();
-		const snapshotDiff = await service.diff(snapshot, { currentSnapshot, force: 'force' in req.query });
+		// service.diff() internally fetches the current snapshot with includeUntracked: true
+		// so db-only tables produce "edit" diffs instead of "new" diffs.
+		const snapshotDiff = await service.diff(snapshot, { force: 'force' in req.query });
 		if (!snapshotDiff) return next();
 
-		const currentSnapshotHash = getVersionedHash(currentSnapshot);
+		// The hash must match what service.apply() will compute (also with includeUntracked)
+		const currentSnapshotHash = service.getHashedSnapshot(
+			await getSnapshot({ includeUntracked: true }),
+		).hash;
+
 		res.locals['payload'] = { data: { hash: currentSnapshotHash, diff: snapshotDiff } };
 		return next();
 	}),

--- a/api/src/services/schema.ts
+++ b/api/src/services/schema.ts
@@ -36,7 +36,9 @@ export class SchemaService {
 	async apply(payload: SnapshotDiffWithHash): Promise<void> {
 		if (this.accountability?.admin !== true) throw new ForbiddenError();
 
-		const currentSnapshot = await this.snapshot();
+		// Include untracked (db-only) tables so the hash matches the diff that was computed
+		// with includeUntracked: true, and so applyDiff sees the full current state.
+		const currentSnapshot = await getSnapshot({ database: this.knex, includeUntracked: true });
 		const snapshotWithHash = this.getHashedSnapshot(currentSnapshot);
 
 		if (!validateApplyDiff(payload, snapshotWithHash)) return;
@@ -52,7 +54,11 @@ export class SchemaService {
 
 		validateSnapshot(snapshot, options?.force);
 
-		const currentSnapshot = options?.currentSnapshot ?? (await getSnapshot({ database: this.knex }));
+		// Include untracked (db-only) tables in the current snapshot so the diff produces
+		// "edit" instead of "new" for tables that already exist in the database.
+		const currentSnapshot =
+			options?.currentSnapshot ?? (await getSnapshot({ database: this.knex, includeUntracked: true }));
+
 		const diff = getSnapshotDiff(currentSnapshot, snapshot);
 
 		if (

--- a/api/src/utils/apply-snapshot.ts
+++ b/api/src/utils/apply-snapshot.ts
@@ -13,7 +13,7 @@ export async function applySnapshot(
 ): Promise<void> {
 	const database = options?.database ?? getDatabase();
 	const schema = options?.schema ?? (await getSchema({ database, bypassCache: true }));
-	const current = options?.current ?? (await getSnapshot({ database, schema }));
+	const current = options?.current ?? (await getSnapshot({ database, schema, includeUntracked: true }));
 	const snapshotDiff = options?.diff ?? getSnapshotDiff(current, snapshot);
 
 	await applyDiff(current, snapshotDiff, { database, schema });

--- a/api/src/utils/get-snapshot-diff.ts
+++ b/api/src/utils/get-snapshot-diff.ts
@@ -6,32 +6,18 @@ import { sanitizeCollection, sanitizeField, sanitizeRelation, sanitizeSystemFiel
 export function getSnapshotDiff(current: Snapshot, after: Snapshot): SnapshotDiff {
 	const diffedSnapshot: SnapshotDiff = {
 		collections: [
-			...current.collections
-				.filter((currentCollection) => {
-					// Skip db-only collections (meta === null) that are not in the target snapshot.
-					// These are untracked tables that should not be deleted.
-					if (currentCollection.meta === null) {
-						const inTarget = after.collections.some(
-							(afterCollection) => afterCollection.collection === currentCollection.collection,
-						);
+			...current.collections.map((currentCollection) => {
+				const afterCollection = after.collections.find(
+					(afterCollection) => afterCollection.collection === currentCollection.collection,
+				);
 
-						return inTarget;
-					}
+				const afterCollectionSanitized = afterCollection ? sanitizeCollection(afterCollection) : undefined;
 
-					return true;
-				})
-				.map((currentCollection) => {
-					const afterCollection = after.collections.find(
-						(afterCollection) => afterCollection.collection === currentCollection.collection,
-					);
-
-					const afterCollectionSanitized = afterCollection ? sanitizeCollection(afterCollection) : undefined;
-
-					return {
-						collection: currentCollection.collection,
-						diff: deepDiff.diff(sanitizeCollection(currentCollection), afterCollectionSanitized),
-					};
-				}),
+				return {
+					collection: currentCollection.collection,
+					diff: deepDiff.diff(sanitizeCollection(currentCollection), afterCollectionSanitized),
+				};
+			}),
 			...after.collections
 				.filter((afterCollection) => {
 					const currentCollection = current.collections.find(
@@ -46,18 +32,7 @@ export function getSnapshotDiff(current: Snapshot, after: Snapshot): SnapshotDif
 				})),
 		].filter((obj) => Array.isArray(obj.diff)) as SnapshotDiff['collections'],
 		fields: [
-			...current.fields
-				.filter((currentField) => {
-					// Skip db-only fields (meta === null) not in the target — don't delete untracked fields
-					if (currentField.meta === null) {
-						return after.fields.some(
-							(af) => af.collection === currentField.collection && af.field === currentField.field,
-						);
-					}
-
-					return true;
-				})
-				.map((currentField) => {
+			...current.fields.map((currentField) => {
 				const afterField = after.fields.find(
 					(afterField) => afterField.collection === currentField.collection && afterField.field === currentField.field,
 				);
@@ -159,18 +134,7 @@ export function getSnapshotDiff(current: Snapshot, after: Snapshot): SnapshotDif
 				}),
 		].filter((obj) => Array.isArray(obj.diff)) as SnapshotDiff['systemFields'],
 		relations: [
-			...current.relations
-				.filter((currentRelation) => {
-					// Skip db-only relations (meta === null) not in the target
-					if (currentRelation.meta === null) {
-						return after.relations.some(
-							(ar) => ar.collection === currentRelation.collection && ar.field === currentRelation.field,
-						);
-					}
-
-					return true;
-				})
-				.map((currentRelation) => {
+			...current.relations.map((currentRelation) => {
 				const afterRelation = after.relations.find(
 					(afterRelation) =>
 						afterRelation.collection === currentRelation.collection && afterRelation.field === currentRelation.field,

--- a/api/src/utils/get-snapshot-diff.ts
+++ b/api/src/utils/get-snapshot-diff.ts
@@ -6,18 +6,32 @@ import { sanitizeCollection, sanitizeField, sanitizeRelation, sanitizeSystemFiel
 export function getSnapshotDiff(current: Snapshot, after: Snapshot): SnapshotDiff {
 	const diffedSnapshot: SnapshotDiff = {
 		collections: [
-			...current.collections.map((currentCollection) => {
-				const afterCollection = after.collections.find(
-					(afterCollection) => afterCollection.collection === currentCollection.collection,
-				);
+			...current.collections
+				.filter((currentCollection) => {
+					// Skip db-only collections (meta === null) that are not in the target snapshot.
+					// These are untracked tables that should not be deleted.
+					if (currentCollection.meta === null) {
+						const inTarget = after.collections.some(
+							(afterCollection) => afterCollection.collection === currentCollection.collection,
+						);
 
-				const afterCollectionSanitized = afterCollection ? sanitizeCollection(afterCollection) : undefined;
+						return inTarget;
+					}
 
-				return {
-					collection: currentCollection.collection,
-					diff: deepDiff.diff(sanitizeCollection(currentCollection), afterCollectionSanitized),
-				};
-			}),
+					return true;
+				})
+				.map((currentCollection) => {
+					const afterCollection = after.collections.find(
+						(afterCollection) => afterCollection.collection === currentCollection.collection,
+					);
+
+					const afterCollectionSanitized = afterCollection ? sanitizeCollection(afterCollection) : undefined;
+
+					return {
+						collection: currentCollection.collection,
+						diff: deepDiff.diff(sanitizeCollection(currentCollection), afterCollectionSanitized),
+					};
+				}),
 			...after.collections
 				.filter((afterCollection) => {
 					const currentCollection = current.collections.find(
@@ -32,7 +46,18 @@ export function getSnapshotDiff(current: Snapshot, after: Snapshot): SnapshotDif
 				})),
 		].filter((obj) => Array.isArray(obj.diff)) as SnapshotDiff['collections'],
 		fields: [
-			...current.fields.map((currentField) => {
+			...current.fields
+				.filter((currentField) => {
+					// Skip db-only fields (meta === null) not in the target — don't delete untracked fields
+					if (currentField.meta === null) {
+						return after.fields.some(
+							(af) => af.collection === currentField.collection && af.field === currentField.field,
+						);
+					}
+
+					return true;
+				})
+				.map((currentField) => {
 				const afterField = after.fields.find(
 					(afterField) => afterField.collection === currentField.collection && afterField.field === currentField.field,
 				);
@@ -134,7 +159,18 @@ export function getSnapshotDiff(current: Snapshot, after: Snapshot): SnapshotDif
 				}),
 		].filter((obj) => Array.isArray(obj.diff)) as SnapshotDiff['systemFields'],
 		relations: [
-			...current.relations.map((currentRelation) => {
+			...current.relations
+				.filter((currentRelation) => {
+					// Skip db-only relations (meta === null) not in the target
+					if (currentRelation.meta === null) {
+						return after.relations.some(
+							(ar) => ar.collection === currentRelation.collection && ar.field === currentRelation.field,
+						);
+					}
+
+					return true;
+				})
+				.map((currentRelation) => {
 				const afterRelation = after.relations.find(
 					(afterRelation) =>
 						afterRelation.collection === currentRelation.collection && afterRelation.field === currentRelation.field,

--- a/api/src/utils/get-snapshot.ts
+++ b/api/src/utils/get-snapshot.ts
@@ -9,7 +9,20 @@ import { RelationsService } from '../services/relations.js';
 import { getSchema } from './get-schema.js';
 import { sanitizeCollection, sanitizeField, sanitizeRelation, sanitizeSystemField } from './sanitize-schema.js';
 
-export async function getSnapshot(options?: { database?: Knex; schema?: SchemaOverview }): Promise<Snapshot> {
+export async function getSnapshot(options?: {
+	database?: Knex;
+	schema?: SchemaOverview;
+	/**
+	 * Include "untracked" (db-only) items in the snapshot. These are tables/fields/relations
+	 * that exist in the database but have no Directus metadata (meta === null).
+	 *
+	 * When true, db-only items are included so that /schema/diff can produce an "edit" diff
+	 * instead of a "new" diff for tables that already exist. This prevents the "Collection
+	 * already exists" error during /schema/apply when tables were created by external
+	 * migrations (e.g. Supabase, Prisma, Flyway).
+	 */
+	includeUntracked?: boolean;
+}): Promise<Snapshot> {
 	const database = options?.database ?? getDatabase();
 	const vendor = getDatabaseClient(database);
 	const schema = options?.schema ?? (await getSchema({ database, bypassCache: true }));
@@ -24,9 +37,11 @@ export async function getSnapshot(options?: { database?: Knex; schema?: SchemaOv
 		relationsService.readAll(),
 	]);
 
-	const collectionsFiltered = collectionsRaw.filter((item) => excludeSystem(item) && excludeUntracked(item));
-	const fieldsFiltered = fieldsRaw.filter((item) => excludeSystem(item) && excludeUntracked(item));
-	const relationsFiltered = relationsRaw.filter((item) => excludeSystem(item) && excludeUntracked(item));
+	const untrackedFilter = options?.includeUntracked ? () => true : excludeUntracked;
+
+	const collectionsFiltered = collectionsRaw.filter((item) => excludeSystem(item) && untrackedFilter(item));
+	const fieldsFiltered = fieldsRaw.filter((item) => excludeSystem(item) && untrackedFilter(item));
+	const relationsFiltered = relationsRaw.filter((item) => excludeSystem(item) && untrackedFilter(item));
 	const systemFieldsFiltered = fieldsRaw.filter((item) => systemFieldWithIndex(item));
 
 	const collectionsSorted = sortBy(mapValues(collectionsFiltered, sortDeep), ['collection']).map((collection) =>

--- a/contributors.yml
+++ b/contributors.yml
@@ -264,3 +264,4 @@
 - Ikromjon1998
 - Zhey-on
 - faizkhairi
+- jamalx31


### PR DESCRIPTION
## Summary

Fixes #25760 — When tables exist in the database but lack Directus metadata (e.g. created by external migrations from Supabase, Prisma, Flyway, etc.), `/schema/apply` fails with `"Collection already exists"`.

**Root cause:** `getSnapshot()` filters out "untracked" items (`meta === null`), so the diff sees these collections as absent in the current state and produces `kind: "N"` (new). The apply logic then tries to CREATE TABLE, which fails because the table already exists.

**Fix:** Add an `includeUntracked` option to `getSnapshot()` and use it in all diff/apply code paths. The diff now produces `kind: "E"` (edit) for db-only tables being upgraded to managed collections, and skips db-only items not in the target snapshot (preventing accidental deletion of untracked tables).

## Changes

| File | Change |
|---|---|
| `api/src/utils/get-snapshot.ts` | Add `includeUntracked?: boolean` option |
| `api/src/utils/get-snapshot-diff.ts` | Filter out db-only items not in target; produce "edit" for those being upgraded |
| `api/src/services/schema.ts` | Pass `includeUntracked: true` in `diff()` and `apply()` |
| `api/src/controllers/schema.ts` | Use `includeUntracked` snapshot for hash computation in `/diff` endpoint |
| `api/src/cli/commands/schema/apply.ts` | Pass `includeUntracked: true` in CLI apply |
| `api/src/utils/apply-snapshot.ts` | Pass `includeUntracked: true` in utility wrapper |

## Context

This is a common issue for teams that use external database migration tools (Supabase CLI, Prisma Migrate, Flyway, etc.) alongside Directus. The external tool creates the tables, and Directus should be able to "adopt" them via schema apply without failing.

The previous attempt at this fix (PR #26125) was closed due to a concern about not dropping extra columns in db-only tables. This PR takes the same approach but considers that behavior (not dropping unknown columns) to be the **correct and safe default** — it's a separate concern from the core bug.

## Test Plan

1. Create a table via raw SQL (external migration) without registering it in Directus
2. Export a schema snapshot that includes this table as a managed collection
3. Run `/schema/apply` with the snapshot
4. **Before fix:** fails with "Collection already exists"
5. **After fix:** succeeds, table is registered as a managed collection with full metadata