### PR TITLE
fix(tus): use sudoFilesItemsService for internal ops in create()

### DIFF
--- a/.changeset/fix-tus-sudo-permissions.md
+++ b/.changeset/fix-tus-sudo-permissions.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+fix(tus): use sudoFilesItemsService for internal housekeeping ops in create() to prevent requiring update permission for TUS upload create operations

--- a/api/src/services/tus/data-store.ts
+++ b/api/src/services/tus/data-store.ts
@@ -55,6 +55,11 @@ export class TusDataStore extends DataStore {
 			knex,
 		});
 
+				const sudoFilesItemsService = new ItemsService<File>('directus_files', {
+								schema: this.schema,
+								knex,
+							});
+
 		upload.creation_date = new Date().toISOString();
 
 		if (!upload.size || !upload.metadata || !upload.metadata['filename_download']) {
@@ -132,7 +137,7 @@ export class TusDataStore extends DataStore {
 
 			fileData.tus_data = upload;
 
-			await filesItemsService.updateOne(primaryKey!, fileData, { emitEvents: false });
+			await sudoFilesItemsService.updateOne(primaryKey!, fileData, { emitEvents: false });
 
 			return upload;
 		} catch (err) {
@@ -140,9 +145,9 @@ export class TusDataStore extends DataStore {
 			logger.warn(err);
 
 			if (isReplacement) {
-				await filesItemsService.updateOne(primaryKey!, { tus_id: null, tus_data: null }, { emitEvents: false });
+				await sudoFilesItemsService.updateOne(primaryKey!, { tus_id: null, tus_data: null }, { emitEvents: false });
 			} else {
-				await filesItemsService.deleteOne(primaryKey!, { emitEvents: false });
+				await sudoFilesItemsService.deleteOne(primaryKey!, { emitEvents: false });
 			}
 
 			throw ERRORS.UNKNOWN_ERROR;
@@ -217,7 +222,7 @@ export class TusDataStore extends DataStore {
 
 		const fileData = await this.getFileById(tus_id);
 		await this.storageDriver.deleteChunkedUpload(fileData.filename_disk!, fileData.tus_data as ChunkedUploadContext);
-		await sudoFilesItemsService.deleteOne(fileData.id!);
+		await sudosudoFilesItemsService.deleteOne(fileData.id!);
 	}
 
 	override async deleteExpired(): Promise<number> {

--- a/contributors.yml
+++ b/contributors.yml
@@ -264,5 +264,6 @@
 - Champ-Goblem
 - Ikromjon1998
 - Zhey-on
+- Vansh1811
 - faizkhairi
 - eric-pennecot


### PR DESCRIPTION
## Problem

TUS resumable uploads fail with `"You don't have permission to perform \"update\" for collection \"directus_files\" or it does not exist."` even when the user only needs `create` permission, not `update` permission.

The `create()` method in `TusDataStore` uses `filesItemsService` (with user-level accountability) for internal operations like:
- Updating `tus_data`/`filename_disk` after storage driver creates the chunked upload
- Cleanup (`updateOne` / `deleteOne`) on error in the catch block

These are internal housekeeping operations that should bypass user permission checks, just like the `write()`, `remove()`, `deleteExpired()`, and `getFileById()` methods already do via `sudoFilesItemsService`.

## Fix

Add a `sudoFilesItemsService` (without accountability) inside `create()` and use it for all internal `updateOne`/`deleteOne` calls. The user-facing `filesItemsService` (with accountability) is still used for the initial `createOne()` call, which correctly enforces `create` permission.

Fixes #26877

## Changes

- `api/src/services/tus/data-store.ts`: Add `sudoFilesItemsService` in `create()` and use it for internal update/delete operations