### PR TITLE
fix(composables): don't fire scoped useShortcut when nothing is focused

### DIFF
--- a/.changeset/fix-useshortcut-scoped-element-hijack.md
+++ b/.changeset/fix-useshortcut-scoped-element-hijack.md
@@ -1,0 +1,5 @@
+---
+'@directus/composables': patch
+---
+
+Fixed `useShortcut` firing scoped shortcuts when no element is focused. Scoped shortcuts (those passed a target element) now only trigger when focus is inside that element; the "no focus" fallback is reserved for unscoped shortcuts that target the document body. This prevents things like the markdown editor's `Cmd+K` hijacking the key press from anywhere on the page.

--- a/contributors.yml
+++ b/contributors.yml
@@ -269,3 +269,4 @@
 - faizkhairi
 - eric-pennecot
 - om-singh-D
+- yogeshwaran-c

--- a/packages/composables/src/use-shortcut.test.ts
+++ b/packages/composables/src/use-shortcut.test.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, Mock, test, vi } from 'vitest';
-import { defineComponent, h } from 'vue';
+import { defineComponent, h, ref } from 'vue';
 import { useShortcut } from './use-shortcut.js';
 
 function getTestComponent(shortcut: string, handler: () => void) {
@@ -9,6 +9,19 @@ function getTestComponent(shortcut: string, handler: () => void) {
 			useShortcut(shortcut, handler);
 		},
 		render: () => h('div'),
+	});
+}
+
+function getScopedTestComponent(shortcut: string, handler: () => void) {
+	return defineComponent({
+		setup() {
+			const target = ref<HTMLElement>();
+			useShortcut(shortcut, handler, target);
+			return { target };
+		},
+		render() {
+			return h('div', { ref: 'target' });
+		},
 	});
 }
 
@@ -48,5 +61,26 @@ describe('useShortcut', () => {
 		await wrapper.trigger('keyup', { key: keys[0] });
 
 		expect(shortcutHandler).toHaveBeenCalledOnce();
+	});
+
+	test('should not trigger scoped shortcut when focus is outside the target element', async () => {
+		const keys = ['meta', 'k'];
+
+		// Focus sink outside of the scoped target — dispatch keydown events from here instead.
+		const focusSink = document.createElement('input');
+		document.body.appendChild(focusSink);
+
+		const testComponent = getScopedTestComponent(keys.join('+'), shortcutHandler);
+		mount(testComponent, { attachTo: document.body });
+
+		for (const key of keys) {
+			focusSink.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+		}
+
+		focusSink.dispatchEvent(new KeyboardEvent('keyup', { key: keys[0], bubbles: true }));
+
+		expect(shortcutHandler).not.toHaveBeenCalled();
+
+		focusSink.remove();
 	});
 });

--- a/packages/composables/src/use-shortcut.ts
+++ b/packages/composables/src/use-shortcut.ts
@@ -36,11 +36,15 @@ export function useShortcut(
 		if (!reference.value) return;
 		const ref = reference.value instanceof HTMLElement ? reference.value : (reference.value.$el as HTMLElement);
 
-		if (
-			document.activeElement === ref ||
-			ref.contains(document.activeElement) ||
-			document.activeElement === document.body
-		) {
+		// Match when the shortcut target is focused or contains focus. When the target is the document
+		// body (the default for unscoped shortcuts) also match when nothing is focused, so that global
+		// shortcuts still fire on an "empty" page. Scoped shortcuts (those passed a specific element)
+		// must not fire on an unfocused page, otherwise they hijack global key presses like Cmd+K
+		// while the user is nowhere near the targeted element.
+		const isFocused = document.activeElement === ref || ref.contains(document.activeElement);
+		const isUnscopedGlobal = ref === document.body && document.activeElement === document.body;
+
+		if (isFocused || isUnscopedGlobal) {
 			event.preventDefault();
 			return handler(event, cancelNext);
 		}


### PR DESCRIPTION
`useShortcut` lets callers pass an element reference to scope a shortcut, but its match check also succeeded whenever `document.activeElement === document.body` (no focus at all). That fallback is useful for unscoped shortcuts so they still fire on an idle page, but it shouldn't apply when a caller explicitly passed a target element. As a result shortcuts like the markdown editor's `Cmd+K` fired from anywhere on the page as long as no input was focused.

The fix limits the "no focus" fallback to shortcuts whose reference is the default `document.body`. Scoped shortcuts now only fire when focus is actually inside the target element.

Added a regression test that dispatches the shortcut keys from an input outside the scoped target and asserts the handler is not invoked.

Closes #22818