### PR TITLE
Refactor sdk error to use class over object

### DIFF
--- a/.changeset/thick-readers-cheer.md
+++ b/.changeset/thick-readers-cheer.md
@@ -1,0 +1,9 @@
+---
+'@directus/sdk': major
+---
+
+Fixed error handling in sdk
+
+:::warning
+Requests that fail will now throw an error instead of returning a response with an `error` property.
+:::

--- a/.changeset/thick-readers-cheer.md
+++ b/.changeset/thick-readers-cheer.md
@@ -2,8 +2,8 @@
 '@directus/sdk': major
 ---
 
-Fixed error handling in sdk
+Refactor sdk error to use class over object
 
 :::warning
-Requests that fail will now throw an error instead of returning a response with an `error` property.
+Requests that fail will now throw a `RequestError` instead of returning a response with an `error` property.
 :::

--- a/sdk/src/types/error.ts
+++ b/sdk/src/types/error.ts
@@ -7,7 +7,7 @@ export interface DirectusApiError {
 	};
 }
 
-export interface DirectusError<R = Response> {
+export interface DirectusError<R = Response> extends Error {
 	message: string;
 	errors: DirectusApiError[];
 	response: R;

--- a/sdk/src/utils/error.ts
+++ b/sdk/src/utils/error.ts
@@ -1,0 +1,16 @@
+import type { DirectusApiError, DirectusError } from '../types/error.js';
+
+export class RequestError<R = Response> extends Error implements DirectusError<R> {
+	override readonly name = 'RequestError';
+	readonly response: R;
+	readonly errors: DirectusApiError[];
+	readonly data?: any;
+
+	constructor(message: string, context: { response: R; errors: DirectusApiError[]; data?: any }) {
+		super(message);
+
+		this.response = context.response;
+		this.errors = context.errors;
+		if (context.data !== undefined) this.data = context.data;
+	}
+}

--- a/sdk/src/utils/request.test.ts
+++ b/sdk/src/utils/request.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, test, vi } from 'vitest';
-import { request } from './request.js';
+import { request, RequestError } from './request.js';
 
 const fetchMock = vi.fn(async () => ({}));
 
@@ -39,25 +39,23 @@ describe('Request', () => {
 				ok: false,
 			});
 
-			await expect(async () => await request('https://example.com', {}, fetchMock)).rejects.toStrictEqual({
-				errors: 'Error',
-				message: '',
-				response: expect.objectContaining({
-					ok: false,
-				}),
-			});
+			await expect(async () => await request('https://example.com', {}, fetchMock)).rejects.toThrowError(
+				new RequestError(
+					'',
+					expect.objectContaining({
+						ok: false,
+					}),
+					'Error',
+				),
+			);
 		});
 
 		it('should handle reason with errors array', async () => {
 			vi.mocked(fetchMock).mockResolvedValue({ errors: [] });
 
-			await expect(async () => await request('https://example.com', {}, fetchMock)).rejects.toStrictEqual({
-				errors: [],
-				message: '',
-				response: {
-					errors: [],
-				},
-			});
+			await expect(async () => await request('https://example.com', {}, fetchMock)).rejects.toThrowError(
+				new RequestError('', expect.objectContaining({ errors: [] }), []),
+			);
 		});
 
 		describe('should handle reason with errors array and data property', () => {
@@ -66,40 +64,26 @@ describe('Request', () => {
 			test.each(types)('Check %o', async (type) => {
 				vi.mocked(fetchMock).mockResolvedValue({ errors: [], data: type });
 
-				await expect(async () => await request('https://example.com', {}, fetchMock)).rejects.toStrictEqual({
-					errors: [],
-					message: '',
-					response: {
-						data: type,
-						errors: [],
-					},
-					data: type,
-				});
+				await expect(async () => await request('https://example.com', {}, fetchMock)).rejects.toThrowError(
+					new RequestError('', expect.objectContaining({ errors: [], data: type }), [], type),
+				);
 			});
 		});
 
 		it('should handle reason with non array errors', async () => {
 			vi.mocked(fetchMock).mockResolvedValue({ errors: 'Error' });
 
-			await expect(async () => await request('https://example.com', {}, fetchMock)).rejects.toStrictEqual({
-				errors: 'Error',
-				message: '',
-				response: {
-					errors: 'Error',
-				},
-			});
+			await expect(async () => await request('https://example.com', {}, fetchMock)).rejects.toThrowError(
+				new RequestError('', expect.objectContaining({ errors: 'Error' }), 'Error'),
+			);
 		});
 
 		it('should handle reason with message property in errors array', async () => {
 			vi.mocked(fetchMock).mockResolvedValue({ errors: [{ message: 'Error' }] });
 
-			await expect(async () => await request('https://example.com', {}, fetchMock)).rejects.toStrictEqual({
-				errors: [{ message: 'Error' }],
-				message: 'Error',
-				response: {
-					errors: [{ message: 'Error' }],
-				},
-			});
+			await expect(async () => await request('https://example.com', {}, fetchMock)).rejects.toThrowError(
+				new RequestError('Error', expect.objectContaining({ errors: [{ message: 'Error' }] }), [{ message: 'Error' }]),
+			);
 		});
 	});
 });

