### PR TITLE
Fix block editor content loss

### DIFF
--- a/.changeset/cyan-cars-agree.md
+++ b/.changeset/cyan-cars-agree.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed block editor content duplication on save-and-stay, stale save emissions, premature translation row creation while relation items are loading, and duplicate relation update entries

--- a/app/src/composables/use-relation-multiple.test.ts
+++ b/app/src/composables/use-relation-multiple.test.ts
@@ -214,6 +214,45 @@ describe('test o2m relation', () => {
 		});
 	});
 
+	test('updating same item twice without metadata should replace update entry', async () => {
+		const wrapper = mount(TestComponent, {
+			props: { relation: relationO2M, value: [], id: 1 },
+		});
+
+		wrapper.vm.update({ id: 2, name: 'first-update' });
+		wrapper.vm.update({ id: 2, name: 'second-update' });
+
+		await flushPromises();
+
+		expect(wrapper.vm.value).toEqual({
+			create: [],
+			update: [
+				{
+					id: 2,
+					name: 'second-update',
+				},
+			],
+			delete: [],
+		});
+	});
+
+	test('updating items without a pk twice should append both entries (pk=undefined always appends)', async () => {
+		const wrapper = mount(TestComponent, {
+			props: { relation: relationO2M, value: [], id: 1 },
+		});
+
+		wrapper.vm.update({ name: 'first-no-pk' });
+		wrapper.vm.update({ name: 'second-no-pk' });
+
+		await flushPromises();
+
+		expect(wrapper.vm.value).toEqual({
+			create: [],
+			update: [{ name: 'first-no-pk' }, { name: 'second-no-pk' }],
+			delete: [],
+		});
+	});
+
 	test('removing an item', async () => {
 		const wrapper = mount(TestComponent, {
 			props: { relation: relationO2M, value: [], id: 1 },

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -255,7 +255,17 @@ export function useRelationMultiple(
 
 			for (const item of items) {
 				if (item.$type === undefined || item.$index === undefined) {
-					target.value.update.push(cleanItem(item));
+					const clean = cleanItem(item);
+					const pk = clean[targetPKField.value];
+
+					const existingIndex =
+						pk === undefined ? -1 : target.value.update.findIndex((existing) => existing[targetPKField.value] === pk);
+
+					if (existingIndex === -1) {
+						target.value.update.push(clean);
+					} else {
+						target.value.update[existingIndex] = clean;
+					}
 				} else if (item.$type === 'created') {
 					target.value.create[item.$index] = cleanItem(item);
 				} else if (item.$type === 'updated') {

--- a/app/src/interfaces/input-block-editor/input-block-editor.test.ts
+++ b/app/src/interfaces/input-block-editor/input-block-editor.test.ts
@@ -1,40 +1,100 @@
 import EditorJS from '@editorjs/editorjs';
 import { flushPromises, mount } from '@vue/test-utils';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import InputBlockEditor from './input-block-editor.vue';
 
 vi.mock('@editorjs/editorjs', () => ({ default: vi.fn() }));
-vi.mock('./tools', () => ({ default: vi.fn(() => ({})) }));
+vi.mock('./tools', () => ({ default: () => ({}) }));
 vi.mock('@/api', () => ({ default: { defaults: { baseURL: '' } } }));
-vi.mock('@/stores/collections', () => ({ useCollectionsStore: () => ({ getCollection: () => null }) }));
-vi.mock('@/stores/server', () => ({ useServerStore: () => ({ info: { files: { mimeTypeAllowList: null } } }) }));
+vi.mock('@/stores/collections', () => ({ useCollectionsStore: () => ({ getCollection: () => false }) }));
+vi.mock('@/stores/server', () => ({ useServerStore: () => ({ info: {} }) }));
 vi.mock('vue-router', () => ({ useRouter: () => ({ push: vi.fn() }) }));
 vi.mock('@/utils/unexpected-error', () => ({ unexpectedError: vi.fn() }));
 
 describe('InputBlockEditor', () => {
-	it('should render content before toggling readOnly on concurrent prop change', async () => {
-		const callOrder: string[] = [];
-		let resolveReady!: () => void;
-		let resolveRender!: () => void;
+	test('should discard stale emitValue results when saves resolve out of order', async () => {
+		let onChangeHandler: ((api: EditorJS.API | EditorJS) => void) | undefined;
+		const saveResolvers: Array<(value: any) => void> = [];
 
-		vi.mocked(EditorJS).mockImplementation(
+		const save = vi.fn(
 			() =>
-				({
-					isReady: new Promise<void>((r) => (resolveReady = r)),
-					render: vi.fn(() => {
-						callOrder.push('render');
-						return new Promise<void>((r) => (resolveRender = r));
-					}),
-					clear: vi.fn(),
-					destroy: vi.fn(),
-					focus: vi.fn(),
-					on: vi.fn(),
-					saver: { save: vi.fn().mockResolvedValue({ blocks: [] }) },
-					readOnly: {
-						toggle: vi.fn((val: boolean) => callOrder.push(`toggle:${val}`)),
-					},
-				}) as any,
+				new Promise((resolve) => {
+					saveResolvers.push(resolve);
+				}),
 		);
+
+		const editorInstance = {
+			isReady: Promise.resolve(),
+			render: vi.fn().mockResolvedValue(undefined),
+			clear: vi.fn(),
+			destroy: vi.fn(),
+			focus: vi.fn(),
+			on: vi.fn(),
+			saver: { save },
+			readOnly: { toggle: vi.fn() },
+		} as any;
+
+		vi.mocked(EditorJS).mockImplementation((options: any) => {
+			onChangeHandler = options.onChange;
+			return editorInstance;
+		});
+
+		const wrapper = mount(InputBlockEditor, {
+			props: { value: null },
+			global: {
+				directives: { 'prevent-focusout': {} },
+				stubs: { VDrawer: true, VUpload: true },
+			},
+		});
+
+		await flushPromises();
+		expect(onChangeHandler).toBeDefined();
+
+		onChangeHandler!(editorInstance);
+		onChangeHandler!(editorInstance);
+		expect(save).toHaveBeenCalledTimes(2);
+
+		saveResolvers[1]?.({
+			blocks: [{ type: 'paragraph', data: { text: 'newer' } }],
+		});
+
+		await flushPromises();
+
+		saveResolvers[0]?.({
+			blocks: [{ type: 'paragraph', data: { text: 'older' } }],
+		});
+
+		await flushPromises();
+
+		expect(wrapper.emitted('input')).toEqual([
+			[
+				{
+					blocks: [{ type: 'paragraph', data: { text: 'newer' } }],
+				},
+			],
+		]);
+
+		wrapper.unmount();
+	});
+
+	test('should destroy and recreate the editor when value blocks change', async () => {
+		const created: any[] = [];
+
+		vi.mocked(EditorJS).mockImplementation(() => {
+			const inst = {
+				isReady: Promise.resolve(),
+				render: vi.fn().mockResolvedValue(undefined),
+				clear: vi.fn().mockResolvedValue(undefined),
+				destroy: vi.fn(),
+				focus: vi.fn(),
+				on: vi.fn(),
+				saver: { save: vi.fn().mockResolvedValue({ blocks: [] }) },
+				readOnly: { toggle: vi.fn() },
+			} as any;
+
+			created.push(inst);
+			return inst;
+		});
 
 		const wrapper = mount(InputBlockEditor, {
 			props: {
@@ -47,31 +107,90 @@ describe('InputBlockEditor', () => {
 			},
 		});
 
-		// Complete initial mount
-		resolveReady();
 		await flushPromises();
-		resolveRender();
-		await flushPromises();
-		callOrder.length = 0;
+		expect(created).toHaveLength(1);
 
-		// Both props change in the same tick — triggers disabled + value watchers
 		await wrapper.setProps({
-			disabled: true,
 			value: { blocks: [{ type: 'paragraph', data: { text: 'updated' } }] },
 		});
 
 		await flushPromises();
 
-		// Without the fix, the sync disabled watcher fires toggle before the value watcher calls render
-		expect(callOrder.indexOf('render')).toBeLessThan(callOrder.indexOf('toggle:true'));
+		expect(created[0]!.destroy).toHaveBeenCalled();
+		expect(created).toHaveLength(2);
 
-		resolveRender();
-		await flushPromises();
+		expect(created[1]!.render).toHaveBeenCalledWith(
+			expect.objectContaining({
+				blocks: [{ type: 'paragraph', data: { text: 'updated' } }],
+			}),
+		);
+
 		wrapper.unmount();
 	});
 
-	it('should not clear content when value becomes null while disabled', async () => {
-		// This test should prevent a regression that results in data loss when the value is temporarily null and the field is disabled
+	test('should apply a value queued in pendingRender after the current renderValue completes', async () => {
+		const created: any[] = [];
+		let resolveBlockedRender!: () => void;
+
+		vi.mocked(EditorJS).mockImplementation(() => {
+			const isBlockedInstance = created.length === 1; // second instance (first-update render) blocks
+
+			const inst = {
+				isReady: Promise.resolve(),
+				render: vi.fn().mockImplementation(async () => {
+					if (isBlockedInstance) {
+						await new Promise<void>((r) => (resolveBlockedRender = r));
+					}
+				}),
+				clear: vi.fn().mockResolvedValue(undefined),
+				destroy: vi.fn(),
+				focus: vi.fn(),
+				on: vi.fn(),
+				saver: { save: vi.fn().mockResolvedValue({ blocks: [] }) },
+				readOnly: { toggle: vi.fn() },
+			} as any;
+
+			created.push(inst);
+			return inst;
+		});
+
+		const wrapper = mount(InputBlockEditor, {
+			props: { value: { blocks: [{ type: 'paragraph', data: { text: 'initial' } }] } },
+			global: {
+				directives: { 'prevent-focusout': {} },
+				stubs: { VDrawer: true, VUpload: true },
+			},
+		});
+
+		await flushPromises();
+		expect(created).toHaveLength(1);
+
+		// Trigger a render — second EditorJS instance will be created, render() blocks
+		wrapper.setProps({ value: { blocks: [{ type: 'paragraph', data: { text: 'first-update' } }] } });
+		await flushPromises();
+		expect(created).toHaveLength(2); // second instance created, render blocked
+
+		// Second update arrives while first renderValue is still in progress → goes to pendingRender
+		wrapper.setProps({ value: { blocks: [{ type: 'paragraph', data: { text: 'queued-update' } }] } });
+		await flushPromises();
+		expect(created).toHaveLength(2); // no new instance yet, still blocked
+
+		// Unblock the blocked render → pendingRender should be drained → third instance created
+		resolveBlockedRender!();
+		await flushPromises();
+
+		expect(created).toHaveLength(3);
+
+		expect(created[2]!.render).toHaveBeenCalledWith(
+			expect.objectContaining({
+				blocks: [{ type: 'paragraph', data: { text: 'queued-update' } }],
+			}),
+		);
+
+		wrapper.unmount();
+	});
+
+	test('should not clear content when value becomes null while disabled', async () => {
 		const clear = vi.fn();
 
 		vi.mocked(EditorJS).mockImplementation(
@@ -84,9 +203,7 @@ describe('InputBlockEditor', () => {
 					focus: vi.fn(),
 					on: vi.fn(),
 					saver: { save: vi.fn().mockResolvedValue({ blocks: [] }) },
-					readOnly: {
-						toggle: vi.fn(),
-					},
+					readOnly: { toggle: vi.fn() },
 				}) as any,
 		);
 
@@ -109,7 +226,167 @@ describe('InputBlockEditor', () => {
 		await wrapper.setProps({ value: null });
 		await flushPromises();
 
+		// clear() must not be called — the watcher exits early when value is null and disabled is true
 		expect(clear).not.toHaveBeenCalled();
+
+		wrapper.unmount();
+	});
+
+	test('should not block external value updates after a no-op onChange (haveValuesChanged fix)', async () => {
+		let onChangeHandler: ((api: EditorJS.API | EditorJS) => void) | undefined;
+
+		const save = vi.fn().mockResolvedValue({
+			blocks: [{ type: 'paragraph', data: { text: 'current' } }],
+		});
+
+		const created: any[] = [];
+
+		vi.mocked(EditorJS).mockImplementation((options: any) => {
+			onChangeHandler = options.onChange;
+
+			const inst = {
+				isReady: Promise.resolve(),
+				render: vi.fn().mockResolvedValue(undefined),
+				clear: vi.fn(),
+				destroy: vi.fn(),
+				focus: vi.fn(),
+				on: vi.fn(),
+				saver: { save },
+				readOnly: { toggle: vi.fn() },
+			} as any;
+
+			created.push(inst);
+			return inst;
+		});
+
+		const wrapper = mount(InputBlockEditor, {
+			props: { value: { blocks: [{ type: 'paragraph', data: { text: 'current' } }] } },
+			global: {
+				directives: { 'prevent-focusout': {} },
+				stubs: { VDrawer: true, VUpload: true },
+			},
+		});
+
+		await flushPromises();
+
+		// onChange fires but save() returns content equal to props.value → isEqual bails, no emit.
+		// Previously this set haveValuesChanged=true which blocked the next real update.
+		onChangeHandler!(created[0]!);
+		await flushPromises();
+		expect(wrapper.emitted('input')).toBeUndefined();
+
+		const instancesBefore = created.length;
+
+		// A real external update should NOT be blocked
+		await wrapper.setProps({
+			value: { blocks: [{ type: 'paragraph', data: { text: 'from-server' } }] },
+		});
+
+		await flushPromises();
+
+		// Destroy/recreate should have happened — exactly one new instance
+		expect(created.length).toBe(instancesBefore + 1);
+
+		wrapper.unmount();
+	});
+
+	test('should ignore emits triggered during programmatic render (isRendering guard)', async () => {
+		let onChangeHandler: ((api: EditorJS.API | EditorJS) => void) | undefined;
+
+		const save = vi.fn().mockResolvedValue({
+			blocks: [{ type: 'paragraph', data: { text: 'stale-during-render' } }],
+		});
+
+		const editorInstance = {
+			isReady: Promise.resolve(),
+			render: vi.fn(async () => {
+				onChangeHandler?.(editorInstance as any);
+			}),
+			clear: vi.fn(),
+			destroy: vi.fn(),
+			focus: vi.fn(),
+			on: vi.fn(),
+			saver: { save },
+			readOnly: { toggle: vi.fn() },
+		} as any;
+
+		vi.mocked(EditorJS).mockImplementation((options: any) => {
+			onChangeHandler = options.onChange;
+			return editorInstance;
+		});
+
+		const wrapper = mount(InputBlockEditor, {
+			props: {
+				disabled: false,
+				value: { blocks: [{ type: 'paragraph', data: { text: 'initial' } }] },
+			},
+			global: {
+				directives: { 'prevent-focusout': {} },
+				stubs: { VDrawer: true, VUpload: true },
+			},
+		});
+
+		await flushPromises();
+
+		await wrapper.setProps({
+			value: { blocks: [{ type: 'paragraph', data: { text: 'server-refresh' } }] },
+		});
+
+		await flushPromises();
+
+		expect(save).not.toHaveBeenCalled();
+		expect(wrapper.emitted('input')).toBeUndefined();
+
+		wrapper.unmount();
+	});
+
+	test('should skip re-render when parent echoes back the same blocks we just emitted', async () => {
+		let onChangeHandler: ((api: EditorJS.API | EditorJS) => void) | undefined;
+		const userBlocks = [{ type: 'paragraph', data: { text: 'typed' } }];
+
+		const created: any[] = [];
+
+		vi.mocked(EditorJS).mockImplementation((options: any) => {
+			onChangeHandler = options.onChange;
+
+			const inst = {
+				isReady: Promise.resolve(),
+				render: vi.fn().mockResolvedValue(undefined),
+				clear: vi.fn(),
+				destroy: vi.fn(),
+				focus: vi.fn(),
+				on: vi.fn(),
+				saver: { save: vi.fn().mockResolvedValue({ blocks: userBlocks }) },
+				readOnly: { toggle: vi.fn() },
+			} as any;
+
+			created.push(inst);
+			return inst;
+		});
+
+		const wrapper = mount(InputBlockEditor, {
+			props: { value: null },
+			global: {
+				directives: { 'prevent-focusout': {} },
+				stubs: { VDrawer: true, VUpload: true },
+			},
+		});
+
+		await flushPromises();
+
+		// User types something — we emit
+		onChangeHandler!(created[0]!);
+		await flushPromises();
+		expect(wrapper.emitted('input')).toHaveLength(1);
+
+		const instancesBefore = created.length;
+
+		// Parent echoes back the exact same blocks — haveValuesChanged should skip re-render
+		await wrapper.setProps({ value: { blocks: userBlocks } });
+		await flushPromises();
+
+		// No new editor instance should have been created (no destroy/recreate)
+		expect(created.length).toBe(instancesBefore);
 
 		wrapper.unmount();
 	});

--- a/app/src/interfaces/input-block-editor/input-block-editor.test.ts
+++ b/app/src/interfaces/input-block-editor/input-block-editor.test.ts
@@ -390,4 +390,42 @@ describe('InputBlockEditor', () => {
 
 		wrapper.unmount();
 	});
+
+	test('should call clear() when value changes to null while editor is enabled', async () => {
+		const clear = vi.fn().mockResolvedValue(undefined);
+
+		vi.mocked(EditorJS).mockImplementation(
+			() =>
+				({
+					isReady: Promise.resolve(),
+					render: vi.fn().mockResolvedValue(undefined),
+					clear,
+					destroy: vi.fn(),
+					focus: vi.fn(),
+					on: vi.fn(),
+					saver: { save: vi.fn().mockResolvedValue({ blocks: [] }) },
+					readOnly: { toggle: vi.fn() },
+				}) as any,
+		);
+
+		const wrapper = mount(InputBlockEditor, {
+			props: {
+				disabled: false,
+				value: { blocks: [{ type: 'paragraph', data: { text: 'initial' } }] },
+			},
+			global: {
+				directives: { 'prevent-focusout': {} },
+				stubs: { VDrawer: true, VUpload: true },
+			},
+		});
+
+		await flushPromises();
+
+		await wrapper.setProps({ value: null });
+		await flushPromises();
+
+		expect(clear).toHaveBeenCalled();
+
+		wrapper.unmount();
+	});
 });

--- a/app/src/interfaces/input-block-editor/input-block-editor.vue
+++ b/app/src/interfaces/input-block-editor/input-block-editor.vue
@@ -155,9 +155,9 @@ watch(
 );
 
 async function renderValue(sanitizedValue: ReturnType<typeof sanitizeValue>) {
-	try {
-		isRendering.value = true;
+	isRendering.value = true;
 
+	try {
 		await nextTick();
 
 		if (!editorElement.value) return;
@@ -194,8 +194,6 @@ async function renderValue(sanitizedValue: ReturnType<typeof sanitizeValue>) {
 		// Sync readOnly — the disabled watcher may have fired while editorjsRef was undefined
 		await nextTick();
 		editor.readOnly?.toggle?.(props.disabled);
-	} catch (error) {
-		unexpectedError(error);
 	} finally {
 		await nextTick();
 		isRendering.value = false;

--- a/app/src/interfaces/input-block-editor/input-block-editor.vue
+++ b/app/src/interfaces/input-block-editor/input-block-editor.vue
@@ -17,9 +17,6 @@ import { unexpectedError } from '@/utils/unexpected-error';
 
 import './editorjs-overrides.css';
 
-// https://github.com/codex-team/editor.js/blob/057bf17a6fc2d5e05c662107918d7c3e943d077c/src/components/events/RedactorDomChanged.ts#L4
-const RedactorDomChanged = 'redactor dom changed';
-
 const props = withDefaults(
 	defineProps<{
 		disabled?: boolean;
@@ -57,6 +54,9 @@ const uploaderComponentElement = ref<HTMLElement>();
 const editorElement = ref<HTMLElement>();
 const haveFilesAccess = Boolean(collectionStore.getCollection('directus_files'));
 const haveValuesChanged = ref(false);
+const isRendering = ref(false); // suppresses onChange → emitValue during programmatic renders
+const emitGeneration = ref(0); // discards out-of-order saver.save() results
+let pendingRender: ReturnType<typeof sanitizeValue> | undefined = undefined; // value queued while a render is in progress
 const router = useRouter();
 
 const tools = getTools(
@@ -80,7 +80,6 @@ onMounted(async () => {
 	editorjsRef.value = new EditorJS({
 		logLevel: 'ERROR' as EditorJS.LogLevels,
 		holder: editorElement.value,
-		// Do not set readOnly to true here — see the watcher below
 		readOnly: false,
 		placeholder: props.placeholder,
 		minHeight: 72,
@@ -93,22 +92,31 @@ onMounted(async () => {
 	const sanitizedValue = sanitizeValue(props.value);
 
 	if (sanitizedValue) {
-		await editorjsRef.value.render(sanitizedValue);
+		isRendering.value = true;
+
+		try {
+			await editorjsRef.value.render(sanitizedValue);
+		} finally {
+			await nextTick();
+			isRendering.value = false;
+
+			if (pendingRender !== undefined) {
+				const next = pendingRender;
+				pendingRender = undefined;
+				await renderValue(next);
+			}
+		}
 	}
 
 	if (props.autofocus) {
 		editorjsRef.value.focus();
 	}
 
-	editorjsRef.value.on(RedactorDomChanged, () => {
-		emitValue(editorjsRef.value!);
-	});
-
 	editorjsIsReady.value = true;
 });
 
 onUnmounted(() => {
-	editorjsRef.value?.destroy();
+	editorjsRef.value?.destroy?.();
 	bus.reset();
 });
 
@@ -117,9 +125,10 @@ watch(
 	async ([isReady, isDisabled]) => {
 		if (!isReady) return;
 
-		// Note: EditorJS must be ready before readOnly is toggled; otherwise, the content won’t render, which could result in data loss!
+		// Note: EditorJS must be ready before readOnly is toggled; otherwise, the content won't render, which could result in data loss!
 		await nextTick();
-		editorjsRef.value?.readOnly.toggle(isDisabled);
+		// Instance may be mid-teardown/recreate; `readOnly` is not always present yet.
+		editorjsRef.value?.readOnly?.toggle?.(isDisabled);
 	},
 	{ immediate: true },
 );
@@ -140,35 +149,90 @@ watch(
 
 		if (isEqual(newVal?.blocks, oldVal?.blocks)) return;
 
-		try {
-			const sanitizedValue = sanitizeValue(newVal);
+		const sanitizedValue = sanitizeValue(newVal);
 
-			if (sanitizedValue) {
-				await editorjsRef.value.render(sanitizedValue);
-			} else {
-				editorjsRef.value.clear();
-			}
-		} catch (error) {
-			unexpectedError(error);
+		if (isRendering.value) {
+			pendingRender = sanitizedValue;
+			return;
 		}
+
+		await renderValue(sanitizedValue);
 	},
 );
 
+async function renderValue(sanitizedValue: ReturnType<typeof sanitizeValue>) {
+	try {
+		isRendering.value = true;
+
+		await nextTick();
+
+		if (!editorElement.value) return;
+
+		// Destroy and rebuild the editor instead of calling render() on the same instance.
+		// Repeated render() calls (especially after save-and-stay / relation refetches) can
+		// leave duplicate blocks in the DOM even though the saved JSON is correct.
+		editorjsRef.value?.destroy?.();
+		editorjsRef.value = undefined;
+
+		// Use a local variable — reading `editorjsRef.value` after an await can return
+		// a stale/different instance if another async watcher execution ran concurrently.
+		const editor = new EditorJS({
+			logLevel: 'ERROR' as EditorJS.LogLevels,
+			holder: editorElement.value!,
+			readOnly: false,
+			placeholder: props.placeholder,
+			minHeight: 72,
+			onChange: (api) => emitValue(api),
+			tools: tools,
+		});
+
+		await editor.isReady;
+		await nextTick();
+
+		editorjsRef.value = editor;
+
+		if (sanitizedValue) {
+			await editor.render(sanitizedValue);
+		} else {
+			await editor.clear();
+		}
+
+		// Sync readOnly — the disabled watcher may have fired while editorjsRef was undefined
+		await nextTick();
+		editor.readOnly?.toggle?.(props.disabled);
+	} catch (error) {
+		unexpectedError(error);
+	} finally {
+		await nextTick();
+		isRendering.value = false;
+
+		if (pendingRender !== undefined) {
+			const next = pendingRender;
+			pendingRender = undefined;
+			await renderValue(next);
+		}
+	}
+}
+
 async function emitValue(context: EditorJS.API | EditorJS) {
-	if (props.disabled || !context || !context.saver) return;
+	if (props.disabled || isRendering.value || !context || !context.saver) return;
+
+	const generation = ++emitGeneration.value;
 
 	try {
 		const result = await context.saver.save();
 
-		haveValuesChanged.value = true;
+		if (generation !== emitGeneration.value) return;
 
 		if (!result || result.blocks.length < 1) {
+			haveValuesChanged.value = true;
 			emit('input', null);
 			return;
 		}
 
 		if (isEqual(result.blocks, props.value?.blocks)) return;
 
+		haveValuesChanged.value = true;
 		emit('input', result);
 	} catch (error) {
 		unexpectedError(error);

--- a/app/src/interfaces/input-block-editor/input-block-editor.vue
+++ b/app/src/interfaces/input-block-editor/input-block-editor.vue
@@ -99,12 +99,6 @@ onMounted(async () => {
 		} finally {
 			await nextTick();
 			isRendering.value = false;
-
-			if (pendingRender !== undefined) {
-				const next = pendingRender;
-				pendingRender = undefined;
-				await renderValue(next);
-			}
 		}
 	}
 

--- a/app/src/interfaces/translations/translations.test.ts
+++ b/app/src/interfaces/translations/translations.test.ts
@@ -1,0 +1,157 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { ref } from 'vue';
+import Translations from './translations.vue';
+
+const {
+	createMock,
+	updateMock,
+	removeMock,
+	state,
+} = vi.hoisted(() => ({
+	createMock: vi.fn(),
+	updateMock: vi.fn(),
+	removeMock: vi.fn(),
+	state: {
+		itemsLoading: false,
+		displayItems: [] as any[],
+		fetchedItems: [] as any[],
+		relationInfo: {
+			junctionField: { field: 'languages_id' },
+			relatedPrimaryKeyField: { field: 'code' },
+			junctionPrimaryKeyField: { field: 'id' },
+			reverseJunctionField: { field: 'posts_id' },
+			junctionCollection: { collection: 'posts_translations' },
+			relatedCollection: { collection: 'languages', meta: {} },
+		},
+	},
+}));
+
+vi.mock('./translation-form.vue', () => ({
+	default: {
+		name: 'TranslationFormStub',
+		props: ['updateValue'],
+		template: `<button data-testid="trigger-update" @click="updateValue(undefined, 'en')">Trigger</button>`,
+	},
+}));
+
+vi.mock('@/composables/use-relation-m2m', () => ({
+	useRelationM2M: () => ({
+		relationInfo: ref(state.relationInfo),
+	}),
+}));
+
+vi.mock('@/composables/use-relation-multiple', () => ({
+	useRelationMultiple: () => ({
+		create: createMock,
+		update: updateMock,
+		remove: removeMock,
+		isLocalItem: () => false,
+		displayItems: ref(state.displayItems),
+		loading: ref(state.itemsLoading),
+		fetchedItems: ref(state.fetchedItems),
+		getItemEdits: (item: Record<string, any>) => item,
+	}),
+}));
+
+vi.mock('@/stores/fields', () => ({
+	useFieldsStore: () => ({
+		getFieldsForCollection: () => [],
+		getField: () => ({ field: 'code' }),
+	}),
+}));
+
+vi.mock('@/composables/use-window-size', () => ({
+	useWindowSize: () => ({
+		width: ref(1400),
+	}),
+}));
+
+vi.mock('@/utils/fetch-all', () => ({
+	fetchAll: vi.fn().mockResolvedValue([{ code: 'en' }]),
+}));
+
+vi.mock('vue-i18n', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('vue-i18n')>();
+
+	return {
+		...actual,
+		useI18n: () => ({
+			locale: ref('en'),
+		}),
+	};
+});
+
+vi.mock('@/composables/use-nested-validation', () => ({
+	useInjectNestedValidation: () => ({
+		updateNestedValidationErrors: vi.fn(),
+	}),
+}));
+
+vi.mock('@/utils/validate-item', () => ({
+	validateItem: () => [],
+}));
+
+describe('translations', () => {
+	beforeEach(() => {
+		createMock.mockReset();
+		updateMock.mockReset();
+		removeMock.mockReset();
+		state.displayItems = [];
+		state.fetchedItems = [];
+		state.itemsLoading = false;
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('does not create translations while relation items are still loading', async () => {
+		state.itemsLoading = true;
+
+		const wrapper = mount(Translations, {
+			props: {
+				collection: 'posts',
+				field: 'translations',
+				primaryKey: 1,
+				version: null,
+			},
+			global: {
+				directives: { tooltip: {} },
+				stubs: { VIcon: true },
+			},
+		});
+
+		await wrapper.find('[data-testid="trigger-update"]').trigger('click');
+
+		expect(createMock).not.toHaveBeenCalled();
+		expect(updateMock).not.toHaveBeenCalled();
+	});
+
+	test('creates translation when relation items finished loading and language is missing', async () => {
+		state.itemsLoading = false;
+
+		const wrapper = mount(Translations, {
+			props: {
+				collection: 'posts',
+				field: 'translations',
+				primaryKey: 1,
+				version: null,
+			},
+			global: {
+				directives: { tooltip: {} },
+				stubs: { VIcon: true },
+			},
+		});
+
+		await wrapper.find('[data-testid="trigger-update"]').trigger('click');
+
+		expect(createMock).toHaveBeenCalledTimes(1);
+
+		expect(createMock).toHaveBeenCalledWith({
+			languages_id: {
+				code: 'en',
+			},
+		});
+	});
+});

--- a/app/src/interfaces/translations/translations.test.ts
+++ b/app/src/interfaces/translations/translations.test.ts
@@ -3,12 +3,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { ref } from 'vue';
 import Translations from './translations.vue';
 
-const {
-	createMock,
-	updateMock,
-	removeMock,
-	state,
-} = vi.hoisted(() => ({
+const { createMock, updateMock, removeMock, state } = vi.hoisted(() => ({
 	createMock: vi.fn(),
 	updateMock: vi.fn(),
 	removeMock: vi.fn(),

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -148,6 +148,9 @@ function updateValue(item: DisplayItem | undefined, lang: string | undefined) {
 
 		update(itemUpdates);
 	} else {
+		// fetched relation items might still be loading, so avoid creating duplicate rows
+		if (itemsLoading.value) return;
+
 		create({
 			...item,
 			[info.junctionField.field]: {


### PR DESCRIPTION
## Scope

What's changed:

- Block editor: Destroy and recreate the EditorJS instance on external value updates instead of calling render() on the existing instance, which caused duplicate blocks to appear in the DOM on save-and-stay
- Block editor: Added isRendering guard to suppress spurious onChange emissions during programmatic renders, and an emitGeneration counter to discard out-of-order saver.save() results
- Block editor: Added pendingRender queue so value updates that arrive while a render is in progress are not lost
- Translations interface: Added a loading guard to prevent create() from firing while relation items are still being fetched
- use-relation-multiple: When updating an item without $type/$index, find and replace the existing entry by primary key instead of pushing a duplicate

## Potential Risks / Drawbacks

- The destroy+recreate approach is heavier than a render() call — each external update tears down and rebuilds the EditorJS instance. In practice this only happens on save-and-stay or server-initiated refreshes, not on every keystroke, so the impact should be negligible.
- Destroying the editor mid-render (e.g. rapid prop changes) is guarded against but is a more complex async flow than before.

## Tested Scenarios

- Editing a block editor field and saving with "Save and Stay" no longer duplicates blocks
- Rapid successive value updates while a render is in progress apply only the latest value
- Setting value to null while the field is disabled (e.g. during a page refresh) does not clear the editor
- Adding a translation row while relation items are loading no longer creates a premature empty entry
- Updating a relation item that already has a pending update replaces rather than appends

## Review Notes / Questions

- The isRendering + emitGeneration + pendingRender trio together handle the save-and-stay race; they're independent concerns and each can be reasoned about separately, but worth reading the test file for the full picture
- The use-relation-multiple PK dedup only applies to the update (no $type/$index) path, the create and explicit $index paths are unchanged
- Re-creating the original but was a bit murky see [this loom](https://www.loom.com/share/4009190d44fb4830b16760c5a0ea3722) for how I could consistently see a similar bug to what was reported but it is not exactly the same. Basically you have one line already in the block then you add another and do a save and stay and it loses the first line visually but when you refresh it's still there.  If you don't hard refresh though and keep adding lines and saving and staying it loses the initial lines.


## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #1346
