### PR TITLE
Add `v-kbd` component

### DIFF
--- a/.changeset/floppy-keys-relax.md
+++ b/.changeset/floppy-keys-relax.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Added `v-kbd` component and support `{ text, kbd }` syntax in tooltip

--- a/app/src/components/app-tooltip.vue
+++ b/app/src/components/app-tooltip.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { TooltipArrow, TooltipContent, TooltipPortal, TooltipRoot, TooltipTrigger } from 'reka-ui';
+import VKbd from '@/components/v-kbd.vue';
 import { TOOLTIP_CONTENT_ID, useGlobalTooltip } from '@/composables/use-global-tooltip';
 
 const { state, closeTooltip } = useGlobalTooltip();
@@ -19,6 +20,9 @@ const { state, closeTooltip } = useGlobalTooltip();
 				:class="{ inverted: state.inverted, monospace: state.monospace }"
 			>
 				{{ state.content }}
+				<span v-if="state.kbd" class="tooltip-kbd">
+					<VKbd v-for="key in state.kbd" :key="key" :value="key" size="small" variant="inverted" />
+				</span>
 				<TooltipArrow />
 			</TooltipContent>
 		</TooltipPortal>

--- a/app/src/components/register.ts
+++ b/app/src/components/register.ts
@@ -36,6 +36,7 @@ import VInfo from './v-info.vue';
 import VInput from './v-input.vue';
 import VItemGroup from './v-item-group.vue';
 import VItem from './v-item.vue';
+import VKbd from './v-kbd.vue';
 import VListGroup from './v-list-group.vue';
 import VListItemContent from './v-list-item-content.vue';
 import VListItemHint from './v-list-item-hint.vue';
