### PR TITLE
fix(api): reject collection names containing "/"

### DIFF
--- a/.changeset/seven-parrots-decide.md
+++ b/.changeset/seven-parrots-decide.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Denied creating collections with `/` in name

--- a/api/src/services/collections.test.ts
+++ b/api/src/services/collections.test.ts
@@ -122,6 +122,7 @@ describe('Integration Tests', () => {
 				[{}, 'collection name is missing'],
 				[{ collection: '' }, 'collection name is empty'],
 				[{ collection: 'directus_test' }, 'collection names start with "directus_"'],
+				[{ collection: 'Folder/Test' }, 'collection name contains "/"'],
 			];
 
 			test.each(invalidPayloads)('should throw InvalidPayloadError when %s', async (payload, _description) => {

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -75,6 +75,10 @@ export class CollectionsService {
 			throw new InvalidPayloadError({ reason: `Collections can't start with "directus_"` });
 		}
 
+		if (payload.collection.includes('/')) {
+			throw new InvalidPayloadError({ reason: `Collection name can't contain "/"` });
+		}
+
 		payload.collection = await this.helpers.schema.parseCollectionName(payload.collection);
 
 		const nestedActionEvents: ActionEventParams[] = [];


### PR DESCRIPTION
## Summary

- Add input validation to reject `/` in collection names at creation time
- Collection names with `/` break Express URL routing, making the collection unreachable via REST API and undeletable via UI
- Follows the existing validation pattern (see `directus_` prefix check)

## Test plan

- [ ] CI passes
- [ ] Creating a collection with `/` in name returns `InvalidPayloadError`
- [ ] Creating a collection without `/` works as before

Closes #27093