### PR TITLE
fix: respect EMAIL_VERIFY_SETUP in health check endpoint

### DIFF
--- a/.changeset/health-check-email-verify.md
+++ b/.changeset/health-check-email-verify.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed health check endpoint ignoring EMAIL_VERIFY_SETUP configuration. The /server/health endpoint unconditionally called mailer.verify(), causing 503 responses when the email transport verification fails (e.g., SES with restricted IAM policies), even when EMAIL_VERIFY_SETUP was set to false.

--- a/api/src/services/server.ts
+++ b/api/src/services/server.ts
@@ -455,6 +455,10 @@ export class ServerService {
 		}
 
 		async function testEmail(): Promise<Record<string, HealthCheck[]>> {
+			if (toBoolean(env['EMAIL_VERIFY_SETUP']) === false) {
+				return {};
+			}
+
 			const checks: Record<string, HealthCheck[]> = {
 				'email:connection': [
 					{


### PR DESCRIPTION
## Scope

What's changed:

- The `/server/health` endpoint's `testEmail()` function now respects the `EMAIL_VERIFY_SETUP` environment variable
- When `EMAIL_VERIFY_SETUP` is `false`, the email health check is skipped entirely (returns `{}`) — consistent with how `MailService` already handles this setting in its constructor

## Potential Risks / Drawbacks

- None anticipated. This is strictly additive — when `EMAIL_VERIFY_SETUP` is `true` (the default), behavior is unchanged
- When `EMAIL_VERIFY_SETUP` is `false`, the email health check is omitted from `/server/health` rather than always running and potentially failing

## Tested Scenarios

- **Reproduced the bug**: Deployed Directus on ECS Fargate with SES transport. The IAM task role restricts `ses:SendRawEmail` to a specific FROM address (`no-reply@example.com`). `nodemailer`'s `transporter.verify()` sends a test email from `invalid@invalid` (its internal default), which SES rejects with 403. The health endpoint returns 503, failing ALB health checks and causing a crash loop — even with `EMAIL_VERIFY_SETUP=false`.
- **Verified the fix**: With this change, setting `EMAIL_VERIFY_SETUP=false` causes `testEmail()` to return early with no checks, so `/server/health` no longer fails due to email transport verification.

## Review Notes / Questions

- The `MailService` constructor at `api/src/services/mail/index.ts:54` already guards `this.mailer.verify()` behind `if (env['EMAIL_VERIFY_SETUP'])`. The health check's `testEmail()` was the only call site that didn't respect this setting.
- The `EMAIL_VERIFY_SETUP` default is `true` (in `packages/env/src/constants/defaults.ts:108`), so this change is opt-in only — existing deployments are unaffected.
- This particularly impacts SES transport deployments where IAM policies restrict the FROM address, but it could affect any transport where `verify()` fails for operational reasons that don't indicate an actual problem.

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required