### PR TITLE
Replace `VMenu` popups with `VTooltip` component

### DIFF
--- a/app/src/components/v-menu.vue
+++ b/app/src/components/v-menu.vue
@@ -51,8 +51,6 @@ interface Props {
 	keepBehind?: boolean;
 	/** Do not focus activator when deactivating focus trap */
 	noFocusReturn?: boolean;
-	/** Invert the menu colors */
-	invert?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/app/src/components/v-tooltip.vue
+++ b/app/src/components/v-tooltip.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { TooltipArrow, TooltipContent, TooltipPortal, TooltipRoot, TooltipTrigger } from 'reka-ui';
+import type { TooltipAlign, TooltipSide } from '@/composables/use-global-tooltip';
+
+interface Props {
+	side?: TooltipSide;
+	align?: TooltipAlign;
+}
+
+withDefaults(defineProps<Props>(), {
+	side: 'top',
+	align: 'center',
+});
+</script>
+
+<template>
+	<TooltipRoot :delay-duration="500">
+		<TooltipTrigger as-child>
+			<slot name="trigger" />
+		</TooltipTrigger>
+		<TooltipPortal>
+			<TooltipContent :side="side" :align="align" :side-offset="8" class="tooltip">
+				<slot />
+				<TooltipArrow />
+			</TooltipContent>
+		</TooltipPortal>
+	</TooltipRoot>
+</template>

--- a/app/src/views/private/components/collab/CollabIndicatorHeader.vue
+++ b/app/src/views/private/components/collab/CollabIndicatorHeader.vue
@@ -90,7 +90,7 @@ function focusIntoView(cid: ClientID) {
 			<template #activator="{ toggle }">
 				<VTooltip side="bottom">
 					<template #trigger>
-						<VAvatar class="more-users" x-small round clickable @click.stop="toggle">
+						<VAvatar class="more-users" x-small round clickable @click="toggle">
 							+{{ users.length - COLLAB_USERS_DISPLAY_LIMIT }}
 						</VAvatar>
 					</template>
@@ -145,6 +145,10 @@ function focusIntoView(cid: ClientID) {
 
 	:deep(.v-avatar) {
 		font-size: 0.6875rem;
+	}
+
+	:deep(.v-avatar + .v-avatar) {
+		margin-inline-start: -0.25rem;
 	}
 }
 

--- a/app/src/views/private/components/collab/CollabIndicatorHeader.vue
+++ b/app/src/views/private/components/collab/CollabIndicatorHeader.vue
@@ -72,17 +72,19 @@ function focusIntoView(cid: ClientID) {
 						<VIcon v-else name="person" small />
 					</VAvatar>
 				</template>
-				<p>
-					{{ user.name ?? t('unknown_user') }}
-					<template v-if="user.isCurrentUser">({{ t('you') }})</template>
-				</p>
-				<p class="collab-header-popover-status">
-					{{
-						user.focusedField
-							? t('collab_editing_field', { field: formatTitle(user.focusedField) })
-							: t('collab_currently_viewing')
-					}}
-				</p>
+				<div class="collab-header-tooltip-content">
+					<p>
+						{{ user.name ?? t('unknown_user') }}
+						<template v-if="user.isCurrentUser">({{ t('you') }})</template>
+					</p>
+					<p class="collab-header-popover-status">
+						{{
+							user.focusedField
+								? t('collab_editing_field', { field: formatTitle(user.focusedField) })
+								: t('collab_currently_viewing')
+						}}
+					</p>
+				</div>
 			</VTooltip>
 		</template>
 
@@ -163,6 +165,11 @@ function focusIntoView(cid: ClientID) {
 		flex-direction: column;
 		align-items: flex-start;
 	}
+}
+
+.collab-header-tooltip-content {
+	padding-inline: 0.125rem;
+	padding-block-end: 0.125rem;
 }
 
 .collab-header-popover-status {

--- a/app/src/views/private/components/collab/CollabIndicatorHeader.vue
+++ b/app/src/views/private/components/collab/CollabIndicatorHeader.vue
@@ -10,6 +10,7 @@ import VIcon from '@/components/v-icon/v-icon.vue';
 import VListItem from '@/components/v-list-item.vue';
 import VList from '@/components/v-list.vue';
 import VMenu from '@/components/v-menu.vue';
+import VTooltip from '@/components/v-tooltip.vue';
 import type { CollabUser } from '@/composables/use-collab';
 
 interface Props {
@@ -56,8 +57,8 @@ function focusIntoView(cid: ClientID) {
 <template>
 	<div class="collab-header">
 		<template v-for="(user, index) in users.slice(0, COLLAB_USERS_DISPLAY_LIMIT)" :key="user.id">
-			<VMenu trigger="hover" show-arrow invert>
-				<template #activator>
+			<VTooltip>
+				<template #trigger>
 					<VAvatar
 						:border="`var(--${user.color})`"
 						:style="{ zIndex: COLLAB_USERS_DISPLAY_LIMIT - index }"
@@ -71,28 +72,30 @@ function focusIntoView(cid: ClientID) {
 						<VIcon v-else name="person" small />
 					</VAvatar>
 				</template>
-
-				<div class="collab-header-popover">
-					<p>
-						{{ user.name ?? t('unknown_user') }}
-						<template v-if="user.isCurrentUser">({{ t('you') }})</template>
-					</p>
-					<p class="collab-header-popover-status">
-						{{
-							user.focusedField
-								? t('collab_editing_field', { field: formatTitle(user.focusedField) })
-								: t('collab_currently_viewing')
-						}}
-					</p>
-				</div>
-			</VMenu>
+				<p>
+					{{ user.name ?? t('unknown_user') }}
+					<template v-if="user.isCurrentUser">({{ t('you') }})</template>
+				</p>
+				<p class="collab-header-popover-status">
+					{{
+						user.focusedField
+							? t('collab_editing_field', { field: formatTitle(user.focusedField) })
+							: t('collab_currently_viewing')
+					}}
+				</p>
+			</VTooltip>
 		</template>
 
 		<VMenu v-if="users.length > COLLAB_USERS_DISPLAY_LIMIT" show-arrow>
 			<template #activator="{ toggle }">
-				<VAvatar v-tooltip.bottom="t('more_users')" class="more-users" x-small round clickable @click="toggle">
-					+{{ users.length - COLLAB_USERS_DISPLAY_LIMIT }}
-				</VAvatar>
+				<VTooltip side="bottom">
+					<template #trigger>
+						<VAvatar class="more-users" x-small round clickable @click.stop="toggle">
+							+{{ users.length - COLLAB_USERS_DISPLAY_LIMIT }}
+						</VAvatar>
+					</template>
+					{{ t('more_users') }}
+				</VTooltip>
 			</template>
 
 			<VList>
@@ -140,26 +143,9 @@ function focusIntoView(cid: ClientID) {
 	display: flex;
 	align-items: center;
 
-	:deep(.v-menu + .v-menu .v-avatar) {
-		margin-inline-start: -0.25rem;
-	}
-
 	:deep(.v-avatar) {
 		font-size: 0.6875rem;
 	}
-}
-
-.collab-header-popover {
-	padding: 0.25rem;
-	padding-block-end: 0.375rem;
-	display: flex;
-	flex-direction: column;
-}
-
-.collab-header-popover-status {
-	font-size: 0.857em;
-	line-height: 1.2;
-	color: var(--theme--foreground-subdued);
 }
 
 .collab-header-more-popover-item {
@@ -173,5 +159,11 @@ function focusIntoView(cid: ClientID) {
 		flex-direction: column;
 		align-items: flex-start;
 	}
+}
+
+.collab-header-popover-status {
+	font-size: 0.857em;
+	line-height: 1.2;
+	color: var(--theme--foreground-subdued);
 }
 </style>

--- a/app/src/views/private/components/collab/CollabIndicatorHeader.vue
+++ b/app/src/views/private/components/collab/CollabIndicatorHeader.vue
@@ -147,10 +147,11 @@ function focusIntoView(cid: ClientID) {
 
 	:deep(.v-avatar) {
 		font-size: 0.6875rem;
-	}
 
-	:deep(.v-avatar + .v-avatar) {
-		margin-inline-start: -0.25rem;
+		+ .v-avatar,
+		+ .v-menu .v-avatar {
+			margin-inline-start: -0.25rem;
+		}
 	}
 }
 


### PR DESCRIPTION
## Scope

What's changed:

- Add new `VTooltip` component (`app/src/components/v-tooltip.vue`) backed by Reka UI's `TooltipRoot`, supporting rich slot content via a `#trigger` slot
- Replace `VMenu trigger="hover"` hover popups in `CollabIndicatorHeader` with `VTooltip` for the visible user avatars

## Tested Scenarios

- Hovering a visible user avatar shows name and editing/viewing status in a tooltip
- Hovering the `+N` overflow button shows "Click to view more" tooltip
- Clicking the `+N` button opens the overflow list correctly
- Overflow list still shows avatar + name + status inline via `VListItem`

## Review Notes / Questions

- I would like reviewers to pay attention to the two-component approach (`app-tooltip` singleton for the directive, `v-tooltip` for rich slot content) — worth discussing if this is the right long-term split or if `app-tooltip` should be extended to support slots

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes [CMS-2096](https://linear.app/directus/issue/CMS-2096/replace-vmenu-in-collabindicatorheader-with-tooltip-component)