### PR TITLE
Feat/searchable o2m and translations

### DIFF
--- a/.changeset/searchable-o2m-search.md
+++ b/.changeset/searchable-o2m-search.md
@@ -1,0 +1,7 @@
+---
+'@directus/api': minor
+'@directus/app': minor
+'@directus/constants': minor
+---
+
+Directus Studio search now matches text in the fields of any one-to-many related collection — including translation junctions — when the o2m alias field and its target fields are marked Searchable. The Searchable toggle is now surfaced in the field detail UI for `translations` and `o2m` localTypes. Existing relational fields default to non-searchable via a one-time data migration; admins opt in per-field.

--- a/api/src/database/migrations/20260420A-default-relational-fields-not-searchable.ts
+++ b/api/src/database/migrations/20260420A-default-relational-fields-not-searchable.ts
@@ -1,0 +1,63 @@
+import { RELATIONAL_TYPES } from '@directus/constants';
+import type { Knex } from 'knex';
+
+/**
+ * Flip existing relational fields to `searchable = false`.
+ *
+ * The `searchable` column on `directus_fields` was introduced by migration
+ * `20251012A-add-field-searchable.ts` with a column-level default of `true`. The Studio
+ * UI has historically hidden the Searchable toggle for relational localTypes, so every
+ * relational field in existing projects currently has `searchable = true` in the DB
+ * despite never being exposed as searchable in the UI.
+ *
+ * This migration pairs with two changes shipped in the same release:
+ *   1. The Studio UI now surfaces the toggle for `translations` and `o2m` relational fields.
+ *   2. The API now emits EXISTS subqueries against o2m-related collections when the alias
+ *      field's `searchable` flag is true — which makes the DB value suddenly meaningful.
+ *
+ * Leaving existing rows at `true` would opt every project in to potentially-heavy
+ * relational search subqueries without the admin asking. Flip them all to `false` so
+ * admins must explicitly opt in per-relation going forward.
+ *
+ * Notes:
+ * - `directus_fields.special` is stored as a comma-joined string. We LIKE-prefilter on
+ *   the server and then exact-match after splitting, so `foom2o` does not match `m2o`.
+ * - The `UPDATE` is idempotent: re-running against already-`false` rows is a no-op, so
+ *   if this migration aborts mid-execution the next boot simply finishes the work.
+ * - Standard fields (no relational special) are left alone — their column-level default
+ *   of `true` remains correct.
+ * - `down` is intentionally a no-op: the prior per-row values cannot be reconstructed
+ *   from the post-update state.
+ */
+export async function up(knex: Knex): Promise<void> {
+	// DB-side prefilter — avoids pulling every `directus_fields` row into Node.
+	const candidates = await knex
+		.select('id', 'special')
+		.from('directus_fields')
+		.where((builder) => {
+			for (const special of RELATIONAL_TYPES) {
+				builder.orWhere('special', 'like', `%${special}%`);
+			}
+		});
+
+	// In-memory exact-match verification (split comma-joined `special`, trim, exact compare).
+	const ids = candidates
+		.filter((row: { id: number; special: string | null }) => {
+			if (!row.special) return false;
+
+			const specials = String(row.special)
+				.split(',')
+				.map((s) => s.trim());
+
+			return specials.some((s) => (RELATIONAL_TYPES as readonly string[]).includes(s));
+		})
+		.map((row) => row.id);
+
+	if (ids.length > 0) {
+		await knex('directus_fields').update({ searchable: false }).whereIn('id', ids);
+	}
+}
+
+export async function down(_knex: Knex): Promise<void> {
+	// Intentional no-op: prior per-row values cannot be reliably restored once overwritten.
+}

--- a/api/src/database/run-ast/lib/apply-query/search.test.ts
+++ b/api/src/database/run-ast/lib/apply-query/search.test.ts
@@ -255,3 +255,320 @@ test(`Return falsy query when all searchable fields are excluded`, async () => {
 	expect(rawQuery.sql).toEqual(`select * where (1 = 0)`);
 	expect(rawQuery.bindings).toEqual([]);
 });
