### PR TITLE
fix(sdk): reflect policies permission system in policy/user types

### DIFF
--- a/.changeset/fix-sdk-policy-user-access-types.md
+++ b/.changeset/fix-sdk-policy-user-access-types.md
@@ -2,4 +2,4 @@
 '@directus/sdk': patch
 ---
 
-Fixed SDK types for `directus_policies.users`, `directus_policies.roles` and `directus_users.policies` to reflect the policies permission system. These relations are M2M through `directus_access` but were typed as direct arrays of `DirectusUser`/`DirectusRole`/`DirectusPolicy`, which did not match the API payload.
+Fixed SDK types linking to `directus_access` junction collection

--- a/.changeset/fix-sdk-policy-user-access-types.md
+++ b/.changeset/fix-sdk-policy-user-access-types.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Fixed SDK types for `directus_policies.users`, `directus_policies.roles` and `directus_users.policies` to reflect the policies permission system. These relations are M2M through `directus_access` but were typed as direct arrays of `DirectusUser`/`DirectusRole`/`DirectusPolicy`, which did not match the API payload.

--- a/contributors.yml
+++ b/contributors.yml
@@ -269,3 +269,4 @@
 - faizkhairi
 - eric-pennecot
 - om-singh-D
+- yogeshwaran-c

--- a/sdk/src/schema/policy.ts
+++ b/sdk/src/schema/policy.ts
@@ -1,7 +1,6 @@
 import type { MergeCoreCollection } from '../index.js';
+import type { DirectusAccess } from './access.js';
 import type { DirectusPermission } from './permission.js';
-import type { DirectusRole } from './role.js';
-import type { DirectusUser } from './user.js';
 
 export type DirectusPolicy<Schema> = MergeCoreCollection<
 	Schema,
@@ -16,7 +15,7 @@ export type DirectusPolicy<Schema> = MergeCoreCollection<
 		admin_access: boolean;
 		app_access: boolean;
 		permissions: number[] | DirectusPermission<Schema>[];
-		users: string[] | DirectusUser<Schema>[];
-		roles: string[] | DirectusRole<Schema>[];
+		users: string[] | DirectusAccess<Schema>[];
+		roles: string[] | DirectusAccess<Schema>[];
 	}
 >;

--- a/sdk/src/schema/user.ts
+++ b/sdk/src/schema/user.ts
@@ -1,6 +1,6 @@
 import type { MergeCoreCollection } from '../index.js';
+import type { DirectusAccess } from './access.js';
 import type { DirectusFile } from './file.js';
-import type { DirectusPolicy } from './policy.js';
 import type { DirectusRole } from './role.js';
 
 /**
@@ -37,6 +37,6 @@ export type DirectusUser<Schema = any> = MergeCoreCollection<
 		theme_light: string | null;
 		theme_light_overrides: Record<string, unknown> | null;
 		theme_dark_overrides: Record<string, unknown> | null;
-		policies: string[] | DirectusPolicy<Schema>[];
+		policies: string[] | DirectusAccess<Schema>[];
 	}
 >;


### PR DESCRIPTION
@Nitwel pointed out in #25757 that `users` on `directus_policies` is typed as a plain user array in the SDK, even though the policies permission system stores it as M2M through `directus_access`. Same pattern applies to `directus_policies.roles` and `directus_users.policies`.

This PR retypes those three relation fields to `DirectusAccess[]` to match the actual schema (confirmed by `packages/system-data/src/fields/policies.yaml` and `users.yaml` — both declare the fields as `list-m2m` with a `directus_access` junction).

This is a breaking type change in the sense that strictly-typed user code will now need to reference `DirectusAccess` shapes instead of `DirectusUser`/`DirectusPolicy` directly, but it matches the runtime payload the API expects.

Closes #25757