### PR TITLE
xiiui ← Extract the card subheader into a reusable subheader component

### DIFF
--- a/.changeset/sour-seas-begin.md
+++ b/.changeset/sour-seas-begin.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Extracted Card subheader into LayoutSubheader component

--- a/.changeset/sour-seas-begin.md
+++ b/.changeset/sour-seas-begin.md
@@ -2,4 +2,4 @@
 '@directus/app': minor
 ---
 
-Extracted Card subheader into LayoutSubheader component
+Extracted the card subheader into a reusable subheader component

--- a/app/src/layouts/cards/cards.vue
+++ b/app/src/layouts/cards/cards.vue
@@ -179,7 +179,7 @@ function onSelectAll() {
 }
 
 .header {
-	margin-block-end: 1.5rem;
+	margin-block-end: var(--content-padding);
 }
 
 .grid {

--- a/app/src/layouts/cards/cards.vue
+++ b/app/src/layouts/cards/cards.vue
@@ -114,6 +114,7 @@ function onSelectAll() {
 				v-model:selection="selectionWritable"
 				v-model:extra-selection="extraSelectionWritable"
 				v-model:sort="sortWritable"
+				class="header"
 				:fields="fieldsInCollection"
 				:show-select="showSelect"
 				@select-all="onSelectAll"
@@ -175,6 +176,10 @@ function onSelectAll() {
 .layout-cards {
 	padding: var(--content-padding);
 	padding-block-start: 0;
+}
+
+.header {
+	margin-block-end: 1.5rem;
 }
 
 .grid {

--- a/app/src/layouts/cards/components/header.vue
+++ b/app/src/layouts/cards/components/header.vue
@@ -7,7 +7,7 @@ import VListItemContent from '@/components/v-list-item-content.vue';
 import VListItem from '@/components/v-list-item.vue';
 import VList from '@/components/v-list.vue';
 import VMenu from '@/components/v-menu.vue';
-import LayoutSubheader from '@/views/private/components/layout-subheader.vue';
+import SubHeader from '@/views/private/components/sub-header.vue';
 
 const props = withDefaults(
 	defineProps<{
@@ -79,7 +79,7 @@ function onClickSelect() {
 </script>
 
 <template>
-	<LayoutSubheader>
+	<SubHeader>
 		<template #start>
 			<button type="button" :class="{ 'no-selection': !totalSelectionCount }" @click="onClickSelect">
 				<template v-if="totalSelectionCount">
@@ -130,7 +130,7 @@ function onClickSelect() {
 				@click="toggleDescending"
 			/>
 		</template>
-	</LayoutSubheader>
+	</SubHeader>
 </template>
 
 <style lang="scss" scoped>

--- a/app/src/layouts/cards/components/header.vue
+++ b/app/src/layouts/cards/components/header.vue
@@ -7,6 +7,7 @@ import VListItemContent from '@/components/v-list-item-content.vue';
 import VListItem from '@/components/v-list-item.vue';
 import VList from '@/components/v-list.vue';
 import VMenu from '@/components/v-menu.vue';
+import LayoutSubheader from '@/views/private/components/layout-subheader.vue';
 
 const props = withDefaults(
 	defineProps<{
@@ -78,8 +79,8 @@ function onClickSelect() {
 </script>
 
 <template>
-	<div class="cards-header">
-		<div class="start">
+	<LayoutSubheader>
+		<template #start>
 			<button type="button" :class="{ 'no-selection': !totalSelectionCount }" @click="onClickSelect">
 				<template v-if="totalSelectionCount">
 					<VIcon name="cancel" outline />
@@ -90,8 +91,8 @@ function onClickSelect() {
 					<span class="label">{{ $t(showSelect === 'multiple' ? 'select_all' : 'select_an_item') }}</span>
 				</template>
 			</button>
-		</div>
-		<div class="end">
+		</template>
+		<template #end>
 			<VIcon
 				v-tooltip.top="$t('card_size')"
 				class="size-selector"
@@ -128,28 +129,11 @@ function onClickSelect() {
 				clickable
 				@click="toggleDescending"
 			/>
-		</div>
-	</div>
+		</template>
+	</LayoutSubheader>
 </template>
 
 <style lang="scss" scoped>
-.cards-header {
-	position: sticky;
-	inset-block-start: var(--layout-offset-top);
-	z-index: 4;
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	inline-size: 100%;
-	block-size: 2.9375rem;
-	margin-block-end: var(--content-padding);
-	padding: 0 0.4375rem;
-	background-color: var(--theme--background);
-	border-block-start: var(--theme--border-width) solid var(--theme--border-color-subdued);
-	border-block-end: var(--theme--border-width) solid var(--theme--border-color-subdued);
-	box-shadow: 0 0 0 2px var(--theme--background);
-}
-
 .start {
 	.label {
 		display: inline-block;

--- a/app/src/layouts/cards/components/header.vue
+++ b/app/src/layouts/cards/components/header.vue
@@ -154,10 +154,10 @@ function onClickSelect() {
 .end {
 	display: flex;
 	align-items: center;
-	color: var(--theme--foreground-subdued);
 
 	.size-selector {
 		margin-inline-end: 0.875rem;
+		color: var(--theme--foreground-subdued);
 		transition: color var(--fast) var(--transition);
 
 		&:hover {
@@ -167,6 +167,7 @@ function onClickSelect() {
 
 	.sort-selector {
 		margin-inline-end: 0.4375rem;
+		color: var(--theme--foreground-subdued);
 		transition: color var(--fast) var(--transition);
 
 		&:hover {
@@ -175,6 +176,7 @@ function onClickSelect() {
 	}
 
 	.sort-direction {
+		color: var(--theme--foreground-subdued);
 		transition: color var(--fast) var(--transition);
 
 		&.descending {

--- a/app/src/layouts/tabular/tabular.vue
+++ b/app/src/layouts/tabular/tabular.vue
@@ -290,8 +290,6 @@ function removeField(fieldKey: string) {
 }
 
 .v-table {
-	--v-table-sticky-offset-top: var(--layout-offset-top);
-
 	display: contents;
 
 	& > :deep(table) {

--- a/app/src/modules/settings/routes/presets/item.vue
+++ b/app/src/modules/settings/routes/presets/item.vue
@@ -601,7 +601,6 @@ function discardAndLeave() {
 .layout {
 	--content-padding: 0;
 	--content-padding-bottom: 0;
-	--layout-offset-top: 0;
 
 	position: relative;
 	inline-size: 100%;

--- a/app/src/styles/_variables.scss
+++ b/app/src/styles/_variables.scss
@@ -10,6 +10,7 @@
 	--medium: 200ms;
 	--slow: 300ms;
 	--header-bar-height: 6.75rem;
+	--sub-header-height: 3rem;
 	--content-padding: 1.125rem;
 	--content-padding-bottom: 1.2656rem;
 	--content-padding-top-table: 0.875rem;

--- a/app/src/styles/lib/_fullcalendar.scss
+++ b/app/src/styles/lib/_fullcalendar.scss
@@ -125,11 +125,10 @@
 			block-size: 2.9375rem;
 			margin-block-end: var(--content-padding);
 			margin-inline: calc(-1 * var(--content-padding));
-			padding: 0 var(--content-padding);
+			padding: 0.625rem 1.5rem;
 			font-weight: inherit !important;
 			font-size: inherit !important;
 			background-color: var(--theme--background);
-			border-block-start: var(--theme--border-width) solid var(--theme--border-color-subdued);
 			border-block-end: var(--theme--border-width) solid var(--theme--border-color-subdued);
 			box-shadow: 0 0 0 2px var(--theme--background);
 		}

--- a/app/src/styles/lib/_fullcalendar.scss
+++ b/app/src/styles/lib/_fullcalendar.scss
@@ -119,17 +119,14 @@
 	.fc-toolbar {
 		&.fc-header-toolbar {
 			position: sticky;
-			inset-block-start: var(--layout-offset-top);
+			inset-block-start: 0;
 			z-index: 4;
-			inline-size: calc(100% + 2 * var(--content-padding));
-			block-size: 2.9375rem;
+			block-size: var(--sub-header-height);
 			margin-block-end: var(--content-padding);
-			margin-inline: calc(-1 * var(--content-padding));
-			padding: 0.625rem 1.5rem;
 			font-weight: inherit !important;
 			font-size: inherit !important;
 			background-color: var(--theme--background);
-			border-block-end: var(--theme--border-width) solid var(--theme--border-color-subdued);
+			border-block-end: var(--theme--border-width) solid var(--theme--border-color);
 			box-shadow: 0 0 0 2px var(--theme--background);
 		}
 	}

--- a/app/src/styles/lib/_fullcalendar.scss
+++ b/app/src/styles/lib/_fullcalendar.scss
@@ -121,7 +121,7 @@
 			position: sticky;
 			inset-block-start: 0;
 			z-index: 4;
-			block-size: var(--sub-header-height);
+			block-size: calc(var(--sub-header-height) + var(--theme--border-width));
 			margin-block-end: var(--content-padding);
 			font-weight: inherit !important;
 			font-size: inherit !important;

--- a/app/src/views/private/components/drawer-collection.vue
+++ b/app/src/views/private/components/drawer-collection.vue
@@ -201,7 +201,5 @@ function useActions() {
 <style lang="scss" scoped>
 .layout {
 	display: contents;
-
-	--layout-offset-top: calc(var(--header-bar-height) - 0.0625rem);
 }
 </style>

--- a/app/src/views/private/components/layout-subheader.vue
+++ b/app/src/views/private/components/layout-subheader.vue
@@ -1,0 +1,29 @@
+<template>
+	<div class="layout-subheader">
+		<div class="start">
+			<slot name="start" />
+		</div>
+		<div class="end">
+			<slot name="end" />
+		</div>
+	</div>
+</template>
+
+<style lang="scss" scoped>
+.layout-subheader {
+	position: sticky;
+	inset-block-start: var(--layout-offset-top);
+	z-index: 4;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	inline-size: calc(100% + 2 * var(--content-padding));
+	block-size: 2.9375rem;
+	margin-inline: calc(-1 * var(--content-padding));
+	margin-block-end: var(--content-padding);
+	padding: 0.625rem 1.5rem;
+	background-color: var(--theme--background);
+	border-block-end: var(--theme--border-width) solid var(--theme--border-color-subdued);
+	box-shadow: 0 0 0 2px var(--theme--background);
+}
+</style>

--- a/app/src/views/private/components/notifications-drawer.vue
+++ b/app/src/views/private/components/notifications-drawer.vue
@@ -36,6 +36,7 @@ import { useUserStore } from '@/stores/user';
 import { formatItemsCountPaginated } from '@/utils/format-items-count';
 import { getCollectionRoute, getItemRoute } from '@/utils/get-route';
 import SearchInput from '@/views/private/components/search-input.vue';
+import SubHeader from '@/views/private/components/sub-header.vue';
 
 type LocalNotification = Notification & {
 	to?: string;
@@ -336,18 +337,16 @@ function clearFilters() {
 			</VList>
 
 			<div v-else class="notifications-block">
-				<VDivider class="select-all-divider" :class="{ dense: totalPages > 1 }" />
-
-				<VCheckbox
-					class="select-all"
-					:class="{ dense: totalPages > 1 }"
-					:label="!allItemsSelected ? $t('select_all') : $t('deselect_all')"
-					:model-value="allItemsSelected"
-					:indeterminate="someItemsSelected"
-					@update:model-value="selectAll"
-				/>
-
-				<VDivider class="select-all-divider" :class="{ dense: totalPages > 1 }" />
+				<SubHeader>
+					<template #start>
+						<VCheckbox
+							:label="!allItemsSelected ? $t('select_all') : $t('deselect_all')"
+							:model-value="allItemsSelected"
+							:indeterminate="someItemsSelected"
+							@update:model-value="selectAll"
+						/>
+					</template>
+				</SubHeader>
 
 				<VList class="notifications">
 					<VListItem
@@ -465,26 +464,6 @@ function clearFilters() {
 				@include mixins.markdown;
 			}
 		}
-	}
-}
-
-.select-all {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	block-size: 1.375rem;
-	margin: 0 calc(var(--theme--form--field--input--padding) + var(--theme--border-width));
-
-	&.dense {
-		margin: 0 calc(0.4375rem + var(--theme--border-width)) 0.6875rem;
-	}
-}
-
-.select-all-divider {
-	margin: 0.4375rem 0;
-
-	&.dense {
-		margin: 0.25rem 0;
 	}
 }
 

--- a/app/src/views/private/components/notifications-drawer.vue
+++ b/app/src/views/private/components/notifications-drawer.vue
@@ -337,7 +337,7 @@ function clearFilters() {
 			</VList>
 
 			<div v-else class="notifications-block">
-				<SubHeader>
+				<SubHeader class="sub-header">
 					<template #start>
 						<VCheckbox
 							:label="!allItemsSelected ? $t('select_all') : $t('deselect_all')"
@@ -415,6 +415,10 @@ function clearFilters() {
 
 .content {
 	padding: 0 var(--content-padding) var(--content-padding-bottom) var(--content-padding);
+}
+
+.sub-header {
+	margin-block-end: var(--content-padding);
 }
 
 .notifications {

--- a/app/src/views/private/components/sub-header.vue
+++ b/app/src/views/private/components/sub-header.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="layout-subheader">
+	<div class="sub-header">
 		<div class="start">
 			<slot name="start" />
 		</div>
@@ -10,7 +10,7 @@
 </template>
 
 <style lang="scss" scoped>
-.layout-subheader {
+.sub-header {
 	position: sticky;
 	inset-block-start: var(--layout-offset-top);
 	z-index: 4;

--- a/app/src/views/private/components/sub-header.vue
+++ b/app/src/views/private/components/sub-header.vue
@@ -12,19 +12,13 @@
 <style lang="scss" scoped>
 .sub-header {
 	position: sticky;
-	inset-block-start: var(--layout-offset-top);
+	inset-block-start: 0;
 	z-index: 4;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	inline-size: calc(100% + 2 * var(--content-padding));
-	block-size: 2.9375rem;
-	margin-inline: calc(-1 * var(--content-padding));
-	margin-block-end: 1.5rem;
-	padding-block: 0.625rem;
-	padding-inline: var(--content-padding);
+	block-size: calc(var(--sub-header-height) + var(--theme--border-width));
 	background-color: var(--theme--background);
-	border-block-end: var(--theme--border-width) solid var(--theme--border-color-subdued);
-	box-shadow: 0 0 0 2px var(--theme--background);
+	border-block-end: var(--theme--border-width) solid var(--theme--border-color);
 }
 </style>

--- a/app/src/views/private/components/sub-header.vue
+++ b/app/src/views/private/components/sub-header.vue
@@ -20,8 +20,9 @@
 	inline-size: calc(100% + 2 * var(--content-padding));
 	block-size: 2.9375rem;
 	margin-inline: calc(-1 * var(--content-padding));
-	margin-block-end: var(--content-padding);
-	padding: 0.625rem 1.5rem;
+	margin-block-end: 1.5rem;
+	padding-block: 0.625rem;
+	padding-inline: var(--content-padding);
 	background-color: var(--theme--background);
 	border-block-end: var(--theme--border-width) solid var(--theme--border-color-subdued);
 	box-shadow: 0 0 0 2px var(--theme--background);


### PR DESCRIPTION
## Scope

What's changed:

- Extract the cards layout sticky subheader into a shared `LayoutSubheader` component (`views/private/components/layout-subheader.vue`) with `#start` and `#end` named slots, so future layouts can reuse the same shell
- Refactor the cards layout header to use `LayoutSubheader` instead of its own inline sticky bar styles
- Align the FullCalendar header toolbar padding (`0.625rem 1.5rem`) and remove its top border to match the shared subheader spec

## Potential Risks / Drawbacks

- `LayoutSubheader` uses `margin-inline: calc(-1 * var(--content-padding))` to escape its parent's inline padding — it assumes it will always be placed inside a container that uses `--content-padding` as inline padding, which is true for all current layout views but worth being aware of for future consumers

## Tested Scenarios

- Cards layout subheader renders correctly with selection, sort, and size controls intact
- Calendar layout toolbar padding and border visually match the cards subheader

## Review Notes / Questions

- I would like reviewers to pay attention to the negative-margin escape pattern in `LayoutSubheader` — it's the same approach already used in `_fullcalendar.scss` for the toolbar, so it's consistent, but it's an implicit contract with the parent container
- The component currently has one consumer (cards); calendar toolbar styling is applied via the existing `_fullcalendar.scss` rather than the component itself, since FullCalendar owns that DOM

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes [CMS-2077](https://linear.app/directus/issue/CMS-2077/ensure-consistent-subheader-styling)