### PR TITLE
Fix MARKETPLACE_REGISTRY env not being passed to registry list call when generating extension settings

### DIFF
--- a/.changeset/polite-colts-glow.md
+++ b/.changeset/polite-colts-glow.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Passed MARKETPLACE_REGISTRY env to registry list call

--- a/.changeset/polite-colts-glow.md
+++ b/.changeset/polite-colts-glow.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Passed MARKETPLACE_REGISTRY env to registry list call
+Fixed MARKETPLACE_REGISTRY env not being passed to registry list call when generating extension settings

--- a/api/src/extensions/lib/get-extensions-settings.test.ts
+++ b/api/src/extensions/lib/get-extensions-settings.test.ts
@@ -1,0 +1,111 @@
+import { useEnv } from '@directus/env';
+import { list } from '@directus/extensions-registry';
+import type { Extension } from '@directus/types';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { getExtensionsSettings } from './get-extensions-settings.js';
+
+vi.mock('@directus/env', () => ({
+	useEnv: vi.fn(() => ({})),
+}));
+
+vi.mock('@directus/extensions-registry', () => ({
+	list: vi.fn(),
+}));
+
+vi.mock('../../database/index.js', () => ({
+	default: vi.fn(() => ({})),
+}));
+
+vi.mock('../../utils/get-schema.js', () => ({
+	getSchema: vi.fn(() => ({})),
+}));
+
+const mockReadByQuery = vi.fn();
+const mockCreateMany = vi.fn();
+const mockDeleteMany = vi.fn();
+
+vi.mock('../../services/extensions.js', () => ({
+	ExtensionsService: vi.fn(() => ({
+		extensionsItemService: {
+			readByQuery: mockReadByQuery,
+			createMany: mockCreateMany,
+			deleteMany: mockDeleteMany,
+		},
+	})),
+}));
+
+const MOCK_EXTENSION_ID = 'test-marketplace-id';
+
+const mockRegistryExtension: Extension = {
+	name: 'directus-extension-test',
+	type: 'interface',
+	path: './extensions/.registry/some-folder',
+	local: false,
+	entrypoint: 'index.js',
+	host: '^11.0.0',
+	version: '1.0.0',
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockReadByQuery.mockResolvedValue([]);
+});
+
+describe('getExtensionsSettings', () => {
+	describe('MARKETPLACE_REGISTRY', () => {
+		test('should pass MARKETPLACE_REGISTRY to list() when set', async () => {
+			const customRegistry = 'https://custom-registry.example.com';
+
+			vi.mocked(useEnv).mockReturnValue({ MARKETPLACE_REGISTRY: customRegistry } as any);
+
+			vi.mocked(list).mockResolvedValue({
+				data: [{ id: MOCK_EXTENSION_ID, name: mockRegistryExtension.name }],
+				meta: {},
+			} as any);
+
+			const registryMap = new Map<string, Extension>();
+			registryMap.set('some-folder', mockRegistryExtension);
+
+			await getExtensionsSettings({
+				local: new Map(),
+				module: new Map(),
+				registry: registryMap,
+			});
+
+			expect(list).toHaveBeenCalledWith({ search: mockRegistryExtension.name }, { registry: customRegistry });
+		});
+
+		test('should pass empty options to list() when MARKETPLACE_REGISTRY is not set', async () => {
+			vi.mocked(useEnv).mockReturnValue({} as any);
+
+			vi.mocked(list).mockResolvedValue({
+				data: [{ id: MOCK_EXTENSION_ID, name: mockRegistryExtension.name }],
+				meta: {},
+			} as any);
+
+			const registryMap = new Map<string, Extension>();
+			registryMap.set('some-folder', mockRegistryExtension);
+
+			await getExtensionsSettings({
+				local: new Map(),
+				module: new Map(),
+				registry: registryMap,
+			});
+
+			expect(list).toHaveBeenCalledWith({ search: mockRegistryExtension.name }, {});
+		});
+
+		test('should not call list() for local extensions', async () => {
+			const localMap = new Map<string, Extension>();
+			localMap.set('local-folder', { ...mockRegistryExtension, local: true });
+
+			await getExtensionsSettings({
+				local: localMap,
+				module: new Map(),
+				registry: new Map(),
+			});
+
+			expect(list).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/api/src/extensions/lib/get-extensions-settings.ts
+++ b/api/src/extensions/lib/get-extensions-settings.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
-import { list } from '@directus/extensions-registry';
+import { useEnv } from '@directus/env';
+import { list, type ListOptions } from '@directus/extensions-registry';
 import type { BundleExtension, Extension, ExtensionSettings } from '@directus/types';
 import getDatabase from '../../database/index.js';
 import { ExtensionsService } from '../../services/extensions.js';
@@ -75,7 +76,14 @@ export const getExtensionsSettings = async ({
 		let marketplaceId;
 
 		if (source === 'registry') {
-			const marketplace = await list({ search: extension.name });
+			const env = useEnv();
+			const listOptions: ListOptions = {};
+
+			if (env['MARKETPLACE_REGISTRY'] && typeof env['MARKETPLACE_REGISTRY'] === 'string') {
+				listOptions.registry = env['MARKETPLACE_REGISTRY'];
+			}
+
+			const marketplace = await list({ search: extension.name }, listOptions);
 			marketplaceId = marketplace.data.find((ext) => ext.name === extension.name)?.id;
 		}
 


### PR DESCRIPTION
## Scope

What's changed:

- `list()` now passes the `MARKETPLACE_REGISTRY` env var as registry option, matching the pattern used by all other registry callers

## Potential Risks / Drawbacks

- None

## Tested Scenarios

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- Unit test: `list()` receives custom registry URL when `MARKETPLACE_REGISTRY` is set
- Unit test: `list()` receives empty options when `MARKETPLACE_REGISTRY` is not set
- Unit test: `list()` is not called for local extensions

## Checklist

- [X] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---
