### PR TITLE
Normalize OpenAI-compatible baseURL to accept full completions endpoint

### DIFF
--- a/.changeset/fix-openai-compatible-base-url-normalization.md
+++ b/.changeset/fix-openai-compatible-base-url-normalization.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Normalized the OpenAI-compatible `baseURL` so pasting a full completions endpoint (e.g. OpenRouter's `/chat/completions`) no longer 404s

--- a/api/src/ai/providers/registry.test.ts
+++ b/api/src/ai/providers/registry.test.ts
@@ -219,6 +219,19 @@ describe('createAIProviderRegistry', () => {
 		expect(createOpenAICompatible).not.toHaveBeenCalled();
 	});
 
+	it.each([
+		['https://openrouter.ai/api/v1/chat/completions', 'https://openrouter.ai/api/v1'],
+		['https://openrouter.ai/api/v1/chat/completions/', 'https://openrouter.ai/api/v1'],
+		['https://api.openai.com/v1/completions', 'https://api.openai.com/v1'],
+		['https://openrouter.ai/api/v1/', 'https://openrouter.ai/api/v1'],
+		['  https://openrouter.ai/api/v1  ', 'https://openrouter.ai/api/v1'],
+		['https://openrouter.ai/api/v1', 'https://openrouter.ai/api/v1'],
+	])('normalizes OpenAI-compatible baseUrl %s to %s', (input, expected) => {
+		const configs: ProviderConfig[] = [{ type: 'openai-compatible', apiKey: 'custom-key', baseUrl: input }];
+		createAIProviderRegistry(configs);
+		expect(createOpenAICompatible).toHaveBeenCalledWith(expect.objectContaining({ baseURL: expected }));
+	});
+
 	it('creates registry with multiple providers', () => {
 		const configs: ProviderConfig[] = [
 			{ type: 'openai', apiKey: 'sk-openai' },

--- a/api/src/ai/providers/registry.ts
+++ b/api/src/ai/providers/registry.ts
@@ -7,6 +7,19 @@ import type { AISettings, ProviderConfig } from './types.js';
 
 type ProviderRegistry = ReturnType<typeof createProviderRegistry>;
 
+/**
+ * The OpenAI-compatible SDK appends `/chat/completions` (and similar paths)
+ * itself. Users frequently paste the full OpenRouter/OpenAI completions URL,
+ * which results in a double-pathed request that 404s. Strip the suffix and
+ * any trailing slash so both conventions work.
+ */
+function normalizeOpenAICompatibleBaseUrl(baseUrl: string): string {
+	return baseUrl
+		.trim()
+		.replace(/\/+(?:chat\/)?completions\/?$/, '')
+		.replace(/\/+$/, '');
+}
+
 export function buildProviderConfigs(settings: AISettings): ProviderConfig[] {
 	const configs: ProviderConfig[] = [];
 
@@ -65,7 +78,7 @@ export function createAIProviderRegistry(configs: ProviderConfig[], settings?: A
 					providers['openai-compatible'] = createOpenAICompatible({
 						name: settings?.openaiCompatibleName ?? 'openai-compatible',
 						apiKey: config.apiKey,
-						baseURL: config.baseUrl,
+						baseURL: normalizeOpenAICompatibleBaseUrl(config.baseUrl),
 						headers: customHeaders,
 					});
 				}


### PR DESCRIPTION
## Scope

What's changed:

- `api/src/ai/providers/registry.ts` now strips a trailing `/chat/completions` (or `/completions`) and any trailing slashes from the configured OpenAI-compatible `baseURL` before passing it to `@ai-sdk/openai-compatible`.
- Added parameterized tests covering the common shapes: the full OpenRouter URL (`.../v1/chat/completions`), the OpenAI completions path (`.../v1/completions`), trailing-slash and whitespace variants, and a URL that was already in the correct shape (unchanged).

## Potential Risks / Drawbacks

- Users whose OpenAI-compatible endpoint legitimately lives *at* a path ending in `/chat/completions` as its base (i.e. the SDK should not append anything to it) would see their URL rewritten. I could not find any real provider in that shape — OpenRouter, Together, Ollama, vLLM, LM Studio all treat `.../v1` as the base — but calling this out as the one behavioural change.
- Users who had worked around this bug by pasting the (incorrect-for-the-SDK) `/chat/completions` URL will continue to work after this change; the stripping makes both conventions resolve to the same base URL.

## Tested Scenarios

- `pnpm exec vitest run src/ai/providers/registry.test.ts` from `api/` — all 22 specs pass (including the 6 new parameterized cases).
- ESLint and Prettier run clean on the modified files.
- I did not stand up an OpenRouter account to verify end-to-end. The fix follows the flow identified in the issue thread by @VincentKempers — removing `/chat/completions` from the configured base URL makes the request succeed — and the unit tests lock that normalization in place.

## Review Notes / Questions

- Happy to fold the normalization into `buildProviderConfigs` instead of `createAIProviderRegistry` if you'd prefer it closer to the settings boundary, but putting it next to the `createOpenAICompatible(...)` call keeps the fix scoped to the one place that actually hands the URL to the SDK.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26607