### PR TITLE
Remove duplicate `@directus/schema-builder` dependency

### DIFF
--- a/.changeset/calm-pears-tan.md
+++ b/.changeset/calm-pears-tan.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Removed duplicate `@directus/schema-builder` dependency

--- a/api/package.json
+++ b/api/package.json
@@ -85,7 +85,6 @@
 		"@directus/memory": "workspace:*",
 		"@directus/pressure": "workspace:*",
 		"@directus/schema": "workspace:*",
-		"@directus/schema-builder": "workspace:*",
 		"@directus/specs": "workspace:*",
 		"@directus/storage": "workspace:*",
 		"@directus/storage-driver-azure": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1069,9 +1069,6 @@ importers:
       '@directus/schema':
         specifier: workspace:*
         version: link:../packages/schema
-      '@directus/schema-builder':
-        specifier: workspace:*
-        version: link:../packages/schema-builder
       '@directus/specs':
         specifier: workspace:*
         version: link:../packages/specs
@@ -1406,6 +1403,9 @@ importers:
         specifier: 'catalog:'
         version: 4.0.2(zod@4.1.12)
     devDependencies:
+      '@directus/schema-builder':
+        specifier: workspace:*
+        version: link:../packages/schema-builder
       '@directus/tsconfig':
         specifier: 'catalog:'
         version: 4.0.0


### PR DESCRIPTION
## Scope

What's changed:

- `@directus/schema-builder` is for testing only, it is already a devDep, no need to have it be direct as well

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Tested Scenarios

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

## Checklist

- [ ] Added or updated tests or **not required**
- [ ] Documentation PR created [here](https://github.com/directus/docs) or **not required**
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or **not required**

---

Fixes N/A
