### PR TITLE
Replace "All Users" tab with Active, Suspended, and Invited status tabs

### DIFF
--- a/.changeset/goofy-eels-smile.md
+++ b/.changeset/goofy-eels-smile.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Replace "All Users" tab with Active, Suspended, and Invited status tabs

--- a/.changeset/goofy-eels-smile.md
+++ b/.changeset/goofy-eels-smile.md
@@ -2,4 +2,4 @@
 '@directus/app': minor
 ---
 
-Replace "All Users" tab with Active, Suspended, and Invited status tabs
+Replaced "All Users" tab with Active, Suspended, and Invited status tabs

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -767,6 +767,10 @@ file_count: 'No Files | One File | {count} Files'
 no_files_copy: There are no files here.
 user_count: 'No Users | One User | {count} Users'
 no_users_copy: There are no users in this role yet.
+no_active_users: No Active Users
+no_suspended_users: No Suspended Users
+no_invited_users: No Invited Users
+no_status_users_copy: 'There are no users with a status of {status}.'
 no_notifications: No Notifications
 no_notifications_copy: You're all caught up!
 activity_log: Activity Log
@@ -914,6 +918,9 @@ flip_vertical: Flip Vertical
 aspect_ratio: Aspect Ratio
 rotate: Rotate
 all_users: All Users
+active_users: Active Users
+suspended_users: Suspended Users
+invited_users: Invited Users
 delete_collection: Delete Collection
 update_collection_success: Updated Collection
 delete_collection_success: Deleted Collection

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -770,7 +770,7 @@ no_users_copy: There are no users in this role yet.
 no_active_users: No Active Users
 no_suspended_users: No Suspended Users
 no_invited_users: No Invited Users
-no_status_users_copy: There are no users with this status.
+no_status_users_copy: 'There are no users with {status} status.'
 no_notifications: No Notifications
 no_notifications_copy: You're all caught up!
 activity_log: Activity Log

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -770,7 +770,7 @@ no_users_copy: There are no users in this role yet.
 no_active_users: No Active Users
 no_suspended_users: No Suspended Users
 no_invited_users: No Invited Users
-no_status_users_copy: 'There are no users with a status of {status}.'
+no_status_users_copy: There are no users with this status.
 no_notifications: No Notifications
 no_notifications_copy: You're all caught up!
 activity_log: Activity Log

