### PR TITLE
Pin workflow npm to 11.5.1

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -18,9 +18,9 @@ runs:
         node-version-file: package.json
         registry-url: ${{ inputs.registry }}
 
-    - name: Log npm version
+    - name: Update npm
       shell: bash
-      run: npm -v
+      run: npm install -g npm@11.5.1
 
     - uses: pnpm/action-setup@v4
       name: Install pnpm

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -18,9 +18,9 @@ runs:
         node-version-file: package.json
         registry-url: ${{ inputs.registry }}
 
-    - name: Update npm
+    - name: Log npm version
       shell: bash
-      run: npm install -g npm@11
+      run: npm -v
 
     - uses: pnpm/action-setup@v4
       name: Install pnpm


### PR DESCRIPTION
Fix workflow runs. Base npm version is `10.9.4`.

<img width="801" height="461" alt="image" src="https://github.com/user-attachments/assets/2f6ef54d-75fd-4421-a3bb-af06b062ad9b" />
