### PR TITLE
Add save as new file option to image editor (CMS-2099)

### DIFF
--- a/.changeset/old-chairs-end.md
+++ b/.changeset/old-chairs-end.md
@@ -2,4 +2,4 @@
 '@directus/app': minor
 ---
 
-add save as new file option to image editor
+Added `Save as New File` option to image editor

--- a/.changeset/old-chairs-end.md
+++ b/.changeset/old-chairs-end.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+add save as new file option to image editor

--- a/app/src/interfaces/file-image/file-image.vue
+++ b/app/src/interfaces/file-image/file-image.vue
@@ -285,7 +285,14 @@ const { createAllowed, updateAllowed } = useRelationPermissionsM2O(relationInfo)
 				</template>
 			</DrawerItem>
 
-			<ImageEditor v-if="!internalDisabled" :id="image.id" v-model="editImageEditor" @refresh="refresh" />
+			<ImageEditor
+				v-if="!internalDisabled"
+				:id="image.id"
+				v-model="editImageEditor"
+				:create-allowed="createAllowed"
+				@refresh="refresh"
+				@new-file="update"
+			/>
 
 			<FileLightbox v-model="lightboxActive" :file="image" />
 		</component>

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -732,6 +732,7 @@ save_and_stay: Save and Stay
 save_and_quit: Save and Quit
 save_and_return_to_main: Save and Return to Main
 save_as_copy: Save as Copy
+save_as_new_file: Save as New File
 add_existing: Add Existing
 creating_items: Creating Items
 enable_create_button: Enable Create Button

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -374,7 +374,14 @@ function revert(values: Record<string, any>) {
 				@replace="refresh"
 			/>
 
-			<ImageEditor v-if="item?.type?.startsWith('image')" :id="item.id" v-model="editActive" @refresh="refresh" />
+			<ImageEditor
+				v-if="item?.type?.startsWith('image')"
+				:id="item.id"
+				v-model="editActive"
+				:create-allowed="createAllowed"
+				@refresh="refresh"
+				@new-file="(id) => router.push(`/files/${id}`)"
+			/>
 
 			<VForm
 				ref="form"

--- a/app/src/views/private/components/image-editor.vue
+++ b/app/src/views/private/components/image-editor.vue
@@ -221,11 +221,12 @@ function useImage() {
 					}
 
 					const formData = new FormData();
-					formData.append('file', blob, imageData.value?.filename_download);
 
 					if (imageData.value?.folder) {
 						formData.append('folder', imageData.value.folder as string);
 					}
+
+					formData.append('file', blob, imageData.value?.filename_download);
 
 					api.post('/files', formData).then(
 						(response) => resolve(response.data.data.id),

--- a/app/src/views/private/components/image-editor.vue
+++ b/app/src/views/private/components/image-editor.vue
@@ -26,6 +26,7 @@ const imageFields = [
 	'type',
 	'filesize',
 	'filename_download',
+	'folder',
 	'width',
 	'height',
 	'focal_point_x',
@@ -37,11 +38,13 @@ type Image = Pick<File, (typeof imageFields)[number]>;
 const props = defineProps<{
 	id: string;
 	modelValue?: boolean;
+	createAllowed?: boolean;
 }>();
 
 const emit = defineEmits<{
 	(e: 'update:modelValue', value: boolean): void;
 	(e: 'refresh'): void;
+	(e: 'new-file', id: string): void;
 }>();
 
 const { n } = useI18n();
@@ -60,7 +63,8 @@ const internalActive = computed({
 	},
 });
 
-const { loading, error, imageData, imageElement, hasEdits, save, saving, fetchImage, onImageLoad } = useImage();
+const { loading, error, imageData, imageElement, hasEdits, save, saveAsNew, saving, fetchImage, onImageLoad } =
+	useImage();
 
 const {
 	cropperInstance,
@@ -149,6 +153,7 @@ function useImage() {
 		imageElement,
 		hasEdits,
 		save,
+		saveAsNew,
 		saving,
 		onImageLoad,
 	};
@@ -198,6 +203,47 @@ function useImage() {
 					);
 				}, imageData.value?.type ?? undefined);
 		});
+	}
+
+	async function saveAsNew() {
+		if (!hasEdits.value || saving.value) return;
+
+		saving.value = true;
+
+		const postRequest = new Promise<string>((resolve, reject) => {
+			cropperInstance.value
+				?.getCroppedCanvas({
+					imageSmoothingQuality: 'high',
+				})
+				.toBlob(async (blob) => {
+					if (blob === null) {
+						return reject(`Couldn't process and save edited image`);
+					}
+
+					const formData = new FormData();
+					formData.append('file', blob, imageData.value?.filename_download);
+
+					if (imageData.value?.folder) {
+						formData.append('folder', imageData.value.folder as string);
+					}
+
+					api.post('/files', formData).then(
+						(response) => resolve(response.data.data.id),
+						(err) => reject(err),
+					);
+				}, imageData.value?.type ?? undefined);
+		});
+
+		try {
+			const newId = await postRequest;
+			emit('new-file', newId);
+			localDragMode.value = 'move';
+			internalActive.value = false;
+		} catch (error) {
+			unexpectedError(error);
+		} finally {
+			saving.value = false;
+		}
 	}
 
 	async function save() {
@@ -594,7 +640,22 @@ function setAspectRatio() {
 				:disabled="!hasEdits"
 				icon="check"
 				@click="save"
-			/>
+			>
+				<template v-if="props.createAllowed" #append-outer>
+					<VMenu show-arrow placement="bottom-end">
+						<template #activator="{ toggle }">
+							<VIcon name="more_vert" clickable @click="toggle" />
+						</template>
+
+						<VList>
+							<VListItem :disabled="!hasEdits" clickable @click="saveAsNew">
+								<VListItemIcon><VIcon name="add_photo_alternate" /></VListItemIcon>
+								<VListItemContent>{{ $t('save_as_new_file') }}</VListItemContent>
+							</VListItem>
+						</VList>
+					</VMenu>
+				</template>
+			</PrivateViewHeaderBarActionButton>
 		</template>
 	</VDrawer>
 </template>


### PR DESCRIPTION
## Scope

What's changed:

- Added "Save as New File" option to the image editor, creating a new file record instead of overwriting the original
- New file inherits the filename and folder of the original
- After saving, the file-image interface updates to reference the new file; the Files module navigates to it
- Option is only surfaced to users with create permission on `directus_files`

<img width="828" height="245" alt="image" src="https://github.com/user-attachments/assets/185941d0-688b-436c-b2da-ba9c286eee42" />


## Potential Risks / Drawbacks

- New file does not inherit manually set title or focal point from the original
- `cropperInstance` being null will leave `saving` stuck as `true` — pre-existing issue in `saveImage`, not introduced here

## Tested Scenarios

- "Save as New File" creates a new file and updates the field reference in the file-image interface
- "Save as New File" navigates to the newly created file when used from the Files module
- Option is hidden for users without create permission on `directus_files`
- Existing "Save" (overwrite) behaviour is unchanged

## Review Notes / Questions

- Should the new file inherit the original's `title`? Currently it is auto-generated from the filename

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs/pull/624) 
- [ ] OpenAPI package PR not required

---

