### PR TITLE
Update dependencies

### DIFF
--- a/.changeset/fancy-clubs-design.md
+++ b/.changeset/fancy-clubs-design.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Updated `lodash`, `samlify` and `@xmldom/xmldom` dependencies

--- a/.changeset/fancy-clubs-design.md
+++ b/.changeset/fancy-clubs-design.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Updated `lodash`, `samlify` and `@xmldom/xmldom` dependencies
+Updated `lodash`, `samlify` and `@xmldom/xmldom` dependencies and add `defu` override

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
 			"express@4>path-to-regexp": "0.1.13",
 			"micromatch>picomatch": "2.3.2",
 			"anymatch>picomatch": "2.3.2",
-			"picomatch": "4.0.4"
+			"picomatch": "4.0.4",
+			"defu": "6.1.5"
 		}
 	},
 	"packageManager": "pnpm@10.27.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
 			"micromatch>picomatch": "2.3.2",
 			"anymatch>picomatch": "2.3.2",
 			"picomatch": "4.0.4",
-			"minimatch": "10.2.4"
+			"minimatch": "10.2.4",
+			"lodash": "4.18.0",
+			"@xmldom/xmldom": "0.8.12"
 		}
 	},
 	"packageManager": "pnpm@10.27.0",

--- a/package.json
+++ b/package.json
@@ -46,10 +46,7 @@
 			"express@4>path-to-regexp": "0.1.13",
 			"micromatch>picomatch": "2.3.2",
 			"anymatch>picomatch": "2.3.2",
-			"picomatch": "4.0.4",
-			"minimatch": "10.2.4",
-			"lodash": "4.18.0",
-			"@xmldom/xmldom": "0.8.12"
+			"picomatch": "4.0.4"
 		}
 	},
 	"packageManager": "pnpm@10.27.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -654,6 +654,9 @@ catalogs:
     liquidjs:
       specifier: 10.25.0
       version: 10.25.0
+    lodash:
+      specifier: 4.18.0
+      version: 4.18.0
     lodash-es:
       specifier: 4.18.0
       version: 4.18.0
@@ -681,6 +684,9 @@ catalogs:
     mime-types:
       specifier: 3.0.1
       version: 3.0.1
+    minimatch:
+      specifier: 10.2.4
+      version: 10.2.4
     mitt:
       specifier: 3.0.1
       version: 3.0.1
@@ -942,9 +948,6 @@ overrides:
   micromatch>picomatch: 2.3.2
   anymatch>picomatch: 2.3.2
   picomatch: 4.0.4
-  minimatch: 10.2.4
-  lodash: 4.18.0
-  '@xmldom/xmldom': 0.8.12
 
 importers:
 
@@ -1287,7 +1290,7 @@ importers:
         specifier: 'catalog:'
         version: 3.0.1
       minimatch:
-        specifier: 10.2.4
+        specifier: 'catalog:'
         version: 10.2.4
       mnemonist:
         specifier: 'catalog:'
@@ -1856,7 +1859,7 @@ importers:
         specifier: 'catalog:'
         version: 1.7.6
       lodash:
-        specifier: 4.18.0
+        specifier: 'catalog:'
         version: 4.18.0
       mapbox-gl:
         specifier: 'catalog:'
@@ -8107,6 +8110,9 @@ packages:
       react-native-b4a:
         optional: true
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@2.0.0:
     resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
 
@@ -8198,6 +8204,12 @@ packages:
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
+
+  brace-expansion@1.1.13:
+    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+
+  brace-expansion@2.0.3:
+    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
@@ -8594,6 +8606,9 @@ packages:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
 
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
   concat-stream@1.5.2:
     resolution: {integrity: sha512-H6xsIBfQ94aESBG8jGHXQ7i5AEpy5ZeVaLDOisDICiTCKpqEfr34/KmTrspKQNoLKNu9gTkovlpQcUi630AKiQ==}
     engines: {'0': node >= 0.8}
@@ -8640,7 +8655,7 @@ packages:
       just: ^0.1.8
       liquid-node: ^3.0.1
       liquor: ^0.0.5
-      lodash: 4.18.0
+      lodash: ^4.17.20
       marko: ^3.14.4
       mote: ^0.2.0
       mustache: ^3.0.0
