### PR TITLE
Restore "All Users" tab

### DIFF
--- a/.changeset/funny-melons-fry.md
+++ b/.changeset/funny-melons-fry.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Restored All Users tab

--- a/.changeset/funny-melons-fry.md
+++ b/.changeset/funny-melons-fry.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Restored All Users tab

--- a/app/src/modules/users/components/navigation.vue
+++ b/app/src/modules/users/components/navigation.vue
@@ -29,7 +29,7 @@ function handleClick({ role }: { role: string }) {
 
 <template>
 	<VList nav>
-		<VListItem to="/users/active" exact>
+		<VListItem to="/users" exact>
 			<VListItemIcon><VIcon name="group" /></VListItemIcon>
 			<VListItemContent>{{ $t('active_users') }}</VListItemContent>
 		</VListItem>
@@ -40,6 +40,10 @@ function handleClick({ role }: { role: string }) {
 		<VListItem to="/users/invited" exact>
 			<VListItemIcon><VIcon name="person_add" /></VListItemIcon>
 			<VListItemContent>{{ $t('invited_users') }}</VListItemContent>
+		</VListItem>
+		<VListItem to="/users/all" exact>
+			<VListItemIcon><VIcon name="folder_shared" /></VListItemIcon>
+			<VListItemContent>{{ $t('all_users') }}</VListItemContent>
 		</VListItem>
 
 		<VDivider v-if="(roles && roles.length > 0) || loading" />

--- a/app/src/modules/users/index.ts
+++ b/app/src/modules/users/index.ts
@@ -8,12 +8,8 @@ export default defineModule({
 	icon: 'people_alt',
 	routes: [
 		{
-			path: '',
-			redirect: '/users/active',
-		},
-		{
 			name: 'users-active',
-			path: 'active',
+			path: '',
 			component: Collection,
 			props: () => ({ status: 'active' }),
 		},
@@ -28,6 +24,12 @@ export default defineModule({
 			path: 'invited',
 			component: Collection,
 			props: () => ({ status: 'invited' }),
+		},
+		{
+			name: 'users-all',
+			path: 'all',
+			component: Collection,
+			props: () => ({}),
 		},
 		{
 			name: 'users-item',

--- a/app/src/modules/users/routes/collection.vue
+++ b/app/src/modules/users/routes/collection.vue
@@ -180,7 +180,7 @@ function useBreadcrumb() {
 
 	const title = computed(() => {
 		if (props.status) return t(`${props.status}_users`);
-		if (!props.role) return t('user_directory');
+		if (!props.role) return t('all_users');
 		return roles.value?.find((role) => role.id === props.role)?.name;
 	});
 


### PR DESCRIPTION
  ## Scope                                                                                                                                          
                                                                                                                                                    
  What's changed:                                                                                                                                   
                                                                                                                                                    
  - Restored the All Users view which was removed in #27036
  - users/all is the new route for viewing all users
  - the primary /users route now displays active users only                                                                                                     
                                                                                                                                                    
  ## Potential Risks / Drawbacks                                                                                                                    
                                                                                                                                                    
 - None I can think of
                                                                                                                                                    
  ## Tested Scenarios                                       
                                                                                                                                                    
  - Navigating directly to `/users/all` shows all users regardless of status                                  
  - Clicking the Users icon in the module bar navigates to `/users` and displays active users only                        
                                                                                                                                                    
  ## Review Notes / Questions
                                                                                                                                                
  ## Checklist
                                                                                                                                                    
  - [ ] Added or updated tests                          
  - [x] Documentation PR created [here](https://github.com/directus/docs) or not required
  - [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required                                                      
   
  ---                                                                                                                                               
                                                            
  Fixes [CMS-2073](https://linear.app/directus/issue/CMS-2073/change-user-directory-tabs-to-active-suspended-invited)