### PR TITLE
Return 400 for Joi number.unsafe validation errors instead of 500

### DIFF
--- a/.changeset/fix-joi-validation-unhandled-number-types.md
+++ b/.changeset/fix-joi-validation-unhandled-number-types.md
@@ -1,0 +1,5 @@
+---
+'@directus/validation': patch
+---
+
+Fixed `number.unsafe` (and other numeric Joi error types) surfacing as an internal 500 error instead of a validation error when a user-configured validation rule rejects an unsafe number

--- a/packages/validation/src/utils/joi-to-error-extensions.test.ts
+++ b/packages/validation/src/utils/joi-to-error-extensions.test.ts
@@ -1,0 +1,45 @@
+import type { ValidationErrorItem } from 'joi';
+import { describe, expect, test } from 'vitest';
+import { joiValidationErrorItemToErrorExtensions } from './joi-to-error-extensions.js';
+
+function buildItem(
+	type: string,
+	context?: Record<string, unknown>,
+	path: (string | number)[] = ['amount'],
+): ValidationErrorItem {
+	return {
+		message: `Validation failed (${type})`,
+		path,
+		type,
+		context,
+	} as unknown as ValidationErrorItem;
+}
+
+describe('joiValidationErrorItemToErrorExtensions', () => {
+	test('maps number.less to lt with the configured limit', () => {
+		const extensions = joiValidationErrorItemToErrorExtensions(buildItem('number.less', { limit: 10000 }));
+		expect(extensions.type).toBe('lt');
+		expect(extensions.valid).toBe(10000);
+	});
+
+	test('maps number.unsafe to the generic regex type instead of throwing', () => {
+		const value = 10000000000000000;
+
+		const extensions = joiValidationErrorItemToErrorExtensions(buildItem('number.unsafe', { value }));
+
+		expect(extensions.type).toBe('regex');
+		expect(extensions.invalid).toBe(value);
+	});
+
+	test.each([['number.infinity'], ['number.precision'], ['number.integer'], ['number.multiple'], ['number.port']])(
+		'falls back to regex for unhandled numeric Joi type %s',
+		(joiType) => {
+			const extensions = joiValidationErrorItemToErrorExtensions(buildItem(joiType, { value: 1 }));
+			expect(extensions.type).toBe('regex');
+		},
+	);
+
+	test('still throws for completely unrecognized Joi types', () => {
+		expect(() => joiValidationErrorItemToErrorExtensions(buildItem('something.weird'))).toThrow();
+	});
+});

--- a/packages/validation/src/utils/joi-to-error-extensions.ts
+++ b/packages/validation/src/utils/joi-to-error-extensions.ts
@@ -117,6 +117,15 @@ export const joiValidationErrorItemToErrorExtensions = (
 		}
 	}
 
+	// Joi emits several number.* error types (number.unsafe, number.infinity,
+	// number.precision, etc.) that don't map cleanly to any of our filter
+	// operators. Surface them as a generic format validation error rather than
+	// throwing, which previously caused the whole request to fail with a 500.
+	if (!extensions.type && joiType.startsWith('number.')) {
+		extensions.type = 'regex';
+		extensions.invalid = validationErrorItem.context?.value;
+	}
+
 	if (!extensions.type) {
 		throw new Error(`Couldn't extract validation error type from Joi validation error item`);
 	}


### PR DESCRIPTION
## Scope

What's changed:

- In `packages/validation/src/utils/joi-to-error-extensions.ts`, if none of the existing mappings match and the Joi type starts with `number.` (e.g. `number.unsafe`, `number.infinity`, `number.precision`, `number.multiple`, `number.integer`, `number.port`, `number.negative`, `number.positive`), fall back to the generic `regex` extension type so the caller can produce a normal `FAILED_VALIDATION` error instead of throwing.
- Added a new test file `packages/validation/src/utils/joi-to-error-extensions.test.ts` covering:
  - The existing `number.less` -> `lt` happy path (regression fence).
  - `number.unsafe` now returns `regex` with the offending value surfaced as `invalid`.
  - Each of the other `number.*` types not explicitly mapped all fall back to `regex`.
  - Truly unknown Joi types (`something.weird`) still throw, keeping the original loud failure mode for genuinely unhandled cases.

## Potential Risks / Drawbacks

- The error message the client sees for these cases will now be the generic regex message (`Value doesn't have the correct format.`) rather than a bespoke "number too large" message. I opted for this over adding new `type` values because `FailedValidationErrorExtensions.type` is constrained to `ClientFilterOperator | 'required' | 'email'`, and introducing new extension types is a bigger API-shape change than this issue warrants.
- The behaviour change is strictly narrower than the previous one: cases that used to 500 now return a 400, all previously-working validation types are untouched.

## Tested Scenarios

- `pnpm --filter @directus/validation exec vitest run src/utils/joi-to-error-extensions.test.ts` — all 8 specs pass (happy path + fallback + negative case).
- ESLint and Prettier run clean.
- I did not reproduce the full Studio UI flow against a live Postgres (decimal field with precision 50, scale 2, validation `less than 10000`, entering `10000000000000000`). The mapper is pure — it receives a `ValidationErrorItem` and returns extensions — so the unit tests exercise exactly the path that previously threw.

## Review Notes / Questions

- If you'd prefer bespoke messages for `number.unsafe` / `number.precision` / `number.multiple`, I'm happy to extend `FailedValidationErrorExtensions['type']` and `messageConstructor` in a follow-up. That's a larger change I didn't want to fold into a bug-fix PR.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26448