@@ -11438,6 +11453,17 @@ packages:
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
+  minimatch@9.0.7:
+    resolution: {integrity: sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist-options@4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
@@ -16683,7 +16709,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@5.5.0)
-      minimatch: 10.2.4
+      minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
@@ -16704,7 +16730,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 10.2.4
+      minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -20141,7 +20167,7 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       fast-glob: 3.3.3
       is-glob: 4.0.3
-      minimatch: 10.2.4
+      minimatch: 9.0.7
       semver: 7.7.3
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -20979,6 +21005,8 @@ snapshots:
 
   b4a@1.7.3: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@2.0.0: {}
 
   balanced-match@4.0.4: {}
@@ -21091,6 +21119,15 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
+  brace-expansion@1.1.13:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.0.3:
+    dependencies:
+      balanced-match: 1.0.2
+
   brace-expansion@5.0.4:
     dependencies:
       balanced-match: 4.0.4
@@ -21119,7 +21156,7 @@ snapshots:
       express: 4.22.1
       graceful-fs: 4.2.11
       http-errors: 2.0.0
-      minimatch: 10.2.4
+      minimatch: 9.0.7
       module-details-from-path: 1.0.4
       mustache: 4.2.0
       pluralize: 8.0.0
@@ -21551,6 +21588,8 @@ snapshots:
       normalize-path: 3.0.0
       readable-stream: 4.7.0
 
+  concat-map@0.0.1: {}
+
   concat-stream@1.5.2:
     dependencies:
       inherits: 2.0.4
@@ -21626,7 +21665,7 @@ snapshots:
   copyfiles@2.4.1:
     dependencies:
       glob: 7.2.3
-      minimatch: 10.2.4
+      minimatch: 3.1.5
       mkdirp: 1.0.4
       noms: 0.0.0
       through2: 2.0.5
@@ -22041,7 +22080,7 @@ snapshots:
     dependencies:
       '@one-ini/wasm': 0.1.1
       commander: 10.0.1
-      minimatch: 10.2.4
+      minimatch: 9.0.7
       semver: 7.7.3
 
   editorjs-toggle-block@0.3.16:
@@ -22364,7 +22403,7 @@ snapshots:
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
-      minimatch: 10.2.4
+      minimatch: 3.1.5
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
@@ -22433,7 +22472,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 10.2.4
+      minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -23100,7 +23139,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 10.2.4
+      minimatch: 9.0.7
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -23119,7 +23158,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 10.2.4
+      minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -23128,7 +23167,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 10.2.4
+      minimatch: 5.1.9
       once: 1.4.0
 
   global-modules@2.0.0:
@@ -23509,7 +23548,7 @@ snapshots:
 
   ignore-walk@5.0.1:
     dependencies:
-      minimatch: 10.2.4
+      minimatch: 5.1.9
 
   ignore@5.3.2: {}
 
@@ -24577,6 +24616,18 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.4
 
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.13
+
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.0.3
+
+  minimatch@9.0.7:
+    dependencies:
+      brace-expansion: 5.0.4
+
   minimist-options@4.1.0:
     dependencies:
       arrify: 1.0.1
@@ -24885,7 +24936,7 @@ snapshots:
       chokidar: 3.6.0
       debug: 4.4.3(supports-color@5.5.0)
       ignore-by-default: 1.0.1
-      minimatch: 10.2.4
+      minimatch: 3.1.5
       pstree.remy: 1.1.8
       semver: 7.7.3
       simple-update-notifier: 2.0.0
@@ -26107,7 +26158,7 @@ snapshots:
 
   readdir-glob@1.1.3:
     dependencies:
-      minimatch: 10.2.4
+      minimatch: 5.1.9
 
   readdirp@3.6.0:
     dependencies:
@@ -27510,7 +27561,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 10.5.0
-      minimatch: 10.2.4
+      minimatch: 9.0.7
 
   text-decoder@1.2.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -654,12 +654,9 @@ catalogs:
     liquidjs:
       specifier: 10.25.0
       version: 10.25.0
-    lodash:
-      specifier: 4.17.23
-      version: 4.17.23
     lodash-es:
-      specifier: 4.17.23
-      version: 4.17.23
+      specifier: 4.18.0
+      version: 4.18.0
     log-symbols:
       specifier: 7.0.1
       version: 7.0.1
