### PR TITLE
fix(specs): declare id path parameter on /comments/{id}

### DIFF
--- a/.changeset/fix-openapi-comment-id-parameter.md
+++ b/.changeset/fix-openapi-comment-id-parameter.md
@@ -1,0 +1,5 @@
+---
+'@directus/specs': patch
+---
+
+Added missing `id` path parameter to the `/comments/{id}` OpenAPI spec so the generated spec validates and imports cleanly in tools like Postman.

--- a/contributors.yml
+++ b/contributors.yml
@@ -269,3 +269,4 @@
 - faizkhairi
 - eric-pennecot
 - om-singh-D
+- yogeshwaran-c

--- a/packages/specs/src/paths/comments/comment.yaml
+++ b/packages/specs/src/paths/comments/comment.yaml
@@ -76,3 +76,6 @@ delete:
       description: Successful request
     '401':
       $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
+
+parameters:
+  - $ref: '../../openapi.yaml#/components/parameters/UUId'


### PR DESCRIPTION
The path item `/comments/{id}` in the generated OpenAPI spec doesn't declare `id` as a path parameter, so it fails schema validation ("Declared path parameter \"id\" needs to be defined as a path parameter at either the path or operation level") and tools like Postman refuse to import the full spec.

Every other entity path file (`users/user.yaml`, `roles/role.yaml`, `files/file.yaml`, etc.) declares a top-level `parameters:` block referencing the shared `UUId` parameter. `comments/comment.yaml` was the only one missing it; this PR adds it.

Closes #24155

Not tested: the actual Postman import end-to-end - verified by building `@directus/specs` and confirming the generated `paths./comments/{id}.parameters` now has the `$ref` to `#/components/parameters/UUId`.