### PR TITLE
Skip non-sortable field types when picking a fallback sort

### DIFF
--- a/.changeset/fix-allowed-sort-skip-non-sortable.md
+++ b/.changeset/fix-allowed-sort-skip-non-sortable.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed API error when the fallback sort field picked for non-admin users was of a type the database cannot sort (e.g. JSON)

--- a/api/src/database/get-ast-from-query/utils/get-allowed-sort.test.ts
+++ b/api/src/database/get-ast-from-query/utils/get-allowed-sort.test.ts
@@ -157,3 +157,43 @@ test('Returns the first allowed field if the user has no access to the sort fiel
 
 	expect(result).toEqual(['allowed-field']);
 });
+
+test('Skips non-sortable fallback fields (json) and picks the next allowed field', async () => {
+	const schema = new SchemaBuilder()
+		.collection('collection', (c) => {
+			c.field('primary').id();
+			c.field('sort').string().sort();
+			c.field('tags').json();
+			c.field('title').string();
+		})
+		.build();
+
+	const accountability = { admin: false } as Accountability;
+
+	// User can read `tags` (json) and `title`, but not the sort field `sort`.
+	// Without filtering, the fallback would pick `tags` and the database would
+	// fail with "could not identify an ordering operator for type json".
+	vi.mocked(fetchAllowedFields).mockResolvedValue(['tags', 'title']);
+
+	const result = await getAllowedSort({ collection: 'collection', accountability }, { schema, knex: {} as Knex });
+
+	expect(result).toEqual(['title']);
+});
+
+test('Returns null if the only allowed fallback fields are non-sortable types', async () => {
+	const schema = new SchemaBuilder()
+		.collection('collection', (c) => {
+			c.field('primary').id();
+			c.field('sort').string().sort();
+			c.field('tags').json();
+		})
+		.build();
+
+	const accountability = { admin: false } as Accountability;
+
+	vi.mocked(fetchAllowedFields).mockResolvedValue(['tags']);
+
+	const result = await getAllowedSort({ collection: 'collection', accountability }, { schema, knex: {} as Knex });
+
+	expect(result).toBeNull();
+});

--- a/api/src/database/get-ast-from-query/utils/get-allowed-sort.ts
+++ b/api/src/database/get-ast-from-query/utils/get-allowed-sort.ts
@@ -9,6 +9,11 @@ export type GetAllowedSortFieldOptions = {
 	relation?: Relation;
 };
 
+// Field types that cannot be used as a sort column at the database level.
+// Picking one of these as a fallback sort causes the database to throw
+// (e.g. PostgreSQL "could not identify an ordering operator for type json").
+const NON_SORTABLE_TYPES = ['json', 'alias'];
+
 export async function getAllowedSort(options: GetAllowedSortFieldOptions, context: Context) {
 	// We'll default to the primary key for the standard sort output
 	let sortField: string | null = context.schema.collections[options.collection]!.primary;
@@ -25,8 +30,7 @@ export async function getAllowedSort(options: GetAllowedSortFieldOptions, contex
 
 	if (options.accountability && options.accountability.admin === false) {
 		// Verify that the user has access to the sort field
-
-		const allowedFields = await fetchAllowedFields(
+		const permissionBasedAllowedFields = await fetchAllowedFields(
 			{
 				collection: options.collection,
 				action: 'read',
@@ -34,6 +38,17 @@ export async function getAllowedSort(options: GetAllowedSortFieldOptions, contex
 			},
 			context,
 		);
+
+		// Exclude non-sortable field types from fallback candidates so we don't
+		// pick e.g. a JSON field and cause the database to error on sort.
+		const collectionFields = context.schema.collections[options.collection]?.fields ?? {};
+
+		const allowedFields = permissionBasedAllowedFields.filter((field) => {
+			if (field === '*') return true;
+			const fieldInfo = collectionFields[field];
+			if (!fieldInfo) return true;
+			return !NON_SORTABLE_TYPES.includes(fieldInfo.type);
+		});
 
 		if (allowedFields.length === 0) {
 			sortField = null;


### PR DESCRIPTION
## Scope

What's changed:

- In `api/src/database/get-ast-from-query/utils/get-allowed-sort.ts`, filter the permission-based allowed fields through a small deny-list of non-sortable types (`json`, `alias`) before choosing the fallback sort field, so non-admin users whose default sort field is not readable don't get a fallback that the database refuses to sort.
- If every allowed field is non-sortable the function now returns `null`, consistent with the behaviour when no allowed fields exist at all.
- Added two unit tests covering the new behaviour: the happy path (fallback picks the next sortable field) and the empty-after-filter path (returns `null`).

## Potential Risks / Drawbacks

- The deny-list is intentionally small (`json`, `alias`). I opted not to include `geometry*` types here because geometry can be ordered in some dialects and I did not want to change behaviour for cases that currently work. If there are more types that consistently error on sort in every supported dialect, they can be added to the same constant.
- Admin users and queries that explicitly supply a sort field are unaffected — this code path is only the non-admin fallback branch.

## Tested Scenarios

- `pnpm exec vitest run src/database/get-ast-from-query/utils/get-allowed-sort.test.ts` from `api/` — all 10 specs pass, including the two new ones.
- ESLint and Prettier run clean on the modified files.
- I did not spin up a real Postgres instance to reproduce the original `could not identify an ordering operator for type json` error against a live collection; the unit tests exercise the field-picking logic directly against a `SchemaBuilder` schema.

## Review Notes / Questions

- @hanneskuettner mentioned in the issue that a longer-term fix would be to mark "system-added" fields so they're skipped during permission processing. This PR does not attempt that larger refactor — it only prevents the concrete "sort picks a JSON column" crash that users are hitting today. Happy to adjust scope if you'd prefer the bigger change instead.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #23652