@@ -101,6 +102,7 @@ export function registerComponents(app: App): void {
 	app.component('VForm', VForm);
 	app.component('VHover', VHover);
 	app.component('VHighlight', VHighlight);
+	app.component('VKbd', VKbd);
 	app.component('VIcon', VIcon);
 	app.component('VImage', VImage);
 	app.component('VIconFile', VIconFile);

--- a/app/src/components/v-drawer-header.vue
+++ b/app/src/components/v-drawer-header.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { translateShortcut } from '@directus/composables';
 import VButton from '@/components/v-button.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
 import VTextOverflow from '@/components/v-text-overflow.vue';
@@ -27,7 +26,7 @@ defineEmits<{
 	<header class="header-bar" :class="{ shadow }">
 		<div class="primary">
 			<VButton
-				v-tooltip.bottom="`${$t('cancel')} (${translateShortcut(['esc'])})`"
+				v-tooltip.bottom="{ text: $t('cancel'), kbd: ['esc'] }"
 				class="cancel-button"
 				rounded
 				icon

--- a/app/src/components/v-drawer.vue
+++ b/app/src/components/v-drawer.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { translateShortcut } from '@directus/composables';
 import { useScroll } from '@vueuse/core';
 import { computed, provide, ref, useTemplateRef } from 'vue';
 import { type ApplyShortcut } from './v-dialog.vue';
@@ -78,7 +77,7 @@ const showHeaderShadow = computed(() => y.value > 0);
 		<article class="v-drawer">
 			<VButton
 				v-if="cancelable"
-				v-tooltip.bottom="`${$t('cancel')} (${translateShortcut(['esc'])})`"
+				v-tooltip.bottom="{ text: $t('cancel'), kbd: ['esc'] }"
 				class="cancel"
 				icon
 				rounded

--- a/app/src/components/v-kbd-shortcut.vue
+++ b/app/src/components/v-kbd-shortcut.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import VKbd, { type Props as VKbdProps } from '@/components/v-kbd.vue';
+
+interface Props extends Omit<VKbdProps, 'value'> {
+	/** Ordered list of key names forming the shortcut (e.g. ['meta', 's']) */
+	value: string[];
+}
+
+defineProps<Props>();
+</script>
+
+<template>
+	<span class="v-kbd-shortcut">
+		<VKbd v-for="key in value" :key="key" :value="key" :size="size" :variant="variant" />
+	</span>
+</template>
+
+<style lang="scss" scoped>
+/*
+
+	Available Variables:
+
+		--v-kbd-shortcut-gap  [0.125rem]
+
+*/
+
+.v-kbd-shortcut {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--v-kbd-shortcut-gap, 0.125rem);
+}
+</style>

--- a/app/src/components/v-kbd.test.ts
+++ b/app/src/components/v-kbd.test.ts
@@ -10,14 +10,6 @@ test('renders as kbd element by default', () => {
 	expect(wrapper.element.tagName).toBe('KBD');
 });
 
-test('renders slot content', () => {
-	const wrapper = mount(VKbd, {
-		slots: { default: 'K' },
-	});
-
-	expect(wrapper.text()).toBe('K');
-});
-
 test('renders translated value on non-mac', () => {
 	vi.stubGlobal('navigator', { platform: 'Win32' });
 

--- a/app/src/components/v-kbd.test.ts
+++ b/app/src/components/v-kbd.test.ts
@@ -1,0 +1,76 @@
+import { mount } from '@vue/test-utils';
+import { expect, test, vi } from 'vitest';
+import VKbd from './v-kbd.vue';
+
+test('renders as kbd element by default', () => {
+	const wrapper = mount(VKbd, {
+		slots: { default: 'K' },
+	});
+
+	expect(wrapper.element.tagName).toBe('KBD');
+});
+
+test('renders slot content', () => {
+	const wrapper = mount(VKbd, {
+		slots: { default: 'K' },
+	});
+
+	expect(wrapper.text()).toBe('K');
+});
+
+test('renders translated value on non-mac', () => {
+	vi.stubGlobal('navigator', { platform: 'Win32' });
+
+	const wrapper = mount(VKbd, {
+		props: { value: 'meta' },
+	});
+
+	expect(wrapper.text()).toBe('Ctrl');
+
+	vi.unstubAllGlobals();
+});
+
+test('renders translated value on mac', () => {
+	vi.stubGlobal('navigator', { platform: 'MacIntel' });
+
+	const wrapper = mount(VKbd, {
+		props: { value: 'meta' },
+	});
+
+	expect(wrapper.text()).toBe('⌘');
+
+	vi.unstubAllGlobals();
+});
+
+test('slot takes precedence over value prop', () => {
+	const wrapper = mount(VKbd, {
+		props: { value: 'meta' },
+		slots: { default: 'Custom' },
+	});
+
+	expect(wrapper.text()).toBe('Custom');
+});
+
+test('size prop adds correct class', () => {
+	for (const size of ['small', 'medium', 'large'] as const) {
+		const wrapper = mount(VKbd, { props: { size } });
+		expect(wrapper.classes()).toContain(size);
+	}
+});
+
+test('defaults to medium size', () => {
+	const wrapper = mount(VKbd);
+	expect(wrapper.classes()).toContain('medium');
+});
+
+test('variant prop adds correct class', () => {
+	for (const variant of ['outlined', 'soft'] as const) {
+		const wrapper = mount(VKbd, { props: { variant } });
+		expect(wrapper.classes()).toContain(variant);
+	}
+});
+
+test('defaults to soft variant', () => {
+	const wrapper = mount(VKbd);
+	expect(wrapper.classes()).toContain('soft');
+});

--- a/app/src/components/v-kbd.test.ts
+++ b/app/src/components/v-kbd.test.ts
@@ -64,7 +64,7 @@ test('defaults to medium size', () => {
 });
 
 test('variant prop adds correct class', () => {
-	for (const variant of ['outlined', 'soft'] as const) {
+	for (const variant of ['outlined', 'soft', 'inverted'] as const) {
 		const wrapper = mount(VKbd, { props: { variant } });
 		expect(wrapper.classes()).toContain(variant);
 	}

--- a/app/src/components/v-kbd.vue
+++ b/app/src/components/v-kbd.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { translateShortcut } from '@directus/composables';
+import { computed } from 'vue';
+
+interface Props {
+	/** Keyboard key name to display, translated per platform (e.g. 'meta' → '⌘' on Mac) */
+	value?: string;
+	/** Size of the key cap */
+	size?: 'small' | 'medium' | 'large';
+	/** Visual style variant */
+	variant?: 'outlined' | 'soft';
+}
+
+const props = withDefaults(defineProps<Props>(), {
+	size: 'medium',
+	variant: 'soft',
+});
+
+const translatedValue = computed(() => (props.value ? translateShortcut([props.value]) : undefined));
+</script>
+
+<template>
+	<kbd class="v-kbd" :class="[size, variant]">
+		<slot>{{ translatedValue }}</slot>
+	</kbd>
+</template>
+
+<style lang="scss" scoped>
+/*
+
+	Available Variables:
+
+		--v-kbd-color             [var(--theme--foreground-subdued)]
+		--v-kbd-background-color  [var(--theme--background-subdued)]
+		--v-kbd-border-color      [var(--theme--border-color)]
+
+*/
+
+.v-kbd {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-inline-size: 1.25rem;
+	block-size: 1.25rem;
+	padding: 0 0.25rem;
+	font-size: 0.6875rem;
+	font-family: var(--theme--fonts--sans--font-family);
+	font-weight: 500;
+	text-transform: uppercase;
+	border-radius: var(--theme--border-radius);
+
+	&.small {
+		min-inline-size: 1rem;
+		block-size: 1rem;
+		font-size: 0.625rem;
+	}
+
+	&.medium {
+		min-inline-size: 1.25rem;
+		block-size: 1.25rem;
+		font-size: 0.6875rem;
+	}
+
+	&.large {
+		min-inline-size: 1.5rem;
+		block-size: 1.5rem;
+		font-size: 0.75rem;
+	}
+
+	&.outlined {
+		color: var(--v-kbd-color, var(--theme--foreground-subdued));
+		box-shadow: inset 0 0 0 var(--theme--border-width) var(--v-kbd-border-color, var(--theme--border-color));
+	}
+
+	&.soft {
+		color: var(--v-kbd-color, var(--theme--foreground-subdued));
+		background-color: var(--v-kbd-background-color, var(--theme--background-subdued));
+	}
+}
+</style>

--- a/app/src/components/v-kbd.vue
+++ b/app/src/components/v-kbd.vue
@@ -2,7 +2,7 @@
 import { translateShortcut } from '@directus/composables';
 import { computed } from 'vue';
 
-interface Props {
+export interface Props {
 	/** Keyboard key name to display, translated per platform (e.g. 'meta' → '⌘' on Mac) */
 	value?: string;
 	/** Size of the key cap */
@@ -13,7 +13,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
 	size: 'medium',
-	variant: 'soft',
+	variant: 'outlined',
 });
 
 const translatedValue = computed(() => {
@@ -72,7 +72,7 @@ const translatedValue = computed(() => {
 
 	&.outlined {
 		color: var(--v-kbd-color, var(--theme--foreground-subdued));
-		box-shadow: inset 0 0 0 var(--theme--border-width) var(--v-kbd-border-color, var(--theme--border-color));
+		box-shadow: inset 0 0 0 1px var(--v-kbd-border-color, var(--theme--border-color));
 	}
 
 	&.soft {
@@ -82,8 +82,8 @@ const translatedValue = computed(() => {
 
 	&.inverted {
 		color: var(--v-kbd-color, var(--foreground-inverted));
-		box-shadow: inset 0 0 0 var(--theme--border-width)
-			var(--v-kbd-border-color, color-mix(in srgb, var(--foreground-inverted) 40%, transparent));
+		box-shadow: inset 0 0 0 1px
+			var(--v-kbd-border-color, color-mix(in srgb, var(--foreground-inverted) 20%, transparent));
 	}
 }
 </style>

--- a/app/src/components/v-kbd.vue
+++ b/app/src/components/v-kbd.vue
@@ -8,7 +8,7 @@ interface Props {
 	/** Size of the key cap */
 	size?: 'small' | 'medium' | 'large';
 	/** Visual style variant */
-	variant?: 'outlined' | 'soft';
+	variant?: 'outlined' | 'soft' | 'inverted';
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -75,6 +75,12 @@ const translatedValue = computed(() => (props.value ? translateShortcut([props.v
 	&.soft {
 		color: var(--v-kbd-color, var(--theme--foreground-subdued));
 		background-color: var(--v-kbd-background-color, var(--theme--background-subdued));
+	}
+
+	&.inverted {
+		color: var(--v-kbd-color, var(--foreground-inverted));
+		box-shadow: inset 0 0 0 var(--theme--border-width)
+			var(--v-kbd-border-color, color-mix(in srgb, var(--foreground-inverted) 40%, transparent));
 	}
 }
 </style>

--- a/app/src/components/v-kbd.vue
+++ b/app/src/components/v-kbd.vue
@@ -16,7 +16,10 @@ const props = withDefaults(defineProps<Props>(), {
 	variant: 'soft',
 });
 
-const translatedValue = computed(() => (props.value ? translateShortcut([props.value]) : undefined));
+const translatedValue = computed(() => {
+	if (!props.value) return undefined;
+	return translateShortcut([props.value]) || props.value;
+});
 </script>
 
 <template>

--- a/app/src/composables/use-global-tooltip.test.ts
+++ b/app/src/composables/use-global-tooltip.test.ts
@@ -94,6 +94,41 @@ describe('useGlobalTooltip', () => {
 		expect(state.open).toBe(false);
 	});
 
+	it('stores kbd keys in state', () => {
+		const { state, openTooltip } = useGlobalTooltip();
+
+		openTooltip({
+			content: 'Save',
+			kbd: ['meta', 's'],
+			side: 'top',
+			align: 'center',
+			inverted: false,
+			monospace: false,
+			delayDuration: 0,
+			virtualRef: null,
+		});
+
+		vi.advanceTimersByTime(0);
+		expect(state.kbd).toEqual(['meta', 's']);
+	});
+
+	it('kbd defaults to undefined when not provided', () => {
+		const { state, openTooltip } = useGlobalTooltip();
+
+		openTooltip({
+			content: 'hello',
+			side: 'top',
+			align: 'center',
+			inverted: false,
+			monospace: false,
+			delayDuration: 0,
+			virtualRef: null,
+		});
+
+		vi.advanceTimersByTime(0);
+		expect(state.kbd).toBeUndefined();
+	});
+
 	it('cancels pending open when closed before delay', () => {
 		const { state, openTooltip, closeTooltip } = useGlobalTooltip();
 

--- a/app/src/composables/use-global-tooltip.ts
+++ b/app/src/composables/use-global-tooltip.ts
@@ -8,6 +8,7 @@ export type TooltipAlign = 'start' | 'center' | 'end';
 
 export interface TooltipPayload {
 	content: string;
+	kbd?: string[];
 	side: TooltipSide;
 	align: TooltipAlign;
 	inverted: boolean;
@@ -23,6 +24,7 @@ interface TooltipState extends Omit<TooltipPayload, 'delayDuration'> {
 const state = reactive<TooltipState>({
 	open: false,
 	content: '',
+	kbd: undefined,
 	side: 'top',
 	align: 'center',
 	inverted: false,
@@ -38,8 +40,9 @@ function openTooltip(payload: TooltipPayload, immediateContent = false): void {
 	if (immediateContent) state.content = payload.content;
 
 	timer = setTimeout(() => {
-		const { delayDuration: _, ...rest } = payload;
+		const { delayDuration: _, kbd, ...rest } = payload;
 		Object.assign(state, rest);
+		state.kbd = kbd;
 		state.open = true;
 	}, payload.delayDuration);
 }

--- a/app/src/directives/tooltip.test.ts
+++ b/app/src/directives/tooltip.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { DirectiveBinding } from 'vue';
-import { isDisabled, resolveAlign, resolveSide } from './tooltip';
+import { isDisabled, resolveAlign, resolveSide, resolveTooltipValue } from './tooltip';
 
 function createElement(html: string): HTMLElement {
 	const div = document.createElement('div');
@@ -100,5 +100,22 @@ describe('resolveAlign', () => {
 
 	it('returns end for .end modifier', () => {
 		expect(resolveAlign(makeBinding({ modifiers: { end: true } }))).toBe('end');
+	});
+});
+
+describe('resolveTooltipValue', () => {
+	it('normalizes a string value to { content, kbd: undefined }', () => {
+		expect(resolveTooltipValue('hello')).toEqual({ content: 'hello', kbd: undefined });
+	});
+
+	it('normalizes an object value with text and kbd', () => {
+		expect(resolveTooltipValue({ text: 'Save', kbd: ['meta', 's'] })).toEqual({
+			content: 'Save',
+			kbd: ['meta', 's'],
+		});
+	});
+
+	it('normalizes an object value with no kbd', () => {
+		expect(resolveTooltipValue({ text: 'Save' })).toEqual({ content: 'Save', kbd: undefined });
 	});
 });

--- a/app/src/directives/tooltip.ts
+++ b/app/src/directives/tooltip.ts
@@ -33,6 +33,16 @@ interface TooltipHandlers {
 	blur: () => void;
 }
 
+export interface TooltipValue {
+	text: string;
+	kbd?: string[];
+}
+
+export function resolveTooltipValue(value: string | TooltipValue): { content: string; kbd: string[] | undefined } {
+	if (typeof value === 'string') return { content: value, kbd: undefined };
+	return { content: value.text, kbd: value.kbd };
+}
+
 const handlerMap = new WeakMap<HTMLElement, TooltipHandlers>();
 const { openTooltip, closeTooltip } = useGlobalTooltip();
 
@@ -40,9 +50,11 @@ function beforeMount(element: HTMLElement, binding: DirectiveBinding): void {
 	if (!binding.value) return;
 
 	const virtualRef = { getBoundingClientRect: () => element.getBoundingClientRect() };
+	const { content, kbd } = resolveTooltipValue(binding.value);
 
 	const buildPayload = (delayDuration: number) => ({
-		content: binding.value,
+		content,
+		kbd,
 		side: resolveSide(binding),
 		align: resolveAlign(binding),
 		inverted: !!binding.modifiers['inverted'],

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { translateShortcut, useShortcut } from '@directus/composables';
+import { useShortcut } from '@directus/composables';
 import CodeMirror from 'codemirror';
 import { computed, onMounted, reactive, ref, watch } from 'vue';
 import { Alteration, applyEdit, CustomSyntax } from './edits';
@@ -12,6 +12,7 @@ import VDialog from '@/components/v-dialog.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
 import VInput from '@/components/v-input.vue';
 import VItemGroup from '@/components/v-item-group.vue';
+import VKbdShortcut from '@/components/v-kbd-shortcut.vue';
 import VListItemContent from '@/components/v-list-item-content.vue';
 import VListItemHint from '@/components/v-list-item-hint.vue';
 import VListItem from '@/components/v-list-item.vue';
@@ -241,7 +242,10 @@ const menuActive = computed(() => imageDialogOpen.value);
 					<VList>
 						<VListItem v-for="n in 6" :key="n" clickable @click="edit('heading', { level: n })">
 							<VListItemContent><VTextOverflow :text="$t(`wysiwyg_options.h${n}`)" /></VListItemContent>
-							<VListItemHint>{{ translateShortcut(['meta', 'alt']) }} {{ n }}</VListItemHint>
+							<VListItemHint>
+								<VKbdShortcut :value="['meta', 'alt']" />
+								{{ n }}
+							</VListItemHint>
 						</VListItem>
 					</VList>
 				</VMenu>

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -248,7 +248,7 @@ const menuActive = computed(() => imageDialogOpen.value);
 
 				<VButton
 					v-if="toolbar?.includes('bold')"
-					v-tooltip="$t('wysiwyg_options.bold') + ' - ' + translateShortcut(['meta', 'b'])"
+					v-tooltip="{ text: $t('wysiwyg_options.bold'), kbd: ['meta', 'b'] }"
 					:disabled="disabled"
 					small
 					icon
@@ -258,7 +258,7 @@ const menuActive = computed(() => imageDialogOpen.value);
 				</VButton>
 				<VButton
 					v-if="toolbar?.includes('italic')"
-					v-tooltip="$t('wysiwyg_options.italic') + ' - ' + translateShortcut(['meta', 'i'])"
+					v-tooltip="{ text: $t('wysiwyg_options.italic'), kbd: ['meta', 'i'] }"
 					:disabled="disabled"
 					small
 					icon
@@ -268,7 +268,7 @@ const menuActive = computed(() => imageDialogOpen.value);
 				</VButton>
 				<VButton
 					v-if="toolbar?.includes('strikethrough')"
-					v-tooltip="$t('wysiwyg_options.strikethrough') + ' - ' + translateShortcut(['meta', 'alt', 'd'])"
+					v-tooltip="{ text: $t('wysiwyg_options.strikethrough'), kbd: ['meta', 'alt', 'd'] }"
 					:disabled="disabled"
 					small
 					icon
@@ -298,7 +298,7 @@ const menuActive = computed(() => imageDialogOpen.value);
 				</VButton>
 				<VButton
 					v-if="toolbar?.includes('blockquote')"
-					v-tooltip="$t('wysiwyg_options.blockquote') + ' - ' + translateShortcut(['meta', 'alt', 'q'])"
+					v-tooltip="{ text: $t('wysiwyg_options.blockquote'), kbd: ['meta', 'alt', 'q'] }"
 					:disabled="disabled"
 					small
 					icon
@@ -308,7 +308,7 @@ const menuActive = computed(() => imageDialogOpen.value);
 				</VButton>
 				<VButton
 					v-if="toolbar?.includes('code')"
-					v-tooltip="$t('wysiwyg_options.codeblock') + ' - ' + translateShortcut(['meta', 'alt', 'c'])"
+					v-tooltip="{ text: $t('wysiwyg_options.codeblock'), kbd: ['meta', 'alt', 'c'] }"
 					:disabled="disabled"
 					small
 					icon
@@ -318,7 +318,7 @@ const menuActive = computed(() => imageDialogOpen.value);
 				</VButton>
 				<VButton
 					v-if="toolbar?.includes('link')"
-					v-tooltip="$t('wysiwyg_options.link') + ' - ' + translateShortcut(['meta', 'k'])"
+					v-tooltip="{ text: $t('wysiwyg_options.link'), kbd: ['meta', 'k'] }"
 					:disabled="disabled"
 					small
 					icon

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { translateShortcut, useCollection, useShortcut } from '@directus/composables';
+import { useCollection, useShortcut } from '@directus/composables';
 import type { PrimaryKey } from '@directus/types';
 import { SplitPanel } from '@directus/vue-split-panel';
 import { useHead } from '@unhead/vue';
@@ -21,6 +21,7 @@ import VCard from '@/components/v-card.vue';
 import VDialog from '@/components/v-dialog.vue';
 import VForm from '@/components/v-form/v-form.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
+import VKbdShortcut from '@/components/v-kbd-shortcut.vue';
 import VListItemContent from '@/components/v-list-item-content.vue';
 import VListItemHint from '@/components/v-list-item-hint.vue';
 import VListItemIcon from '@/components/v-list-item-icon.vue';
@@ -834,12 +835,12 @@ function useItemNavigation() {
 							<VListItem clickable @click="saveVersionAction('main')">
 								<VListItemIcon><VIcon name="check" /></VListItemIcon>
 								<VListItemContent>{{ $t('save_and_return_to_main') }}</VListItemContent>
-								<VListItemHint>{{ translateShortcut(['meta', 'alt', 's']) }}</VListItemHint>
+								<VListItemHint><VKbdShortcut :value="['meta', 'alt', 's']" /></VListItemHint>
 							</VListItem>
 							<VListItem clickable @click="saveVersionAction('quit')">
 								<VListItemIcon><VIcon name="done_all" /></VListItemIcon>
 								<VListItemContent>{{ $t('save_and_quit') }}</VListItemContent>
-								<VListItemHint>{{ translateShortcut(['meta', 'shift', 's']) }}</VListItemHint>
+								<VListItemHint><VKbdShortcut :value="['meta', 'shift', 's']" /></VListItemHint>
 							</VListItem>
 							<VListItem clickable @click="discardAndStay">
 								<VListItemIcon><VIcon name="undo" /></VListItemIcon>

--- a/app/src/styles/_tooltip.scss
+++ b/app/src/styles/_tooltip.scss
@@ -31,6 +31,12 @@
 		font-family: var(--theme--fonts--monospace--font-family);
 	}
 
+	.tooltip-kbd {
+		display: inline-flex;
+		gap: 0.125rem;
+		margin-inline-start: 0.375rem;
+	}
+
 	svg {
 		fill: var(--tooltip-background-color);
 	}

--- a/app/src/styles/_tooltip.scss
+++ b/app/src/styles/_tooltip.scss
@@ -3,6 +3,8 @@
 	--tooltip-background-color: var(--background-inverted);
 
 	z-index: 850;
+	display: flex;
+	align-items: center;
 	max-inline-size: 14.625rem;
 	padding: 0.25rem 0.4375rem;
 	color: var(--tooltip-foreground-color);
@@ -33,6 +35,7 @@
 
 	.tooltip-kbd {
 		display: inline-flex;
+		align-items: center;
 		gap: 0.125rem;
 		margin-inline-start: 0.375rem;
 	}

--- a/app/src/views/private/components/comparison/comparison-modal.vue
+++ b/app/src/views/private/components/comparison/comparison-modal.vue
@@ -377,11 +377,7 @@ function onIncomingSelectionChange(newDeltaId: PrimaryKey) {
 								</VCheckbox>
 							</div>
 							<div class="buttons-container">
-								<VButton
-									v-tooltip.top="`${$t('cancel')} (${translateShortcut(['esc'])})`"
-									secondary
-									@click="$emit('cancel')"
-								>
+								<VButton v-tooltip.top="{ text: $t('cancel'), kbd: ['esc'] }" secondary @click="$emit('cancel')">
 									<VIcon name="close" left />
 									<span class="button-text">{{ $t(mode === 'collab' ? 'discard' : 'cancel') }}</span>
 								</VButton>

--- a/app/src/views/private/components/save-options.vue
+++ b/app/src/views/private/components/save-options.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { translateShortcut } from '@directus/composables';
 import VIcon from '@/components/v-icon/v-icon.vue';
+import VKbdShortcut from '@/components/v-kbd-shortcut.vue';
 import VListItemContent from '@/components/v-list-item-content.vue';
 import VListItemHint from '@/components/v-list-item-hint.vue';
 import VListItemIcon from '@/components/v-list-item-icon.vue';
@@ -30,12 +30,12 @@ defineEmits<{
 			<VListItem v-if="!disabledOptions?.includes('save-and-stay')" clickable @click="$emit('save-and-stay')">
 				<VListItemIcon><VIcon name="check" /></VListItemIcon>
 				<VListItemContent>{{ $t('save_and_stay') }}</VListItemContent>
-				<VListItemHint>{{ translateShortcut(['meta', 's']) }}</VListItemHint>
+				<VListItemHint><VKbdShortcut :value="['meta', 's']" /></VListItemHint>
 			</VListItem>
 			<VListItem v-if="!disabledOptions?.includes('save-and-add-new')" clickable @click="$emit('save-and-add-new')">
 				<VListItemIcon><VIcon name="add" /></VListItemIcon>
 				<VListItemContent>{{ $t('save_and_create_new') }}</VListItemContent>
-				<VListItemHint>{{ translateShortcut(['meta', 'shift', 's']) }}</VListItemHint>
+				<VListItemHint><VKbdShortcut :value="['meta', 'shift', 's']" /></VListItemHint>
 			</VListItem>
 			<VListItem v-if="!disabledOptions?.includes('save-as-copy')" clickable @click="$emit('save-as-copy')">
 				<VListItemIcon><VIcon name="done_all" /></VListItemIcon>


### PR DESCRIPTION
## Scope

What's changed:

- Add `v-kbd` component to display individual keyboard keys with platform-aware translation (e.g. `meta` → `⌘` on Mac, `Ctrl` on Windows), supporting three sizes and three visual variants (`outlined`, `soft`, `inverted`)
- Add `v-kbd-shortcut` companion component that renders a sequence of `v-kbd` keys with consistent spacing, extending `v-kbd`'s props interface
- Register `v-kbd` as a global component
- Replace all `translateShortcut()` plain-text usages in list item hints with `VKbdShortcut` — covers `save-options.vue`, `item.vue`, and `input-rich-text-md.vue`
- Integrate `v-kbd` into the tooltip system via the `kbd` option on the `v-tooltip` directive, replacing inline string concatenation in toolbar buttons

## Potential Risks / Drawbacks

- `translateShortcut` is still used as a plain string in `comparison-modal.vue` and `overlay-item.vue` (JS logic, not template) — these are out of scope but leave the migration incomplete
- `app-tooltip.vue` still renders individual `VKbd` in a `v-for` loop rather than using `VKbdShortcut` — minor inconsistency

## Tested Scenarios

- `v-kbd` renders the correct translated symbol for `meta` on Mac (`⌘`) and non-Mac (`Ctrl`)
- Slot content takes precedence over the `value` prop
- All size and variant props apply the correct CSS classes (covered by unit tests in `v-kbd.test.ts`)
- `v-kbd-shortcut` renders multiple keys with gap spacing
- Save options menu displays keyboard shortcut hints as styled key caps instead of plain text
- Tooltip on markdown editor toolbar buttons shows `VKbd`-rendered shortcuts

## Review Notes / Questions

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #CMS-2090
