### PR TITLE
Fix `VBadge` intercepting pointer events on slotted elements

### DIFF
--- a/.changeset/social-rings-invent.md
+++ b/.changeset/social-rings-invent.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed `VBadge` intercepting pointer events on slotted elements

--- a/app/src/components/v-badge.vue
+++ b/app/src/components/v-badge.vue
@@ -67,6 +67,7 @@ withDefaults(
 		inset-block-start: calc(var(--v-badge-size, 0.875rem) / -2 + var(--v-badge-offset-y, 0rem));
 		inset-inline-end: calc(var(--v-badge-size, 0.875rem) / -2 + var(--v-badge-offset-x, 0rem));
 		z-index: 1;
+		pointer-events: none;
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;


### PR DESCRIPTION

What's changed:

- Add `pointer-events: none` to the `.badge` element in `VBadge` to prevent it from intercepting pointer events on slotted content

## Potential Risks / Drawbacks

- None identified — the badge is purely decorative and has no interactive behavior of its own

## Tested Scenarios

- Clicking the notifications button in the module bar now registers correctly across the full button surface, including the top-right corner previously covered by the badge

## Review Notes / Questions

- I would like reviewers to confirm there are no other `VBadge` usages where the badge itself is expected to be interactive

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #27086