--- a/app/src/modules/users/components/navigation.vue
+++ b/app/src/modules/users/components/navigation.vue
@@ -29,9 +29,17 @@ function handleClick({ role }: { role: string }) {
 
 <template>
 	<VList nav>
-		<VListItem to="/users" exact :active="!currentRole">
+		<VListItem to="/users/active" exact>
 			<VListItemIcon><VIcon name="folder_shared" /></VListItemIcon>
-			<VListItemContent>{{ $t('all_users') }}</VListItemContent>
+			<VListItemContent>{{ $t('active_users') }}</VListItemContent>
+		</VListItem>
+		<VListItem to="/users/suspended" exact>
+			<VListItemIcon><VIcon name="pause_circle" /></VListItemIcon>
+			<VListItemContent>{{ $t('suspended_users') }}</VListItemContent>
+		</VListItem>
+		<VListItem to="/users/invited" exact>
+			<VListItemIcon><VIcon name="person_add" /></VListItemIcon>
+			<VListItemContent>{{ $t('invited_users') }}</VListItemContent>
 		</VListItem>
 
 		<VDivider v-if="(roles && roles.length > 0) || loading" />

--- a/app/src/modules/users/components/navigation.vue
+++ b/app/src/modules/users/components/navigation.vue
@@ -30,11 +30,11 @@ function handleClick({ role }: { role: string }) {
 <template>
 	<VList nav>
 		<VListItem to="/users/active" exact>
-			<VListItemIcon><VIcon name="folder_shared" /></VListItemIcon>
+			<VListItemIcon><VIcon name="group" /></VListItemIcon>
 			<VListItemContent>{{ $t('active_users') }}</VListItemContent>
 		</VListItem>
 		<VListItem to="/users/suspended" exact>
-			<VListItemIcon><VIcon name="pause_circle" /></VListItemIcon>
+			<VListItemIcon><VIcon name="group_off" /></VListItemIcon>
 			<VListItemContent>{{ $t('suspended_users') }}</VListItemContent>
 		</VListItem>
 		<VListItem to="/users/invited" exact>

--- a/app/src/modules/users/index.ts
+++ b/app/src/modules/users/index.ts
@@ -8,9 +8,26 @@ export default defineModule({
 	icon: 'people_alt',
 	routes: [
 		{
-			name: 'users-collection',
 			path: '',
+			redirect: '/users/active',
+		},
+		{
+			name: 'users-active',
+			path: 'active',
 			component: Collection,
+			props: () => ({ status: 'active' }),
+		},
+		{
+			name: 'users-suspended',
+			path: 'suspended',
+			component: Collection,
+			props: () => ({ status: 'suspended' }),
+		},
+		{
+			name: 'users-invited',
+			path: 'invited',
+			component: Collection,
+			props: () => ({ status: 'invited' }),
 		},
 		{
 			name: 'users-item',

--- a/app/src/modules/users/routes/collection.vue
+++ b/app/src/modules/users/routes/collection.vue
@@ -28,7 +28,7 @@ import LayoutSidebarDetail from '@/views/private/components/layout-sidebar-detai
 import SearchInput from '@/views/private/components/search-input.vue';
 import UsersInvite from '@/views/private/components/users-invite.vue';
 
-const props = defineProps<{ role?: string }>();
+const props = defineProps<{ role?: string; status?: string }>();
 
 const { role } = toRefs(props);
 
@@ -63,6 +63,24 @@ const roleFilter = computed(() => {
 
 	return null;
 });
+
+const statusFilter = computed(() => {
+	if (props.status) {
+		return {
+			_and: [
+				{
+					status: {
+						_eq: props.status,
+					},
+				},
+			],
+		};
+	}
+
+	return null;
+});
+
+const combinedSystemFilter = computed(() => mergeFilters(roleFilter.value, statusFilter.value));
 
 const {
 	createAllowed,
@@ -161,6 +179,7 @@ function useBreadcrumb() {
 	});
 
 	const title = computed(() => {
+		if (props.status) return t(`${props.status}_users`);
 		if (!props.role) return t('user_directory');
 		return roles.value?.find((role) => role.id === props.role)?.name;
 	});
@@ -182,9 +201,9 @@ function clearFilters() {
 		v-model:selection="selection"
 		v-model:layout-options="layoutOptions"
 		v-model:layout-query="layoutQuery"
-		:filter="mergeFilters(filter, roleFilter)"
+		:filter="mergeFilters(filter, combinedSystemFilter)"
 		:filter-user="filter"
-		:filter-system="roleFilter"
+		:filter-system="combinedSystemFilter"
 		:search="search"
 		collection="directus_users"
 		:reset-preset="resetPreset"
@@ -260,10 +279,15 @@ function clearFilters() {
 
 			<component :is="`layout-${layout}`" v-bind="layoutState">
 				<template #no-results>
-					<VInfo v-if="!filter && !search" :title="$t('user_count', 0)" icon="people_alt" center>
-						{{ $t('no_users_copy') }}
+					<VInfo
+						v-if="!filter && !search"
+						:title="status ? $t(`no_${status}_users`) : $t('user_count', 0)"
+						icon="people_alt"
+						center
+					>
+						{{ status ? $t('no_status_users_copy', { status }) : $t('no_users_copy') }}
 
-						<template v-if="canInviteUsers" #append>
+						<template v-if="canInviteUsers && (!status || status === 'active')" #append>
 							<VButton :to="role ? { path: `/users/roles/${role}/+` } : { path: '/users/+' }">
 								{{ $t('create_user') }}
 							</VButton>
@@ -280,10 +304,10 @@ function clearFilters() {
 				</template>
 
 				<template #no-items>
-					<VInfo :title="$t('user_count', 0)" icon="people_alt" center>
-						{{ $t('no_users_copy') }}
+					<VInfo :title="status ? $t(`no_${status}_users`) : $t('user_count', 0)" icon="people_alt" center>
+						{{ status ? $t('no_status_users_copy', { status }) : $t('no_users_copy') }}
 
-						<template v-if="canInviteUsers" #append>
+						<template v-if="canInviteUsers && (!status || status === 'active')" #append>
 							<VButton :to="role ? { path: `/users/roles/${role}/+` } : { path: '/users/+' }">
 								{{ $t('create_user') }}
 							</VButton>
@@ -307,8 +331,8 @@ function clearFilters() {
 				<ExportSidebarDetail
 					collection="directus_users"
 					:layout-query="layoutQuery"
-					:filter="mergeFilters(filter, roleFilter)"
-					:search="search"
+					:filter="mergeFilters(filter, combinedSystemFilter) ?? undefined"
+					:search="search ?? undefined"
 					@refresh="refresh"
 				/>
 			</template>

--- a/app/src/modules/users/routes/collection.vue
+++ b/app/src/modules/users/routes/collection.vue
@@ -280,7 +280,7 @@ function clearFilters() {
 			<component :is="`layout-${layout}`" v-bind="layoutState">
 				<template #no-results>
 					<VInfo v-if="!filter && !search" :title="$t('user_count', 0)" icon="people_alt" center>
-						{{ status ? $t('no_status_users_copy') : $t('no_users_copy') }}
+						{{ status ? $t('no_status_users_copy', { status }) : $t('no_users_copy') }}
 
 						<template v-if="canInviteUsers && (!status || status === 'active')" #append>
 							<VButton :to="role ? { path: `/users/roles/${role}/+` } : { path: '/users/+' }">
@@ -300,7 +300,7 @@ function clearFilters() {
 
 				<template #no-items>
 					<VInfo v-if="!layoutState.loadingItemCount" :title="$t('user_count', 0)" icon="people_alt" center>
-						{{ status ? $t('no_status_users_copy') : $t('no_users_copy') }}
+						{{ status ? $t('no_status_users_copy', { status }) : $t('no_users_copy') }}
 
 						<template v-if="canInviteUsers && (!status || status === 'active')" #append>
 							<VButton :to="role ? { path: `/users/roles/${role}/+` } : { path: '/users/+' }">

--- a/app/src/modules/users/routes/collection.vue
+++ b/app/src/modules/users/routes/collection.vue
@@ -304,7 +304,12 @@ function clearFilters() {
 				</template>
 
 				<template #no-items>
-					<VInfo :title="status ? $t(`no_${status}_users`) : $t('user_count', 0)" icon="people_alt" center>
+					<VInfo
+						v-if="!layoutState.loadingItemCount"
+						:title="status ? $t(`no_${status}_users`) : $t('user_count', 0)"
+						icon="people_alt"
+						center
+					>
 						{{ status ? $t('no_status_users_copy', { status }) : $t('no_users_copy') }}
 
 						<template v-if="canInviteUsers && (!status || status === 'active')" #append>

--- a/app/src/modules/users/routes/collection.vue
+++ b/app/src/modules/users/routes/collection.vue
@@ -279,13 +279,8 @@ function clearFilters() {
 
 			<component :is="`layout-${layout}`" v-bind="layoutState">
 				<template #no-results>
-					<VInfo
-						v-if="!filter && !search"
-						:title="status ? $t(`no_${status}_users`) : $t('user_count', 0)"
-						icon="people_alt"
-						center
-					>
-						{{ status ? $t('no_status_users_copy', { status }) : $t('no_users_copy') }}
+					<VInfo v-if="!filter && !search" :title="$t('user_count', 0)" icon="people_alt" center>
+						{{ status ? $t('no_status_users_copy') : $t('no_users_copy') }}
 
 						<template v-if="canInviteUsers && (!status || status === 'active')" #append>
 							<VButton :to="role ? { path: `/users/roles/${role}/+` } : { path: '/users/+' }">
@@ -304,13 +299,8 @@ function clearFilters() {
 				</template>
 
 				<template #no-items>
-					<VInfo
-						v-if="!layoutState.loadingItemCount"
-						:title="status ? $t(`no_${status}_users`) : $t('user_count', 0)"
-						icon="people_alt"
-						center
-					>
-						{{ status ? $t('no_status_users_copy', { status }) : $t('no_users_copy') }}
+					<VInfo v-if="!layoutState.loadingItemCount" :title="$t('user_count', 0)" icon="people_alt" center>
+						{{ status ? $t('no_status_users_copy') : $t('no_users_copy') }}
 
 						<template v-if="canInviteUsers && (!status || status === 'active')" #append>
 							<VButton :to="role ? { path: `/users/roles/${role}/+` } : { path: '/users/+' }">

--- a/app/src/stores/presets.ts
+++ b/app/src/stores/presets.ts
@@ -41,18 +41,22 @@ const systemDefaults: Record<string, Partial<Preset>> = {
 	},
 	directus_users: {
 		collection: 'directus_users',
-		layout: 'cards',
+		layout: 'tabular',
 		layout_query: {
-			cards: {
+			tabular: {
 				sort: ['email'],
+				fields: ['avatar', 'first_name', 'last_name', 'email', 'role'],
 			},
 		},
 		layout_options: {
-			cards: {
-				icon: 'account_circle',
-				title: '{{ first_name }} {{ last_name }}',
-				subtitle: '{{ email }}',
-				size: 4,
+			tabular: {
+				widths: {
+					avatar: 36,
+					first_name: 200,
+					last_name: 200,
+					email: 300,
+					role: 200,
+				},
 			},
 		},
 	},


### PR DESCRIPTION
 ## Scope                                                                                                                           
                                                                                                                                     
  What's changed:
                                                                                                                                     
  - Replaced the single "All Users" navigation item in the User Directory with three status-specific tabs: **Active Users**,         
  **Suspended Users**, and **Invited Users**
  - Added routes `/users/active`, `/users/suspended`, `/users/invited` (the`/users` path now redirects to `/users/active`)        
                                                                                                                                     
  ## Potential Risks / Drawbacks                                                                                                     
                                                                                                                                     
  - The /users route no longer exists, though it will redirect to /users/active now. I don't think this will be an issue, but keep this in mind when testing.
  - You can no longer see all the users in a single list.                                                                                       
   
  ## Tested Scenarios                                                                                                                
                  
  - Navigating to `/users` redirects to `/users/active`                                                                              
  - Each tab (Active, Suspended, Invited) filters users correctly by status
  - Empty state shows correct message and icon for each status tab                                                                   
  - "Create User" button appears on Active tab and is hidden on Suspended/Invited tabs                                                                                                                        
                                                                                                                                     
  ## Review Notes / Questions                                                                                                        
  I'm not so sure we need the Create Users button for the zero state on any of the tabs. Right now I only have it showing for the zero state of the active users tab, but to even get there, you'd have to be using an active user, so I don't think there can be a zero state here?        
                                                                                                                                     
  ## Checklist                                                                                                                       
                                                                                                                                     
  - [ ] Added or updated tests                                                                                                       
  - [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
  - [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required                                       
                                                                                                                                     
  ---                                                                                                                                
                                                                                                                                     
  Fixes [CMS-2073](https://linear.app/directus/issue/CMS-2073/change-user-directory-tabs-to-active-suspended-invited)                                              