### PR TITLE
Fix document is not defined when loading API extensions

### DIFF
--- a/.changeset/fix-use-shortcut-document-guard.md
+++ b/.changeset/fix-use-shortcut-document-guard.md
@@ -1,0 +1,5 @@
+---
+'@directus/composables': patch
+---
+
+Fixed `document is not defined` error when loading API extensions that depend on `@directus/composables` via `@directus/extensions-sdk`

--- a/packages/composables/src/use-shortcut.ts
+++ b/packages/composables/src/use-shortcut.ts
@@ -13,17 +13,19 @@ export const systemKeys = ['meta', 'shift', 'alt', 'backspace', 'delete', 'tab',
 const keysDown: Set<string> = new Set([]);
 const handlers: Record<string, ShortcutHandler[]> = {};
 
-document.body.addEventListener('keydown', (event: KeyboardEvent) => {
-	if (event.repeat || !event.key) return;
+if (typeof document !== 'undefined') {
+	document.body.addEventListener('keydown', (event: KeyboardEvent) => {
+		if (event.repeat || !event.key) return;
 
-	keysDown.add(mapKeys(event));
-	callHandlers(event);
-});
+		keysDown.add(mapKeys(event));
+		callHandlers(event);
+	});
 
-document.body.addEventListener('keyup', (event: KeyboardEvent) => {
-	if (event.repeat || !event.key) return;
-	keysDown.clear();
-});
+	document.body.addEventListener('keyup', (event: KeyboardEvent) => {
+		if (event.repeat || !event.key) return;
+		keysDown.clear();
+	});
+}
 
 export function useShortcut(
 	shortcuts: string | string[],


### PR DESCRIPTION
## Scope

What's changed:

- Guarded the top-level `document.body.addEventListener(...)` registrations in `packages/composables/src/use-shortcut.ts` with a `typeof document !== 'undefined'` check so that the module can be evaluated in a Node runtime without throwing.

## Potential Risks / Drawbacks

- Behaviour in the browser is unchanged: `document` is always defined there, so both listeners still register exactly as before. The only difference is that loading the module outside a browser no longer throws.

## Tested Scenarios

- Ran the existing `packages/composables` test suite locally (`pnpm --filter @directus/composables test`) – `use-shortcut.test.ts` continues to pass, and all previously passing specs still pass. The one failing suite (`use-items.test.ts`) is a pre-existing `@vueuse/core` resolution problem unrelated to this change.
- I did not stand up a full end-to-end reproduction of the extension loader against a custom Dockerfile. The fix is narrow: the stack trace in the issue points at the top-level listener registration in `use-shortcut.ts`, which is the only code in the module that touches `document` at import time, and the guard is the minimal change that prevents evaluation on the API server from throwing.

## Review Notes / Questions

- Happy to move the listener bootstrap into an exported `initShortcutListeners()` if a lazier initialization is preferred, but the `typeof document` guard matches patterns used elsewhere in shared packages and avoids changing the public API.

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #27119