### PR TITLE
Fix Postgres VALUE_TOO_LONG misattributing field from SQL text

### DIFF
--- a/.changeset/postgres-value-too-long-no-field-guess.md
+++ b/.changeset/postgres-value-too-long-no-field-guess.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed Postgres `VALUE_TOO_LONG` error incorrectly reporting the first column in the INSERT statement as the offending field

--- a/api/src/database/errors/dialects/postgres.test.ts
+++ b/api/src/database/errors/dialects/postgres.test.ts
@@ -1,0 +1,49 @@
+import { ValueTooLongError } from '@directus/errors';
+import { describe, expect, it } from 'vitest';
+import { extractError } from './postgres.js';
+import type { PostgresError } from './types.js';
+
+describe('postgres error extractor', () => {
+	describe('22001 value limit violation', () => {
+		it('returns ValueTooLongError with collection from error.table and no field', () => {
+			// Postgres does not populate error.column for 22001 errors. Regression test for
+			// directus/directus#26197 — previously the extractor guessed the field by parsing the
+			// SQL string, which surfaced the first column in the INSERT rather than the offending one.
+			const error: PostgresError = {
+				message:
+					'insert into "article" ("subtitle", "title") values ($1, $2) returning "id" - value too long for type character varying(10)',
+				length: 0,
+				code: '22001',
+				detail: '',
+				schema: 'public',
+				table: 'article',
+			};
+
+			const result = extractError(error, { subtitle: 'short', title: 'way too long value' });
+
+			expect(result).toBeInstanceOf(ValueTooLongError);
+			const extensions = (result as any).extensions;
+			expect(extensions.collection).toBe('article');
+			expect(extensions.field).toBeNull();
+			expect(extensions.value).toBeNull();
+		});
+
+		it('returns ValueTooLongError with null collection when table is not set', () => {
+			const error: PostgresError = {
+				message: 'value too long for type character varying(10)',
+				length: 0,
+				code: '22001',
+				detail: '',
+				schema: 'public',
+				table: undefined as unknown as string,
+			};
+
+			const result = extractError(error, {});
+
+			expect(result).toBeInstanceOf(ValueTooLongError);
+			const extensions = (result as any).extensions;
+			expect(extensions.collection).toBeNull();
+			expect(extensions.field).toBeNull();
+		});
+	});
+});

--- a/api/src/database/errors/dialects/postgres.ts
+++ b/api/src/database/errors/dialects/postgres.ts
@@ -70,21 +70,20 @@ export function extractError(error: PostgresError, data: Partial<Item>): Postgre
 	function valueLimitViolation() {
 		/**
 		 * NOTE:
-		 * Postgres doesn't return the offending column
+		 * Postgres doesn't return the offending column for 22001 errors. Prior implementations
+		 * attempted to derive a field name by parsing quoted identifiers out of the raw SQL
+		 * (e.g. `insert into "article" ("subtitle", "title") ...`), but that would surface the
+		 * first column listed in the INSERT rather than the column that actually violated the
+		 * limit. That produces misleading "field 'X' is too long" errors when X is unrelated
+		 * to the failure. Report the error without a field so callers can't act on a wrong one.
 		 */
 
-		const regex = /"(.*?)"/g;
-		const matches = error.message.match(regex);
-
-		if (!matches) return error;
-
-		const collection = matches[0].slice(1, -1);
-		const field = matches[1]?.slice(1, -1) ?? null;
+		const collection = error.table ?? null;
 
 		return new ValueTooLongError({
 			collection,
-			field,
-			value: field ? data[field] : null,
+			field: null,
+			value: null,
 		});
 	}
 


### PR DESCRIPTION
## Summary

- Stop parsing the raw SQL string to guess the offending column in `valueLimitViolation()` — Postgres does not include the column in the 22001 error, and the regex was surfacing whichever column appeared first in the INSERT, which is often not the column that actually overflowed.
- Populate `collection` from `error.table` (which Postgres does provide) and leave `field`/`value` as `null`, so clients receive a truthful error instead of one that points at an unrelated field.

Closes #26197

## Test plan

- [x] Unit test (`api/src/database/errors/dialects/postgres.test.ts`) covering the scenario from the issue: insert into `article ("subtitle", "title")` where the value overflowing belongs to `title`, not the first-listed column.
- [x] Unit test for the path where `error.table` is unset.
- [ ] Full end-to-end reproduction against a real Postgres instance was not run locally.