### PR TITLE
fix: resolve 403 error when using "Save as copy" in file library

### DIFF
--- a/.changeset/wet-fans-share.md
+++ b/.changeset/wet-fans-share.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+'@directus/app': patch
+---
+
+Fixed "Save as copy" in the file library throwing a 403 error

--- a/api/src/controllers/files.ts
+++ b/api/src/controllers/files.ts
@@ -145,6 +145,8 @@ router.post(
 
 		if (req.is('multipart/form-data')) {
 			keys = res.locals['savedFiles'];
+		} else if (req.query['copy'] === '1') {
+			keys = await service.copyOne(req.body);
 		} else {
 			keys = await service.createOne(req.body);
 		}

--- a/api/src/services/files.test.ts
+++ b/api/src/services/files.test.ts
@@ -880,4 +880,108 @@ describe('Service / Files', () => {
 			);
 		});
 	});
+
+	describe('copyOne', () => {
+		let service: FilesService;
+		let mockDriver: Driver;
+		let mockStorage: StorageManager;
+
+		const sample = {
+			id: 'new-file-id-456',
+			sourceId: 'source-file-id-123',
+		};
+
+		beforeEach(() => {
+			service = new FilesService({
+				knex: db,
+				schema: { collections: {}, relations: [] },
+			});
+
+			mockDriver = createMockDriver();
+			mockStorage = createMockStorage(mockDriver);
+			vi.mocked(getStorage).mockResolvedValue(mockStorage);
+
+			vi.spyOn(ItemsService.prototype, 'createOne').mockResolvedValue(sample.id);
+			vi.spyOn(ItemsService.prototype, 'updateOne').mockResolvedValue(sample.id);
+			vi.spyOn(ItemsService.prototype, 'deleteMany').mockResolvedValue([sample.id]);
+		});
+
+		test('should throw InvalidPayloadError when "filename_disk" is not provided', async () => {
+			await expect(service.copyOne({ title: 'Copy' })).rejects.toBeInstanceOf(InvalidPayloadError);
+			expect(ItemsService.prototype.createOne).not.toHaveBeenCalled();
+		});
+
+		test('should throw InvalidPayloadError when source file is not found', async () => {
+			tracker.on
+				.select(
+					'select "storage", "filesize", "type", "width", "height" from "directus_files" where "filename_disk" = ?',
+				)
+				.response(undefined);
+
+			await expect(service.copyOne({ filename_disk: 'nonexistent.jpg' })).rejects.toBeInstanceOf(InvalidPayloadError);
+			expect(ItemsService.prototype.createOne).not.toHaveBeenCalled();
+		});
+
+		test('creates new record with source metadata merged with caller data', async () => {
+			tracker.on
+				.select(
+					'select "storage", "filesize", "type", "width", "height" from "directus_files" where "filename_disk" = ?',
+				)
+				.response({ storage: 'local', filesize: 1024, type: 'image/jpeg', width: 800, height: 600 });
+
+			await service.copyOne({ filename_disk: `${sample.sourceId}.jpg`, title: 'My Copy' });
+
+			expect(ItemsService.prototype.createOne).toHaveBeenCalledWith(
+				expect.objectContaining({
+					storage: 'local',
+					type: 'image/jpeg',
+					title: 'My Copy',
+				}),
+				{},
+			);
+		});
+
+		test('should copy file on disk and update filename_disk on the new record', async () => {
+			tracker.on
+				.select(
+					'select "storage", "filesize", "type", "width", "height" from "directus_files" where "filename_disk" = ?',
+				)
+				.response({ storage: 'local', filesize: 1024, type: 'image/jpeg', width: 800, height: 600 });
+
+			await service.copyOne({ filename_disk: `${sample.sourceId}.jpg` });
+
+			expect(mockDriver.copy).toHaveBeenCalledWith(`${sample.sourceId}.jpg`, `${sample.id}.jpg`);
+
+			expect(ItemsService.prototype.updateOne).toHaveBeenCalledWith(sample.id, {
+				filename_disk: `${sample.id}.jpg`,
+			});
+		});
+
+		test('should delete new record and rethrow when disk copy fails', async () => {
+			tracker.on
+				.select(
+					'select "storage", "filesize", "type", "width", "height" from "directus_files" where "filename_disk" = ?',
+				)
+				.response({ storage: 'local', filesize: 1024, type: 'image/jpeg', width: 800, height: 600 });
+
+			vi.mocked(mockDriver.copy).mockRejectedValue(new Error('Disk full'));
+
+			await expect(service.copyOne({ filename_disk: `${sample.sourceId}.jpg` })).rejects.toThrow('Disk full');
+
+			expect(ItemsService.prototype.deleteMany).toHaveBeenCalledWith([sample.id]);
+			expect(ItemsService.prototype.updateOne).not.toHaveBeenCalled();
+		});
+
+		test('should infer extension from type when source filename has no extension', async () => {
+			tracker.on
+				.select(
+					'select "storage", "filesize", "type", "width", "height" from "directus_files" where "filename_disk" = ?',
+				)
+				.response({ storage: 'local', filesize: 512, type: 'image/png', width: 100, height: 100 });
+
+			await service.copyOne({ filename_disk: sample.sourceId });
+
+			expect(mockDriver.copy).toHaveBeenCalledWith(sample.sourceId, `${sample.id}.png`);
+		});
+	});
 });

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -510,6 +510,53 @@ export class FilesService extends ItemsService<File> {
 
 		return super.readByQuery(filteredQuery, opts);
 	}