@@ -799,8 +796,8 @@ catalogs:
       specifier: 2.0.0
       version: 2.0.0
     samlify:
-      specifier: 2.11.0
-      version: 2.11.0
+      specifier: 2.12.0
+      version: 2.12.0
     sanitize-filename:
       specifier: 1.6.3
       version: 1.6.3
@@ -946,6 +943,8 @@ overrides:
   anymatch>picomatch: 2.3.2
   picomatch: 4.0.4
   minimatch: 10.2.4
+  lodash: 4.18.0
+  '@xmldom/xmldom': 0.8.12
 
 importers:
 
@@ -1025,7 +1024,7 @@ importers:
         version: 2.0.35(zod@4.1.12)
       '@authenio/samlify-node-xmllint':
         specifier: 'catalog:'
-        version: 2.0.0(samlify@2.11.0)
+        version: 2.0.0(samlify@2.12.0)
       '@aws-sdk/client-sesv2':
         specifier: 'catalog:'
         version: 3.928.0
@@ -1277,7 +1276,7 @@ importers:
         version: 10.25.0
       lodash-es:
         specifier: 'catalog:'
-        version: 4.17.23
+        version: 4.18.0
       marked:
         specifier: 'catalog:'
         version: 16.4.1
@@ -1364,7 +1363,7 @@ importers:
         version: 4.59.0
       samlify:
         specifier: 'catalog:'
-        version: 2.11.0
+        version: 2.12.0
       sanitize-filename:
         specifier: 'catalog:'
         version: 1.6.3
@@ -1534,7 +1533,7 @@ importers:
         version: 3.15.3
       nodemailer-mailgun-transport:
         specifier: 'catalog:'
-        version: 2.1.5(lodash@4.17.23)(underscore@1.13.8)
+        version: 2.1.5(lodash@4.18.0)(underscore@1.13.8)
       oracledb:
         specifier: 'catalog:'
         version: 6.10.0
@@ -1857,8 +1856,8 @@ importers:
         specifier: 'catalog:'
         version: 1.7.6
       lodash:
-        specifier: 'catalog:'
-        version: 4.17.23
+        specifier: 4.18.0
+        version: 4.18.0
       mapbox-gl:
         specifier: 'catalog:'
         version: 1.13.3
@@ -1984,7 +1983,7 @@ importers:
         version: 1.13.5
       lodash-es:
         specifier: 'catalog:'
-        version: 4.17.23
+        version: 4.18.0
       nanoid:
         specifier: 'catalog:'
         version: 5.1.6
@@ -2098,7 +2097,7 @@ importers:
         version: 17.2.3
       lodash-es:
         specifier: 'catalog:'
-        version: 4.17.23
+        version: 4.18.0
     devDependencies:
       '@directus/tsconfig':
         specifier: 'catalog:'
@@ -2172,7 +2171,7 @@ importers:
         version: 11.3.2
       lodash-es:
         specifier: 'catalog:'
-        version: 4.17.23
+        version: 4.18.0
       zod:
         specifier: 'catalog:'
         version: 4.1.12
@@ -2503,7 +2502,7 @@ importers:
         version: link:../types
       lodash-es:
         specifier: 'catalog:'
-        version: 4.17.23
+        version: 4.18.0
     devDependencies:
       '@directus/tsconfig':
         specifier: 'catalog:'
@@ -2854,7 +2853,7 @@ importers:
         version: 6.0.1
       lodash-es:
         specifier: 'catalog:'
-        version: 4.17.23
+        version: 4.18.0
     devDependencies:
       '@directus/tsconfig':
         specifier: 'catalog:'
@@ -3040,7 +3039,7 @@ importers:
         version: 4.1.1
       lodash-es:
         specifier: 'catalog:'
-        version: 4.17.23
+        version: 4.18.0
       micromustache:
         specifier: 'catalog:'
         version: 8.0.3
@@ -3225,7 +3224,7 @@ importers:
         version: 9.0.5
       lodash-es:
         specifier: 'catalog:'
-        version: 4.17.23
+        version: 4.18.0
       mailparser:
         specifier: 3.9.3
         version: 3.9.3