+
+// --- o2m / translation EXISTS-subquery tests ---
+
+// Translation alias defaults to `searchable: true` via SchemaBuilder's FIELD_DEFAULTS,
+// which models a project whose admin has explicitly opted the translations alias in.
+const translationSchema = new SchemaBuilder()
+	.collection('articles', (c) => {
+		c.field('id').id();
+		c.field('status').string();
+		c.field('translations').translations();
+	})
+	.collection('articles_translations', (c) => {
+		c.field('id').id();
+		c.field('title').string();
+		c.field('body').text();
+	})
+	.build();
+
+test(`Emits EXISTS subquery against translation junction for admin (opted-in alias)`, async () => {
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+
+	applySearch(db as any, translationSchema, queryBuilder, 'hello', 'articles', {}, []);
+
+	const rawQuery = queryBuilder.toSQL();
+
+	expect(rawQuery.sql).toContain(`LOWER("articles"."status") LIKE ?`);
+	expect(rawQuery.sql).toContain(`exists`);
+	expect(rawQuery.sql).toContain(`"articles_translations"`);
+	expect(rawQuery.sql).toContain(`LOWER("articles_translations"."title") LIKE ?`);
+	expect(rawQuery.sql).toContain(`LOWER("articles_translations"."body") LIKE ?`);
+	expect(rawQuery.bindings).toContain('%hello%');
+});
+
+test(`EXISTS subquery correlates on parent FK and PK for translations`, async () => {
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+
+	applySearch(db as any, translationSchema, queryBuilder, 'test', 'articles', {}, []);
+
+	const rawQuery = queryBuilder.toSQL();
+
+	expect(rawQuery.sql).toContain(`"articles_translations"."articles_id" = "articles"."id"`);
+});
+
+test(`Omits translation subquery when alias field has searchable=false (master switch)`, async () => {
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+
+	const schemaTranslationsOptOut = new SchemaBuilder()
+		.collection('articles', (c) => {
+			c.field('id').id();
+			c.field('status').string();
+			c.field('translations').translations().options({ searchable: false });
+		})
+		.collection('articles_translations', (c) => {
+			c.field('id').id();
+			c.field('title').string();
+			c.field('body').text();
+		})
+		.build();
+
+	applySearch(db as any, schemaTranslationsOptOut, queryBuilder, 'hello', 'articles', {}, []);
+
+	const rawQuery = queryBuilder.toSQL();
+
+	expect(rawQuery.sql).toContain(`LOWER("articles"."status") LIKE ?`);
+	expect(rawQuery.sql).not.toContain(`exists`);
+	expect(rawQuery.sql).not.toContain(`articles_translations`);
+});
+
+test(`Restricts translation fields based on junction collection permissions`, async () => {
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+
+	const restrictedPermissions = [
+		{
+			collection: 'articles',
+			action: 'read',
+			fields: ['*'],
+			permissions: null,
+		},
+		{
+			collection: 'articles_translations',
+			action: 'read',
+			fields: ['title'],
+			permissions: {
+				title: {},
+			},
+		},
+	] as unknown as Permission[];
+
+	applySearch(db as any, translationSchema, queryBuilder, 'hello', 'articles', {}, restrictedPermissions);
+
+	const rawQuery = queryBuilder.toSQL();
+
+	expect(rawQuery.sql).toContain(`LOWER("articles_translations"."title") LIKE ?`);
+	expect(rawQuery.sql).not.toContain(`"articles_translations"."body"`);
+});
+
+test(`Omits translation subquery when user has no junction collection permissions`, async () => {
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+
+	const noJunctionPermissions = [
+		{
+			collection: 'articles',
+			action: 'read',
+			fields: ['*'],
+			permissions: null,
+		},
+	] as unknown as Permission[];
+
+	applySearch(db as any, translationSchema, queryBuilder, 'hello', 'articles', {}, noJunctionPermissions);
+
+	const rawQuery = queryBuilder.toSQL();
+
+	expect(rawQuery.sql).toContain(`LOWER("articles"."status") LIKE ?`);
+	expect(rawQuery.sql).not.toContain(`articles_translations`);
+	expect(rawQuery.sql).not.toContain(`exists`);
+});
+
+test(`Excludes non-searchable translation fields from subquery`, async () => {
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+
+	const schemaWithNonSearchable = new SchemaBuilder()
+		.collection('pages', (c) => {
+			c.field('id').id();
+			c.field('slug').string();
+			c.field('translations').translations();
+		})
+		.collection('pages_translations', (c) => {
+			c.field('id').id();
+			c.field('title').string();
+			c.field('internal_notes').string().options({ searchable: false });
+		})
+		.build();
+
+	applySearch(db as any, schemaWithNonSearchable, queryBuilder, 'test', 'pages', {}, []);
+
+	const rawQuery = queryBuilder.toSQL();
+
+	expect(rawQuery.sql).toContain(`LOWER("pages_translations"."title") LIKE ?`);
+	expect(rawQuery.sql).not.toContain(`"pages_translations"."internal_notes"`);
+});
+
+test(`Excludes concealed translation fields from subquery`, async () => {
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+
+	const schemaWithConcealed = new SchemaBuilder()
+		.collection('pages', (c) => {
+			c.field('id').id();
+			c.field('translations').translations();
+		})
+		.collection('pages_translations', (c) => {
+			c.field('id').id();
+			c.field('title').string();
+
+			c.field('secret')
+				.string()
+				.options({ special: ['conceal'] });
+		})
+		.build();
+
+	applySearch(db as any, schemaWithConcealed, queryBuilder, 'test', 'pages', {}, []);
+
+	const rawQuery = queryBuilder.toSQL();
+
+	expect(rawQuery.sql).toContain(`LOWER("pages_translations"."title") LIKE ?`);
+	expect(rawQuery.sql).not.toContain(`"pages_translations"."secret"`);
+});
+
+test(`Avoids fallback 1=0 when root has no searchable fields but translations do`, async () => {
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+
+	const schemaRootUnsearchable = new SchemaBuilder()
+		.collection('items', (c) => {
+			c.field('id').id();
+			c.field('translations').translations();
+		})
+		.collection('items_translations', (c) => {
+			c.field('id').id();
+			c.field('title').string();
+		})
+		.build();
+
+	applySearch(db as any, schemaRootUnsearchable, queryBuilder, 'test', 'items', {}, []);
+
+	const rawQuery = queryBuilder.toSQL();
+
+	expect(rawQuery.sql).not.toContain(`1 = 0`);
+	expect(rawQuery.sql).toContain(`exists`);
+	expect(rawQuery.sql).toContain(`LOWER("items_translations"."title") LIKE ?`);
+});
+
+test(`Excludes structural (FK / junction_field) columns from translation subquery`, async () => {
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+
+	applySearch(db as any, translationSchema, queryBuilder, 'hello', 'articles', {}, []);
+
+	const rawQuery = queryBuilder.toSQL();
+
+	// FK to parent and the junction_field (language FK) must not appear in LIKE conditions
+	expect(rawQuery.sql).not.toContain(`LOWER("articles_translations"."articles_id") LIKE ?`);
+	expect(rawQuery.sql).not.toContain(`LOWER("articles_translations"."languages_code") LIKE ?`);
+});
+
+// --- vanilla o2m tests (generalization beyond translations) ---
+
+// A non-translations o2m alias. SchemaBuilder's default `searchable: true` on the alias
+// means the master switch is on, matching a project whose admin has opted the relation in.
+const vanillaO2MSchema = new SchemaBuilder()
+	.collection('articles', (c) => {
+		c.field('id').id();
+		c.field('status').string();
+		c.field('comments').o2m('comments', 'article_id');
+	})
+	.collection('comments', (c) => {
+		c.field('id').id();
+		c.field('article_id').integer();
+		c.field('text').text();
+		c.field('internal_notes').string();
+	})
+	.build();
+
+test(`Emits EXISTS subquery for searchable vanilla o2m alias`, async () => {
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+
+	applySearch(db as any, vanillaO2MSchema, queryBuilder, 'hello', 'articles', {}, []);
+
+	const rawQuery = queryBuilder.toSQL();
+
+	expect(rawQuery.sql).toContain(`LOWER("articles"."status") LIKE ?`);
+	expect(rawQuery.sql).toContain(`exists`);
+	expect(rawQuery.sql).toContain(`LOWER("comments"."text") LIKE ?`);
+	expect(rawQuery.sql).toContain(`LOWER("comments"."internal_notes") LIKE ?`);
+	expect(rawQuery.bindings).toContain('%hello%');
+});
+
+test(`EXISTS subquery correlates on parent PK and related-collection FK for vanilla o2m`, async () => {
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+
+	applySearch(db as any, vanillaO2MSchema, queryBuilder, 'test', 'articles', {}, []);
+
+	const rawQuery = queryBuilder.toSQL();
+
+	expect(rawQuery.sql).toContain(`"comments"."article_id" = "articles"."id"`);
+});
+
+test(`Omits vanilla o2m subquery when alias has searchable=false`, async () => {
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+
+	const schemaO2MOptOut = new SchemaBuilder()
+		.collection('articles', (c) => {
+			c.field('id').id();
+			c.field('status').string();
+			c.field('comments').o2m('comments', 'article_id').options({ searchable: false });
+		})
+		.collection('comments', (c) => {
+			c.field('id').id();
+			c.field('article_id').integer();
+			c.field('text').text();
+		})
+		.build();
+
+	applySearch(db as any, schemaO2MOptOut, queryBuilder, 'hello', 'articles', {}, []);
+
+	const rawQuery = queryBuilder.toSQL();
+
+	expect(rawQuery.sql).toContain(`LOWER("articles"."status") LIKE ?`);
+	expect(rawQuery.sql).not.toContain(`exists`);
+	expect(rawQuery.sql).not.toContain(`"comments"`);
+});
+
+test(`Excludes non-searchable related-collection fields from vanilla o2m subquery`, async () => {
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+
+	const schemaPerFieldOptOut = new SchemaBuilder()
+		.collection('articles', (c) => {
+			c.field('id').id();
+			c.field('comments').o2m('comments', 'article_id');
+		})
+		.collection('comments', (c) => {
+			c.field('id').id();
+			c.field('article_id').integer();
+			c.field('text').text();
+			c.field('internal_notes').string().options({ searchable: false });
+		})
+		.build();
+
+	applySearch(db as any, schemaPerFieldOptOut, queryBuilder, 'hello', 'articles', {}, []);
+
+	const rawQuery = queryBuilder.toSQL();
+
+	expect(rawQuery.sql).toContain(`LOWER("comments"."text") LIKE ?`);
+	expect(rawQuery.sql).not.toContain(`LOWER("comments"."internal_notes")`);
+});
+
+test(`Excludes structural FK back to parent from vanilla o2m subquery`, async () => {
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+
+	applySearch(db as any, vanillaO2MSchema, queryBuilder, 'hello', 'articles', {}, []);
+
+	const rawQuery = queryBuilder.toSQL();
+
+	// The FK back to the parent (article_id) is used in correlation, not in LIKE conditions.
+	expect(rawQuery.sql).not.toContain(`LOWER("comments"."article_id") LIKE ?`);
+});

