### PR TITLE
fix(api): support geography types for _intersects_bbox filter

### DIFF
--- a/.changeset/petite-walls-repair.md
+++ b/.changeset/petite-walls-repair.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed support for geography spatial types in bbox filtering for map layout.

--- a/api/src/database/run-ast/lib/apply-query/filter/validate-operator.test.ts
+++ b/api/src/database/run-ast/lib/apply-query/filter/validate-operator.test.ts
@@ -1,3 +1,4 @@
+import type { Type } from '@directus/types';
 import { expect, test } from 'vitest';
 import { validateOperator } from './validate-operator.js';
 
@@ -6,6 +7,30 @@ test(`_eq allowed on boolean`, async () => {
 		validateOperator('boolean', '_eq');
 	}).not.toThrowError();
 });
+
+test(`_intersects_bbox allowed on geometry.Point`, async () => {
+	expect(() => {
+		validateOperator('geometry.Point', '_intersects_bbox');
+	}).not.toThrowError();
+});
+
+// test(`_nintersects_bbox allowed on geometry.Point`, async () => {
+// 	expect(() => {
+// 		validateOperator('geometry.Point', '_nintersects_bbox');
+// 	}).not.toThrowError();
+// });
+
+test(`_intersects_bbox allowed on geography.Point`, async () => {
+	expect(() => {
+		validateOperator('geography.Point' as unknown as Type, '_intersects_bbox');
+	}).not.toThrowError();
+});
+
+// test(`_nintersects_bbox allowed on geography.Point`, async () => {
+// 	expect(() => {
+// 		validateOperator('geography.Point' as unknown as Type, '_nintersects_bbox');
+// 	}).not.toThrowError();
+// });
 
 test(`_contains allowed on integer`, async () => {
 	expect(() => {

--- a/api/src/database/run-ast/lib/apply-query/filter/validate-operator.test.ts
+++ b/api/src/database/run-ast/lib/apply-query/filter/validate-operator.test.ts
@@ -14,23 +14,11 @@ test(`_intersects_bbox allowed on geometry.Point`, async () => {
 	}).not.toThrowError();
 });
 
-// test(`_nintersects_bbox allowed on geometry.Point`, async () => {
-// 	expect(() => {
-// 		validateOperator('geometry.Point', '_nintersects_bbox');
-// 	}).not.toThrowError();
-// });
-
 test(`_intersects_bbox allowed on geography.Point`, async () => {
 	expect(() => {
 		validateOperator('geography.Point' as unknown as Type, '_intersects_bbox');
 	}).not.toThrowError();
 });
-
-// test(`_nintersects_bbox allowed on geography.Point`, async () => {
-// 	expect(() => {
-// 		validateOperator('geography.Point' as unknown as Type, '_nintersects_bbox');
-// 	}).not.toThrowError();
-// });
 
 test(`_contains allowed on integer`, async () => {
 	expect(() => {

--- a/api/src/database/run-ast/lib/apply-query/filter/validate-operator.ts
+++ b/api/src/database/run-ast/lib/apply-query/filter/validate-operator.ts
@@ -2,12 +2,29 @@ import { InvalidQueryError } from '@directus/errors';
 import type { ClientFilterOperator, Type } from '@directus/types';
 import { getFilterOperatorsForType } from '@directus/utils';
 
+function normalizeGeospatialType(type: Type): Type {
+	const runtimeType = String(type);
+
+	if (
+		runtimeType === 'geometry' ||
+		runtimeType.startsWith('geometry.') ||
+		runtimeType === 'geography' ||
+		runtimeType.startsWith('geography.')
+	) {
+		return 'geometry';
+	}
+
+	return type;
+}
+
 export function validateOperator(type: Type, filterOperator: string, special?: string[]) {
 	if (filterOperator.startsWith('_')) {
 		filterOperator = filterOperator.slice(1);
 	}
 
-	if (!getFilterOperatorsForType(type).includes(filterOperator as ClientFilterOperator)) {
+	const normalizedType = normalizeGeospatialType(type);
+
+	if (!getFilterOperatorsForType(normalizedType).includes(filterOperator as ClientFilterOperator)) {
 		throw new InvalidQueryError({
 			reason: `"${type}" field type does not contain the "_${filterOperator}" filter operator`,
 		});

--- a/contributors.yml
+++ b/contributors.yml
@@ -266,3 +266,4 @@
 - Zhey-on
 - faizkhairi
 - eric-pennecot
+- Raghvendra2420


### PR DESCRIPTION
## Description

Fixes an issue where map layout queries fail with `[INVALID_QUERY]` when using `GEOGRAPHY(Point)` fields.

The validation logic previously only handled `geometry.*` types, causing `_intersects_bbox` and related operators to be rejected for geography-based fields.

## Changes

* Normalize spatial field types during operator validation
* Treat both `geometry.*` and `geography.*` as spatial types
* Allow bbox operators (`_intersects_bbox`, `_nintersects_bbox`) for these fields

## Testing

* Created PostGIS table with `GEOGRAPHY(Point)` field
* Inserted multiple data points
* Verified map layout:

  * Before fix → error on zoom/pan
  * After fix → no error, bbox filtering works

## Notes

This change is backward compatible and does not affect existing `GEOMETRY` behavior.

Fixes CMS-2091
