### PR TITLE
Fixed resolve aliased relational fields correctly in GraphQL fragments

### DIFF
--- a/.changeset/fix-graphql-alias-relation.md
+++ b/.changeset/fix-graphql-alias-relation.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed aliased relational fields returning null in GraphQL fragments

--- a/api/src/services/graphql/schema/get-types.ts
+++ b/api/src/services/graphql/schema/get-types.ts
@@ -189,7 +189,7 @@ export function getTypes(
 				[relation.field]: {
 					type: CollectionTypes[relation.related_collection]!,
 					resolve: (obj: Record<string, any>, _, __, info) => {
-						return obj[info?.path?.key ?? relation.field];
+						return obj[info?.fieldName ?? relation.field];
 					},
 				},
 			});
@@ -198,7 +198,7 @@ export function getTypes(
 				[relation.field]: {
 					type: GraphQLJSON,
 					resolve: (obj: Record<string, any>, _, __, info) => {
-						return obj[info?.path?.key ?? relation.field];
+						return obj[info?.fieldName ?? relation.field];
 					},
 				},
 			});
@@ -208,7 +208,7 @@ export function getTypes(
 					[relation.meta.one_field]: {
 						type: [CollectionTypes[relation.collection]!],
 						resolve: (obj: Record<string, any>, _, __, info) => {
-							return obj[info?.path?.key ?? relation.meta!.one_field];
+							return obj[info?.fieldName ?? relation.meta!.one_field];
 						},
 					},
 				});
@@ -218,7 +218,7 @@ export function getTypes(
 						[relation.meta.one_field]: {
 							type: GraphQLJSON,
 							resolve: (obj: Record<string, any>, _, __, info) => {
-								return obj[info?.path?.key ?? relation.meta!.one_field];
+								return obj[info?.fieldName ?? relation.meta!.one_field];
 							},
 						},
 					});
@@ -253,7 +253,7 @@ export function getTypes(
 						},
 					}),
 					resolve: (obj: Record<string, any>, _, __, info) => {
-						return obj[info?.path?.key ?? relation.field];
+						return obj[info?.fieldName ?? relation.field];
 					},
 				},
 			});

--- a/api/src/services/graphql/schema/parse-query.test.ts
+++ b/api/src/services/graphql/schema/parse-query.test.ts
@@ -256,4 +256,83 @@ describe('parseFields', () => {
 		const query = await getQuery({}, mockSchema, selections, mockVariableValues, mockAccountability);
 		expect(query.fields).toEqual(['parent.child.grandchild']);
 	});
+
+	test('should parse aliased relational field inside non-M2A InlineFragment', async () => {
+		// fragment BlogPostSummary on blog_post { author { id }, authorAlias: author { id } }
+		const o2mSchema = {
+			relations: [
+				{
+					collection: 'blog_post',
+					field: 'author',
+					related_collection: 'author',
+					meta: { one_field: null, one_collection_field: null, one_allowed_collections: null },
+				},
+			],
+		} as any;
+
+		const selections = [
+			inlineFragment('blog_post', [
+				field('author', { children: [field('id')] }),
+				field('author', { alias: 'authorAlias', children: [field('id')] }),
+			]),
+		];
+
+		const query = await getQuery({}, o2mSchema, selections, mockVariableValues, mockAccountability, 'blog_post');
+
+		expect(query.fields).toContain('author.id');
+		expect(query.fields).toContain('authorAlias.id');
+	});
+
+	test('should parse aliased relational field at top level', async () => {
+		const o2mSchema = {
+			relations: [
+				{
+					collection: 'blog_post',
+					field: 'author',
+					related_collection: 'author',
+					meta: { one_field: null, one_collection_field: null, one_allowed_collections: null },
+				},
+			],
+		} as any;
+
+		const selections = [
+			field('author', { children: [field('id')] }),
+			field('author', { alias: 'authorAlias', children: [field('id')] }),
+		];
+
+		const query = await getQuery({}, o2mSchema, selections, mockVariableValues, mockAccountability, 'blog_post');
+
+		expect(query.fields).toContain('author.id');
+		expect(query.fields).toContain('authorAlias.id');
+		expect(query.alias).toEqual({ authorAlias: 'author' });
+	});
+
+	test('should parse aliased O2M relational field inside non-M2A InlineFragment', async () => {
+		const o2mSchema = {
+			relations: [
+				{
+					collection: 'blog_post',
+					field: 'author_id',
+					related_collection: 'author',
+					meta: { one_field: 'posts', one_collection_field: null, one_allowed_collections: null },
+				},
+			],
+		} as any;
+
+		const selections = [
+			field('author', {
+				children: [
+					inlineFragment('author', [
+						field('posts', { children: [field('id')] }),
+						field('posts', { alias: 'recentPosts', children: [field('id')] }),
+					]),
+				],
+			}),
+		];
+
+		const query = await getQuery({}, o2mSchema, selections, mockVariableValues, mockAccountability, 'blog_post');
+
+		expect(query.fields).toContain('author.posts.id');
+		expect(query.fields).toContain('author.recentPosts.id');
+	});
 });