--- a/api/src/database/run-ast/lib/apply-query/search.ts
+++ b/api/src/database/run-ast/lib/apply-query/search.ts
@@ -1,5 +1,5 @@
 import { NUMERIC_TYPES } from '@directus/constants';
-import type { FieldOverview, NumericType, Permission, SchemaOverview } from '@directus/types';
+import type { FieldOverview, NumericType, Permission, Relation, SchemaOverview } from '@directus/types';
 import { isIn } from '@directus/utils';
 import type { Knex } from 'knex';
 import { getCases } from '../../../../permissions/modules/process-ast/lib/get-cases.js';
@@ -8,6 +8,90 @@ import { isValidUuid } from '../../../../utils/is-valid-uuid.js';
 import { parseNumericString } from '../../../../utils/parse-numeric-string.js';
 import { getHelpers } from '../../../helpers/index.js';
 import { applyFilter } from './filter/index.js';
+
+interface O2MSearchInfo {
+	/** Collection on the "many" side of the o2m relation (e.g. `articles_translations`, `comments`). */
+	relatedCollection: string;
+	/** Field on the related collection that stores the FK back to the parent. */
+	parentFkField: string;
+	/** PK on the parent collection used for the EXISTS correlation. */
+	parentPkField: string;
+	/** Text/string fields on the related collection eligible for LIKE matching. */
+	fields: [string, FieldOverview][];
+}
+
+/**
+ * Detect o2m-backed alias fields on `collection` and return the information needed to build
+ * an EXISTS subquery against the related collection for each one.
+ *
+ * This handles both vanilla o2m aliases (e.g. `articles.comments`) and translation aliases
+ * (`articles.translations`), since a translation relation is just an o2m in the schema —
+ * the only difference is the `special: ['translations']` marker on the alias field, which
+ * we deliberately ignore here so the same generator applies.
+ *
+ * Per-relation gating:
+ *   - The alias field's `searchable` flag is the master switch for that relation.
+ *   - Individual related-collection fields are then filtered by their own `searchable` flag,
+ *     the `conceal` special, and field-type eligibility.
+ */
+function getO2MSearchInfo(schema: SchemaOverview, relations: Relation[], collection: string): O2MSearchInfo[] {
+	const collectionSchema = schema.collections[collection];
+	if (!collectionSchema) return [];
+
+	const results: O2MSearchInfo[] = [];
+
+	for (const relation of relations) {
+		// Only o2m-shaped relations where `collection` is the "one" side
+		if (relation.related_collection !== collection) continue;
+
+		// No alias on the parent means the relation is not addressable by field name — skip
+		const aliasFieldName = relation.meta?.one_field;
+		if (!aliasFieldName) continue;
+
+		const aliasField = collectionSchema.fields[aliasFieldName];
+		if (!aliasField) continue;
+
+		// Master switch: admins opt in per-relation via the alias field's `searchable` flag
+		if (aliasField.searchable === false) continue;
+
+		const relatedSchema = schema.collections[relation.collection];
+		if (!relatedSchema) continue;
+
+		const parentPkField = collectionSchema.primary;
+		const parentFkField = relation.field;
+
+		// Identify structural fields to exclude from LIKE matching: PKs and the FK back to parent.
+		// We intentionally do NOT exclude the junction_field FK (e.g. `languages_code` on a
+		// translations junction) here — that's just another m2o to a related collection, whose
+		// target-table values are not part of this EXISTS. Including it in LIKE is harmless for
+		// searches that don't match the raw FK value and cheap to skip via the type filter below,
+		// but to preserve parity with the original translation helper we also treat the
+		// `junction_field` (when present) as a structural exclusion.
+		const structuralFields = new Set<string>(
+			[relatedSchema.primary, parentFkField, relation.meta?.junction_field].filter((f): f is string => f != null),
+		);
+
+		// Eligible fields: text/string columns with `searchable !== false`, not concealed.
+		const fields = Object.entries(relatedSchema.fields).filter(
+			([name, f]) =>
+				!structuralFields.has(name) &&
+				f.searchable !== false &&
+				!f.special.includes('conceal') &&
+				['text', 'string'].includes(f.type),
+		);
+
+		if (fields.length === 0) continue;
+
+		results.push({
+			relatedCollection: relation.collection,
+			parentFkField,
+			parentPkField,
+			fields,
+		});
+	}
+
+	return results;
+}
 
 export function applySearch(
 	knex: Knex,
@@ -59,6 +143,71 @@ export function applySearch(
 				addSearchCondition(queryBuilder, name, fieldType, 'or');
 			}
 		});
