### PR TITLE
fix(app): hide required and readonly options for presentation fields

### DIFF
--- a/.changeset/hide-required-readonly-for-presentation-fields.md
+++ b/.changeset/hide-required-readonly-for-presentation-fields.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Hide "required" and "readonly" toggles for presentation fields in the field settings UI, since presentation fields don't store values and these options can cause validation errors.

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
@@ -22,6 +22,8 @@ const isGenerated = computed(() => field.value.schema?.is_generated);
 const userStore = useUserStore();
 const searchable = syncFieldDetailStoreProperty('field.meta.searchable', true);
 
+const isPresentation = computed(() => localType.value === 'presentation');
+
 const isSearchableType = computed(() => {
 	// exclude alias fields (o2m, m2m, m2a) as they don't store searchable data
 	if (type.value === 'alias') return false;
@@ -35,17 +37,17 @@ const isSearchableType = computed(() => {
 
 <template>
 	<div class="form">
-		<div v-if="!isGenerated" class="field half-left">
+		<div v-if="!isGenerated && !isPresentation" class="field half-left">
 			<div class="label type-label">{{ $t('readonly') }}</div>
 			<VCheckbox v-model="readonly" :label="$t('readonly_field_label')" block />
 		</div>
 
-		<div v-if="!isGenerated" class="field half-right">
+		<div v-if="!isGenerated && !isPresentation" class="field half-right">
 			<div class="label type-label">{{ $t('required') }}</div>
 			<VCheckbox v-model="required" :label="$t('require_value_to_be_set')" block />
 		</div>
 
-		<VNotice v-if="readonly && required" type="warning" class="full no-margin">
+		<VNotice v-if="readonly && required && !isPresentation" type="warning" class="full no-margin">
 			{{ $t('required_readonly_field_warning') }}
 		</VNotice>
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -271,3 +271,4 @@
 - eric-pennecot
 - om-singh-D
 - yogeshwaran-c
+- singhvishalkr


### PR DESCRIPTION
Fixes #26961

## Summary

Presentation fields (dividers, notices, etc.) are display-only and have no stored data. However, the field configuration UI currently allows setting `required` and `readonly` on them. Setting `required` on a presentation field causes a validation error when creating records since the field can never hold a value.

## Changes

In `field-detail-advanced-field.vue`:
- Added `isPresentation` computed property that checks if `localType === 'presentation'`
- Added `!isPresentation` guard to the `v-if` conditions on the `readonly` and `required` checkbox containers
- Also guarded the `readonly + required` warning notice

## Verification

1. Create a collection
2. Add a presentation field (e.g., divider)
3. Open field settings > go to "Field" tab
4. Confirm `readonly` and `required` checkboxes are no longer visible
5. Add a standard field (e.g., string)
6. Confirm `readonly` and `required` checkboxes still appear as normal