--- a/sdk/src/utils/request.test.ts
+++ b/sdk/src/utils/request.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, test, vi } from 'vitest';
-import { request, RequestError } from './request.js';
+import { RequestError } from './error.js';
+import { request } from './request.js';
 
 const fetchMock = vi.fn(async () => ({}));
 
@@ -40,13 +41,10 @@ describe('Request', () => {
 			});
 
 			await expect(async () => await request('https://example.com', {}, fetchMock)).rejects.toThrowError(
-				new RequestError(
-					'',
-					expect.objectContaining({
-						ok: false,
-					}),
-					'Error',
-				),
+				new RequestError('', {
+					response: expect.objectContaining({ ok: false }) as unknown as Response,
+					errors: 'Error' as any,
+				}),
 			);
 		});
 
@@ -54,7 +52,10 @@ describe('Request', () => {
 			vi.mocked(fetchMock).mockResolvedValue({ errors: [] });
 
 			await expect(async () => await request('https://example.com', {}, fetchMock)).rejects.toThrowError(
-				new RequestError('', expect.objectContaining({ errors: [] }), []),
+				new RequestError('', {
+					response: expect.objectContaining({ errors: [] }) as unknown as Response,
+					errors: [],
+				}),
 			);
 		});
 
@@ -65,7 +66,11 @@ describe('Request', () => {
 				vi.mocked(fetchMock).mockResolvedValue({ errors: [], data: type });
 
 				await expect(async () => await request('https://example.com', {}, fetchMock)).rejects.toThrowError(
-					new RequestError('', expect.objectContaining({ errors: [], data: type }), [], type),
+					new RequestError('', {
+						response: expect.objectContaining({ errors: [], data: type }) as unknown as Response,
+						errors: [],
+						data: type,
+					}),
 				);
 			});
 		});
@@ -74,7 +79,10 @@ describe('Request', () => {
 			vi.mocked(fetchMock).mockResolvedValue({ errors: 'Error' });
 
 			await expect(async () => await request('https://example.com', {}, fetchMock)).rejects.toThrowError(
-				new RequestError('', expect.objectContaining({ errors: 'Error' }), 'Error'),
+				new RequestError('', {
+					response: expect.objectContaining({ errors: 'Error' }) as unknown as Response,
+					errors: 'Error' as any,
+				}),
 			);
 		});
 
@@ -82,7 +90,10 @@ describe('Request', () => {
 			vi.mocked(fetchMock).mockResolvedValue({ errors: [{ message: 'Error' }] });
 
 			await expect(async () => await request('https://example.com', {}, fetchMock)).rejects.toThrowError(
-				new RequestError('Error', expect.objectContaining({ errors: [{ message: 'Error' }] }), [{ message: 'Error' }]),
+				new RequestError('Error', {
+					response: expect.objectContaining({ errors: [{ message: 'Error' }] }) as unknown as Response,
+					errors: [{ message: 'Error' }] as any,
+				}),
 			);
 		});
 	});

--- a/sdk/src/utils/request.ts
+++ b/sdk/src/utils/request.ts
@@ -1,18 +1,6 @@
 import type { FetchInterface } from '../index.js';
+import { RequestError } from './error.js';
 import { extractData } from './extract-data.js';
-
-export class RequestError extends Error {
-	response: unknown;
-	errors: any;
-	data?: any;
-
-	constructor(message: string, response: unknown, errors: any, data?: any) {
-		super(message);
-		this.response = response;
-		this.errors = errors;
-		if (data) this.data = data;
-	}
-}
 
 /**
  * Request helper providing default settings
@@ -46,7 +34,13 @@ export const request = async <Output = any>(
 				result.message = result.errors[0].message;
 			}
 
-			return Promise.reject(new RequestError(result.message, result.response, result.errors, result.data));
+			return Promise.reject(
+				new RequestError(result.message, {
+					response: result.response,
+					errors: result.errors,
+					data: result.data,
+				}),
+			);
 		});
 	});
 };

--- a/sdk/src/utils/request.ts
+++ b/sdk/src/utils/request.ts
@@ -1,6 +1,19 @@
 import type { FetchInterface } from '../index.js';
 import { extractData } from './extract-data.js';
 
+export class RequestError extends Error {
+	response: unknown;
+	errors: any;
+	data?: any;
+
+	constructor(message: string, response: unknown, errors: any, data?: any) {
+		super(message);
+		this.response = response;
+		this.errors = errors;
+		if (data) this.data = data;
+	}
+}
+
 /**
  * Request helper providing default settings
  *
@@ -33,7 +46,7 @@ export const request = async <Output = any>(
 				result.message = result.errors[0].message;
 			}
 
-			return Promise.reject(result);
+			return Promise.reject(new RequestError(result.message, result.response, result.errors, result.data));
 		});
 	});
 };


### PR DESCRIPTION
## Scope

What's changed:

- Fixed rejecting with an object instead of an error object

## Potential Risks / Drawbacks

- Breaking change

## Tested Scenarios

- Yes

## Review Notes / Questions

- No

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #TBD
