### PR TITLE
Fix `useShortcut` attempting to access document before available

### DIFF
--- a/.changeset/plain-mice-arrive.md
+++ b/.changeset/plain-mice-arrive.md
@@ -1,0 +1,5 @@
+---
+'@directus/composables': patch
+---
+
+Fixed `useShortcut` attempting to access document before available

--- a/packages/composables/src/use-shortcut.ts
+++ b/packages/composables/src/use-shortcut.ts
@@ -12,18 +12,24 @@ export const systemKeys = ['meta', 'shift', 'alt', 'backspace', 'delete', 'tab',
 
 const keysDown: Set<string> = new Set([]);
 const handlers: Record<string, ShortcutHandler[]> = {};
+let listenersAttached = false;
 
-document.body.addEventListener('keydown', (event: KeyboardEvent) => {
-	if (event.repeat || !event.key) return;
+function attachGlobalListeners() {
+	if (listenersAttached) return;
+	listenersAttached = true;
 
-	keysDown.add(mapKeys(event));
-	callHandlers(event);
-});
+	document.body.addEventListener('keydown', (event: KeyboardEvent) => {
+		if (event.repeat || !event.key) return;
 
-document.body.addEventListener('keyup', (event: KeyboardEvent) => {
-	if (event.repeat || !event.key) return;
-	keysDown.clear();
-});
+		keysDown.add(mapKeys(event));
+		callHandlers(event);
+	});
+
+	document.body.addEventListener('keyup', (event: KeyboardEvent) => {
+		if (event.repeat || !event.key) return;
+		keysDown.clear();
+	});
+}
 
 export function useShortcut(
 	shortcuts: string | string[],
@@ -49,6 +55,8 @@ export function useShortcut(
 	};
 
 	onMounted(() => {
+		attachGlobalListeners();
+
 		[shortcuts].flat().forEach((shortcut) => {
 			if (shortcut in handlers) {
 				handlers[shortcut]?.unshift(callback);


### PR DESCRIPTION
## Scope

What's changed:

- `useShortcut` only registers key listeners once the DOM is available instead of file load

## Potential Risks / Drawbacks

- Should be none, calling a shortcut before the dom is ready would not be expected to do anything

## Tested Scenarios

- [x] Exporting a function from the package no longer errors with document undefined in non browser contexts
   - `node packages/composables/index.js`
- [x] Shortcuts still work in app

## Review Notes / Questions

- Alternative fixes are two imrpove/rework our export paths to ensure browser functions will never be loaded in non browser contexts. This results in a fairly large breaking change, the PR fix was determined to be less breaking.

## Checklist

- [ ] Added or updated tests - NA
- [ ] Documentation PR created [here](https://github.com/directus/docs) or **not required**
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or **not required**

---

Fixes #27119
