### PR TITLE
fix(app): show descriptive translatable error on weak password validation

### DIFF
--- a/.changeset/fix-password-policy-error-display.md
+++ b/.changeset/fix-password-policy-error-display.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed weak password error on invite acceptance and password reset to show a descriptive, translatable message instead of the generic "Validation failed"

--- a/app/src/lang/index.test.ts
+++ b/app/src/lang/index.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+import { translateAPIError } from './index';
+
+describe('translateAPIError', () => {
+	test('returns dedicated password policy message for FAILED_VALIDATION password regex', () => {
+		const error = {
+			response: {
+				data: {
+					errors: [
+						{
+							message: 'Validation failed for field "password". Value doesn\'t have the correct format.',
+							extensions: {
+								code: 'FAILED_VALIDATION',
+								field: 'password',
+								type: 'regex',
+								invalid: 'test',
+							},
+						},
+					],
+				},
+			},
+		};
+
+		expect(translateAPIError(error as any)).toBe("Password doesn't meet the configured password policy");
+	});
+
+	test('falls back to detailed server message for FAILED_VALIDATION when no mapped type exists', () => {
+		const error = {
+			errors: [
+				{
+					message: 'Validation failed for field "password". Value is not acceptable.',
+					extensions: {
+						code: 'FAILED_VALIDATION',
+						field: 'password',
+						type: 'custom',
+					},
+				},
+			],
+		};
+
+		expect(translateAPIError(error as any)).toBe('Validation failed for field "password". Value is not acceptable.');
+	});
+});

--- a/app/src/lang/index.ts
+++ b/app/src/lang/index.ts
@@ -4,6 +4,7 @@ import datetimeFormats from './date-formats.yaml';
 import numberFormats from './number-formats.yaml';
 import enUSBase from './translations/en-US.yaml';
 import { RequestError } from '@/api';