+
+		// Search into o2m-related collections (including translations) via EXISTS subqueries,
+		// one per eligible relation. Gated by `searchable` on the alias field (master switch)
+		// and on each related-collection field (per-field opt-out).
+		const o2mSearchInfos = getO2MSearchInfo(schema, schema.relations, collection);
+
+		for (const info of o2mSearchInfos) {
+			const relatedPermissions = permissions.filter((p) => p.collection === info.relatedCollection);
+
+			// Non-admins (permissions array populated) must have at least one permission entry for the
+			// related collection; otherwise they have no access and the subquery is omitted entirely.
+			// Admins arrive with an empty permissions array and see the subquery unconditionally.
+			if (permissions.length > 0 && relatedPermissions.length === 0) {
+				continue;
+			}
+
+			const relatedAllowedFields = new Set(relatedPermissions.flatMap((p) => p.fields ?? []));
+
+			const { cases: relatedCases } = getCases(info.relatedCollection, permissions, []);
+
+			let relatedFields = info.fields;
+
+			// Apply per-field permission restrictions on the related collection.
+			if (relatedPermissions.length > 0 && !relatedAllowedFields.has('*')) {
+				relatedFields = relatedFields.filter(([name]) => relatedAllowedFields.has(name));
+			}
+
+			// If permission filtering stripped every field, skip this relation.
+			if (relatedFields.length === 0) {
+				continue;
+			}
+
+			if (relatedFields.length > 0) {
+				needsFallbackCondition = false;
+
+				queryBuilder.orWhereExists(function (subQuery) {
+					subQuery
+						.select(knex.raw('1'))
+						.from(info.relatedCollection)
+						.where(`${info.relatedCollection}.${info.parentFkField}`, knex.ref(`${collection}.${info.parentPkField}`))
+						.andWhere(function (innerWhere) {
+							for (const [fieldName] of relatedFields) {
+								innerWhere.orWhereRaw(`LOWER(??) LIKE ?`, [
+									`${info.relatedCollection}.${fieldName}`,
+									`%${searchQuery.toLowerCase()}%`,
+								]);
+							}
+						});
+
+					// Apply related-collection permission filters inside the subquery.
+					if (relatedCases.length > 0) {
+						applyFilter(
+							knex,
+							schema,
+							subQuery,
+							{ _or: relatedCases },
+							info.relatedCollection,
+							aliasMap,
+							relatedCases,
+							permissions,
+						);
+					}
+				});
+			}
+		}
 
 		if (needsFallbackCondition) {
 			queryBuilder.orWhereRaw('1 = 0');

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -500,6 +500,8 @@ unique: Unique
 index: Index
 searchable: Searchable
 field_searchable: Include field in search queries
+field_searchable_relational_hint:
+  When enabled, Studio search also checks fields marked Searchable on the related collection.
 updated_on: Updated On
 updated_by: Updated By
 primary_key: Primary Key

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { SEARCHABLE_TYPES } from '@directus/constants';
+import { SEARCHABLE_RELATIONAL_LOCAL_TYPES, SEARCHABLE_TYPES } from '@directus/constants';
 import { storeToRefs } from 'pinia';
 import { computed } from 'vue';
 import { syncFieldDetailStoreProperty, useFieldDetailStore } from '../store';
@@ -23,6 +23,13 @@ const userStore = useUserStore();
 const searchable = syncFieldDetailStoreProperty('field.meta.searchable', true);
 
 const isSearchableType = computed(() => {
+	// Relational localTypes that support search via an EXISTS subquery over the related collection.
+	// Surfaces the toggle for `translations` and vanilla `o2m` aliases; m2o/m2m/m2a remain hidden
+	// until their query generators land.
+	if (localType.value && (SEARCHABLE_RELATIONAL_LOCAL_TYPES as readonly string[]).includes(localType.value)) {
+		return true;
+	}
+
 	// exclude alias fields (o2m, m2m, m2a) as they don't store searchable data
 	if (type.value === 'alias') return false;
 
@@ -31,6 +38,10 @@ const isSearchableType = computed(() => {
 
 	return SEARCHABLE_TYPES.includes(type.value);
 });
+
+const isRelationalSearchable = computed(
+	() => !!localType.value && (SEARCHABLE_RELATIONAL_LOCAL_TYPES as readonly string[]).includes(localType.value),
+);
 </script>
 
 <template>
@@ -57,6 +68,9 @@ const isSearchableType = computed(() => {
 		<div v-if="isSearchableType" class="field half-right">
 			<div class="label type-label">{{ $t('searchable') }}</div>
 			<VCheckbox v-model="searchable" :label="$t('field_searchable')" block />
+			<small v-if="isRelationalSearchable" class="relational-searchable-hint">
+				{{ $t('field_searchable_relational_hint') }}
+			</small>
 		</div>
 
 		<div v-if="type !== 'group'" class="field full">
@@ -134,5 +148,13 @@ const isSearchableType = computed(() => {
 
 .v-notice:not(.no-margin) {
 	margin-block-end: 2rem;
+}
+
+.relational-searchable-hint {
+	display: block;
+	margin-block-start: 0.5rem;
+	color: var(--theme--foreground-subdued);
+	font-size: 0.75rem;
+	line-height: 1.4;
 }
 </style>

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/global.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/global.ts
@@ -82,6 +82,38 @@ export function setSpecialForLocalType(updates: StateUpdates) {
 	}
 }
 
+/**
+ * Set the default `searchable` value when creating or converting a field.
+ *
+ * Relational localTypes opt-out by default because enabling search on them introduces
+ * EXISTS subqueries (for o2m/translations) or additional JOINs (future m2o/m2m/m2a)
+ * that have non-trivial query-plan impact. Admins opt in per-relation.
+ *
+ * Standard fields reset to `true` so that toggling `standard → translations → standard`
+ * during field creation doesn't leave a plain field stuck at `searchable=false`.
+ *
+ * Presentation / group / other non-search-bearing localTypes are left alone — the
+ * column has no meaning for them.
+ */
+export function setSearchableForLocalType(updates: StateUpdates) {
+	const localType = updates?.localType;
+
+	switch (localType) {
+		case 'o2m':
+		case 'm2m':
+		case 'm2a':
+		case 'm2o':
+		case 'translations':
+		case 'file':
+		case 'files':
+			set(updates, 'field.meta.searchable', false);
+			break;
+		case 'standard':
+			set(updates, 'field.meta.searchable', true);
+			break;
+	}
+}
+
 export function resetRelations(updates: StateUpdates) {
 	if (!updates.relations) updates.relations = {};
 	updates.relations.m2o = undefined;

--- a/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/index.ts
@@ -157,6 +157,7 @@ export const useFieldDetailStore = defineStore({
 					alterations.global.resetSchema(updates, state);
 					alterations.global.resetRelations(updates);
 					alterations.global.setSpecialForLocalType(updates);
+					alterations.global.setSearchableForLocalType(updates);
 				}
 
 				const localType = getCurrent('localType') as LocalType | undefined;

--- a/contributors.yml
+++ b/contributors.yml
@@ -267,3 +267,4 @@
 - faizkhairi
 - eric-pennecot
 - om-singh-D
+- JeremieLeblanc

--- a/packages/constants/src/fields.ts
+++ b/packages/constants/src/fields.ts
@@ -114,3 +114,10 @@ export const FUNCTIONS = [
 ] as const;
 
 export const SEARCHABLE_TYPES = ['text', 'string', 'integer', 'bigInteger', 'float', 'decimal', 'uuid'] as const;
+
+/**
+ * Relational localTypes for which the "searchable" toggle is surfaced in the Studio field-detail UI
+ * and honored by the API's o2m search generator. New strategies (m2o join, m2m two-hop) can extend
+ * this list as their SQL generators land.
+ */
+export const SEARCHABLE_RELATIONAL_LOCAL_TYPES = ['translations', 'o2m'] as const;


### PR DESCRIPTION
## Scope

What's changed:

- **Search generator (`api/src/database/run-ast/lib/apply-query/search.ts`)** emits one EXISTS subquery per eligible o2m relation (translations included). Honors per-field `searchable`, `conceal`, junction-collection field permissions, and row-level cases via `applyFilter` inside the subquery. Excludes structural columns (PKs, FK to parent, `junction_field`).
- **Studio UI** surfaces the existing **Searchable** toggle for `translations` and `o2m` localTypes via the new `SEARCHABLE_RELATIONAL_LOCAL_TYPES` constant in `@directus/constants`. Adds a short hint string explaining the related-collection semantics.
- **Field-creation defaults** — new `setSearchableForLocalType` alteration in `field-detail/store/alterations/global.ts` defaults relational localTypes to `searchable: false` (and `standard` back to `true`).
- **Data migration `20260420A-default-relational-fields-not-searchable.ts`** — one-time flip of existing relational rows in `directus_fields` to `searchable = false`. Two-phase: DB-side LIKE prefilter on `special`, then in-memory exact-match (split on `,`, trim) so substrings like `filename` aren't wrongly flipped. Idempotent; `down` is a no-op.
- **Tests** — 14 new EXISTS-subquery cases in `search.test.ts` covering admin/non-admin, master switch, per-field opt-out, conceal, structural exclusion, vanilla o2m, no-fallback when only translations contribute. All 31 tests pass.

## Potential Risks / Drawbacks

- **Existing m2o / `file` FK search regresses**: prior to this PR the column-level `searchable` default of `true` meant pasting a UUID or numeric FK into global search would match on m2o / file columns. The migration flips all relational fields to `false`, including these. Admins who relied on that behavior must re-enable per field. Documented in the changeset.
- **Migration is not reversibly downward**: `down` is a no-op by design — the prior per-row values are not reconstructible. Re-running `migrate:up` is safe (idempotent), but `migrate:down` followed by `migrate:up` will not restore any custom searchability admins set between those steps.
- **Query plan cost when admins opt in**: each enabled o2m alias adds an EXISTS subquery to global search. On large junction tables without indexes on the FK back to parent this can be slow. Opt-in surface (toggle off by default) limits blast radius.
- **LIKE prefilter on `directus_fields.special` is non-sargable** (`'%m2o%'`). Acceptable because `directus_fields` is small (low thousands of rows even on big projects); verified with a smoke test, not measured on large fixtures.

## Tested Scenarios

- `pnpm vitest run api/src/database/run-ast/lib/apply-query/search.test.ts` → 31/31 pass
- `pnpm vitest run api/src/database/migrations/` → 8/8 pass
- Local smoke test of the migration against an in-memory SQLite DB with 17 fixtures: standard fields stay `true`; all relational fields flip to `false`; tricky substrings (`filename`, `bonm2o`, `m2official`, `foom2ofoo`) are correctly NOT flipped; comma-joined `special` with whitespace is handled; empty / NULL `special` skipped; re-run is idempotent
- Lint clean on every changed `.ts` / `.vue` file

## Review Notes / Questions

- **This branch supersedes `feat/translation-aware-search`.** Same user problem, different design:
  | | `feat/translation-aware-search` | this branch |
  |---|---|---|
  | Scope | Translations only | Translations **+** vanilla o2m (extension path for m2o/m2m/m2a) |
  | Opt-in storage | New flag inside `directus_fields.options` JSON (parsed into a new `FieldOverview.searchTranslations`) | Re-uses the existing `directus_fields.searchable` column |
  | UI surface | Bespoke checkbox on the translations interface options panel | Same Searchable toggle as standard fields, conditionally surfaced |
  | Type changes | Adds `FieldOverview.searchTranslations?` | None |
  | Existing data | None — new flag defaults to `false` | One-time migration flips existing relational rows to `false` |
  | Generator | `getTranslationSearchInfo` (translations-only filter) | `getO2MSearchInfo` (iterates `schema.relations`, treats translations as a special case) |

  Argument for this approach: one concept (`searchable`) governs every field type, generalizes to all o2m without a per-localType code change, and the migration makes the rollout safe for existing projects.
- **Please scrutinize the migration's `special`-matching logic** (LIKE prefilter + in-memory exact-match). I added a smoke test that covers the tricky substring cases, but the matching pattern is the part I'd most like a second pair of eyes on.
- **Permissions inside the subquery** — the EXISTS body calls `applyFilter` with the related collection's row-level cases, sharing `aliasMap` with the parent query. Existing tests cover field-level permission filtering but not row-level cases that introduce additional joins; worth flagging in case there's a known concern.

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required
