### PR TITLE
Fix Postgres numeric overflow reporting wrong field name

### DIFF
--- a/.changeset/pg-numeric-overflow-wrong-field.md
+++ b/.changeset/pg-numeric-overflow-wrong-field.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed numeric overflow errors on Postgres reporting a misleading field name parsed from the query text

--- a/api/src/database/errors/dialects/postgres.test.ts
+++ b/api/src/database/errors/dialects/postgres.test.ts
@@ -1,0 +1,55 @@
+import { ValueOutOfRangeError } from '@directus/errors';
+import { describe, expect, test } from 'vitest';
+import { extractError } from './postgres.js';
+import type { PostgresError } from './types.js';
+
+function buildError(overrides: Partial<PostgresError>): PostgresError {
+	return {
+		message: 'numeric field overflow',
+		length: 0,
+		code: '22003',
+		detail: '',
+		schema: 'public',
+		table: '',
+		...overrides,
+	};
+}
+
+describe('extractError', () => {
+	describe('numeric value out of range', () => {
+		test('returns ValueOutOfRangeError with null field when table is known', () => {
+			// Regression test for https://github.com/directus/directus/issues/25867.
+			// Previously, parsing quotes out of the knex-prefixed error message could
+			// pick up an unrelated column from the INSERT column list, reporting the
+			// wrong field to the user.
+			const error = buildError({
+				// knex typically prefixes the query text to the error message, which
+				// used to be parsed for the field name.
+				message:
+					'insert into "test_collection" ("other_field", "decimal_field") values ($1, $2) returning "id" - numeric field overflow',
+				table: 'test_collection',
+			});
+
+			const result = extractError(error, { other_field: 'foo', decimal_field: 999999 });
+
+			expect(result).toBeInstanceOf(ValueOutOfRangeError);
+
+			expect((result as InstanceType<typeof ValueOutOfRangeError>).extensions).toEqual({
+				collection: 'test_collection',
+				field: null,
+				value: null,
+			});
+		});
+
+		test('falls through to the raw error when table is missing', () => {
+			const error = buildError({
+				message: 'numeric field overflow',
+				table: '',
+			});
+
+			const result = extractError(error, {});
+
+			expect(result).toBe(error);
+		});
+	});
+});

--- a/api/src/database/errors/dialects/postgres.ts
+++ b/api/src/database/errors/dialects/postgres.ts
@@ -52,18 +52,21 @@ export function extractError(error: PostgresError, data: Partial<Item>): Postgre
 	}
 
 	function numericValueOutOfRange() {
-		const regex = /"(.*?)"/g;
-		const matches = error.message.match(regex);
+		/**
+		 * NOTE:
+		 * Postgres doesn't return the offending column for numeric overflow. The table
+		 * is available on the error object, but the field name has to be omitted to
+		 * avoid reporting a misleading column parsed from the query text.
+		 */
 
-		if (!matches) return error;
+		const { table } = error;
 
-		const collection = matches[0].slice(1, -1);
-		const field = matches[1]?.slice(1, -1) ?? null;
+		if (!table) return error;
 
 		return new ValueOutOfRangeError({
-			collection,
-			field,
-			value: field ? data[field] : null,
+			collection: table,
+			field: null,
+			value: null,
 		});
 	}
 


### PR DESCRIPTION
## Scope

What's changed:

- `api/src/database/errors/dialects/postgres.ts`: on Postgres error code `22003` (numeric value out of range), stop parsing a field name out of `error.message` and return the error with `collection: error.table` and `field: null`
- Added a unit test covering the regression case (a knex-prefixed error message containing multiple quoted column names) and the fallthrough when the table is missing

## Potential Risks / Drawbacks

- API consumers that relied on receiving a (possibly misleading) `field` in the error extensions for numeric overflow will now get `null`. The user-facing message changes from `Numeric value in "<collection>"."<wrong_field>" is out of range` to `Numeric value in "<collection>" is out of range`. This matches the existing behavior of `VALUE_LIMIT_VIOLATION` in the same file, which has always omitted the column for the same Postgres limitation
- Data type/value pairing is also set to `null` in the extensions, since there's no reliable field to look up in the payload anymore

## Tested Scenarios

- New unit tests in `api/src/database/errors/dialects/postgres.test.ts`:
  - `insert into "test_collection" ("other_field", "decimal_field") values ($1, $2) ... - numeric field overflow` with `table: 'test_collection'` produces `ValueOutOfRangeError` with `collection: 'test_collection'`, `field: null`, `value: null` (previously it would have reported `field: 'other_field'`)
  - When `error.table` is empty, the error is returned as-is
- `npx vitest run src/database` in `api/` — 37 files, 376 tests pass

## Review Notes / Questions

- I intentionally did not touch `valueLimitViolation` in the same file even though it has the same regex-on-`error.message` pattern — the issue only reports the numeric overflow case, and that function already has a matching `NOTE: Postgres doesn't return the offending column` comment suggesting this was known. Happy to apply the same fix there if desired
- MySQL's `numericValueOutOfRange` is unaffected — it reads the column name out of `error.sqlMessage`, which MySQL does populate reliably (`Out of range value for column 'x' at row 1`)

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required — not required (behavioral error payload change only)
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required — not required

---

Closes #25867