### PR TITLE
Fix geometry.Point as a Geospatial Field throwing error

### DIFF
--- a/.changeset/small-yaks-fry.md
+++ b/.changeset/small-yaks-fry.md
@@ -1,0 +1,5 @@
+---
+'@directus/utils': patch
+---
+
+Added support for specific geometry types in the getFilterOperatorsForType function

--- a/packages/utils/shared/get-filter-operators-for-type.test.ts
+++ b/packages/utils/shared/get-filter-operators-for-type.test.ts
@@ -107,7 +107,7 @@ describe('', () => {
 	});
 
 	it('returns the filter operators for geometry', () => {
-		expect(getFilterOperatorsForType('geometry')).toStrictEqual([
+		const geometryOperators = [
 			'eq',
 			'neq',
 			'null',
@@ -116,7 +116,15 @@ describe('', () => {
 			'nintersects',
 			'intersects_bbox',
 			'nintersects_bbox',
-		]);
+		];
+
+		expect(getFilterOperatorsForType('geometry')).toStrictEqual(geometryOperators);
+		expect(getFilterOperatorsForType('geometry.Point')).toStrictEqual(geometryOperators);
+		expect(getFilterOperatorsForType('geometry.LineString')).toStrictEqual(geometryOperators);
+		expect(getFilterOperatorsForType('geometry.Polygon')).toStrictEqual(geometryOperators);
+		expect(getFilterOperatorsForType('geometry.MultiPoint')).toStrictEqual(geometryOperators);
+		expect(getFilterOperatorsForType('geometry.MultiLineString')).toStrictEqual(geometryOperators);
+		expect(getFilterOperatorsForType('geometry.MultiPolygon')).toStrictEqual(geometryOperators);
 	});
 
 	it('includes validation only types', () => {

--- a/packages/utils/shared/get-filter-operators-for-type.ts
+++ b/packages/utils/shared/get-filter-operators-for-type.ts
@@ -65,6 +65,12 @@ export function getFilterOperatorsForType(
 			return ['eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'between', 'nbetween', 'null', 'nnull', 'in', 'nin'];
 
 		case 'geometry':
+		case 'geometry.Point':
+		case 'geometry.LineString':
+		case 'geometry.Polygon':
+		case 'geometry.MultiPoint':
+		case 'geometry.MultiLineString':
+		case 'geometry.MultiPolygon':
 			return ['eq', 'neq', 'null', 'nnull', 'intersects', 'nintersects', 'intersects_bbox', 'nintersects_bbox'];
 
 		default:


### PR DESCRIPTION
## Scope

What's changed:

- Added support for specific geometry types in the `getFilterOperatorsForType` function.
- Updated tests to verify the correct filter operators for various geometry types.

## Potential Risks / Drawbacks

- Changes may affect existing functionality if other parts of the code rely on the previous behavior of the `getFilterOperatorsForType` function.

## Tested Scenarios

- Verified that the function returns the correct filter operators for geometry types and their specific subtypes.

## Review Notes / Questions

- NA

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes CMS-2091