@@ -7734,10 +7733,9 @@ packages:
     resolution: {integrity: sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q==}
     engines: {node: '>= 16'}
 
-  '@xmldom/xmldom@0.8.11':
-    resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
+  '@xmldom/xmldom@0.8.12':
+    resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
 
   '@yarnpkg/fslib@3.1.3':
     resolution: {integrity: sha512-LqfyD3r/8SJm8rPPfmGVHfp4Ag2xTKscDwihOJt+QNrtOeaLykikqKWoBVRBw1cCIbtU7kjT7l1JcWW26hAKtA==}
@@ -8325,10 +8323,6 @@ packages:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
 
-  camelcase@9.0.0:
-    resolution: {integrity: sha512-TO9xmyXTZ9HUHI8M1OnvExxYB0eYVS/1e5s7IDMTAoIcwUd+aNcFODs6Xk83mobk0velyHFQgA1yIrvYc6wclw==}
-    engines: {node: '>=20'}
-
   can-link@2.0.0:
     resolution: {integrity: sha512-2W2yAdkQQrrL0WM6BrGqkrLkWlVon8riZch0EBNklid2CZsOzZnqR5HE7W3Q3BrMWUop+9I2dpjyZqhSOYh6Yg==}
     engines: {node: '>=10'}
@@ -8646,7 +8640,7 @@ packages:
       just: ^0.1.8
       liquid-node: ^3.0.1
       liquor: ^0.0.5
-      lodash: ^4.17.20
+      lodash: 4.18.0
       marko: ^3.14.4
       mote: ^0.2.0
       mustache: ^3.0.0
@@ -11076,8 +11070,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash-es@4.17.23:
-    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
+  lodash-es@4.18.0:
+    resolution: {integrity: sha512-koAgswPPA+UTaPN64Etp+PGP+WT6oqOS2NMi5yDkMaiGw9qY4VxQbQF0mtKMyr4BlTznWyzePV5UpECTJQmSUA==}
+    deprecated: Bad release. Please use lodash-es@4.17.23 instead.
 
   lodash._baseiteratee@4.7.0:
     resolution: {integrity: sha512-nqB9M+wITz0BX/Q2xg6fQ8mLkyfF7MU7eE+MNBNjTHFKeKaZAPEzEg+E8LWxKWf1DQVflNEn9N49yAuqKh2mWQ==}
