### PR TITLE
Fix non-nullable fields with default value nullable in GraphQL read schema

### DIFF
--- a/.changeset/graphql-non-null-with-default-on-read.md
+++ b/.changeset/graphql-non-null-with-default-on-read.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed non-nullable fields with a default value appearing as nullable in the GraphQL read schema

--- a/api/src/services/graphql/schema/get-types.ts
+++ b/api/src/services/graphql/schema/get-types.ts
@@ -93,10 +93,12 @@ export function getTypes(
 
 					// GraphQL doesn't differentiate between not-null and has-to-be-submitted. We
 					// can't non-null in update, as that would require every not-nullable field to be
-					// submitted on updates
+					// submitted on updates. On create, fields with a default value also don't need
+					// to be submitted. On read, however, a non-nullable field is always non-null
+					// regardless of whether it has a default value.
 					if (
 						field.nullable === false &&
-						!field.defaultValue &&
+						(action === 'read' || !field.defaultValue) &&
 						!GENERATE_SPECIAL.some((flag) => field.special.includes(flag)) &&
 						fieldIsInconsistent === false &&
 						action !== 'update'


### PR DESCRIPTION
## Scope

What's changed:

- In the GraphQL schema, fields with `nullable: false` and a default value are now correctly typed as non-null (`!`) for the `read` action
- `create` behavior is unchanged — such fields remain nullable in `create` input types because the user doesn't need to submit them when a default is present
- `update` behavior is unchanged — all fields remain nullable in `update` input types

## Potential Risks / Drawbacks

- Clients that relied on the previous (incorrect) nullable typing on read responses will need to update their generated TypeScript/GraphQL types. The runtime payload is unchanged — only the schema types are now stricter (and accurate)

## Tested Scenarios

- Manually traced the condition in `api/src/services/graphql/schema/get-types.ts` against the four GraphQL actions (read / create / update / delete):
  - `nullable: false`, `defaultValue: null`, action `read` → non-null (unchanged)
  - `nullable: false`, `defaultValue: 'medium'`, action `read` → non-null (fixed; was nullable)
  - `nullable: false`, `defaultValue: 'medium'`, action `create` → nullable (unchanged — default means optional input)
  - `nullable: false`, any default, action `update` → nullable (unchanged — same rationale as before)
  - `nullable: true`, any default, any action → nullable (unchanged)
- Ran `api` graphql tests: `npx vitest run src/services/graphql/` — 8 files, 81 tests pass
- Attempted a unit test for `getTypes` with `@directus/schema-builder` + a fresh `SchemaComposer`, but ran into an unrelated `graphql` / `graphql-compose` module-resolution issue in ESM vitest (TypeMapper cannot convert `GraphQLInt`). Happy to add a test if the reviewer has a pointer for a working harness

## Review Notes / Questions

- The comment on the condition is updated to spell out the intent per action
- No tests are added because I could not get the module-level harness working — see above. The change itself is a two-line condition tweak

## Checklist

- [x] Added or updated tests (see review notes above — I ran the existing graphql test suite)
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required — not required (no docs reference this behavior)
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required — not required

---

Closes #25888