--- a/api/src/services/graphql/utils/replace-fragments.test.ts
+++ b/api/src/services/graphql/utils/replace-fragments.test.ts
@@ -115,6 +115,48 @@ describe('replaceFragmentsInSelections', () => {
 		expect(innerSelections[1].arguments).toHaveLength(1);
 	});
 
+	test('preserves field aliases inside fragment when wrapping in InlineFragment', () => {
+		const selections = [{ kind: 'FragmentSpread', name: { value: 'BlogPostSummary' } }] as unknown as SelectionNode[];
+
+		const fragments = {
+			BlogPostSummary: {
+				kind: 'FragmentDefinition',
+				name: { value: 'BlogPostSummary' },
+				typeCondition: { kind: 'NamedType', name: { value: 'blog_post' } },
+				selectionSet: {
+					kind: 'SelectionSet',
+					selections: [
+						{
+							kind: 'Field',
+							name: { value: 'author' },
+							selectionSet: { selections: [{ kind: 'Field', name: { value: 'id' } }] },
+						},
+						{
+							kind: 'Field',
+							name: { value: 'author' },
+							alias: { value: 'authorAlias' },
+							selectionSet: { selections: [{ kind: 'Field', name: { value: 'id' } }] },
+						},
+					] as unknown as SelectionNode[],
+				},
+			},
+		} as unknown as Record<string, FragmentDefinitionNode>;
+
+		const result = replaceFragmentsInSelections(selections, fragments);
+
+		expect(result).toHaveLength(1);
+		expect((result![0] as any).kind).toBe('InlineFragment');
+
+		const innerSelections = (result![0] as any).selectionSet.selections;
+		expect(innerSelections).toHaveLength(2);
+
+		expect(innerSelections[0].name.value).toBe('author');
+		expect(innerSelections[0].alias).toBeUndefined();
+
+		expect(innerSelections[1].name.value).toBe('author');
+		expect(innerSelections[1].alias.value).toBe('authorAlias');
+	});
+
 	test('handles nested fragments (fragment referencing another fragment)', () => {
 		const selections = [{ kind: 'FragmentSpread', name: { value: 'Outer' } }] as unknown as SelectionNode[];
 


### PR DESCRIPTION
## Summary

Fixes #27003

When a GraphQL fragment uses an alias on a relational field, the resolver returns `null` instead of the expected data:

```graphql
fragment BlogPostSummary on blog_post {
  author { id }               # ✅ works
  authorAlias: author { id }  # ❌ returns null
}
```

### Root Cause

In `get-types.ts`, all relational field resolvers use `info?.path?.key` to look up the value in the parent data object:

```ts
resolve: (obj, _, __, info) => {
    return obj[info?.path?.key ?? relation.field];
}
```

When a field has an alias, `info.path.key` returns the **alias name** (e.g., `"authorAlias"`), but the data object stores values under the **original field name** (e.g., `"author"`). So `obj["authorAlias"]` returns `undefined` → `null`.

### Fix

Replace `info?.path?.key` with `info?.fieldName` in all 5 relational field resolvers. `info.fieldName` always returns the original field name regardless of aliasing, correctly matching the keys in the data object returned by the items service.

## Changes

- `api/src/services/graphql/schema/get-types.ts` — 5 occurrences changed (`info?.path?.key` → `info?.fieldName`)

This is a copy of https://github.com/directus/directus/pull/27020 after @mango766 failure to sign CLA agreement