@@ -11164,8 +11159,9 @@ packages:
   lodash.uniqby@4.5.0:
     resolution: {integrity: sha512-IRt7cfTtHy6f1aRVA5n7kT8rgN3N1nH6MOWLcHfpWG2SH19E3JksLK38MktLxZDhlAjCP9jpIXkOnRXlu6oByQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.0:
+    resolution: {integrity: sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==}
+    deprecated: Bad release. Please use lodash@4.17.21 instead.
 
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
@@ -13066,8 +13062,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  samlify@2.11.0:
-    resolution: {integrity: sha512-1C9ukjlf0rRsuyqdzztqikdItqa33j9NCCDZgeBiWk0etU6vxNB+SWJKW4Flk07ZlhXeev/twALEKrPhIAyfDg==}
+  samlify@2.12.0:
+    resolution: {integrity: sha512-ewGsHyY4kInDH0BfprlAZ1rHpH1jBmbqYiXDbuI3t1Y8h71gqEt4Z7jdCFyPHFR8jItJkbdckTijUZGg14CDlg==}
 
   sanitize-filename@1.6.3:
     resolution: {integrity: sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==}
@@ -15093,14 +15089,14 @@ snapshots:
 
   '@assemblyscript/loader@0.19.23': {}
 
-  '@authenio/samlify-node-xmllint@2.0.0(samlify@2.11.0)':
+  '@authenio/samlify-node-xmllint@2.0.0(samlify@2.12.0)':
     dependencies:
       node-xmllint: 1.0.0
-      samlify: 2.11.0
+      samlify: 2.12.0
 
   '@authenio/xml-encryption@2.0.2':
     dependencies:
-      '@xmldom/xmldom': 0.8.11
+      '@xmldom/xmldom': 0.8.12
       escape-html: 1.0.3
       xpath: 0.0.32
 
@@ -20547,7 +20543,7 @@ snapshots:
 
   '@xmldom/is-dom-node@1.0.1': {}
 
-  '@xmldom/xmldom@0.8.11': {}
+  '@xmldom/xmldom@0.8.12': {}
 
   '@yarnpkg/fslib@3.1.3':
     dependencies:
@@ -20768,7 +20764,7 @@ snapshots:
       graceful-fs: 4.2.11
       is-stream: 2.0.1
       lazystream: 1.0.1
-      lodash: 4.17.23
+      lodash: 4.18.0
       normalize-path: 3.0.0
       readable-stream: 4.7.0
 
@@ -20923,7 +20919,7 @@ snapshots:
 
   async@2.6.4:
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.0
 
   async@3.2.6: {}
 
@@ -21287,8 +21283,6 @@ snapshots:
 
   camelcase@8.0.0: {}
 
-  camelcase@9.0.0: {}
-
   can-link@2.0.0: {}
 
   can-write-to-dir@1.1.1:
@@ -21582,11 +21576,11 @@ snapshots:
   console-control-strings@1.1.0:
     optional: true
 
-  consolidate@0.15.1(lodash@4.17.23)(underscore@1.13.8):
+  consolidate@0.15.1(lodash@4.18.0)(underscore@1.13.8):
     dependencies:
       bluebird: 3.7.2
     optionalDependencies:
-      lodash: 4.17.23
+      lodash: 4.18.0
       underscore: 1.13.8
     optional: true
 
@@ -24032,7 +24026,7 @@ snapshots:
       get-package-type: 0.1.0
       getopts: 2.3.0
       interpret: 2.2.0
-      lodash: 4.17.23
+      lodash: 4.18.0
       pg-connection-string: 2.6.2
       rechoir: 0.8.0
       resolve-from: 5.0.0
@@ -24189,7 +24183,7 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash-es@4.17.23: {}
+  lodash-es@4.18.0: {}
 
   lodash._baseiteratee@4.7.0:
     dependencies:
@@ -24257,7 +24251,7 @@ snapshots:
       lodash._baseiteratee: 4.7.0
       lodash._baseuniq: 4.6.0
 
-  lodash@4.17.23: {}
+  lodash@4.18.0: {}
 
   log-symbols@6.0.0:
     dependencies:
@@ -24820,9 +24814,9 @@ snapshots:
 
   node-xmllint@1.0.0: {}
 
-  nodemailer-mailgun-transport@2.1.5(lodash@4.17.23)(underscore@1.13.8):
+  nodemailer-mailgun-transport@2.1.5(lodash@4.18.0)(underscore@1.13.8):
     dependencies:
-      consolidate: 0.15.1(lodash@4.17.23)(underscore@1.13.8)
+      consolidate: 0.15.1(lodash@4.18.0)(underscore@1.13.8)
       form-data: 4.0.5
       mailgun.js: 8.2.2
     transitivePeerDependencies:
@@ -26494,11 +26488,10 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  samlify@2.11.0:
+  samlify@2.12.0:
     dependencies:
       '@authenio/xml-encryption': 2.0.2
-      '@xmldom/xmldom': 0.8.11
-      camelcase: 9.0.0
+      '@xmldom/xmldom': 0.8.12
       node-rsa: 1.1.1
       xml: 1.0.1
       xml-crypto: 6.1.2
@@ -28604,7 +28597,7 @@ snapshots:
   xml-crypto@6.1.2:
     dependencies:
       '@xmldom/is-dom-node': 1.0.1
-      '@xmldom/xmldom': 0.8.11
+      '@xmldom/xmldom': 0.8.12
       xpath: 0.0.33
 
   xml-escape@1.1.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -948,6 +948,7 @@ overrides:
   micromatch>picomatch: 2.3.2
   anymatch>picomatch: 2.3.2
   picomatch: 4.0.4
+  defu: 6.1.5
 
 importers:
 
@@ -9151,8 +9152,8 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+  defu@6.1.5:
+    resolution: {integrity: sha512-pwdBJxJuJXmqrLO6s0VBmfbRz+G7FUzkjldAsdi9Yrv86mPyzq0ll1o8+8gB4Gsr6GJHbK1Lh3ngllgTInDCjA==}
 
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
@@ -21952,7 +21953,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
-  defu@6.1.4: {}
+  defu@6.1.5: {}
 
   degenerator@5.0.1:
     dependencies:
@@ -23371,7 +23372,7 @@ snapshots:
       change-case: 4.1.2
       chokidar: 3.6.0
       connect: 3.7.0
-      defu: 6.1.4
+      defu: 6.1.5
       diacritics: 1.3.0
       flexsearch: 0.7.21
       fs-extra: 10.1.0
@@ -26232,7 +26233,7 @@ snapshots:
       '@vueuse/core': 14.2.1(vue@3.5.24(typescript@5.9.3))
       '@vueuse/shared': 14.2.1(vue@3.5.24(typescript@5.9.3))
       aria-hidden: 1.2.6
-      defu: 6.1.4
+      defu: 6.1.5
       ohash: 2.0.11
       vue: 3.5.24(typescript@5.9.3)
     transitivePeerDependencies:
@@ -27847,7 +27848,7 @@ snapshots:
   unconfig@7.3.3:
     dependencies:
       '@quansync/fs': 0.1.5
-      defu: 6.1.4
+      defu: 6.1.5
       jiti: 2.6.1
       quansync: 0.2.11
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -655,11 +655,11 @@ catalogs:
       specifier: 10.25.0
       version: 10.25.0
     lodash:
-      specifier: 4.18.0
-      version: 4.18.0
+      specifier: 4.18.1
+      version: 4.18.1
     lodash-es:
-      specifier: 4.18.0
-      version: 4.18.0
+      specifier: 4.18.1
+      version: 4.18.1
     log-symbols:
       specifier: 7.0.1
       version: 7.0.1
@@ -1279,7 +1279,7 @@ importers:
         version: 10.25.0
       lodash-es:
         specifier: 'catalog:'
-        version: 4.18.0
+        version: 4.18.1
       marked:
         specifier: 'catalog:'
         version: 16.4.1
@@ -1536,7 +1536,7 @@ importers:
         version: 3.15.3
       nodemailer-mailgun-transport:
         specifier: 'catalog:'
-        version: 2.1.5(lodash@4.18.0)(underscore@1.13.8)
+        version: 2.1.5(lodash@4.18.1)(underscore@1.13.8)
       oracledb:
         specifier: 'catalog:'
         version: 6.10.0
@@ -1860,7 +1860,7 @@ importers:
         version: 1.7.6
       lodash:
         specifier: 'catalog:'
-        version: 4.18.0
+        version: 4.18.1
       mapbox-gl:
         specifier: 'catalog:'
         version: 1.13.3
@@ -1986,7 +1986,7 @@ importers:
         version: 1.13.5
       lodash-es:
         specifier: 'catalog:'
-        version: 4.18.0
+        version: 4.18.1
       nanoid:
         specifier: 'catalog:'
         version: 5.1.6
@@ -2100,7 +2100,7 @@ importers:
         version: 17.2.3
       lodash-es:
         specifier: 'catalog:'
-        version: 4.18.0
+        version: 4.18.1
     devDependencies:
       '@directus/tsconfig':
         specifier: 'catalog:'
@@ -2174,7 +2174,7 @@ importers:
         version: 11.3.2
       lodash-es:
         specifier: 'catalog:'
-        version: 4.18.0
+        version: 4.18.1
       zod:
         specifier: 'catalog:'
         version: 4.1.12
@@ -2505,7 +2505,7 @@ importers:
         version: link:../types
       lodash-es:
         specifier: 'catalog:'
-        version: 4.18.0
+        version: 4.18.1
     devDependencies:
       '@directus/tsconfig':
         specifier: 'catalog:'
@@ -2856,7 +2856,7 @@ importers:
         version: 6.0.1
       lodash-es:
         specifier: 'catalog:'
-        version: 4.18.0
+        version: 4.18.1
     devDependencies:
       '@directus/tsconfig':
         specifier: 'catalog:'
@@ -3042,7 +3042,7 @@ importers:
         version: 4.1.1
       lodash-es:
         specifier: 'catalog:'
-        version: 4.18.0
+        version: 4.18.1
       micromustache:
         specifier: 'catalog:'
         version: 8.0.3
@@ -3227,7 +3227,7 @@ importers:
         version: 9.0.5
       lodash-es:
         specifier: 'catalog:'
-        version: 4.18.0
+        version: 4.18.1
       mailparser:
         specifier: 3.9.3
         version: 3.9.3
@@ -11085,9 +11085,8 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash-es@4.18.0:
-    resolution: {integrity: sha512-koAgswPPA+UTaPN64Etp+PGP+WT6oqOS2NMi5yDkMaiGw9qY4VxQbQF0mtKMyr4BlTznWyzePV5UpECTJQmSUA==}
-    deprecated: Bad release. Please use lodash-es@4.17.23 instead.
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash._baseiteratee@4.7.0:
     resolution: {integrity: sha512-nqB9M+wITz0BX/Q2xg6fQ8mLkyfF7MU7eE+MNBNjTHFKeKaZAPEzEg+E8LWxKWf1DQVflNEn9N49yAuqKh2mWQ==}
@@ -11177,6 +11176,9 @@ packages:
   lodash@4.18.0:
     resolution: {integrity: sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==}
     deprecated: Bad release. Please use lodash@4.17.21 instead.
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
@@ -21615,11 +21617,11 @@ snapshots:
   console-control-strings@1.1.0:
     optional: true
 
-  consolidate@0.15.1(lodash@4.18.0)(underscore@1.13.8):
+  consolidate@0.15.1(lodash@4.18.1)(underscore@1.13.8):
     dependencies:
       bluebird: 3.7.2
     optionalDependencies:
-      lodash: 4.18.0
+      lodash: 4.18.1
       underscore: 1.13.8
     optional: true
 
@@ -24222,7 +24224,7 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash-es@4.18.0: {}
+  lodash-es@4.18.1: {}
 
   lodash._baseiteratee@4.7.0:
     dependencies:
@@ -24291,6 +24293,8 @@ snapshots:
       lodash._baseuniq: 4.6.0
 
   lodash@4.18.0: {}
+
+  lodash@4.18.1: {}
 
   log-symbols@6.0.0:
     dependencies:
@@ -24865,9 +24869,9 @@ snapshots:
 
   node-xmllint@1.0.0: {}
 
-  nodemailer-mailgun-transport@2.1.5(lodash@4.18.0)(underscore@1.13.8):
+  nodemailer-mailgun-transport@2.1.5(lodash@4.18.1)(underscore@1.13.8):
     dependencies:
-      consolidate: 0.15.1(lodash@4.18.0)(underscore@1.13.8)
+      consolidate: 0.15.1(lodash@4.18.1)(underscore@1.13.8)
       form-data: 4.0.5
       mailgun.js: 8.2.2
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -228,8 +228,8 @@ catalog:
   ky: 1.14.0
   ldapts: 8.1.3
   liquidjs: 10.25.0
-  lodash: 4.18.0
-  lodash-es: 4.18.0
+  lodash: 4.18.1
+  lodash-es: 4.18.1
   log-symbols: 7.0.1
   lru-cache: 11.2.2
   mapbox-gl: 1.13.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -228,8 +228,8 @@ catalog:
   ky: 1.14.0
   ldapts: 8.1.3
   liquidjs: 10.25.0
-  lodash: 4.17.23
-  lodash-es: 4.17.23
+  lodash: 4.18.0
+  lodash-es: 4.18.0
   log-symbols: 7.0.1
   lru-cache: 11.2.2
   mapbox-gl: 1.13.3
@@ -280,7 +280,7 @@ catalog:
   rollup-plugin-esbuild: 6.2.1
   rollup-plugin-node-externals: 8.1.2
   rollup-plugin-styler: 2.0.0
-  samlify: 2.11.0
+  samlify: 2.12.0
   sanitize-filename: 1.6.3
   sanitize-html: 2.17.0
   sass-embedded: 1.93.3


### PR DESCRIPTION
## Scope

What's changed:

Updated:
- `lodash`/`lodash-es` `4.17.23 -> 4.18.1` https://github.com/advisories/GHSA-r5fr-rjxr-66jc 
- `samlify` `2.11.0 -> 2.12.0` in an attempt to bump `@xmldom/xmldom` https://github.com/advisories/GHSA-wh4c-j3r5-mjhp
- override `defu` `6.1.4` -> `6.1.5`

## Potential Risks / Drawbacks

- No large version bumps

