### PR TITLE
fix(app): honor locale when rendering numeric inputs

### DIFF
--- a/.changeset/rare-forks-rest.md
+++ b/.changeset/rare-forks-rest.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed numeric inputs to honor the active app locale when rendering native number fields.

--- a/app/src/components/__snapshots__/v-input.test.ts.snap
+++ b/app/src/components/__snapshots__/v-input.test.ts.snap
@@ -5,7 +5,7 @@ exports[`inline warning > should appear for invalid input 1`] = `
   <!--v-if-->
   <div data-v-418390f4="" class="input">
     <!--v-if-->
-    <!--v-if--><input data-v-418390f4="" autocomplete="off" type="number" step="1" value="">
+    <!--v-if--><input data-v-418390f4="" lang="en-US" autocomplete="off" type="number" step="1" value="">
     <v-icon-stub data-v-418390f4="" name="warning" filled="false" sup="false" left="false" right="false" disabled="false" clickable="false" xsmall="false" small="false" large="false" xlarge="false" class="inline-warning"></v-icon-stub>
     <!--v-if--><span data-v-418390f4=""><v-icon-stub data-v-418390f4="" name="keyboard_arrow_up" filled="false" sup="false" left="false" right="false" disabled="false" clickable="true" xsmall="false" small="false" large="false" xlarge="false" class="step-up" tabindex="-1"></v-icon-stub><v-icon-stub data-v-418390f4="" name="keyboard_arrow_down" filled="false" sup="false" left="false" right="false" disabled="false" clickable="true" xsmall="false" small="false" large="false" xlarge="false" class="step-down" tabindex="-1"></v-icon-stub></span>
     <!--v-if-->
@@ -19,7 +19,7 @@ exports[`inline warning > should not appear for valid input 1`] = `
   <!--v-if-->
   <div data-v-418390f4="" class="input">
     <!--v-if-->
-    <!--v-if--><input data-v-418390f4="" autocomplete="off" type="number" step="1" value="">
+    <!--v-if--><input data-v-418390f4="" lang="en-US" autocomplete="off" type="number" step="1" value="">
     <!--v-if-->
     <!--v-if--><span data-v-418390f4=""><v-icon-stub data-v-418390f4="" name="keyboard_arrow_up" filled="false" sup="false" left="false" right="false" disabled="false" clickable="true" xsmall="false" small="false" large="false" xlarge="false" class="step-up" tabindex="-1"></v-icon-stub><v-icon-stub data-v-418390f4="" name="keyboard_arrow_down" filled="false" sup="false" left="false" right="false" disabled="false" clickable="true" xsmall="false" small="false" large="false" xlarge="false" class="step-down" tabindex="-1"></v-icon-stub></span>
     <!--v-if-->

--- a/app/src/components/v-input.test.ts
+++ b/app/src/components/v-input.test.ts
@@ -254,6 +254,49 @@ describe('emitValue', () => {
 	});
 });
 
+describe('locale handling', () => {
+	test('uses the current app locale for number inputs', () => {
+		const wrapper = mount(VInput, {
+			props: {
+				type: 'number',
+				modelValue: 300.44,
+				float: true,
+			},
+			global,
+		});
+
+		expect(wrapper.get('input').attributes('lang')).toBe('en-US');
+	});
+
+	test('does not force a locale on text inputs', () => {
+		const wrapper = mount(VInput, {
+			props: {
+				type: 'text',
+				modelValue: '300.44',
+				float: true,
+			},
+			global,
+		});
+
+		expect(wrapper.get('input').attributes('lang')).toBeUndefined();
+	});
+
+	test('prefers an explicitly provided lang attribute', () => {
+		const wrapper = mount(VInput, {
+			props: {
+				type: 'number',
+				modelValue: 300.44,
+			},
+			attrs: {
+				lang: 'fr-FR',
+			},
+			global,
+		});
+
+		expect(wrapper.get('input').attributes('lang')).toBe('fr-FR');
+	});
+});
+
 describe('inline warning', () => {
 	afterEach(() => {
 		vi.restoreAllMocks();

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -90,7 +90,7 @@ const emit = defineEmits(['click', 'keydown', 'update:modelValue', 'focus', 'key
 
 const attrs = useAttrs();
 
-const { t } = useI18n();
+const { t, locale } = useI18n();
 
 const input = ref<HTMLInputElement | null>(null);
 
@@ -108,6 +108,20 @@ const listeners = computed(() => ({
 }));
 
 const attributes = computed(() => omit(attrs, ['class']));
+
+const inputLanguage = computed(() => {
+	const explicitLang = attrs.lang;
+
+	if (typeof explicitLang === 'string' && explicitLang.length > 0) {
+		return explicitLang;
+	}
+
+	if (props.type === 'number') {
+		return locale.value;
+	}
+
+	return undefined;
+});
 
 const classes = computed(() => [
 	{
@@ -342,6 +356,7 @@ function useInlineWarning() {
 					ref="input"
 					v-focus="autofocus"
 					v-bind="attributes"
+					:lang="inputLanguage"
 					:placeholder="placeholder ? String(placeholder) : undefined"
 					:autocomplete="autocomplete"
 					:type="type"

--- a/contributors.yml
+++ b/contributors.yml
@@ -218,6 +218,7 @@
 - AfaqJaved
 - Mehdi-YC
 - MrGreenTea
+- Hartnakig
 - smgrol
 - Abdallah-Awwad
 - DantonMariano


### PR DESCRIPTION
## Scope

What's changed:

- Bound native number inputs in `VInput` to the active app locale so numeric fields can render with the locale selected inside Directus.
- Preserved any explicit `lang` attribute passed to `VInput` so callers can still override the browser behavior.
- Added locale handling tests and updated the affected snapshots.
- Added a changeset for `@directus/app`.

## Potential Risks / Drawbacks

- Browsers may differ slightly in how they apply `lang` to native number inputs.
- This only affects inputs rendered with `type="number"`; text-based decimal handling is unchanged.

## Tested Scenarios

- `pnpm --filter @directus/app exec vitest run src/components/v-input.test.ts src/interfaces/input/input.test.ts`
- `pnpm exec eslint app/src/components/v-input.vue app/src/components/v-input.test.ts`
- `pnpm exec stylelint app/src/components/v-input.vue`
- `pnpm exec prettier --check app/src/components/v-input.vue app/src/components/v-input.test.ts .changeset/rare-forks-rest.md`

## Review Notes / Questions

- This follows the feedback on previous attempts by making native number inputs locale-aware instead of hard-normalizing `,` to `.`.
- Explicit `lang` attributes still take precedence if an interface needs to force a specific locale.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #24803
