### PR TITLE
Fix presentation fields allowing required and readonly options

### DIFF
--- a/.changeset/fix-presentation-fields-required-readonly.md
+++ b/.changeset/fix-presentation-fields-required-readonly.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed presentation fields (divider, header, notice, links) allowing the `required` and `readonly` options, which previously caused item creation to fail with a validation error when either option was enabled on a presentation field.

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
@@ -9,6 +9,7 @@ import VSkeletonLoader from '@/components/v-skeleton-loader.vue';
 import InterfaceSystemInputTranslatedString from '@/interfaces/_system/system-input-translated-string/input-translated-string.vue';
 import InterfaceList from '@/interfaces/list/list.vue';
 import { useUserStore } from '@/stores/user';
+import { isPresentationField } from '@/utils/field-utils';
 
 const fieldDetailStore = useFieldDetailStore();
 const readonly = syncFieldDetailStoreProperty('field.meta.readonly', false);
@@ -21,6 +22,10 @@ const type = computed(() => field.value.type);
 const isGenerated = computed(() => field.value.schema?.is_generated);
 const userStore = useUserStore();
 const searchable = syncFieldDetailStoreProperty('field.meta.searchable', true);
+
+// Presentation fields (divider, header, notice, links) have no underlying data, so the
+// `readonly` and `required` options don't apply to them. See issue #26961.
+const isPresentation = computed(() => isPresentationField(field.value));
 
 const isSearchableType = computed(() => {
 	// exclude alias fields (o2m, m2m, m2a) as they don't store searchable data
@@ -35,17 +40,17 @@ const isSearchableType = computed(() => {
 
 <template>
 	<div class="form">
-		<div v-if="!isGenerated" class="field half-left">
+		<div v-if="!isGenerated && !isPresentation" class="field half-left">
 			<div class="label type-label">{{ $t('readonly') }}</div>
 			<VCheckbox v-model="readonly" :label="$t('readonly_field_label')" block />
 		</div>
 
-		<div v-if="!isGenerated" class="field half-right">
+		<div v-if="!isGenerated && !isPresentation" class="field half-right">
 			<div class="label type-label">{{ $t('required') }}</div>
 			<VCheckbox v-model="required" :label="$t('require_value_to_be_set')" block />
 		</div>
 
-		<VNotice v-if="readonly && required" type="warning" class="full no-margin">
+		<VNotice v-if="!isPresentation && readonly && required" type="warning" class="full no-margin">
 			{{ $t('required_readonly_field_warning') }}
 		</VNotice>
 

--- a/app/src/stores/fields.test.ts
+++ b/app/src/stores/fields.test.ts
@@ -138,4 +138,88 @@ describe('parseField action', () => {
 		expect(fieldsStore.fields[0].name).toEqual('Name');
 		expect(i18n.global.te(`fields.${mockField.collection}.${mockField.field}`)).toBe(false);
 	});
+
+	test('should normalize required and readonly to false for presentation fields', () => {
+		const fieldsStore = useFieldsStore();
+
+		const presentationField = {
+			collection: 'a',
+			field: 'divider',
+			type: 'alias',
+			schema: null,
+			meta: {
+				collection: 'a',
+				field: 'divider',
+				interface: 'presentation-divider',
+				special: ['alias', 'no-data'],
+				options: null,
+				display_options: null,
+				note: null,
+				validation_message: null,
+				required: true,
+				readonly: true,
+			},
+		} as unknown as Field;
+
+		const parsed = fieldsStore.parseField(presentationField);
+
+		expect(parsed.meta?.required).toBe(false);
+		expect(parsed.meta?.readonly).toBe(false);
+	});
+
+	test('should not touch required or readonly on group (alias + no-data + group) fields', () => {
+		const fieldsStore = useFieldsStore();
+
+		const groupField = {
+			collection: 'a',
+			field: 'my_group',
+			type: 'alias',
+			schema: null,
+			meta: {
+				collection: 'a',
+				field: 'my_group',
+				interface: 'group-raw',
+				special: ['alias', 'no-data', 'group'],
+				options: null,
+				display_options: null,
+				note: null,
+				validation_message: null,
+				required: true,
+				readonly: true,
+			},
+		} as unknown as Field;
+
+		const parsed = fieldsStore.parseField(groupField);
+
+		expect(parsed.meta?.required).toBe(true);
+		expect(parsed.meta?.readonly).toBe(true);
+	});
+
+	test('should not touch required or readonly on relational alias fields', () => {
+		const fieldsStore = useFieldsStore();
+
+		const o2mField = {
+			collection: 'a',
+			field: 'children',
+			type: 'alias',
+			schema: null,
+			meta: {
+				collection: 'a',
+				field: 'children',
+				interface: 'list-o2m',
+				special: ['o2m'],
+				options: null,
+				display_options: null,
+				note: null,
+				validation_message: null,
+				required: true,
+				readonly: false,
+			},
+		} as unknown as Field;
+
+		const parsed = fieldsStore.parseField(o2mField);
+
+		expect(parsed.meta?.required).toBe(true);
+		expect(parsed.meta?.readonly).toBe(false);
+	});
 });

--- a/app/src/stores/fields.ts
+++ b/app/src/stores/fields.ts
@@ -9,6 +9,7 @@ import api from '@/api';
 import { i18n } from '@/lang';
 import { useCollectionsStore } from '@/stores/collections';
 import { useRelationsStore } from '@/stores/relations';
+import { isPresentationField } from '@/utils/field-utils';
 import { getLiteralInterpolatedTranslation } from '@/utils/get-literal-interpolated-translation';
 import { translate as translateLiteral } from '@/utils/translate-literal';
 import { translate } from '@/utils/translate-object-values';
@@ -112,6 +113,15 @@ export const useFieldsStore = defineStore('fieldsStore', () => {
 
 	function parseField(field: FieldRaw): Field {
 		let name = formatTitle(field.field);
+
+		// Presentation fields (divider, header, notice, links) have no underlying data so marking
+		// them as required or readonly is meaningless and causes item validation to fail. Normalize
+		// the stored values to `false` at read time so legacy fields that already have these set
+		// don't break item creation or editing. See issue #26961.
+		if (isPresentationField(field) && field.meta) {
+			if (field.meta.required) field.meta.required = false;
+			if (field.meta.readonly) field.meta.readonly = false;
+		}
 
 		const localesToKeep =
 			field.meta && !isNil(field.meta.translations) && Array.isArray(field.meta.translations)

--- a/app/src/utils/field-utils.test.ts
+++ b/app/src/utils/field-utils.test.ts
@@ -4,6 +4,7 @@ import {
 	isDateCreated,
 	isDateUpdated,
 	isHidden,
+	isPresentationField,
 	isPrimaryKey,
 	isRelational,
 	isUserCreated,
@@ -70,6 +71,21 @@ test('isUserCreated', () => {
 
 	expect(isUserCreated(field!)).toBe(true);
 	expect(isUserCreated(wrongField!)).toBe(false);
+});
+
+test('isPresentationField', () => {
+	const dividerField = fields.find((f) => f.field === 'divider');
+	const groupField = fields.find((f) => f.field === 'group');
+	const o2mField = fields.find((f) => f.field === 'o2m');
+	const standardField = fields.find((f) => f.field === 'title');
+
+	expect(isPresentationField(dividerField!)).toBe(true);
+	// groups are alias fields but are containers with data, not presentation-only
+	expect(isPresentationField(groupField!)).toBe(false);
+	// relational alias fields are not presentation fields
+	expect(isPresentationField(o2mField!)).toBe(false);
+	// standard non-alias fields are not presentation fields
+	expect(isPresentationField(standardField!)).toBe(false);
 });
 
 const fields: Field[] = [
@@ -636,5 +652,63 @@ const fields: Field[] = [
 			validation_message: null,
 		},
 		name: 'M2A',
+	},
+	{
+		collection: 'test_collection',
+		field: 'divider',
+		type: 'alias',
+		schema: null,
+		meta: {
+			id: 208,
+			collection: 'test_collection',
+			field: 'divider',
+			special: ['alias', 'no-data'],
+			interface: 'presentation-divider',
+			options: null,
+			display: null,
+			display_options: null,
+			readonly: false,
+			hidden: false,
+			searchable: false,
+			sort: 14,
+			width: 'full',
+			translations: null,
+			note: null,
+			conditions: null,
+			required: false,
+			group: null,
+			validation: null,
+			validation_message: null,
+		},
+		name: 'Divider',
+	},
+	{
+		collection: 'test_collection',
+		field: 'group',
+		type: 'alias',
+		schema: null,
+		meta: {
+			id: 209,
+			collection: 'test_collection',
+			field: 'group',
+			special: ['alias', 'no-data', 'group'],
+			interface: 'group-raw',
+			options: null,
+			display: null,
+			display_options: null,
+			readonly: false,
+			hidden: false,
+			searchable: false,
+			sort: 15,
+			width: 'full',
+			translations: null,
+			note: null,
+			conditions: null,
+			required: false,
+			group: null,
+			validation: null,
+			validation_message: null,
+		},
+		name: 'Group',
 	},
 ];

--- a/app/src/utils/field-utils.ts
+++ b/app/src/utils/field-utils.ts
@@ -1,5 +1,5 @@
 import { RELATIONAL_TYPES } from '@directus/constants';
-import type { DeepPartial, Field, RelationalType } from '@directus/types';
+import type { DeepPartial, Field, FieldRaw, RelationalType } from '@directus/types';
 
 export function isPrimaryKey(field: DeepPartial<Field>) {
 	return field.schema?.is_primary_key === true;
@@ -11,6 +11,21 @@ export function isHidden(field: DeepPartial<Field>) {
 
 export function isRelational(field: DeepPartial<Field>) {
 	return field.meta?.special?.find((type) => RELATIONAL_TYPES.includes(type as RelationalType)) !== undefined;
+}
+
+/**
+ * Returns true for presentation-only alias fields (divider, header, notice, links). These are
+ * identified by `type === 'alias'` with a `no-data` flag in `meta.special` and without the
+ * `group` flag (which would indicate a field group container instead of a presentation field).
+ */
+export function isPresentationField(field: DeepPartial<Field> | FieldRaw) {
+	if (field.type !== 'alias') return false;
+
+	const special = field.meta?.special;
+
+	if (!Array.isArray(special)) return false;
+
+	return special.includes('no-data') && !special.includes('group');
 }
 
 export function isDateUpdated(field: DeepPartial<Field>) {

--- a/contributors.yml
+++ b/contributors.yml
@@ -266,3 +266,4 @@
 - Zhey-on
 - faizkhairi
 - eric-pennecot
+- yogeshwaran-c


### PR DESCRIPTION
## Scope

What's changed:

- Added an `isPresentationField` helper in `app/src/utils/field-utils.ts` that identifies presentation-only alias fields (`type === 'alias'` with `no-data` in `meta.special` and without the `group` flag).
- Normalized `meta.required` and `meta.readonly` to `false` for presentation fields in the fields store's `parseField`, so that legacy records where these flags were already set in the database no longer break item creation or editing.
- Hid the `readonly` and `required` checkboxes (and the `required && readonly` warning notice) in the advanced field configuration (`field-detail-advanced-field.vue`) when the edited field is a presentation field, so users can't toggle the options in the first place. The simple configuration already hides these via `autoKey: true` on the built-in presentation interfaces (divider / header / notice / links).
- Added unit tests for `isPresentationField`, the `parseField` normalization (presentation vs. group vs. relational alias), and extended existing fixtures with presentation and group entries.
- Added a changeset describing the user-visible fix.

## Potential Risks / Drawbacks

- The normalization runs on every field hydrated from `/fields`. The runtime cost is a type check and up to two property writes per field — trivially cheap.
- Existing presentation fields in the database keep whatever values they had stored for `required` / `readonly`. They are sanitized on read, so on the next write through the field editor they will be persisted back as `false`. This is intentional and avoids the need for a migration.
- If a custom (user-authored) interface extension uses `localTypes: ['presentation']` with `type === 'alias'` and `special: ['alias', 'no-data']`, it will also be normalized — which is the desired behavior, because such extensions have the same "no underlying data" semantics as the built-ins.

## Tested Scenarios

- `pnpm --filter @directus/app exec vitest run src/stores/fields.test.ts src/utils/field-utils.test.ts src/utils/validate-item.test.ts` — all tests pass, including the new ones that cover:
  - presentation field (`['alias', 'no-data']`) has `required` / `readonly` forced to `false`
  - group field (`['alias', 'no-data', 'group']`) is untouched (still a container that can legitimately carry these flags)
  - relational alias field (e.g. `['o2m']`) is untouched, so required o2m/m2m fields still validate as before
- `pnpm --filter @directus/app exec vitest run src/modules/settings/routes/data-model/field-detail/store/index.test.ts` — existing field-detail store tests still pass.
- Verified via `vue-tsc --noEmit` that no new type errors are introduced (the same 13 pre-existing errors on `main` are still there, and no new ones in the touched files).
- Traced the fix end-to-end: `parseField` is the single source of field data consumed by `useCollection` → `useItemPermissions.fields` → `validateItem`, which is the exact function (`app/src/utils/validate-item.ts`) that previously pushed `_submitted` / `_nnull` rules for presentation fields and produced the "X is required" error during item create/edit.

## Review Notes / Questions

- This is the "fix at the source" approach @Nitwel suggested on #26963 ("not returning true for required presentation fields ... when receiving the field information in the app"), without needing a database migration. Both existing and future fields are handled.
- `no-data` was chosen as the discriminator because that's how the API already filters presentation fields out of the schema overview (`api/src/utils/get-schema.ts`), which is also why the API's `process-payload` required-field validation never even sees these fields — the bug was exclusively on the app side.
- Group fields are deliberately excluded from the normalization because they are containers that conceptually aggregate other fields; `required` / `readonly` still have meaning there and are applied by existing app logic.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required (not required — no user-facing docs describe these checkboxes on presentation fields, and no migration is needed)
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required (not required — no API surface changes)

---

Fixes #26961