### PR TITLE
Fix AI chat request not honoring PUBLIC_URL sub-path

### DIFF
--- a/.changeset/fix-ai-chat-public-url-path.md
+++ b/.changeset/fix-ai-chat-public-url-path.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed AI chat request failing with a 404 when `PUBLIC_URL` has a sub-path (e.g. `https://example.com/api`)

--- a/app/src/ai/stores/use-ai.ts
+++ b/app/src/ai/stores/use-ai.ts
@@ -12,6 +12,7 @@ import { isVisualElement, type UploadedFileResult } from '../types/context';
 import { useAiContextStore } from './use-ai-context';
 import { useAiToolsStore } from './use-ai-tools';
 import { useSettingsStore } from '@/stores/settings';
+import { getRootPath } from '@/utils/get-root-path';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { useSidebarStore } from '@/views/private/private-view/stores/sidebar';
 
@@ -270,6 +271,7 @@ export const useAiStore = defineStore('ai-store', () => {
 
 			return {
 				...req,
+				api: `${getRootPath()}ai/chat`,
 				body: {
 					...req.body,
 					messages,


### PR DESCRIPTION
## Scope

What's changed:

- The AI chat transport in `app/src/ai/stores/use-ai.ts` now computes the request URL with `getRootPath()` inside `prepareSendMessagesRequest` instead of hard-coding `/ai/chat`, so requests stay scoped to the configured `PUBLIC_URL` sub-path.

## Potential Risks / Drawbacks

- `getRootPath()` is already used throughout the app (the main axios instance uses it for `baseURL`), so behaviour against deployments without a sub-path (`PUBLIC_URL=https://example.com/`) is unchanged: `getRootPath()` returns `/` and the resolved URL becomes `/ai/chat`, identical to before.
- I chose to override `api` inside `prepareSendMessagesRequest` rather than at store instantiation so that test environments which reset `window.location` between specs are not affected — calling `getRootPath()` only at send time keeps the existing `use-ai.test.ts` suite passing.

## Tested Scenarios

- Ran `pnpm exec vitest run src/ai/stores/use-ai.test.ts` from `app/` — all 15 specs pass.
- Ran `npx eslint app/src/ai/stores/use-ai.ts` — clean.
- Ran `npx prettier --check app/src/ai/stores/use-ai.ts` — clean.
- I did not stand up a full self-hosted Directus instance behind a `PUBLIC_URL` with a sub-path to hit the AI chat endpoint end-to-end. The fix mirrors how every other app-side API call derives its base path, so the behaviour under `PUBLIC_URL=https://example.com/api` should now be `POST https://example.com/api/ai/chat` instead of `POST https://example.com/ai/chat`.

## Review Notes / Questions

- An alternative would be to set `api` on the `DefaultChatTransport` constructor directly. I tried that first but it forced `getRootPath()` to run at store setup, which broke a handful of existing `use-ai.test.ts` cases when other specs had previously mutated `window.location`. The lazy `prepareSendMessagesRequest` override avoids that coupling.

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26368