+
+	/**
+	 * Copy a file
+	 */
+	async copyOne(data: Partial<File>, opts: MutationOptions = {}): Promise<PrimaryKey> {
+		if (!data.filename_disk) {
+			throw new InvalidPayloadError({ reason: `"filename_disk" is required` });
+		}
+
+		const sourceFilename = this.generateFilenamePath(data.filename_disk);
+
+		const sourceFile = await this.knex
+			.select('storage', 'filesize', 'type', 'width', 'height')
+			.from('directus_files')
+			.where({ filename_disk: sourceFilename })
+			.first();
+
+		if (!sourceFile) {
+			throw new InvalidPayloadError({
+				reason: `Source file not found for copy`,
+			});
+		}
+
+		const payload = { ...data, ...sourceFile, uploaded_on: new Date().toISOString() };
+		delete payload.filename_disk;
+
+		const storage = await getStorage();
+		const disk = storage.location(payload.storage);
+
+		const newId = await super.createOne(payload, opts);
+
+		const ext = path.extname(sourceFilename) || (payload.type && '.' + extension(payload.type)) || '';
+		const finalFilename = newId + (ext || '');
+
+		try {
+			await disk.copy(sourceFilename, finalFilename);
+		} catch (err) {
+			await super.deleteMany([newId]);
+			throw err;
+		}
+
+		await super.updateOne(newId, {
+			filename_disk: finalFilename,
+		});
+
+		return newId;
+	}
 }
 
 function decompressResponse(stream: Readable, headers: AxiosResponse['headers']) {

--- a/app/src/composables/use-item/index.ts
+++ b/app/src/composables/use-item/index.ts
@@ -337,6 +337,9 @@ export function useItem<T extends Item>(
 				requestEndpoint(getEndpoint(collection.value), {
 					method: 'POST',
 					body: newItem,
+					params: {
+						copy: 1,
+					},
 				}),
 			);
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -266,3 +266,4 @@
 - Zhey-on
 - faizkhairi
 - eric-pennecot
+- sanskar-soni-9


### PR DESCRIPTION
## Scope

What's changed:

- Added `copyOne` method to `FilesService` that copies an existing file's metadata and disk content to a new record
- Added `?copy=1` query param branch in the files controller to route "Save as copy" requests to `copyOne`

## Potential Risks / Drawbacks

- If `disk.copy` fails and the subsequent deleteMany also throws, the original copy error will be swallowed

## Tested Scenarios

- "Save as copy" no longer throws 403 for admin users
- Source file metadata is correctly merged into the new record
- Disk copy failure correctly rolls back the new DB record
- Extension is correctly inferred from MIME type when source filename has no extension

## Review Notes / Questions

- Special attention should be paid to the merge order `{ ...data, ...sourceFile }` — certain file related properties overrides caller provided data these are: `storage`, `filesize`, `type`, `width`, `height`.
- Configured copy flow using explicit declaration with query param `?copy=1`, is there any other preferred way to identify a copy request I would be happy to switch to

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #27091 
