### PR TITLE
Fix block editor content loss when nested inside a translation

### DIFF
--- a/.changeset/beige-monkeys-think.md
+++ b/.changeset/beige-monkeys-think.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed block editor content loss when nested inside a translation

--- a/app/src/interfaces/input-block-editor/input-block-editor.test.ts
+++ b/app/src/interfaces/input-block-editor/input-block-editor.test.ts
@@ -70,6 +70,67 @@ describe('InputBlockEditor', () => {
 		wrapper.unmount();
 	});
 
+	it('should temporarily unlock readOnly when a value update arrives while editor is already disabled (translation case)', async () => {
+		const callOrder: string[] = [];
+
+		vi.mocked(EditorJS).mockImplementation(() => {
+			let readOnlyEnabled = false;
+
+			return {
+				isReady: Promise.resolve(),
+				render: vi.fn(() => {
+					callOrder.push('render');
+					return Promise.resolve();
+				}),
+				clear: vi.fn(),
+				destroy: vi.fn(),
+				focus: vi.fn(),
+				on: vi.fn(),
+				saver: { save: vi.fn().mockResolvedValue({ blocks: [] }) },
+				readOnly: {
+					get isEnabled() {
+						return readOnlyEnabled;
+					},
+					toggle: vi.fn((val: boolean) => {
+						readOnlyEnabled = val;
+						callOrder.push(`toggle:${val}`);
+						return Promise.resolve(val);
+					}),
+				},
+			} as any;
+		});
+
+		const wrapper = mount(InputBlockEditor, {
+			props: {
+				disabled: false,
+				value: { blocks: [{ type: 'paragraph', data: { text: 'initial' } }] },
+			},
+			global: {
+				directives: { 'prevent-focusout': {} },
+				stubs: { VDrawer: true, VUpload: true },
+			},
+		});
+
+		await flushPromises();
+		callOrder.length = 0;
+
+		// Step 1: disabled becomes true — editor enters readOnly (separate tick from value change)
+		await wrapper.setProps({ disabled: true });
+		await flushPromises();
+
+		callOrder.length = 0;
+
+		// Step 2: value changes while still disabled
+		await wrapper.setProps({ value: { blocks: [{ type: 'paragraph', data: { text: 'updated' } }] } });
+		await flushPromises();
+
+		// toggle(false) unlocks, render() updates content, toggle(true) re-locks
+		const relevant = callOrder.filter((e) => ['toggle:false', 'render', 'toggle:true'].includes(e));
+		expect(relevant).toEqual(['toggle:false', 'render', 'toggle:true']);
+
+		wrapper.unmount();
+	});
+
 	it('should not clear content when value becomes null while disabled', async () => {
 		// This test should prevent a regression that results in data loss when the value is temporarily null and the field is disabled
 		const clear = vi.fn();

--- a/app/src/interfaces/input-block-editor/input-block-editor.vue
+++ b/app/src/interfaces/input-block-editor/input-block-editor.vue
@@ -141,30 +141,36 @@ watch(
 		if (isEqual(newVal?.blocks, oldVal?.blocks)) return;
 
 		try {
-			const sanitizedValue = sanitizeValue(newVal);
-			const wasReadOnly = editorjsRef.value.readOnly.isEnabled;
-
-			// Temporarily unlock so render() can update content regardless of disabled state.
-			if (wasReadOnly) {
-				await editorjsRef.value.readOnly.toggle(false);
-			}
-
-			if (sanitizedValue) {
-				await editorjsRef.value.render(sanitizedValue);
-			} else {
-				editorjsRef.value.clear();
-			}
-
-			// Restore readOnly state to match current disabled prop.
-			// props.disabled may have changed during the async render.
-			if (props.disabled) {
-				await editorjsRef.value.readOnly.toggle(true);
-			}
+			await renderValue(newVal);
 		} catch (error) {
 			unexpectedError(error);
 		}
 	},
 );
+
+async function renderValue(value: Record<string, any> | null | undefined) {
+	if (!editorjsRef.value) return;
+
+	const sanitizedValue = sanitizeValue(value);
+	const wasReadOnly = editorjsRef.value.readOnly.isEnabled;
+
+	// Temporarily unlock so render() can update content regardless of disabled state.
+	if (wasReadOnly) {
+		await editorjsRef.value.readOnly.toggle(false);
+	}
+
+	if (sanitizedValue) {
+		await editorjsRef.value.render(sanitizedValue);
+	} else {
+		editorjsRef.value.clear();
+	}
+
+	// Restore readOnly state to match current disabled prop.
+	// props.disabled may have changed during the async render.
+	if (props.disabled) {
+		await editorjsRef.value.readOnly.toggle(true);
+	}
+}
 
 async function emitValue(context: EditorJS.API | EditorJS) {
 	if (props.disabled || !context || !context.saver) return;

--- a/app/src/interfaces/input-block-editor/input-block-editor.vue
+++ b/app/src/interfaces/input-block-editor/input-block-editor.vue
@@ -119,7 +119,7 @@ watch(
 
 		// Note: EditorJS must be ready before readOnly is toggled; otherwise, the content won’t render, which could result in data loss!
 		await nextTick();
-		editorjsRef.value?.readOnly.toggle(isDisabled);
+		await editorjsRef.value?.readOnly.toggle(isDisabled);
 	},
 	{ immediate: true },
 );
@@ -142,11 +142,23 @@ watch(
 
 		try {
 			const sanitizedValue = sanitizeValue(newVal);
+			const wasReadOnly = editorjsRef.value.readOnly.isEnabled;
+
+			// Temporarily unlock so render() can update content regardless of disabled state.
+			if (wasReadOnly) {
+				await editorjsRef.value.readOnly.toggle(false);
+			}
 
 			if (sanitizedValue) {
 				await editorjsRef.value.render(sanitizedValue);
 			} else {
 				editorjsRef.value.clear();
+			}
+
+			// Restore readOnly state to match current disabled prop.
+			// props.disabled may have changed during the async render.
+			if (props.disabled) {
+				await editorjsRef.value.readOnly.toggle(true);
 			}
 		} catch (error) {
 			unexpectedError(error);


### PR DESCRIPTION
## Scope                                                                                               
                                                                                                         
  What's changed:             
                                                                                                         
  - `input-block-editor.vue`: Added `renderValue()` function that temporarily disables EditorJS's        
  `readOnly` mode before calling `render()`, then restores it based on the current `disabled` prop which is the source of truth. This fix should prevent the buggy behavior with data duplication/loss when a block editor is nested in a translation.                                    
                                                                                                         
  ## Potential Risks / Drawbacks                                                                         
   
  - None I can think of                                                 
                                                                                                       
  ## Tested Scenarios                                                                                    
                                                                                                       
  - Block editor inside a translation: edit content, save with "Save and Stay" — no duplication or data  
  loss
  - Block editor inside a translation: switch language tabs — correct content shown for each language    
  - Standalone block editor: save with "Save and Stay" still works correctly (regression check for       
  #26808)                                                                                                
                                                            
  ## Review Notes / Questions                                                        
   
  ## Checklist                                                                                           
                                                            
  - [x] Added or updated tests                                                                           
  - [x] Documentation PR created [here](https://github.com/directus/docs) or not required
  - [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required           
   
  ---                                                                                                    
                                                            
  Fixes