### PR TITLE
fix(app): skip auth refresh on public routes when tab becomes active

### DIFF
--- a/.changeset/accept-invite-tab-active.md
+++ b/.changeset/accept-invite-tab-active.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed invitation, password reset, and share links expiring immediately after the browser tab loses focus.

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -94,6 +94,15 @@ emitter.on(Events.tabIdle, () => {
 // Restart the auto-refresh process when the app is used again
 emitter.on(Events.tabActive, () => {
 	if (idle === true) {
+		// Skip the refresh when the user is on a public route (e.g. /accept-invite, /reset-password).
+		// These pages intentionally operate without an authenticated session, so attempting to
+		// refresh here would fail and redirect the user to /login with a "session expired"
+		// message — losing the invite/reset token they came in with. See #25812.
+		if (router.currentRoute.value.meta.public === true) {
+			idle = false;
+			return;
+		}
+
 		refresh();
 		idle = false;
 	}

--- a/contributors.yml
+++ b/contributors.yml
@@ -269,3 +269,4 @@
 - faizkhairi
 - eric-pennecot
 - om-singh-D
+- yogeshwaran-c


### PR DESCRIPTION
## Scope

What's changed:

- `app/src/auth.ts` — the `tabActive` handler now bails out of the refresh attempt when the current route has `meta.public === true`.

## Potential Risks / Drawbacks

- The idle state is still cleared on every `tabActive`, so once the user logs in from a public page the refresh loop resumes normally on the next idle/active cycle. I don't see any regressions for authenticated users from this, but worth a second pair of eyes on whether there's a case where a public route also needs the token refresh (I don't see one — every public route in `router.ts` is for unauthenticated flows: login, setup, accept-invite, reset-password, register, logout, shared).

## Tested Scenarios

- Reproduced the bug on main: opened `/accept-invite?token=...`, switched to a different tab and waited past the idle timeout, switched back — the page redirected to `/login?reason=SESSION_EXPIRED` as @ComfortablyCoding described in the issue thread.
- With the fix applied: the same flow keeps the user on `/accept-invite` with the token still active.
- Also spot-checked `/reset-password` and `/login` — both stable across tab focus changes.
- Did not add an automated test; `app/src` has no existing `auth.test.ts`, and `idle.ts`/`refresh-sidebar-detail.vue` are the only files with tests for these emitter listeners. Happy to add one if preferred, but wanted to keep this diff minimal.

## Review Notes / Questions

- @ComfortablyCoding — you suggested in the issue thread that "a potential solution would be to add an exception for the invite page (and any similar pages if applicable)". I went one level broader than the invite page and keyed the exception off `route.meta.public`, because the same problem exists for `/reset-password`, `/register`, and share-link flows, and they share the same `public: true` flag in the router. Let me know if you'd rather hardcode specific route names.
- The early `return` intentionally still clears `idle = false`, so the refresh loop will not be stuck "idle forever" if the user later logs in on the same tab.

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Closes #25812