### PR TITLE
fix(sdk): guard heartbeat pong send against closed connection race co…

### DIFF
--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -213,8 +213,8 @@ export function realtime(config: WebSocketConfig = {}) {
 				}
 
 				if (config.heartbeat && message['type'] === 'ping') {
-									if (state.code !== 'open') continue;
-				state.connection.send(pong());
+					if (state.code !== 'open') continue;
+					state.connection.send(pong());
 					state.firstMessage = false;
 					continue;
 				}

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -213,7 +213,8 @@ export function realtime(config: WebSocketConfig = {}) {
 				}
 
 				if (config.heartbeat && message['type'] === 'ping') {
-					state.connection.send(pong());
+									if (state.code !== 'open') continue;
+				state.connection.send(pong());
 					state.firstMessage = false;
 					continue;
 				}


### PR DESCRIPTION
## Problem

When realtime is enabled, the `handleMessages` loop awaits `messageCallback(state.connection)` which yields control. During that await, the WebSocket can close, transitioning `state` from `{ code: 'open', connection: ws }` to `{ code: 'closed' }`. When a `ping` message is then processed, `state.connection` is `undefined`, causing:

```
unhandledRejection: TypeError: Cannot read properties of undefined (reading 'send')
```

This appears randomly every 1-2 hours in production setups using the realtime SDK (reported in #25078).

## Root Cause

The `while (state.code === 'open')` loop guard on line 202 protects against entering a new iteration when state is closed, but the state **can change during** the `await messageCallback(...)` call. After the await resolves with a `ping` message, `state.code` may already be `'closed'`, making `state.connection` undefined.

## Fix

Add a guard check `if (state.code !== 'open') continue` immediately before calling `state.connection.send(pong())` inside the heartbeat handler. This is the same pattern already used for the `eventHandlers['message']` forEach callback on line 222.

## Changes

- `sdk/src/realtime/composable.ts`: Add connection state guard before sending pong response in heartbeat handler

Fixes #25078