### PR TITLE
fix: exclude $thumbnail from JSON export field parsing

### DIFF
--- a/.changeset/fix-thumbnail-json-export.md
+++ b/.changeset/fix-thumbnail-json-export.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed $thumbnail field breaking JSON export due to permission errors when the virtual field gets resolved during field parsing.

--- a/api/src/database/get-ast-from-query/lib/parse-fields.test.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.test.ts
@@ -669,3 +669,62 @@ test('parse fields distinguishes json function from relational fields', async ()
 
 	expect(result[2]?.type).toBe('m2o');
 });
+
+test('filters out $-prefixed virtual fields that do not exist in schema', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
+
+	const result = await parseFields(
+		{ accountability, fields: ['id', '$thumbnail', 'title'], parentCollection: 'articles', query: {} },
+		{ knex: db, schema },
+	);
+
+	expect(result).toEqual([
+		{
+			alias: false,
+			fieldKey: 'id',
+			name: 'id',
+			type: 'field',
+			whenCase: [],
+		},
+		{
+			alias: false,
+			fieldKey: 'title',
+			name: 'title',
+			type: 'field',
+			whenCase: [],
+		},
+	]);
+});
+
+test('keeps $-prefixed fields that exist in schema', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
+
+	const schemaWithDollarField = new SchemaBuilder()
+		.collection('articles', (c) => {
+			c.field('id').id();
+			c.field('$thumbnail').string();
+		})
+		.build();
+
+	const result = await parseFields(
+		{ accountability, fields: ['id', '$thumbnail'], parentCollection: 'articles', query: {} },
+		{ knex: db, schema: schemaWithDollarField },
+	);
+
+	expect(result).toEqual([
+		{
+			alias: false,
+			fieldKey: 'id',
+			name: 'id',
+			type: 'field',
+			whenCase: [],
+		},
+		{
+			alias: false,
+			fieldKey: '$thumbnail',
+			name: '$thumbnail',
+			type: 'field',
+			whenCase: [],
+		},
+	]);
+});

--- a/api/src/database/get-ast-from-query/lib/parse-fields.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.ts
@@ -49,6 +49,22 @@ export async function parseFields(
 
 	if (!fields || !Array.isArray(fields)) return [];
 
+	// Filter out $-prefixed virtual fields (like $thumbnail) that don't exist in the schema.
+	// These are display-only tokens used by the app and should not be queried from the database.
+	const collectionFields = context.schema.collections[options.parentCollection]?.fields;
+
+	if (collectionFields) {
+		fields = fields.filter((field) => {
+			const rootField = field.split('.')[0]!;
+
+			if (rootField.startsWith('$') && !(rootField in collectionFields)) {
+				return false;
+			}
+
+			return true;
+		});
+	}
+
 	const children: (NestedCollectionNode | FieldNode | FunctionFieldNode)[] = [];
 
 	const policies =

--- a/contributors.yml
+++ b/contributors.yml
@@ -266,3 +266,4 @@
 - Zhey-on
 - faizkhairi
 - eric-pennecot
+- SAY-5


### PR DESCRIPTION
The $thumbnail virtual field was getting resolved during JSON export, which triggered a permission check that fails for users without direct file access. Filtered it out early in parseFields so it never reaches the permission layer during exports.

Includes a test to make sure it stays excluded.

Fixes #25588