### PR TITLE
Fix typos in test descriptions: 'occurence', 'propogate'

### DIFF
--- a/.changeset/soft-squids-listen.md
+++ b/.changeset/soft-squids-listen.md
@@ -1,4 +1,6 @@
 ---
+'@directus/api': patch
 ---
 
-Add a no-op changeset so test-only updates satisfy the required workflow.
+Add a changeset entry for the API package so the required workflow accepts the
+test updates in this PR.

--- a/.changeset/soft-squids-listen.md
+++ b/.changeset/soft-squids-listen.md
@@ -1,6 +1,0 @@
----
-'@directus/api': patch
----
-
-Add a changeset entry for the API package so the required workflow accepts the
-test updates in this PR.

--- a/.changeset/soft-squids-listen.md
+++ b/.changeset/soft-squids-listen.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a no-op changeset so test-only updates satisfy the required workflow.

--- a/api/src/ai/tools/trigger-flow/index.test.ts
+++ b/api/src/ai/tools/trigger-flow/index.test.ts
@@ -103,7 +103,7 @@ describe('trigger flow tool', () => {
 			vi.mocked(FlowsService).mockImplementation(() => mockFlowsService as unknown as FlowsService);
 		});
 
-		test('should propogate error from flowService', async () => {
+		test('should propagate error from flowService', async () => {
 			mockFlowsService.readOne.mockImplementation(() => Promise.reject('Forbidden'));
 
 			const mockArgs = {

--- a/api/src/services/assets/name-deduper.test.ts
+++ b/api/src/services/assets/name-deduper.test.ts
@@ -13,7 +13,7 @@ describe('NameDeduper', () => {
 			expect(deduper.add('abc')).toEqual('abc');
 		});
 
-		test('should deduplicate names by appending occurence count (occurence) on subsequent matches', () => {
+		test('should deduplicate names by appending occurrence count (occurrence) on subsequent matches', () => {
 			expect(deduper.add('abc')).toEqual('abc');
 			expect(deduper.add('abc')).toEqual('abc (1)');
 		});

--- a/contributors.yml
+++ b/contributors.yml
@@ -118,6 +118,7 @@
 - dasantonym
 - appy-one
 - fanmingfei
+- MukundaKatta
 - Joehoel
 - girtskokars
 - kaifulee


### PR DESCRIPTION
Typo fixes in two test case descriptions:

- `api/src/services/assets/name-deduper.test.ts`: `occurence` -> `occurrence`
- `api/src/ai/tools/trigger-flow/index.test.ts`: `should propogate error` -> `should propagate error`

Test description strings only; no behavior changes.