+import { extractFirstError } from '@/utils/extract-error-code';
 
 export const i18n = createI18n({
 	legacy: false,
@@ -24,21 +25,13 @@ export const loadedLanguages: Language[] = ['en-US'];
 export function translateAPIError(error: RequestError | string): string {
 	const defaultMsg = i18n.global.t('unexpected_error');
 
-	let code = error;
-	let errorExtensions: Record<string, unknown> | undefined;
-	let errorMessage: string | undefined;
-
-	if (typeof error === 'object') {
-		const firstError =
-			error?.response?.data?.errors?.[0] ||
-			(error as unknown as { errors?: Array<{ extensions?: Record<string, unknown>; message?: string }> })?.errors?.[0];
-
-		errorExtensions = firstError?.extensions;
-		errorMessage = firstError?.message;
-		code = errorExtensions?.['code'] as string | undefined;
+	if (typeof error === 'string') {
+		return error;
 	}
 
-	if (!error || !code) return defaultMsg;
+	const { code, extensions: errorExtensions, message: errorMessage } = extractFirstError(error);
+
+	if (!code || code === 'UNKNOWN') return defaultMsg;
 
 	// Prefer specific validation detail messages over generic FAILED_VALIDATION.
 	if (code === 'FAILED_VALIDATION' && errorExtensions) {

--- a/app/src/lang/index.ts
+++ b/app/src/lang/index.ts
@@ -25,12 +25,43 @@ export function translateAPIError(error: RequestError | string): string {
 	const defaultMsg = i18n.global.t('unexpected_error');
 
 	let code = error;
+	let errorExtensions: Record<string, unknown> | undefined;
+	let errorMessage: string | undefined;
 
 	if (typeof error === 'object') {
-		code = error?.response?.data?.errors?.[0]?.extensions?.code;
+		const firstError =
+			error?.response?.data?.errors?.[0] ||
+			(error as unknown as { errors?: Array<{ extensions?: Record<string, unknown>; message?: string }> })?.errors?.[0];
+
+		errorExtensions = firstError?.extensions;
+		errorMessage = firstError?.message;
+		code = errorExtensions?.['code'] as string | undefined;
 	}
 
 	if (!error || !code) return defaultMsg;
+
+	// Prefer specific validation detail messages over generic FAILED_VALIDATION.
+	if (code === 'FAILED_VALIDATION' && errorExtensions) {
+		if (errorExtensions['field'] === 'password' && errorExtensions['type'] === 'regex') {
+			const passwordPolicyKey = 'password_policy_validation_error';
+
+			if (i18n.global.te(passwordPolicyKey)) {
+				return i18n.global.t(passwordPolicyKey);
+			}
+		}
+
+		if (typeof errorExtensions['type'] === 'string') {
+			const validationKey = `validationError.${errorExtensions['type']}`;
+
+			if (i18n.global.te(validationKey)) {
+				return i18n.global.t(validationKey, errorExtensions);
+			}
+		}
+
+		if (errorMessage) {
+			return errorMessage;
+		}
+	}
 
 	const key = `errors.${code}`;
 	const exists = i18n.global.te(key);

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -842,6 +842,7 @@ tfa_scan_code: Scan the code in your authenticator app to finish setting up 2FA
 enter_otp_to_disable_tfa: Enter the OTP to disable 2FA
 create_account: Create Account
 account_created_successfully: Account Created Successfully
+password_policy_validation_error: Password doesn't meet the configured password policy
 auto_fill: Auto Fill
 corresponding_field: Corresponding Field
 errors:

--- a/app/src/utils/extract-error-code.ts
+++ b/app/src/utils/extract-error-code.ts
@@ -2,6 +2,12 @@ import type { DirectusError } from '@directus/sdk';
 import type { RequestError } from '@/api';
 import type { APIError } from '@/types/error';
 
+export type FirstError = {
+	code: string;
+	extensions?: Record<string, unknown>;
+	message?: string;
+};
+
 export function extractErrorCode(error: unknown): string {
 	return (
 		(error as RequestError).response?.data?.errors?.[0]?.extensions?.code ||
@@ -9,4 +15,17 @@ export function extractErrorCode(error: unknown): string {
 		(error as APIError)?.extensions?.code ||
 		'UNKNOWN'
 	);
+}
+
+export function extractFirstError(error: unknown): FirstError {
+	const firstError =
+		(error as RequestError).response?.data?.errors?.[0] ||
+		(error as DirectusError)?.errors?.[0] ||
+		(error as APIError);
+
+	return {
+		code: firstError?.extensions?.code ?? 'UNKNOWN',
+		extensions: firstError?.extensions,
+		message: firstError?.message,
+	};
 }


### PR DESCRIPTION
## Scope

What's changed:

- Extended `translateAPIError` in `app/src/lang/index.ts` to inspect the full first error object (both `error.response.data.errors[0]` and `error.errors[0]` shapes) so that `extensions` and `message` fields are available for inspection
- Added special handling for `FAILED_VALIDATION` errors: when `field === 'password'` and `type === 'regex'`, returns a dedicated `password_policy_validation_error` i18n key instead of the generic 'Validation failed' string
- Added a secondary fallback to typed `validationError.*` keys for other validation types, and a tertiary fallback to the raw server message when no key is registered
- Added the `password_policy_validation_error` translation key to `en-US.yaml` (Crowdin will pick this up for all other locales)
- Added `app/src/lang/index.test.ts` with two unit tests covering the password-policy path and the message-fallback path

## Potential Risks / Drawbacks

- The API contract is entirely unchanged: `checkPasswordPolicy` still throws a `FailedValidationError` with Joi-style extensions (`type: 'custom.pattern.base'` which `joiValidationErrorItemToErrorExtensions` maps to `type: 'regex'`). No inconsistency is introduced with the rest of the validation layer.
- Other `FAILED_VALIDATION` errors that previously returned the generic 'Validation failed' message may now surface a more specific typed message or the raw server message. This is an improvement, but reviewers should verify no existing UI relies on the exact 'Validation failed' string.

## Tested Scenarios

- Set Auth Password Policy to 'strong' in settings, invite a user, and navigate to the create-password flow from the email link. Entering a weak password now shows **"Password doesn't meet the configured password policy"** instead of 'Validation failed'.
- Same scenario via the password reset flow (`/auth/password/reset`) also shows the descriptive message.
- All other validation errors (non-password, non-regex) continue to work as before.
- Two new unit tests pass: one asserting the dedicated password policy message, one asserting the message-string fallback for an unmapped validation type.

## Review Notes / Questions

- This follows the exact approach discussed in #27021 and agreed upon with @AlexGaillard: keep the existing Joi-style `FailedValidationError` on the API and fix the display on the frontend by inspecting the `FAILED_VALIDATION` extensions.
- The `password_policy_validation_error` key is plain English and will be sent to Crowdin for translation, so the fix is i18n-safe.
- I checked that `joiValidationErrorItemToErrorExtensions` maps `'custom.pattern.base'` → `type: 'regex'` (the `.pattern.base` suffix check overwrites the earlier `.base` → `'required'` assignment), so the frontend condition `type === 'regex'` matches correctly.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #27016