### PR TITLE
Add collection exclusions

### DIFF
--- a/api/src/database/get-ast-from-query/lib/parse-fields.test.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.test.ts
@@ -116,6 +116,50 @@ test('parse fields with m2o relation', async () => {
 	]);
 });
 
+test('rejects relational fields that target excluded collections', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
+
+	const schemaWithExcludedRelation = {
+		...schemaRelational,
+		collections: {
+			articles: schemaRelational.collections['articles']!,
+		},
+	};
+
+	await expect(
+		parseFields(
+			{ accountability, fields: ['author.name'], parentCollection: 'articles', query: {} },
+			{ knex: db, schema: schemaWithExcludedRelation as typeof schemaRelational },
+		),
+	).rejects.toThrow(/don't have permission|does not exist/i);
+});
+
+test('allows scalar m2o field reads when the related collection is excluded', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
+
+	const schemaWithExcludedRelation = {
+		...schemaRelational,
+		collections: {
+			articles: schemaRelational.collections['articles']!,
+		},
+	};
+
+	const result = await parseFields(
+		{ accountability, fields: ['author'], parentCollection: 'articles', query: {} },
+		{ knex: db, schema: schemaWithExcludedRelation as typeof schemaRelational },
+	);
+
+	expect(result).toEqual([
+		{
+			alias: false,
+			fieldKey: 'author',
+			name: 'author',
+			type: 'field',
+			whenCase: [],
+		},
+	]);
+});
+
 test('parse fields with o2m relation', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
 

--- a/api/src/database/get-ast-from-query/lib/parse-fields.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.ts
@@ -5,6 +5,7 @@ import type { Knex } from 'knex';
 import { isEmpty } from 'lodash-es';
 import { fetchPermissions } from '../../../permissions/lib/fetch-permissions.js';
 import { fetchPolicies } from '../../../permissions/lib/fetch-policies.js';
+import { createCollectionForbiddenError } from '../../../permissions/modules/process-ast/utils/validate-path/create-error.js';
 import type { FieldNode, FunctionFieldNode, NestedCollectionNode, O2MNode } from '../../../types/index.js';
 import { getAllowedSort } from '../utils/get-allowed-sort.js';
 import { getDeepQuery } from '../utils/get-deep-query.js';
@@ -244,6 +245,12 @@ export async function parseFields(
 			};
 
 			for (const relatedCollection of allowedCollections) {
+				const relatedCollectionSchema = context.schema.collections[relatedCollection];
+
+				if (!relatedCollectionSchema) {
+					throw createCollectionForbiddenError(fieldKey, relatedCollection);
+				}
+
 				child.children[relatedCollection] = await parseFields(
 					{
 						parentCollection: relatedCollection,
@@ -262,6 +269,12 @@ export async function parseFields(
 				child.relatedKey[relatedCollection] = context.schema.collections[relatedCollection]!.primary;
 			}
 		} else if (relatedCollection) {
+			const relatedCollectionSchema = context.schema.collections[relatedCollection];
+
+			if (!relatedCollectionSchema) {
+				throw createCollectionForbiddenError(fieldKey, relatedCollection);
+			}
+
 			if (options.accountability && options.accountability.admin === false && policies) {
 				const permissions = await fetchPermissions(
 					{
@@ -292,7 +305,7 @@ export async function parseFields(
 				name: relatedCollection,
 				fieldKey: fieldKey,
 				parentKey: context.schema.collections[options.parentCollection]!.primary,
-				relatedKey: context.schema.collections[relatedCollection]!.primary,
+				relatedKey: relatedCollectionSchema.primary,
 				relation: relation,
 				query: getDeepQuery(options.deep?.[fieldKey] || {}),
 				children: await parseFields(

--- a/api/src/database/migrations/20260219B-add-collection-excluded.ts
+++ b/api/src/database/migrations/20260219B-add-collection-excluded.ts
@@ -1,0 +1,13 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_collections', (table) => {
+		table.boolean('excluded').defaultTo(false).notNullable();
+	});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_collections', (table) => {
+		table.dropColumn('excluded');
+	});
+}

--- a/api/src/license/numeric-gate.test.ts
+++ b/api/src/license/numeric-gate.test.ts
@@ -1,0 +1,147 @@
+import { LimitExceededError } from '@directus/errors';
+import { describe, expect, test } from 'vitest';
+import { getNumericEntitlementLimit, validateNumericEntitlementLimit } from './numeric-gate.js';
+
+describe('getNumericEntitlementLimit', () => {
+	test('returns hard_limit when present', () => {
+		expect(
+			getNumericEntitlementLimit({
+				limit: 50,
+				hard_limit: 10,
+				is_overage_allowed: true,
+			}),
+		).toBe(10);
+	});
+
+	test('returns null when overage is allowed without a hard limit', () => {
+		expect(
+			getNumericEntitlementLimit({
+				limit: 50,
+				hard_limit: null,
+				is_overage_allowed: true,
+			}),
+		).toBeNull();
+	});
+
+	test('returns null when the engine contract marks the limit as unlimited', () => {
+		expect(
+			getNumericEntitlementLimit({
+				limit: null,
+				hard_limit: null,
+				is_overage_allowed: false,
+			}),
+		).toBeNull();
+	});
+
+	test('returns limit when no hard limit is present and overage is not allowed', () => {
+		expect(
+			getNumericEntitlementLimit({
+				limit: 50,
+				hard_limit: null,
+				is_overage_allowed: false,
+			}),
+		).toBe(50);
+	});
+});
+
+describe('validateNumericEntitlementLimit', () => {
+	test('enforces hard_limit even when overage is allowed', () => {
+		expect(() =>
+			validateNumericEntitlementLimit({
+				entitlement: {
+					limit: 30,
+					hard_limit: 50,
+					is_overage_allowed: true,
+				},
+				current: 50,
+				delta: 1,
+				category: 'Collections',
+			}),
+		).toThrow(LimitExceededError);
+	});
+
+	test('does not throw when the projected total is within the limit', () => {
+		expect(() =>
+			validateNumericEntitlementLimit({
+				entitlement: {
+					limit: 50,
+					hard_limit: null,
+					is_overage_allowed: false,
+				},
+				current: 49,
+				delta: 1,
+				category: 'Collections',
+			}),
+		).not.toThrow();
+	});
+
+	test('throws when the projected total exceeds the enforced limit', () => {
+		expect(() =>
+			validateNumericEntitlementLimit({
+				entitlement: {
+					limit: 50,
+					hard_limit: null,
+					is_overage_allowed: false,
+				},
+				current: 50,
+				delta: 1,
+				category: 'Collections',
+			}),
+		).toThrow(LimitExceededError);
+	});
+
+	test('passes through optional limit metadata', () => {
+		try {
+			validateNumericEntitlementLimit({
+				entitlement: {
+					limit: 50,
+					hard_limit: null,
+					is_overage_allowed: false,
+				},
+				current: 50,
+				delta: 1,
+				category: 'Collections',
+				limit_type: 'license',
+			});
+		} catch (error) {
+			expect(error).toMatchObject({
+				code: 'LIMIT_EXCEEDED',
+				message: 'Collections limit exceeded.',
+				extensions: {
+					category: 'Collections',
+					limit_type: 'license',
+				},
+			});
+		}
+	});
+
+	test('does not throw when overage is allowed and no hard limit exists', () => {
+		expect(() =>
+			validateNumericEntitlementLimit({
+				entitlement: {
+					limit: 50,
+					hard_limit: null,
+					is_overage_allowed: true,
+				},
+				current: 50,
+				delta: 100,
+				category: 'Collections',
+			}),
+		).not.toThrow();
+	});
+
+	test('does not throw when the entitlement limit is explicitly unlimited', () => {
+		expect(() =>
+			validateNumericEntitlementLimit({
+				entitlement: {
+					limit: null,
+					hard_limit: null,
+					is_overage_allowed: false,
+				},
+				current: 50,
+				delta: 100,
+				category: 'Collections',
+			}),
+		).not.toThrow();
+	});
+});

--- a/api/src/license/numeric-gate.ts
+++ b/api/src/license/numeric-gate.ts
@@ -1,0 +1,39 @@
+import { LimitExceededError } from '@directus/errors';
+import type { NumericGate } from './types.js';
+
+export function getNumericEntitlementLimit(entitlement: NumericGate): number | null {
+	if (entitlement.hard_limit !== undefined && entitlement.hard_limit !== null) {
+		return entitlement.hard_limit;
+	}
+
+	if (entitlement.limit === null) {
+		return null;
+	}
+
+	if (entitlement.is_overage_allowed === true) {
+		return null;
+	}
+
+	return entitlement.limit;
+}
+
+export function validateNumericEntitlementLimit(options: {
+	entitlement: NumericGate;
+	current: number;
+	delta?: number;
+	category: string;
+	limit_type?: 'license';
+}): void {
+	const limit = getNumericEntitlementLimit(options.entitlement);
+
+	if (limit === null) return;
+
+	const delta = options.delta ?? 0;
+
+	if (options.current + delta > limit) {
+		throw new LimitExceededError({
+			category: options.category,
+			...(options.limit_type ? { limit_type: options.limit_type } : {}),
+		});
+	}
+}

--- a/api/src/license/summary.ts
+++ b/api/src/license/summary.ts
@@ -1,4 +1,5 @@
 import { isSystemCollection } from '@directus/system-data';
+import { toBoolean } from '@directus/utils';
 import type { Knex } from 'knex';
 import { useLogger } from '../logger/index.js';
 import { fetchUserCount, getUserSeatsCount } from '../utils/fetch-user-count/fetch-user-count.js';
@@ -150,7 +151,11 @@ function getSeatLimit(entitlements: LicenseEntitlements): number | null {
 	return entitlements.seats.limit;
 }
 
-async function countActiveCollections(knex: Knex): Promise<number> {
-	const collections = await knex('directus_collections').select('collection');
-	return collections.filter(({ collection }) => !isSystemCollection(collection)).length;
+export async function countActiveCollections(knex: Knex): Promise<number> {
+	const collections = (await knex('directus_collections').select('collection', 'excluded')) as {
+		collection: string;
+		excluded?: boolean | null;
+	}[];
+
+	return collections.filter(({ collection, excluded }) => !isSystemCollection(collection) && !toBoolean(excluded)).length;
 }

--- a/api/src/permissions/modules/process-ast/process-ast.test.ts
+++ b/api/src/permissions/modules/process-ast/process-ast.test.ts
@@ -3,13 +3,27 @@ import { SchemaBuilder } from '@directus/schema-builder';
 import type { Accountability } from '@directus/types';
 import { beforeEach, expect, test, vi } from 'vitest';
 import type { AST } from '../../../types/ast.js';
+import { getExcludedCollections } from '../../../utils/get-excluded-collections.js';
 import { fetchPermissions } from '../../lib/fetch-permissions.js';
 import { fetchPolicies } from '../../lib/fetch-policies.js';
 import type { Context } from '../../types.js';
 import { processAst } from './process-ast.js';
 
+const createKnexMock = (excludedCollections: string[] = []) =>
+	({
+		select: () => ({
+			from: () => ({
+				where: async () => excludedCollections.map((collection) => ({ collection })),
+			}),
+		}),
+	}) as unknown as Context['knex'];
+
 vi.mock('../../lib/fetch-policies.js');
 vi.mock('../../lib/fetch-permissions.js');
+
+vi.mock('../../../utils/get-excluded-collections.js', () => ({
+	getExcludedCollections: vi.fn(),
+}));
 
 vi.mock('../../../services/permissions.js', () => ({
 	PermissionsService: vi.fn(),
@@ -24,6 +38,7 @@ beforeEach(() => {
 
 	vi.mocked(fetchPolicies).mockResolvedValue([]);
 	vi.mocked(fetchPermissions).mockResolvedValue([]);
+	vi.mocked(getExcludedCollections).mockResolvedValue(new Set());
 });
 
 test('Returns AST unmodified if accountability is null', async () => {
@@ -36,7 +51,10 @@ test('Returns AST unmodified if accountability is null', async () => {
 	const ast = { type: 'root', name: 'test-collection', children: [] } as unknown as AST;
 	const accountability = null;
 
-	const output = await processAst({ action: 'read', accountability, ast }, { schema } as Context);
+	const output = await processAst({ action: 'read', accountability, ast }, {
+		schema,
+		knex: createKnexMock(),
+	} as Context);
 
 	expect(output).toBe(ast);
 });
@@ -51,7 +69,10 @@ test('Returns AST unmodified and unverified is current user is admin', async () 
 	const ast = { type: 'root', name: 'test-collection', children: [] } as unknown as AST;
 	const accountability = { user: null, roles: [], admin: true } as unknown as Accountability;
 
-	const output = await processAst({ accountability, action: 'read', ast }, { schema } as Context);
+	const output = await processAst({ accountability, action: 'read', ast }, {
+		schema,
+		knex: createKnexMock(),
+	} as Context);
 
 	expect(output).toBe(ast);
 });
@@ -62,7 +83,7 @@ test('Validates all paths existence in AST if accountability is null', async () 
 	const accountability = null;
 
 	await expect(async () =>
-		processAst({ action: 'read', accountability, ast }, { schema } as Context),
+		processAst({ action: 'read', accountability, ast }, { schema, knex: createKnexMock() } as Context),
 	).rejects.toThrowError(ForbiddenError);
 });
 
@@ -72,7 +93,7 @@ test('Validates all paths existence in AST if current user is admin', async () =
 	const accountability = { admin: true } as unknown as Accountability;
 
 	await expect(async () =>
-		processAst({ action: 'read', accountability, ast }, { schema } as Context),
+		processAst({ action: 'read', accountability, ast }, { schema, knex: createKnexMock() } as Context),
 	).rejects.toThrowError(ForbiddenError);
 });
 
@@ -89,7 +110,8 @@ test('Validates all paths in AST and throws if no permissions match', async () =
 	vi.mocked(fetchPolicies).mockResolvedValue(['test-policy-1']);
 
 	await expect(
-		async () => await processAst({ action: 'read', ast, accountability }, { schema } as Context),
+		async () =>
+			await processAst({ action: 'read', ast, accountability }, { schema, knex: createKnexMock() } as Context),
 	).rejects.toThrowError(ForbiddenError);
 
 	expect(fetchPermissions).toHaveBeenCalledWith(
@@ -99,9 +121,10 @@ test('Validates all paths in AST and throws if no permissions match', async () =
 			policies: ['test-policy-1'],
 			collections: ['test-collection'],
 		},
-		{
+		expect.objectContaining({
+			knex: expect.any(Object),
 			schema,
-		},
+		}),
 	);
 });
 
@@ -140,7 +163,7 @@ test('Injects permission cases for the provided AST', async () => {
 		},
 	]);
 
-	await processAst({ ast, action: 'read', accountability }, { schema } as Context);
+	await processAst({ ast, action: 'read', accountability }, { schema, knex: createKnexMock() } as Context);
 
 	expect(ast).toEqual({
 		type: 'root',
@@ -161,4 +184,276 @@ test('Injects permission cases for the provided AST', async () => {
 			},
 		],
 	});
+});
+
+test('rejects relational traversal to excluded collections', async () => {
+	vi.mocked(getExcludedCollections).mockResolvedValueOnce(new Set(['secret_notes']));
+
+	const schema = {
+		collections: {
+			articles: {
+				collection: 'articles',
+				primary: 'id',
+				singleton: false,
+				accountability: null,
+				note: null,
+				sortField: null,
+				fields: {
+					id: {
+						field: 'id',
+						type: 'integer',
+						dbType: null,
+						defaultValue: null,
+						nullable: false,
+						generated: false,
+						alias: false,
+						searchable: true,
+						note: null,
+						precision: null,
+						scale: null,
+						special: [],
+						validation: null,
+					},
+					secret: {
+						field: 'secret',
+						type: 'alias',
+						dbType: null,
+						defaultValue: null,
+						nullable: true,
+						generated: false,
+						alias: true,
+						searchable: true,
+						note: null,
+						precision: null,
+						scale: null,
+						special: ['m2o'],
+						validation: null,
+					},
+				},
+			},
+			secret_notes: {
+				collection: 'secret_notes',
+				primary: 'id',
+				singleton: false,
+				accountability: null,
+				note: null,
+				sortField: null,
+				fields: {
+					id: {
+						field: 'id',
+						type: 'integer',
+						dbType: null,
+						defaultValue: null,
+						nullable: false,
+						generated: false,
+						alias: false,
+						searchable: true,
+						note: null,
+						precision: null,
+						scale: null,
+						special: [],
+						validation: null,
+					},
+				},
+			},
+		},
+		relations: [
+			{
+				collection: 'articles',
+				field: 'secret',
+				related_collection: 'secret_notes',
+				schema: null,
+				meta: null,
+			},
+		],
+	} as Context['schema'];
+
+	const ast = {
+		type: 'root',
+		name: 'articles',
+		children: [
+			{
+				type: 'm2o',
+				fieldKey: 'secret',
+				name: 'secret',
+				relation: {
+					collection: 'articles',
+					field: 'secret',
+					related_collection: 'secret_notes',
+					schema: null,
+					meta: null,
+				},
+				children: [{ type: 'field', fieldKey: 'id', name: 'id' }],
+				query: {},
+				parentKey: 'id',
+				relatedKey: 'id',
+				whenCase: [],
+				cases: [],
+			},
+		],
+	} as unknown as AST;
+
+	const accountability = { user: null, roles: [] } as unknown as Accountability;
+
+	vi.mocked(fetchPolicies).mockResolvedValue(['test-policy-1']);
+
+	vi.mocked(fetchPermissions).mockResolvedValue([
+		{
+			policy: 'test-policy-1',
+			collection: 'articles',
+			action: 'read',
+			fields: ['*'],
+			permissions: null,
+			validation: null,
+			presets: null,
+		},
+	]);
+
+	const knex = Object.assign(
+		(_table: 'directus_relations') => ({
+			select: () => ({
+				where: async () => [],
+			}),
+		}),
+		{
+			select: () => ({
+				from: () => ({
+					where: async () => [{ collection: 'secret_notes' }],
+				}),
+			}),
+		},
+	) as unknown as Context['knex'];
+
+	await expect(processAst({ action: 'read', accountability, ast }, { schema, knex } as Context)).rejects.toThrow(
+		ForbiddenError,
+	);
+});
+
+test('rejects relational traversal to excluded collections for admins', async () => {
+	vi.mocked(getExcludedCollections).mockResolvedValueOnce(new Set(['secret_notes']));
+
+	const schema = {
+		collections: {
+			articles: {
+				collection: 'articles',
+				primary: 'id',
+				singleton: false,
+				accountability: null,
+				note: null,
+				sortField: null,
+				fields: {
+					id: {
+						field: 'id',
+						type: 'integer',
+						dbType: null,
+						defaultValue: null,
+						nullable: false,
+						generated: false,
+						alias: false,
+						searchable: true,
+						note: null,
+						precision: null,
+						scale: null,
+						special: [],
+						validation: null,
+					},
+					secret: {
+						field: 'secret',
+						type: 'alias',
+						dbType: null,
+						defaultValue: null,
+						nullable: true,
+						generated: false,
+						alias: true,
+						searchable: true,
+						note: null,
+						precision: null,
+						scale: null,
+						special: ['m2o'],
+						validation: null,
+					},
+				},
+			},
+			secret_notes: {
+				collection: 'secret_notes',
+				primary: 'id',
+				singleton: false,
+				accountability: null,
+				note: null,
+				sortField: null,
+				fields: {
+					id: {
+						field: 'id',
+						type: 'integer',
+						dbType: null,
+						defaultValue: null,
+						nullable: false,
+						generated: false,
+						alias: false,
+						searchable: true,
+						note: null,
+						precision: null,
+						scale: null,
+						special: [],
+						validation: null,
+					},
+				},
+			},
+		},
+		relations: [
+			{
+				collection: 'articles',
+				field: 'secret',
+				related_collection: 'secret_notes',
+				schema: null,
+				meta: null,
+			},
+		],
+	} as Context['schema'];
+
+	const ast = {
+		type: 'root',
+		name: 'articles',
+		children: [
+			{
+				type: 'm2o',
+				fieldKey: 'secret',
+				name: 'secret',
+				relation: {
+					collection: 'articles',
+					field: 'secret',
+					related_collection: 'secret_notes',
+					schema: null,
+					meta: null,
+				},
+				children: [{ type: 'field', fieldKey: 'id', name: 'id' }],
+				query: {},
+				parentKey: 'id',
+				relatedKey: 'id',
+				whenCase: [],
+				cases: [],
+			},
+		],
+	} as unknown as AST;
+
+	const accountability = { admin: true } as unknown as Accountability;
+
+	const knex = Object.assign(
+		(_table: 'directus_relations') => ({
+			select: () => ({
+				where: async () => [],
+			}),
+		}),
+		{
+			select: () => ({
+				from: () => ({
+					where: async () => [{ collection: 'secret_notes' }],
+				}),
+			}),
+		},
+	) as unknown as Context['knex'];
+
+	await expect(processAst({ action: 'read', accountability, ast }, { schema, knex } as Context)).rejects.toThrow(
+		ForbiddenError,
+	);
 });

--- a/api/src/permissions/modules/process-ast/process-ast.ts
+++ b/api/src/permissions/modules/process-ast/process-ast.ts
@@ -7,6 +7,7 @@ import { fieldMapFromAst } from './lib/field-map-from-ast.js';
 import { injectCases } from './lib/inject-cases.js';
 import type { FieldMap } from './types.js';
 import { collectionsInFieldMap } from './utils/collections-in-field-map.js';
+import { validateExcludedRelations } from './utils/validate-path/validate-excluded-relations.js';
 import { validatePathExistence } from './utils/validate-path/validate-path-existence.js';
 import { validatePathPermissions } from './utils/validate-path/validate-path-permissions.js';
 
@@ -27,6 +28,8 @@ export async function processAst(options: ProcessAstOptions, context: Context) {
 		for (const [path, { collection, fields }] of [...fieldMap.read.entries(), ...fieldMap.other.entries()]) {
 			validatePathExistence(path, collection, fields, context.schema);
 		}
+
+		await validateExcludedRelations(fieldMap, context.schema, context.knex);
 
 		return options.ast;
 	}
@@ -50,6 +53,8 @@ export async function processAst(options: ProcessAstOptions, context: Context) {
 	for (const [path, { collection, fields }] of [...fieldMap.read.entries(), ...fieldMap.other.entries()]) {
 		validatePathExistence(path, collection, fields, context.schema);
 	}
+
+	await validateExcludedRelations(fieldMap, context.schema, context.knex);
 
 	// Validate permissions for the fields
 	for (const [path, { collection, fields }] of fieldMap.other.entries()) {

--- a/api/src/permissions/modules/process-ast/utils/validate-path/validate-excluded-relations.test.ts
+++ b/api/src/permissions/modules/process-ast/utils/validate-path/validate-excluded-relations.test.ts
@@ -1,0 +1,256 @@
+import { ForbiddenError } from '@directus/errors';
+import type { Relation, RelationMeta, SchemaOverview } from '@directus/types';
+import { describe, expect, test, vi } from 'vitest';
+import { getExcludedCollections } from '../../../../../utils/get-excluded-collections.js';
+import type { FieldMap } from '../../types.js';
+import { validateExcludedRelations } from './validate-excluded-relations.js';
+
+vi.mock('../../../../../utils/get-excluded-collections.js', () => ({
+	getExcludedCollections: vi.fn(),
+}));
+
+type DirectusCollectionsRow = { collection: string };
+
+type RelationMetaRow = {
+	many_collection: string;
+	many_field: string;
+	one_collection: string | null;
+	one_field: string | null;
+	one_allowed_collections: unknown;
+};
+
+type KnexLike = {
+	select: (column: 'collection') => {
+		from: (table: 'directus_collections') => {
+			where: (column: 'excluded', value: boolean) => Promise<DirectusCollectionsRow[]>;
+		};
+	};
+	(table: 'directus_relations'): {
+		select: (
+			...columns: ['many_collection', 'many_field', 'one_collection', 'one_field', 'one_allowed_collections']
+		) => {
+			where: (
+				callback: (queryBuilder: {
+					orWhere: (callback: (inner: { where: (obj: unknown) => void }) => void) => void;
+				}) => void,
+			) => Promise<RelationMetaRow[]>;
+		};
+	};
+};
+
+function createKnexMock(options: { excludedCollections: string[]; relationRows?: RelationMetaRow[] }): KnexLike {
+	const relationRows = options.relationRows ?? [];
+
+	return Object.assign(
+		(_table: 'directus_relations') => ({
+			select: () => ({
+				where: async () => relationRows,
+			}),
+		}),
+		{
+			select: () => ({
+				from: () => ({
+					where: async () => options.excludedCollections.map((collection) => ({ collection })),
+				}),
+			}),
+		},
+	);
+}
+
+function createSchemaOverview(options: {
+	collection: string;
+	field: string;
+	special: string[];
+	relations: Relation[];
+}): SchemaOverview {
+	return {
+		collections: {
+			[options.collection]: {
+				collection: options.collection,
+				primary: 'id',
+				singleton: false,
+				accountability: null,
+				note: null,
+				sortField: null,
+				fields: {
+					id: {
+						field: 'id',
+						type: 'integer',
+						dbType: null,
+						defaultValue: null,
+						nullable: false,
+						generated: false,
+						alias: false,
+						searchable: true,
+						note: null,
+						precision: null,
+						scale: null,
+						special: [],
+						validation: null,
+					},
+					[options.field]: {
+						field: options.field,
+						type: 'alias',
+						dbType: null,
+						defaultValue: null,
+						nullable: true,
+						generated: false,
+						alias: true,
+						searchable: true,
+						note: null,
+						precision: null,
+						scale: null,
+						special: options.special,
+						validation: null,
+					},
+				},
+			},
+		},
+		relations: options.relations,
+	} as unknown as SchemaOverview;
+}
+
+function createFieldMap(collection: string, fields: string[]): FieldMap {
+	return {
+		read: new Map(),
+		other: new Map([['', { collection, fields: new Set(fields) }]]),
+	};
+}
+
+function createTraversedFieldMap(
+	rootCollection: string,
+	rootField: string,
+	nestedCollection: string,
+	nestedField: string,
+): FieldMap {
+	return {
+		read: new Map([
+			[
+				rootField,
+				{
+					collection: nestedCollection,
+					fields: new Set([nestedField]),
+				},
+			],
+		]),
+		other: new Map([['', { collection: rootCollection, fields: new Set([rootField]) }]]),
+	};
+}
+
+describe('validateExcludedRelations', () => {
+	test('does nothing when no collections are excluded', async () => {
+		vi.mocked(getExcludedCollections).mockResolvedValueOnce(new Set());
+
+		const schema = createSchemaOverview({
+			collection: 'cities',
+			field: 'country',
+			special: ['m2o'],
+			relations: [
+				{
+					collection: 'cities',
+					field: 'country',
+					related_collection: 'countries',
+					schema: null,
+					meta: null,
+				},
+			],
+		});
+
+		const knex = createKnexMock({ excludedCollections: [] });
+		const fieldMap = createFieldMap('cities', ['country']);
+
+		await expect(
+			validateExcludedRelations(fieldMap, schema, knex as unknown as Parameters<typeof validateExcludedRelations>[2]),
+		).resolves.toBeUndefined();
+	});
+
+	test('throws ForbiddenError when stitched relation points to excluded collection (m2o)', async () => {
+		vi.mocked(getExcludedCollections).mockResolvedValueOnce(new Set(['countries']));
+
+		const schema = createSchemaOverview({
+			collection: 'cities',
+			field: 'country',
+			special: ['m2o'],
+			relations: [
+				{
+					collection: 'cities',
+					field: 'country',
+					related_collection: 'countries',
+					schema: null,
+					meta: null,
+				},
+			],
+		});
+
+		const knex = createKnexMock({ excludedCollections: ['countries'] });
+		const fieldMap = createTraversedFieldMap('cities', 'country', 'countries', 'name');
+
+		await expect(
+			validateExcludedRelations(fieldMap, schema, knex as unknown as Parameters<typeof validateExcludedRelations>[2]),
+		).rejects.toThrowError(ForbiddenError);
+	});
+
+	test('allows scalar relational fields when the related collection is excluded', async () => {
+		vi.mocked(getExcludedCollections).mockResolvedValueOnce(new Set(['countries']));
+
+		const schema = createSchemaOverview({
+			collection: 'cities',
+			field: 'country',
+			special: ['m2o'],
+			relations: [
+				{
+					collection: 'cities',
+					field: 'country',
+					related_collection: 'countries',
+					schema: null,
+					meta: null,
+				},
+			],
+		});
+
+		const knex = createKnexMock({ excludedCollections: ['countries'] });
+		const fieldMap = createFieldMap('cities', ['country']);
+
+		await expect(
+			validateExcludedRelations(fieldMap, schema, knex as unknown as Parameters<typeof validateExcludedRelations>[2]),
+		).resolves.toBeUndefined();
+	});
+
+	test('throws ForbiddenError when m2a allowed targets include an excluded collection', async () => {
+		vi.mocked(getExcludedCollections).mockResolvedValueOnce(new Set(['secret']));
+
+		const schema = createSchemaOverview({
+			collection: 'feed',
+			field: 'items',
+			special: ['m2a'],
+			relations: [
+				{
+					collection: 'feed',
+					field: 'items',
+					related_collection: null,
+					schema: null,
+					meta: {
+						id: 1,
+						many_collection: 'feed',
+						many_field: 'items',
+						one_collection: null,
+						one_field: null,
+						one_collection_field: null,
+						one_allowed_collections: ['articles', 'secret'],
+						one_deselect_action: 'nullify',
+						junction_field: null,
+						sort_field: null,
+						system: false,
+					} satisfies RelationMeta,
+				},
+			],
+		});
+
+		const knex = createKnexMock({ excludedCollections: ['secret'] });
+		const fieldMap = createFieldMap('feed', ['items']);
+
+		await expect(
+			validateExcludedRelations(fieldMap, schema, knex as unknown as Parameters<typeof validateExcludedRelations>[2]),
+		).rejects.toThrowError(ForbiddenError);
+	});
+});

--- a/api/src/permissions/modules/process-ast/utils/validate-path/validate-excluded-relations.ts
+++ b/api/src/permissions/modules/process-ast/utils/validate-path/validate-excluded-relations.ts
@@ -1,0 +1,145 @@
+import type { SchemaOverview } from '@directus/types';
+import { getRelations } from '@directus/utils';
+import type { Knex } from 'knex';
+import { getExcludedCollections } from '../../../../../utils/get-excluded-collections.js';
+import type { FieldMap } from '../../types.js';
+import { createFieldsForbiddenError } from './create-error.js';
+
+const RELATIONAL_SPECIALS = new Set(['m2o', 'o2m', 'm2m', 'm2a']);
+
+type RelationMetaRow = {
+	many_collection: string;
+	many_field: string;
+	one_collection: string | null;
+	one_field: string | null;
+	one_allowed_collections: unknown;
+};
+
+function isRelationalField(schema: SchemaOverview, collection: string, field: string): boolean {
+	const special = schema.collections[collection]?.fields[field]?.special;
+	return special?.some((value) => RELATIONAL_SPECIALS.has(value)) ?? false;
+}
+
+function getCollectionsTouchedByFieldRelation(
+	schema: SchemaOverview,
+	collection: string,
+	field: string,
+	metaRows: RelationMetaRow[],
+): Set<string> {
+	const touched = new Set<string>();
+
+	for (const relation of getRelations(schema.relations, collection, field)) {
+		touched.add(relation.collection);
+
+		if (relation.related_collection) {
+			touched.add(relation.related_collection);
+		}
+
+		if (relation.meta?.one_allowed_collections) {
+			for (const collection of relation.meta.one_allowed_collections) {
+				touched.add(collection);
+			}
+		}
+	}
+
+	for (const row of metaRows) {
+		const matchesManySide = row.many_collection === collection && row.many_field === field;
+		const matchesOneSide = row.one_collection === collection && row.one_field === field;
+
+		if (matchesManySide || matchesOneSide) {
+			touched.add(row.many_collection);
+
+			if (row.one_collection) {
+				touched.add(row.one_collection);
+			}
+
+			if (Array.isArray(row.one_allowed_collections)) {
+				for (const collection of row.one_allowed_collections) {
+					if (typeof collection === 'string') {
+						touched.add(collection);
+					}
+				}
+			}
+		}
+	}
+
+	return touched;
+}
+
+export async function validateExcludedRelations(fieldMap: FieldMap, schema: SchemaOverview, knex: Knex): Promise<void> {
+	const excludedCollections = await getExcludedCollections(knex);
+
+	if (excludedCollections.size === 0) {
+		return;
+	}
+
+	const pairKeys = new Set<string>();
+
+	for (const [, { collection, fields }] of [...fieldMap.read.entries(), ...fieldMap.other.entries()]) {
+		for (const field of fields) {
+			if (isRelationalField(schema, collection, field)) {
+				pairKeys.add(`${collection}\x00${field}`);
+			}
+		}
+	}
+
+	const pairs = [...pairKeys].map((key) => {
+		const separator = key.indexOf('\x00');
+		return [key.slice(0, separator), key.slice(separator + 1)] as [string, string];
+	});
+
+	let relationMetaRows: RelationMetaRow[] = [];
+
+	if (pairs.length > 0) {
+		relationMetaRows = (await knex('directus_relations')
+			.select('many_collection', 'many_field', 'one_collection', 'one_field', 'one_allowed_collections')
+			.where((queryBuilder) => {
+				for (const [collection, field] of pairs) {
+					queryBuilder.orWhere((inner) => {
+						inner.where({ many_collection: collection, many_field: field });
+					});
+
+					queryBuilder.orWhere((inner) => {
+						inner.where({ one_collection: collection, one_field: field });
+					});
+				}
+			})) as RelationMetaRow[];
+	}
+
+	for (const [path, { collection, fields }] of [...fieldMap.read.entries(), ...fieldMap.other.entries()]) {
+		const invalidFields: string[] = [];
+		const fieldMapKeys = [...fieldMap.read.keys(), ...fieldMap.other.keys()];
+
+		for (const field of fields) {
+			if (!isRelationalField(schema, collection, field)) continue;
+
+			const nextPath = path ? `${path}.${field}` : field;
+
+			const isTraversedRelation = fieldMapKeys.some(
+				(key) => key === nextPath || key.startsWith(`${nextPath}.`) || key.startsWith(`${nextPath}:`),
+			);
+
+			const isScalarM2O = schema.collections[collection]?.fields[field]?.special?.includes('m2o') ?? false;
+
+			if (!isTraversedRelation && isScalarM2O) {
+				continue;
+			}
+
+			const touchedCollections = getCollectionsTouchedByFieldRelation(schema, collection, field, relationMetaRows);
+
+			if (touchedCollections.size === 0) continue;
+
+			if (
+				[...touchedCollections].some(
+					(touchedCollection) => touchedCollection !== collection && excludedCollections.has(touchedCollection),
+				)
+			) {
+				invalidFields.push(field);
+			}
+		}
+
+		if (invalidFields.length > 0) {
+			throw createFieldsForbiddenError(path, collection, invalidFields);
+		}
+	}
+}

--- a/api/src/services/collections.test.ts
+++ b/api/src/services/collections.test.ts
@@ -1,8 +1,9 @@
-import { ForbiddenError, InvalidPayloadError } from '@directus/errors';
+import { ForbiddenError, InvalidPayloadError, LimitExceededError } from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import type { Accountability, Collection, FieldMutationOptions } from '@directus/types';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as cacheModule from '../cache.js';
+import * as licenseSummaryModule from '../license/summary.js';
 import { createMockKnex, resetKnexMocks, setupSystemCollectionMocks } from '../test-utils/knex.js';
 import * as getSchemaModule from '../utils/get-schema.js';
 import { CollectionsService } from './collections.js';
@@ -55,6 +56,11 @@ vi.mock('../permissions/modules/validate-access/validate-access.js', () => ({
 	validateAccess: vi.fn(),
 }));
 
+vi.mock('../license/summary.js', () => ({
+	getLicenseEntitlements: vi.fn(),
+	countActiveCollections: vi.fn(),
+}));
+
 vi.mock('../utils/should-clear-cache.js', () => ({
 	shouldClearCache: vi.fn().mockReturnValue(true),
 }));
@@ -100,6 +106,20 @@ describe('Integration Tests', () => {
 	// Common setup
 	beforeEach(() => {
 		vi.mocked(getSchemaModule.getSchema).mockResolvedValue(schema);
+
+		vi.mocked(licenseSummaryModule.getLicenseEntitlements).mockResolvedValue({
+			collections: { limit: 50, hard_limit: 50, is_overage_allowed: false },
+			seats: { limit: 3, hard_limit: 3, is_overage_allowed: false },
+			activity_log_retention_days: { limit: 30 },
+			revisions_retention_days: { limit: 30 },
+			sso_enabled: false,
+			custom_policy_rules_enabled: false,
+			scheduled_publishing_enabled: false,
+			custom_llm_enabled: false,
+			analytics_opt_out_enabled: false,
+		});
+
+		vi.mocked(licenseSummaryModule.countActiveCollections).mockResolvedValue(0);
 	});
 
 	afterEach(() => {
@@ -147,6 +167,43 @@ describe('Integration Tests', () => {
 
 				expect(result).toBe('new_collection');
 				expect(mockSchemaBuilder.createTable).toHaveBeenCalledWith('new_collection', expect.any(Function));
+			});
+
+			test('should throw LimitExceededError when collection limit is reached', async () => {
+				tracker.on.select('directus_collections').response([]);
+				vi.mocked(licenseSummaryModule.countActiveCollections).mockResolvedValue(50);
+
+				const service = new CollectionsService({ knex: db, schema, accountability: null });
+
+				await expect(service.createOne({ collection: 'over_limit', schema: {} })).rejects.toMatchObject({
+					code: 'LIMIT_EXCEEDED',
+					message: 'Collections limit exceeded.',
+					extensions: {
+						category: 'Collections',
+						limit_type: 'license',
+					},
+				});
+			});
+
+			test('should allow collection creation past limit when overage is allowed without a hard limit', async () => {
+				tracker.on.select('directus_collections').response([]);
+				vi.mocked(licenseSummaryModule.countActiveCollections).mockResolvedValue(50);
+
+				vi.mocked(licenseSummaryModule.getLicenseEntitlements).mockResolvedValue({
+					collections: { limit: 50, hard_limit: null, is_overage_allowed: true },
+					seats: { limit: 3, hard_limit: 3, is_overage_allowed: false },
+					activity_log_retention_days: { limit: 30 },
+					revisions_retention_days: { limit: 30 },
+					sso_enabled: false,
+					custom_policy_rules_enabled: false,
+					scheduled_publishing_enabled: false,
+					custom_llm_enabled: false,
+					analytics_opt_out_enabled: false,
+				});
+
+				const service = new CollectionsService({ knex: db, schema, accountability: null });
+
+				await expect(service.createOne({ collection: 'allowed_overage', schema: {} })).resolves.toBe('allowed_overage');
 			});
 
 			test('should parse collection name before creating', async () => {
@@ -299,7 +356,7 @@ describe('Integration Tests', () => {
 			});
 
 			test('should create multiple collections', async () => {
-				const createOneSpy = vi.spyOn(CollectionsService.prototype, 'createOne').mockResolvedValue('test');
+				tracker.on.select('directus_collections').response([]);
 
 				const service = new CollectionsService({
 					knex: db,
@@ -309,8 +366,21 @@ describe('Integration Tests', () => {
 
 				const result = await service.createMany([{ collection: 'collection1' }, { collection: 'collection2' }]);
 
-				expect(result).toEqual(['test', 'test']);
-				expect(createOneSpy).toHaveBeenCalledTimes(2);
+				expect(result).toEqual(['collection1', 'collection2']);
+			});
+
+			test('should throw LimitExceededError when batch exceeds collection limit', async () => {
+				vi.mocked(licenseSummaryModule.countActiveCollections).mockResolvedValue(49);
+
+				const service = new CollectionsService({
+					knex: db,
+					schema,
+					accountability: null,
+				});
+
+				await expect(service.createMany([{ collection: 'one' }, { collection: 'two' }])).rejects.toThrow(
+					LimitExceededError,
+				);
 			});
 		});
 
@@ -453,8 +523,10 @@ describe('Integration Tests', () => {
 				await expect(service.updateOne('test_collection', {})).rejects.toThrow(ForbiddenError);
 			});
 
-			test('should update existing collection meta', async () => {
-				tracker.on.select('directus_collections').response([{ collection: 'test_collection' }]);
+			test('should update an existing collection metadata row', async () => {
+				vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([
+					{ collection: 'test_collection', excluded: false },
+				]);
 
 				const updateOneSpy = vi.spyOn(ItemsService.prototype, 'updateOne').mockResolvedValue('test_collection');
 
@@ -471,9 +543,8 @@ describe('Integration Tests', () => {
 				expect(updateOneSpy).toHaveBeenCalled();
 			});
 
-			test('should create collection meta if not exists', async () => {
-				tracker.on.select('directus_collections').response([]);
-
+			test('should create a collection metadata row when one does not exist', async () => {
+				vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([]);
 				const createOneSpy = vi.spyOn(ItemsService.prototype, 'createOne').mockResolvedValue('test_collection');
 
 				const service = new CollectionsService({
@@ -487,6 +558,47 @@ describe('Integration Tests', () => {
 				} as Partial<Collection>);
 
 				expect(createOneSpy).toHaveBeenCalled();
+			});
+
+			test('should throw LimitExceededError when configuring a db-only collection over the limit', async () => {
+				vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([]);
+				vi.mocked(licenseSummaryModule.countActiveCollections).mockResolvedValue(50);
+
+				const service = new CollectionsService({
+					knex: db,
+					schema,
+					accountability: null,
+				});
+
+				await expect(
+					service.updateOne('test_collection', {
+						meta: { collection: 'test_collection', hidden: true },
+					} as Partial<Collection>),
+				).rejects.toThrow(LimitExceededError);
+			});
+
+			test('should ignore excluded updates for system collections', async () => {
+				vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([
+					{ collection: 'directus_collections', excluded: false },
+				]);
+
+				const updateOneSpy = vi.spyOn(ItemsService.prototype, 'updateOne').mockResolvedValue('directus_collections');
+
+				const service = new CollectionsService({
+					knex: db,
+					schema,
+					accountability: null,
+				});
+
+				await service.updateOne('directus_collections', {
+					meta: { excluded: true, note: 'System collection note' },
+				} as Partial<Collection>);
+
+				expect(updateOneSpy).toHaveBeenCalledWith(
+					'directus_collections',
+					expect.not.objectContaining({ excluded: true }),
+					expect.anything(),
+				);
 			});
 		});
 
@@ -525,8 +637,28 @@ describe('Integration Tests', () => {
 				await expect(service.updateBatch([{ meta: {} } as any])).rejects.toThrow(InvalidPayloadError);
 			});
 
-			test('should update multiple collections', async () => {
-				const updateOneSpy = vi.spyOn(CollectionsService.prototype, 'updateOne').mockResolvedValue('test');
+			test('should throw InvalidPayloadError when duplicate collection keys are provided', async () => {
+				const service = new CollectionsService({
+					knex: db,
+					schema,
+					accountability: null,
+				});
+
+				await expect(
+					service.updateBatch([
+						{ collection: 'collection1', meta: { hidden: true } } as Partial<Collection>,
+						{ collection: 'collection1', meta: { hidden: false } } as Partial<Collection>,
+					]),
+				).rejects.toThrow(InvalidPayloadError);
+			});
+
+			test('should update metadata for multiple collections', async () => {
+				vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([
+					{ collection: 'collection1', excluded: false },
+					{ collection: 'collection2', excluded: false },
+				]);
+
+				const updateOneSpy = vi.spyOn(ItemsService.prototype, 'updateOne').mockResolvedValue('test');
 
 				const service = new CollectionsService({
 					knex: db,
@@ -541,6 +673,28 @@ describe('Integration Tests', () => {
 
 				expect(result).toEqual(['collection1', 'collection2']);
 				expect(updateOneSpy).toHaveBeenCalledTimes(2);
+			});
+
+			test('should ignore system excluded updates during collection limit validation', async () => {
+				vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([
+					{ collection: 'directus_collections', excluded: false },
+					{ collection: 'regular_collection', excluded: true },
+				]);
+
+				vi.mocked(licenseSummaryModule.countActiveCollections).mockResolvedValue(50);
+
+				const service = new CollectionsService({
+					knex: db,
+					schema,
+					accountability: null,
+				});
+
+				await expect(
+					service.updateBatch([
+						{ collection: 'directus_collections', meta: { excluded: true } } as Partial<Collection>,
+						{ collection: 'regular_collection', meta: { excluded: false } } as Partial<Collection>,
+					]),
+				).rejects.toThrow(LimitExceededError);
 			});
 		});
 
@@ -559,8 +713,13 @@ describe('Integration Tests', () => {
 				await expect(service.updateMany([], {})).rejects.toThrow(ForbiddenError);
 			});
 
-			test('should update multiple collections with same data', async () => {
-				const updateOneSpy = vi.spyOn(CollectionsService.prototype, 'updateOne').mockResolvedValue('test');
+			test('should update shared metadata for multiple collections', async () => {
+				vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([
+					{ collection: 'collection1', excluded: false },
+					{ collection: 'collection2', excluded: false },
+				]);
+
+				const updateOneSpy = vi.spyOn(ItemsService.prototype, 'updateOne').mockResolvedValue('test');
 
 				const service = new CollectionsService({
 					knex: db,
@@ -574,6 +733,20 @@ describe('Integration Tests', () => {
 
 				expect(result).toEqual(['collection1', 'collection2']);
 				expect(updateOneSpy).toHaveBeenCalledTimes(2);
+			});
+
+			test('should throw InvalidPayloadError when duplicate collection keys are provided', async () => {
+				const service = new CollectionsService({
+					knex: db,
+					schema,
+					accountability: null,
+				});
+
+				await expect(
+					service.updateMany(['collection1', 'collection1'], {
+						meta: { hidden: true },
+					} as Partial<Collection>),
+				).rejects.toThrow(InvalidPayloadError);
 			});
 		});
 

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -2,11 +2,12 @@ import { useEnv } from '@directus/env';
 import { ForbiddenError, InvalidPayloadError } from '@directus/errors';
 import type { SchemaInspector } from '@directus/schema';
 import { createInspector } from '@directus/schema';
-import { type BaseCollectionMeta, systemCollectionRows } from '@directus/system-data';
+import { isSystemCollection, systemCollectionRows } from '@directus/system-data';
 import type {
 	AbstractServiceOptions,
 	Accountability,
 	ActionEventParams,
+	BaseCollectionMeta,
 	FieldMeta,
 	FieldMutationOptions,
 	MutationOptions,
@@ -14,7 +15,7 @@ import type {
 	RawField,
 	SchemaOverview,
 } from '@directus/types';
-import { addFieldFlag } from '@directus/utils';
+import { addFieldFlag, toBoolean } from '@directus/utils';
 import type Keyv from 'keyv';
 import type { Knex } from 'knex';
 import { chunk, groupBy, merge, omit } from 'lodash-es';
@@ -24,6 +25,8 @@ import type { Helpers } from '../database/helpers/index.js';
 import { getHelpers } from '../database/helpers/index.js';
 import getDatabase, { getSchemaInspector } from '../database/index.js';
 import emitter from '../emitter.js';
+import { validateNumericEntitlementLimit } from '../license/numeric-gate.js';
+import { countActiveCollections, getLicenseEntitlements } from '../license/summary.js';
 import { fetchAllowedCollections } from '../permissions/modules/fetch-allowed-collections/fetch-allowed-collections.js';
 import { validateAccess } from '../permissions/modules/validate-access/validate-access.js';
 import type { Collection } from '../types/index.js';
@@ -61,6 +64,14 @@ export class CollectionsService {
 	 * Create a single new collection
 	 */
 	async createOne(payload: RawCollection, opts?: FieldMutationOptions): Promise<string> {
+		return this._createOne(payload, opts);
+	}
+
+	private async _createOne(
+		payload: RawCollection,
+		opts?: FieldMutationOptions,
+		skipCollectionLimitCheck = false,
+	): Promise<string> {
 		if (this.accountability && this.accountability.admin !== true) {
 			throw new ForbiddenError();
 		}
@@ -88,6 +99,10 @@ export class CollectionsService {
 
 			if (existingCollections.includes(payload.collection)) {
 				throw new InvalidPayloadError({ reason: `Collection "${payload.collection}" already exists` });
+			}
+
+			if (skipCollectionLimitCheck === false && !toBoolean(payload.meta?.excluded)) {
+				await this.validateCollectionLimit(1);
 			}
 
 			const attemptConcurrentIndex = Boolean(opts?.attemptConcurrentIndex);
@@ -262,6 +277,15 @@ export class CollectionsService {
 		const nestedActionEvents: ActionEventParams[] = [];
 
 		try {
+			const collectionsToAdd = payloads.reduce(
+				(count, payload) => count + (toBoolean(payload.meta?.excluded) ? 0 : 1),
+				0,
+			);
+
+			if (collectionsToAdd > 0) {
+				await this.validateCollectionLimit(collectionsToAdd);
+			}
+
 			const collections = await transaction(this.knex, async (trx) => {
 				const service = new CollectionsService({
 					schema: this.schema,
@@ -272,12 +296,16 @@ export class CollectionsService {
 				const collectionNames: string[] = [];
 
 				for (const payload of payloads) {
-					const name = await service.createOne(payload, {
-						autoPurgeCache: false,
-						autoPurgeSystemCache: false,
-						bypassEmitAction: (params) => nestedActionEvents.push(params),
-						attemptConcurrentIndex: Boolean(opts?.attemptConcurrentIndex),
-					});
+					const name = await service._createOne(
+						payload,
+						{
+							autoPurgeCache: false,
+							autoPurgeSystemCache: false,
+							bypassEmitAction: (params) => nestedActionEvents.push(params),
+							attemptConcurrentIndex: Boolean(opts?.attemptConcurrentIndex),
+						},
+						true,
+					);
 
 					collectionNames.push(name);
 				}
@@ -438,6 +466,15 @@ export class CollectionsService {
 	 * Update a single collection by name
 	 */
 	async updateOne(collectionKey: string, data: Partial<Collection>, opts?: MutationOptions): Promise<string> {
+		return this._updateOne(collectionKey, data, opts);
+	}
+
+	private async _updateOne(
+		collectionKey: string,
+		data: Partial<Collection>,
+		opts?: MutationOptions,
+		skipCollectionLimitCheck = false,
+	): Promise<string> {
 		if (this.accountability && this.accountability.admin !== true) {
 			throw new ForbiddenError();
 		}
@@ -451,27 +488,39 @@ export class CollectionsService {
 				schema: this.schema,
 			});
 
+			const collectionExclusions = await this.fetchCollectionExclusions(collectionsItemsService, [collectionKey]);
+
 			const payload = data as Partial<Collection>;
 
 			if (!payload.meta) {
 				return collectionKey;
 			}
 
-			const exists = !!(await this.knex
-				.select('collection')
-				.from('directus_collections')
-				.where({ collection: collectionKey })
-				.first());
+			const meta = this.sanitizeCollectionMeta(collectionKey, payload.meta);
+
+			if (!meta) {
+				return collectionKey;
+			}
+
+			if (skipCollectionLimitCheck === false) {
+				const collectionCountChange = this.calculateCollectionCountChange(collectionExclusions, collectionKey, meta);
+
+				if (collectionCountChange > 0) {
+					await this.validateCollectionLimit(collectionCountChange);
+				}
+			}
+
+			const exists = collectionExclusions.has(collectionKey);
 
 			if (exists) {
-				await collectionsItemsService.updateOne(collectionKey, payload.meta, {
+				await collectionsItemsService.updateOne(collectionKey, meta, {
 					...opts,
 					bypassEmitAction: (params) =>
 						opts?.bypassEmitAction ? opts.bypassEmitAction(params) : nestedActionEvents.push(params),
 				});
 			} else {
 				await collectionsItemsService.createOne(
-					{ ...payload.meta, collection: collectionKey },
+					{ ...meta, collection: collectionKey },
 					{
 						...opts,
 						bypassEmitAction: (params) =>
@@ -517,6 +566,36 @@ export class CollectionsService {
 		const collectionKeys: string[] = [];
 		const nestedActionEvents: ActionEventParams[] = [];
 
+		for (const payload of data) {
+			if (!payload[collectionKey]) {
+				throw new InvalidPayloadError({ reason: `Collection in update misses collection key` });
+			}
+
+			collectionKeys.push(payload[collectionKey] as string);
+		}
+
+		this.validateCollectionKeysAreUnique(collectionKeys);
+
+		const collectionsItemsService = new ItemsService('directus_collections', {
+			knex: this.knex,
+			accountability: this.accountability,
+			schema: this.schema,
+		});
+
+		const excludedCollections = await this.fetchCollectionExclusions(collectionsItemsService, collectionKeys);
+
+		let collectionCountChange = 0;
+
+		for (const payload of data) {
+			const collectionName = payload[collectionKey] as string;
+			const meta = this.sanitizeCollectionMeta(collectionName, payload.meta);
+			collectionCountChange += this.calculateCollectionCountChange(excludedCollections, collectionName, meta);
+		}
+
+		if (collectionCountChange > 0) {
+			await this.validateCollectionLimit(collectionCountChange);
+		}
+
 		try {
 			await transaction(this.knex, async (trx) => {
 				const collectionItemsService = new CollectionsService({
@@ -526,18 +605,19 @@ export class CollectionsService {
 				});
 
 				for (const payload of data) {
-					if (!payload[collectionKey]) {
-						throw new InvalidPayloadError({ reason: `Collection in update misses collection key` });
-					}
+					const collectionName = payload[collectionKey] as string;
 
-					await collectionItemsService.updateOne(payload[collectionKey], omit(payload, collectionKey), {
-						autoPurgeCache: false,
-						autoPurgeSystemCache: false,
-						bypassEmitAction: (params) =>
-							opts?.bypassEmitAction ? opts.bypassEmitAction(params) : nestedActionEvents.push(params),
-					});
-
-					collectionKeys.push(payload[collectionKey]);
+					await collectionItemsService._updateOne(
+						collectionName,
+						omit(payload, collectionKey),
+						{
+							autoPurgeCache: false,
+							autoPurgeSystemCache: false,
+							bypassEmitAction: (params) =>
+								opts?.bypassEmitAction ? opts.bypassEmitAction(params) : nestedActionEvents.push(params),
+						},
+						true,
+					);
 				}
 			});
 		} finally {
@@ -570,7 +650,28 @@ export class CollectionsService {
 			throw new ForbiddenError();
 		}
 
+		this.validateCollectionKeysAreUnique(collectionKeys);
+
 		const nestedActionEvents: ActionEventParams[] = [];
+
+		const collectionsItemsService = new ItemsService('directus_collections', {
+			knex: this.knex,
+			accountability: this.accountability,
+			schema: this.schema,
+		});
+
+		const excludedCollections = await this.fetchCollectionExclusions(collectionsItemsService, collectionKeys);
+
+		let collectionCountChange = 0;
+
+		for (const collectionKey of collectionKeys) {
+			const meta = this.sanitizeCollectionMeta(collectionKey, data.meta);
+			collectionCountChange += this.calculateCollectionCountChange(excludedCollections, collectionKey, meta);
+		}
+
+		if (collectionCountChange > 0) {
+			await this.validateCollectionLimit(collectionCountChange);
+		}
 
 		try {
 			await transaction(this.knex, async (trx) => {
@@ -581,11 +682,16 @@ export class CollectionsService {
 				});
 
 				for (const collectionKey of collectionKeys) {
-					await service.updateOne(collectionKey, data, {
-						autoPurgeCache: false,
-						autoPurgeSystemCache: false,
-						bypassEmitAction: (params) => nestedActionEvents.push(params),
-					});
+					await service._updateOne(
+						collectionKey,
+						data,
+						{
+							autoPurgeCache: false,
+							autoPurgeSystemCache: false,
+							bypassEmitAction: (params) => nestedActionEvents.push(params),
+						},
+						true,
+					);
 				}
 			});
 
@@ -839,6 +945,91 @@ export class CollectionsService {
 					emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
 				}
 			}
+		}
+	}
+
+	private async validateCollectionLimit(count: number): Promise<void> {
+		const entitlements = await getLicenseEntitlements();
+		const currentCollections = await countActiveCollections(this.knex);
+
+		validateNumericEntitlementLimit({
+			entitlement: entitlements.collections,
+			current: currentCollections,
+			delta: count,
+			category: 'Collections',
+			limit_type: 'license',
+		});
+	}
+
+	private calculateCollectionCountChange(
+		collectionExclusions: Map<string, boolean>,
+		collectionKey: string,
+		meta: Partial<Collection['meta']> | null | undefined,
+	): number {
+		if (!meta) return 0;
+		const hasMeta = collectionExclusions.has(collectionKey);
+		const excludedValue = meta.excluded;
+
+		if (hasMeta === false) {
+			return toBoolean(excludedValue) ? 0 : 1;
+		}
+
+		if (excludedValue === undefined) {
+			return 0;
+		}
+
+		const isExcluded = collectionExclusions.get(collectionKey) === true;
+
+		if (isExcluded && !toBoolean(excludedValue)) {
+			return 1;
+		}
+
+		if (isExcluded === false && toBoolean(excludedValue)) {
+			return -1;
+		}
+
+		return 0;
+	}
+
+	private sanitizeCollectionMeta(
+		collectionKey: string,
+		meta: Partial<Collection['meta']> | null | undefined,
+	): Partial<Collection['meta']> | null {
+		if (!meta) return null;
+
+		if (!isSystemCollection(collectionKey)) {
+			return meta;
+		}
+
+		const { excluded: _excluded, ...sanitizedMeta } = meta;
+		return Object.keys(sanitizedMeta).length > 0 ? sanitizedMeta : null;
+	}
+
+	private async fetchCollectionExclusions(
+		collectionsItemsService: ItemsService,
+		collectionKeys?: string[],
+	): Promise<Map<string, boolean>> {
+		if (collectionKeys?.length === 0) {
+			return new Map();
+		}
+
+		const query = {
+			fields: ['collection', 'excluded'],
+			limit: -1,
+			...(collectionKeys ? { filter: { collection: { _in: collectionKeys } } } : {}),
+		};
+
+		const metaRows = (await collectionsItemsService.readByQuery(query)) as Pick<
+			BaseCollectionMeta,
+			'collection' | 'excluded'
+		>[];
+
+		return new Map(metaRows.map(({ collection, excluded }) => [collection, toBoolean(excluded)]));
+	}
+
+	private validateCollectionKeysAreUnique(collectionKeys: string[]): void {
+		if (new Set(collectionKeys).size !== collectionKeys.length) {
+			throw new InvalidPayloadError({ reason: 'Collection updates must not contain duplicate collection keys' });
 		}
 	}
 }

--- a/api/src/services/deployment-projects.test.ts
+++ b/api/src/services/deployment-projects.test.ts
@@ -61,6 +61,7 @@ describe('DeploymentProjectsService', () => {
 			});
 
 			tracker.on.select('directus_deployments').response([vercelConfig]);
+			tracker.on.select('directus_collections').response([]);
 		});
 
 		it('should skip validation when projectsToCreate is empty', async () => {

--- a/api/src/services/deployment.test.ts
+++ b/api/src/services/deployment.test.ts
@@ -12,6 +12,8 @@ const {
 	mockListProjects,
 	mockGetProject,
 	mockGetCacheValueWithTTL,
+	mockLocalSchemaCacheGet,
+	mockLocalSchemaCacheSet,
 	mockSetCacheValueWithExpiry,
 	mockLoggerDebug,
 	mockLoggerError,
@@ -20,6 +22,8 @@ const {
 	mockListProjects: vi.fn(),
 	mockGetProject: vi.fn(),
 	mockGetCacheValueWithTTL: vi.fn(),
+	mockLocalSchemaCacheGet: vi.fn(),
+	mockLocalSchemaCacheSet: vi.fn(),
 	mockSetCacheValueWithExpiry: vi.fn(),
 	mockLoggerDebug: vi.fn(),
 	mockLoggerError: vi.fn(),
@@ -34,7 +38,13 @@ vi.mock('../deployment.js', () => ({
 }));
 
 vi.mock('../cache.js', () => ({
-	getCache: vi.fn(() => ({ deploymentCache: {} })),
+	getCache: vi.fn(() => ({
+		deploymentCache: {},
+		localSchemaCache: {
+			get: mockLocalSchemaCacheGet,
+			set: mockLocalSchemaCacheSet,
+		},
+	})),
 	getCacheValueWithTTL: mockGetCacheValueWithTTL,
 	setCacheValueWithExpiry: mockSetCacheValueWithExpiry,
 }));
@@ -210,6 +220,8 @@ describe('DeploymentService', () => {
 			superUpdateOne = vi.spyOn(ItemsService.prototype, 'updateOne').mockResolvedValue(1);
 			vi.spyOn(ItemsService.prototype, 'readOne').mockResolvedValue(existingConfig);
 			mockTestConnection.mockResolvedValue(undefined);
+			mockLocalSchemaCacheGet.mockResolvedValue([]);
+			mockLocalSchemaCacheSet.mockResolvedValue(undefined);
 
 			// Mock DB query for readConfig (internal readByQuery)
 			tracker.on.select('directus_deployments').response([existingConfig]);

--- a/api/src/services/fields.test.ts
+++ b/api/src/services/fields.test.ts
@@ -237,6 +237,40 @@ describe('Integration Tests', () => {
 				expect(result.every((field) => field.collection === 'test_collection')).toBe(true);
 			});
 
+			test('should include fields for collections outside the runtime schema', async () => {
+				const mockColumns = [
+					{
+						table: 'excluded_collection',
+						name: 'id',
+						data_type: 'integer',
+						default_value: null,
+						is_nullable: false,
+					},
+					{
+						table: 'excluded_collection',
+						name: 'name',
+						data_type: 'varchar',
+						default_value: null,
+						is_nullable: true,
+					},
+				];
+
+				const service = new FieldsService({
+					knex: db,
+					schema,
+					accountability: { role: 'admin', admin: true } as Accountability,
+				});
+
+				service.schemaInspector.columnInfo = vi.fn().mockResolvedValue(mockColumns);
+
+				tracker.on.select('directus_fields').response([]);
+
+				const result = await service.readAll();
+
+				expect(result.some((field) => field.collection === 'excluded_collection' && field.field === 'id')).toBe(true);
+				expect(result.some((field) => field.collection === 'excluded_collection' && field.field === 'name')).toBe(true);
+			});
+
 			test('should throw ForbiddenError for non-admin users without access', async () => {
 				vi.mocked(fetchPermissions).mockResolvedValueOnce([]);
 

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -222,10 +222,10 @@ export class FieldsService {
 			return data;
 		}) as Field[];
 
-		const knownCollections = Object.keys(this.schema.collections);
+		const knownCollections = new Set(columns.map((column) => column.table));
 
 		let result = [...columnsWithSystem, ...aliasFieldsAsField].filter((field) =>
-			knownCollections.includes(field.collection),
+			knownCollections.has(field.collection),
 		);
 
 		// Filter the result so we only return the fields you have read access to

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -1,3 +1,4 @@
+import { ForbiddenError } from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import { UserIntegrityCheckFlag } from '@directus/types';
 import knex, { type Knex } from 'knex';
@@ -71,11 +72,14 @@ describe('Integration Tests', () => {
 			test('on readSingleton', async () => {
 				vi.mocked(handleVersion).mockReturnValueOnce(new Promise((resolve) => resolve([{ id: 1 }])));
 
-				vi.spyOn(db, 'select').mockReturnValueOnce({
-					from: () => ({
-						first: async () => ({ id: 1 }),
-					}),
-				} as any);
+				vi.spyOn(db, 'select').mockImplementationOnce(
+					() =>
+						({
+							from: () => ({
+								first: async () => ({ id: 1 }),
+							}),
+						}) as any,
+				);
 
 				await service.readSingleton({ version: 'test' });
 
@@ -102,6 +106,15 @@ describe('Integration Tests', () => {
 		});
 
 		describe('createOne', () => {
+			it('should throw ForbiddenError for collections that are not in the runtime schema', async () => {
+				const dbOnlyService = new ItemsService('db_only', {
+					knex: db,
+					schema,
+				});
+
+				await expect(dbOnlyService.createOne({})).rejects.toThrow(ForbiddenError);
+			});
+
 			it('should validate user count if requested', async () => {
 				await service.createOne({}, { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
 
@@ -156,6 +169,15 @@ describe('Integration Tests', () => {
 		});
 
 		describe('createMany', () => {
+			it('should throw ForbiddenError for collections that are not in the runtime schema', async () => {
+				const dbOnlyService = new ItemsService('db_only', {
+					knex: db,
+					schema,
+				});
+
+				await expect(dbOnlyService.createMany([{}])).rejects.toThrow(ForbiddenError);
+			});
+
 			it('should validate user count if requested', async () => {
 				await service.createMany([{}], { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
 
@@ -164,6 +186,15 @@ describe('Integration Tests', () => {
 		});
 
 		describe('updateBatch', () => {
+			it('should throw ForbiddenError for collections that are not in the runtime schema', async () => {
+				const dbOnlyService = new ItemsService('db_only', {
+					knex: db,
+					schema,
+				});
+
+				await expect(dbOnlyService.updateBatch([{ id: 1 }])).rejects.toThrow(ForbiddenError);
+			});
+
 			it('should validate user count if requested', async () => {
 				await service.updateBatch([{ id: 1 }], { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
 
@@ -172,6 +203,15 @@ describe('Integration Tests', () => {
 		});
 
 		describe('updateMany', () => {
+			it('should throw ForbiddenError for collections that are not in the runtime schema', async () => {
+				const dbOnlyService = new ItemsService('db_only', {
+					knex: db,
+					schema,
+				});
+
+				await expect(dbOnlyService.updateMany([1], {})).rejects.toThrow(ForbiddenError);
+			});
+
 			it('should validate user count if requested', async () => {
 				await service.updateMany([1], {}, { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
 
@@ -180,6 +220,15 @@ describe('Integration Tests', () => {
 		});
 
 		describe('deleteMany', () => {
+			it('should throw ForbiddenError for collections that are not in the runtime schema', async () => {
+				const dbOnlyService = new ItemsService('db_only', {
+					knex: db,
+					schema,
+				});
+
+				await expect(dbOnlyService.deleteMany([1])).rejects.toThrow(ForbiddenError);
+			});
+
 			it('should validate user count if requested', async () => {
 				await service.deleteMany([1], { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
 

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -28,6 +28,7 @@ import getDatabase, { getDatabaseClient } from '../database/index.js';
 import { runAst } from '../database/run-ast/run-ast.js';
 import emitter from '../emitter.js';
 import { processAst } from '../permissions/modules/process-ast/process-ast.js';
+import { createCollectionForbiddenError } from '../permissions/modules/process-ast/utils/validate-path/create-error.js';
 import { processPayload } from '../permissions/modules/process-payload/process-payload.js';
 import { validateAccess } from '../permissions/modules/validate-access/validate-access.js';
 import { shouldClearCache } from '../utils/should-clear-cache.js';
@@ -60,6 +61,16 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		this.nested = options.nested ?? [];
 
 		return this;
+	}
+
+	private async assertCollectionAvailable(): Promise<void> {
+		if (isSystemCollection(this.collection)) {
+			return;
+		}
+
+		if (!this.schema.collections[this.collection]) {
+			throw createCollectionForbiddenError('', this.collection);
+		}
 	}
 
 	/**
@@ -105,13 +116,16 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	}
 
 	async getKeysByQuery(query: Query): Promise<PrimaryKey[]> {
+		await this.assertCollectionAvailable();
+
 		const primaryKeyField = this.schema.collections[this.collection]!.primary;
 		const readQuery = cloneDeep(query);
 		readQuery.fields = [primaryKeyField];
 
 		// Allow unauthenticated access
-		const itemsService = new ItemsService(this.collection, {
+		const itemsService = this.fork({
 			knex: this.knex,
+			accountability: null,
 			schema: this.schema,
 		});
 
@@ -125,6 +139,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 * Create a single new item.
 	 */
 	async createOne(data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey> {
+		await this.assertCollectionAvailable();
+
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		if (!opts.bypassLimits) {
@@ -431,6 +447,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 * Uses `this.createOne` under the hood.
 	 */
 	async createMany(data: Partial<Item>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
+		await this.assertCollectionAvailable();
+
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		const { primaryKeys, nestedActionEvents } = await transaction(this.knex, async (knex) => {
@@ -497,6 +515,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 * Get items by query.
 	 */
 	async readByQuery(query: Query, opts?: QueryOptions): Promise<Item[]> {
+		await this.assertCollectionAvailable();
+
 		const updatedQuery =
 			opts?.emitEvents !== false
 				? await emitter.emitFilter(
@@ -585,6 +605,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 * Uses `this.readByQuery` under the hood.
 	 */
 	async readOne(key: PrimaryKey, query: Query = {}, opts?: QueryOptions): Promise<Item> {
+		await this.assertCollectionAvailable();
+
 		const primaryKeyField = this.schema.collections[this.collection]!.primary;
 		validateKeys(this.schema, this.collection, primaryKeyField, key);
 
@@ -612,6 +634,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 * Uses `this.readByQuery` under the hood.
 	 */
 	async readMany(keys: PrimaryKey[], query: Query = {}, opts?: QueryOptions): Promise<Item[]> {
+		await this.assertCollectionAvailable();
+
 		const primaryKeyField = this.schema.collections[this.collection]!.primary;
 		validateKeys(this.schema, this.collection, primaryKeyField, keys);
 
@@ -634,6 +658,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 * Uses `this.updateMany` under the hood.
 	 */
 	async updateByQuery(query: Query, data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]> {
+		await this.assertCollectionAvailable();
+
 		const keys = await this.getKeysByQuery(query);
 
 		return keys.length ? await this.updateMany(keys, data, opts) : [];
@@ -645,6 +671,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 * Uses `this.updateMany` under the hood.
 	 */
 	async updateOne(key: PrimaryKey, data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
+		await this.assertCollectionAvailable();
+
 		await this.updateMany([key], data, opts);
 		return key;
 	}
@@ -655,6 +683,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 * Uses `this.updateOne` under the hood.
 	 */
 	async updateBatch(data: Partial<Item>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
+		await this.assertCollectionAvailable();
+
 		if (!Array.isArray(data)) {
 			throw new InvalidPayloadError({ reason: 'Input should be an array of items' });
 		}
@@ -707,6 +737,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 * Update many items by primary key, setting all items to the same change.
 	 */
 	async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey[]> {
+		await this.assertCollectionAvailable();
+
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		if (!opts.bypassLimits) {
@@ -979,6 +1011,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 * Uses `this.createOne` / `this.updateOne` under the hood.
 	 */
 	async upsertOne(payload: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
+		await this.assertCollectionAvailable();
+
 		const primaryKeyField = this.schema.collections[this.collection]!.primary;
 		const primaryKey: PrimaryKey | undefined = payload[primaryKeyField];
 
@@ -1008,6 +1042,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 * Uses `this.upsertOne` under the hood.
 	 */
 	async upsertMany(payloads: Partial<Item>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
+		await this.assertCollectionAvailable();
+
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		const primaryKeys = await transaction(this.knex, async (knex) => {
@@ -1043,6 +1079,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 * Uses `this.deleteMany` under the hood.
 	 */
 	async deleteByQuery(query: Query, opts?: MutationOptions): Promise<PrimaryKey[]> {
+		await this.assertCollectionAvailable();
+
 		const keys = await this.getKeysByQuery(query);
 
 		const primaryKeyField = this.schema.collections[this.collection]!.primary;
@@ -1057,6 +1095,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 * Uses `this.deleteMany` under the hood.
 	 */
 	async deleteOne(key: PrimaryKey, opts?: MutationOptions): Promise<PrimaryKey> {
+		await this.assertCollectionAvailable();
+
 		const primaryKeyField = this.schema.collections[this.collection]!.primary;
 		validateKeys(this.schema, this.collection, primaryKeyField, key);
 
@@ -1068,6 +1108,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 * Delete multiple items by primary key.
 	 */
 	async deleteMany(keys: PrimaryKey[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
+		await this.assertCollectionAvailable();
+
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		if (!opts.bypassLimits) {
@@ -1188,6 +1230,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 * Read/treat collection as singleton.
 	 */
 	async readSingleton(query: Query, opts?: QueryOptions): Promise<Partial<Item>> {
+		await this.assertCollectionAvailable();
+
 		query = clone(query);
 
 		query.limit = 1;
@@ -1236,6 +1280,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 * Uses `this.createOne` / `this.updateOne` under the hood.
 	 */
 	async upsertSingleton(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
+		await this.assertCollectionAvailable();
+
 		const primaryKeyField = this.schema.collections[this.collection]!.primary;
 
 		const record = await this.knex.select(primaryKeyField).from(this.collection).limit(1).first();

--- a/api/src/services/payload.test.ts
+++ b/api/src/services/payload.test.ts
@@ -655,6 +655,130 @@ describe('Integration Tests', () => {
 			});
 		});
 
+		describe('processM2O', () => {
+			test('rejects nested writes that target excluded collections', async () => {
+				const schema = new SchemaBuilder()
+					.collection('articles', (c) => {
+						c.field('id').id();
+						c.field('author').m2o('users');
+					})
+					.collection('users', (c) => {
+						c.field('id').id();
+						c.field('name').string();
+					})
+					.build();
+
+				const schemaWithExcludedRelation = {
+					...schema,
+					collections: {
+						articles: schema.collections['articles']!,
+					},
+				};
+
+				const service = new PayloadService('articles', {
+					knex: db,
+					schema: schemaWithExcludedRelation as typeof schema,
+				});
+
+				await expect(
+					service.processM2O({
+						author: {
+							id: 1,
+							name: 'Excluded User',
+						},
+					}),
+				).rejects.toThrow(/don't have permission|does not exist/i);
+			});
+		});
+
+		describe('processA2O', () => {
+			test('rejects nested writes that target excluded collections', async () => {
+				const schemaWithExcludedRelation = {
+					collections: {
+						articles: {
+							collection: 'articles',
+							primary: 'id',
+							fields: {},
+						},
+					},
+					relations: [
+						{
+							collection: 'articles',
+							field: 'blocks',
+							related_collection: null,
+							meta: {
+								one_collection_field: 'collection',
+								one_allowed_collections: ['users'],
+							},
+						},
+					],
+				} as any;
+
+				const service = new PayloadService('articles', {
+					knex: db,
+					schema: schemaWithExcludedRelation,
+				});
+
+				await expect(
+					service.processA2O({
+						collection: 'users',
+						blocks: {
+							id: 1,
+							name: 'Excluded User',
+						},
+					}),
+				).rejects.toThrow(/don't have permission|does not exist/i);
+			});
+		});
+
+		describe('processO2M', () => {
+			test('rejects nested writes that target excluded collections', async () => {
+				const schema = new SchemaBuilder()
+					.collection('authors', (c) => {
+						c.field('id').id();
+						c.field('articles').o2m('articles', 'author');
+					})
+					.collection('articles', (c) => {
+						c.field('id').id();
+						c.field('title').string();
+						c.field('author').m2o('authors');
+					})
+					.build();
+
+				const articlesRelation = schema.relations.find(
+					(relation) => relation.collection === 'articles' && relation.related_collection === 'authors',
+				);
+
+				const oneField = articlesRelation?.meta?.one_field;
+
+				const schemaWithExcludedRelation = {
+					...schema,
+					collections: {
+						authors: schema.collections['authors']!,
+					},
+				};
+
+				const service = new PayloadService('authors', {
+					knex: db,
+					schema: schemaWithExcludedRelation as typeof schema,
+				});
+
+				await expect(
+					service.processO2M(
+						{
+							[oneField!]: [
+								{
+									id: 1,
+									title: 'Excluded Article',
+								},
+							],
+						},
+						1,
+					),
+				).rejects.toThrow(/don't have permission|does not exist/i);
+			});
+		});
+
 		describe('processJsonFunctionResults', () => {
 			let service: PayloadService;
 

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -27,6 +27,7 @@ import type { Helpers } from '../database/helpers/index.js';
 import { getFunctions, getHelpers } from '../database/helpers/index.js';
 import getDatabase from '../database/index.js';
 import { useLogger } from '../logger/index.js';
+import { createCollectionForbiddenError } from '../permissions/modules/process-ast/utils/validate-path/create-error.js';
 import { decrypt, encrypt } from '../utils/encrypt.js';
 import { generateHash } from '../utils/generate-hash.js';
 import { getSecret } from '../utils/get-secret.js';
@@ -600,7 +601,13 @@ export class PayloadService {
 				nested: [...this.nested, relation.field],
 			});
 
-			const relatedPrimaryKeyField = this.schema.collections[relatedCollection]!.primary;
+			const relatedCollectionSchema = this.schema.collections[relatedCollection];
+
+			if (!relatedCollectionSchema) {
+				throw createCollectionForbiddenError(relation.field, relatedCollection);
+			}
+
+			const relatedPrimaryKeyField = relatedCollectionSchema.primary;
 			const relatedRecord: Partial<Item> = payload[relation.field];
 
 			if (['string', 'number'].includes(typeof relatedRecord)) continue;
@@ -690,7 +697,14 @@ export class PayloadService {
 		for (const relation of relationsToProcess) {
 			// If no "one collection" exists, this is a A2O, not a M2O
 			if (!relation.related_collection) continue;
-			const relatedPrimaryKeyField = this.schema.collections[relation.related_collection]!.primary;
+
+			const relatedCollectionSchema = this.schema.collections[relation.related_collection];
+
+			if (!relatedCollectionSchema) {
+				throw createCollectionForbiddenError(relation.field, relation.related_collection);
+			}
+
+			const relatedPrimaryKeyField = relatedCollectionSchema.primary;
 
 			const { getService } = await import('../utils/get-service.js');
 
@@ -793,7 +807,13 @@ export class PayloadService {
 			if (!relation.meta) continue;
 
 			const currentPrimaryKeyField = this.schema.collections[relation.related_collection!]!.primary;
-			const relatedPrimaryKeyField = this.schema.collections[relation.collection]!.primary;
+			const relatedCollectionSchema = this.schema.collections[relation.collection];
+
+			if (!relatedCollectionSchema) {
+				throw createCollectionForbiddenError(relation.meta.one_field ?? relation.field, relation.collection);
+			}
+
+			const relatedPrimaryKeyField = relatedCollectionSchema.primary;
 
 			const { getService } = await import('../utils/get-service.js');
 

--- a/api/src/utils/get-excluded-collections.ts
+++ b/api/src/utils/get-excluded-collections.ts
@@ -1,0 +1,49 @@
+import { isSystemCollection } from '@directus/system-data';
+import type { Knex } from 'knex';
+import { getCache, getSystemCache, setSystemCache } from '../cache.js';
+
+const EXCLUDED_COLLECTIONS_CACHE_KEY = 'excluded-collections';
+
+type ExcludedCollectionsCacheValue = {
+	collections: string[];
+};
+
+function isExcludedCollectionsCacheValue(value: unknown): value is ExcludedCollectionsCacheValue {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'collections' in value &&
+		Array.isArray(value.collections) &&
+		value.collections.every((collection) => typeof collection === 'string')
+	);
+}
+
+export async function getExcludedCollections(knex: Knex): Promise<Set<string>> {
+	const { localSchemaCache } = getCache();
+
+	const localCollections = await localSchemaCache.get(EXCLUDED_COLLECTIONS_CACHE_KEY);
+
+	if (Array.isArray(localCollections) && localCollections.every((collection) => typeof collection === 'string')) {
+		return new Set(localCollections);
+	}
+
+	const cachedValue = await getSystemCache(EXCLUDED_COLLECTIONS_CACHE_KEY);
+
+	if (isExcludedCollectionsCacheValue(cachedValue)) {
+		await localSchemaCache.set(EXCLUDED_COLLECTIONS_CACHE_KEY, cachedValue.collections);
+		return new Set(cachedValue.collections);
+	}
+
+	const rows = (await knex.select('collection').from('directus_collections').where('excluded', true)) as {
+		collection: string;
+	}[];
+
+	const collections = rows.map((row) => row.collection).filter((collection) => !isSystemCollection(collection));
+
+	await Promise.all([
+		localSchemaCache.set(EXCLUDED_COLLECTIONS_CACHE_KEY, collections),
+		setSystemCache(EXCLUDED_COLLECTIONS_CACHE_KEY, { collections }),
+	]);
+
+	return new Set(collections);
+}

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -1,7 +1,7 @@
 import { useEnv } from '@directus/env';
 import type { SchemaInspector } from '@directus/schema';
 import { createInspector } from '@directus/schema';
-import { systemCollectionRows } from '@directus/system-data';
+import { isSystemCollection, systemCollectionRows } from '@directus/system-data';
 import type { Filter, SchemaOverview } from '@directus/types';
 import { parseJSON, toArray, toBoolean } from '@directus/utils';
 import type { Knex } from 'knex';
@@ -127,7 +127,7 @@ async function getDatabaseSchema(database: Knex, schemaInspector: SchemaInspecto
 
 	const collections = [
 		...(await database
-			.select('collection', 'singleton', 'note', 'sort_field', 'accountability')
+			.select('collection', 'singleton', 'excluded', 'note', 'sort_field', 'accountability')
 			.from('directus_collections')),
 		...systemCollectionRows,
 	];
@@ -149,6 +149,16 @@ async function getDatabaseSchema(database: Knex, schemaInspector: SchemaInspecto
 		}
 
 		const collectionMeta = collections.find((collectionMeta) => collectionMeta.collection === collection);
+
+		if (!isSystemCollection(collection)) {
+			if (!collectionMeta) {
+				logger.trace(`Collection "${collection}" is not configured in Directus and will be ignored`);
+				continue;
+			} else if (toBoolean(collectionMeta?.excluded)) {
+				logger.trace(`Collection "${collection}" is marked as excluded and will be ignored`);
+				continue;
+			}
+		}
 
 		result.collections[collection] = {
 			collection,

--- a/app/src/composables/use-relation-m2a.ts
+++ b/app/src/composables/use-relation-m2a.ts
@@ -1,9 +1,11 @@
+import { isSystemCollection } from '@directus/system-data';
 import { Field, Relation } from '@directus/types';
 import { computed, Ref } from 'vue';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
 import { Collection } from '@/types/collections';
+import { isExcludedCollection } from '@/utils/is-excluded-collection';
 
 export type RelationM2A = {
 	allowedCollections: Collection[];
@@ -57,32 +59,53 @@ export function useRelationM2A(collection: Ref<string>, field: Ref<string>) {
 		);
 
 		if (!relation) return undefined;
+		const relationPrimaryKeyFields = {} as Record<string, Field>;
+		const allowedCollections = [] as Collection[];
 
-		const allowedCollections = (relation.meta?.one_allowed_collections ?? []).reduce((acc, collection) => {
+		for (const collection of relation.meta?.one_allowed_collections ?? []) {
 			const collectionInfo = collectionsStore.getCollection(collection);
-			if (collectionInfo) acc.push(collectionInfo);
-			return acc;
-		}, [] as Collection[]);
 
-		const relationPrimaryKeyFields = allowedCollections.reduce(
-			(acc, collection) => {
-				const pkField = fieldsStore.getPrimaryKeyFieldForCollection(collection?.collection);
-				if (pkField) acc[collection.collection] = pkField;
-				return acc;
-			},
-			{} as Record<string, Field>,
-		);
+			if (
+				!collectionInfo ||
+				(!isSystemCollection(collectionInfo.collection) &&
+					(!collectionInfo.meta || isExcludedCollection(collectionInfo)))
+			) {
+				return undefined;
+			}
+
+			const primaryKeyField = fieldsStore.getPrimaryKeyFieldForCollection(collectionInfo.collection);
+			if (!primaryKeyField) return undefined;
+
+			relationPrimaryKeyFields[collectionInfo.collection] = primaryKeyField;
+			allowedCollections.push(collectionInfo);
+		}
+
+		const collectionField = fieldsStore.getField(junction.collection, relation.meta?.one_collection_field as string);
+		const junctionCollection = collectionsStore.getCollection(junction.collection);
+		const junctionPrimaryKeyField = fieldsStore.getPrimaryKeyFieldForCollection(junction.collection);
+		const junctionField = fieldsStore.getField(junction.collection, junction.meta?.junction_field as string);
+		const reverseJunctionField = fieldsStore.getField(junction.collection, relation.meta?.junction_field as string);
+
+		if (
+			!collectionField ||
+			!junctionCollection ||
+			!junctionPrimaryKeyField ||
+			!junctionField ||
+			!reverseJunctionField
+		) {
+			return undefined;
+		}
 
 		return {
 			allowedCollections,
 			relationPrimaryKeyFields,
-			collectionField: fieldsStore.getField(junction.collection, relation.meta?.one_collection_field as string),
-			junctionCollection: collectionsStore.getCollection(junction.collection),
-			junctionPrimaryKeyField: fieldsStore.getPrimaryKeyFieldForCollection(junction.collection),
-			junctionField: fieldsStore.getField(junction.collection, junction.meta?.junction_field as string),
-			reverseJunctionField: fieldsStore.getField(junction.collection, relation.meta?.junction_field as string),
-			junction: junction,
-			relation: relation,
+			collectionField,
+			junctionCollection,
+			junctionPrimaryKeyField,
+			junctionField,
+			reverseJunctionField,
+			junction,
+			relation,
 			sortField: junction.meta?.sort_field ?? undefined,
 			type: 'm2a',
 		} as RelationM2A;

--- a/app/src/composables/use-relation-m2m.ts
+++ b/app/src/composables/use-relation-m2m.ts
@@ -50,16 +50,33 @@ export function useRelationM2M(collection: Ref<string>, field: Ref<string>) {
 		);
 
 		if (!relation) return undefined;
+		const relatedCollection = collectionsStore.getCollection(relation.related_collection as string);
+		const relatedPrimaryKeyField = fieldsStore.getPrimaryKeyFieldForCollection(relation.related_collection as string);
+		const junctionCollection = collectionsStore.getCollection(junction.collection);
+		const junctionPrimaryKeyField = fieldsStore.getPrimaryKeyFieldForCollection(junction.collection);
+		const junctionField = fieldsStore.getField(junction.collection, junction.meta?.junction_field as string);
+		const reverseJunctionField = fieldsStore.getField(junction.collection, relation.meta?.junction_field as string);
+
+		if (
+			!relatedCollection ||
+			!relatedPrimaryKeyField ||
+			!junctionCollection ||
+			!junctionPrimaryKeyField ||
+			!junctionField ||
+			!reverseJunctionField
+		) {
+			return undefined;
+		}
 
 		return {
 			relation: relation,
-			relatedCollection: collectionsStore.getCollection(relation.related_collection as string),
-			relatedPrimaryKeyField: fieldsStore.getPrimaryKeyFieldForCollection(relation.related_collection as string),
+			relatedCollection,
+			relatedPrimaryKeyField,
 			sortField: junction.meta?.sort_field ?? undefined,
-			junctionCollection: collectionsStore.getCollection(junction.collection),
-			junctionPrimaryKeyField: fieldsStore.getPrimaryKeyFieldForCollection(junction.collection),
-			junctionField: fieldsStore.getField(junction.collection, junction.meta?.junction_field as string),
-			reverseJunctionField: fieldsStore.getField(junction.collection, relation.meta?.junction_field as string),
+			junctionCollection,
+			junctionPrimaryKeyField,
+			junctionField,
+			reverseJunctionField,
 			junction: junction,
 			type: 'm2m',
 		} as RelationM2M;

--- a/app/src/composables/use-relation-m2o.ts
+++ b/app/src/composables/use-relation-m2o.ts
@@ -31,11 +31,15 @@ export function useRelationM2O(collection: Ref<string>, field: Ref<string>) {
 		if (relations.length === 0) return undefined;
 
 		const relation = relations[0] as Relation;
+		const relatedCollection = collectionsStore.getCollection(relation.related_collection);
+		const relatedPrimaryKeyField = fieldsStore.getPrimaryKeyFieldForCollection(relation.related_collection);
+
+		if (!relatedCollection || !relatedPrimaryKeyField) return undefined;
 
 		return {
 			relation,
-			relatedCollection: collectionsStore.getCollection(relation.related_collection),
-			relatedPrimaryKeyField: fieldsStore.getPrimaryKeyFieldForCollection(relation.related_collection),
+			relatedCollection,
+			relatedPrimaryKeyField,
 			type: 'm2o',
 		} as RelationM2O;
 	});

--- a/app/src/composables/use-relation-o2m.ts
+++ b/app/src/composables/use-relation-o2m.ts
@@ -34,12 +34,17 @@ export function useRelationO2M(collection: Ref<string>, field: Ref<string>) {
 		if (relations.length !== 1) return undefined;
 
 		const relation = relations[0] as Relation;
+		const relatedCollection = collectionsStore.getCollection(relation.collection);
+		const relatedPrimaryKeyField = fieldsStore.getPrimaryKeyFieldForCollection(relation.collection);
+		const reverseJunctionField = fieldsStore.getField(relation.collection, relation.meta?.many_field);
+
+		if (!relatedCollection || !relatedPrimaryKeyField || !reverseJunctionField) return undefined;
 
 		return {
 			relation,
-			relatedCollection: collectionsStore.getCollection(relation.collection),
-			relatedPrimaryKeyField: fieldsStore.getPrimaryKeyFieldForCollection(relation.collection),
-			reverseJunctionField: fieldsStore.getField(relation.collection, relation.meta?.many_field),
+			relatedCollection,
+			relatedPrimaryKeyField,
+			reverseJunctionField,
 			sortField: relation.meta?.sort_field ?? undefined,
 			type: 'o2m',
 		} as RelationO2M;

--- a/app/src/composables/use-relation-single.ts
+++ b/app/src/composables/use-relation-single.ts
@@ -1,3 +1,4 @@
+import { isSystemCollection } from '@directus/system-data';
 import { getEndpoint } from '@directus/utils';
 import { merge } from 'lodash';
 import { computed, MaybeRefOrGetter, ref, Ref, toValue, watch } from 'vue';
@@ -27,6 +28,18 @@ export function useRelationSingle<T extends Record<string, any>>(
 	watch(
 		[value, previewQuery, relation, enabled],
 		() => {
+			const relationCollection = relation.value?.relatedCollection;
+
+			const isInactiveRelationCollection =
+				relationCollection &&
+				!isSystemCollection(relationCollection.collection) &&
+				(!relationCollection.meta || relationCollection.meta.excluded === true);
+
+			if (isInactiveRelationCollection) {
+				displayItem.value = null;
+				return;
+			}
+
 			if (enabled.value) getDisplayItem();
 		},
 		{ immediate: true },

--- a/app/src/interfaces/_system/system-permissions/add-collection/use-collections.test.ts
+++ b/app/src/interfaces/_system/system-permissions/add-collection/use-collections.test.ts
@@ -69,6 +69,19 @@ describe('useCollections', () => {
 			expect(products?.disabled).toBe(true);
 			expect(categories?.disabled).toBe(false);
 		});
+
+		it('omits collections that are license-excluded', () => {
+			const collectionsStore = useCollectionsStore();
+
+			collectionsStore.collections = [
+				makeCollection('articles'),
+				{ ...makeCollection('products'), meta: { excluded: true } },
+			];
+
+			const { availableCollections } = useCollections({ excludeCollections: [] });
+
+			expect(availableCollections.value.map((c) => c.collection)).toEqual(['articles']);
+		});
 	});
 
 	describe('systemCollections', () => {

--- a/app/src/interfaces/_system/system-permissions/add-collection/use-collections.ts
+++ b/app/src/interfaces/_system/system-permissions/add-collection/use-collections.ts
@@ -4,6 +4,7 @@ import type { MaybeRefOrGetter } from 'vue';
 import { computed, toValue } from 'vue';
 import { useCollectionsStore } from '@/stores/collections';
 import { Collection } from '@/types/collections';
+import { isExcludedCollection } from '@/utils/is-excluded-collection';
 
 export interface UseCollectionsOptions {
 	excludeCollections: MaybeRefOrGetter<string[]>;
@@ -14,7 +15,9 @@ export const useCollections = (options: UseCollectionsOptions) => {
 
 	const availableCollections = computed(() => {
 		return orderBy(
-			collectionsStore.databaseCollections.filter((collection) => collection.meta).map(disableSelectedCollection),
+			collectionsStore.databaseCollections
+				.filter((collection) => collection.meta && !isExcludedCollection(collection))
+				.map(disableSelectedCollection),
 			['collection'],
 		);
 	});

--- a/app/src/interfaces/list-m2m/list-m2m.test.ts
+++ b/app/src/interfaces/list-m2m/list-m2m.test.ts
@@ -9,35 +9,11 @@ import { i18n } from '@/lang';
 import { Collection } from '@/types/collections';
 import { LAYOUTS } from '@/types/interfaces';
 
+const relationInfo = vi.hoisted(() => ({ value: null as any }));
+
 vi.mock('@/composables/use-relation-m2m', () => ({
 	useRelationM2M: () => ({
-		relationInfo: computed(() => ({
-			relation: {
-				collection: 'junction-collection',
-				field: 'related_id',
-				related_collection: 'related-collection',
-				schema: null,
-				meta: null,
-			} as Relation,
-			relatedCollection: {
-				collection: 'related-collection',
-			} as Collection,
-			relatedPrimaryKeyField: { field: 'id' } as Field,
-			junctionCollection: {
-				collection: 'junction-collection',
-			} as Collection,
-			junctionPrimaryKeyField: { field: 'id' } as Field,
-			junctionField: { field: 'related_id' } as Field,
-			reverseJunctionField: { field: 'item_id' } as Field,
-			junction: {
-				collection: 'junction-collection',
-				field: 'item_id',
-				related_collection: 'test-collection',
-				schema: null,
-				meta: null,
-			} as Relation,
-			type: 'm2m',
-		})),
+		relationInfo: computed(() => relationInfo.value),
 	}),
 }));
 
@@ -96,13 +72,49 @@ afterEach(() => {
 	vi.clearAllMocks();
 });
 
+beforeEach(() => {
+	relationInfo.value = {
+		relation: {
+			collection: 'junction-collection',
+			field: 'related_id',
+			related_collection: 'related-collection',
+			schema: null,
+			meta: null,
+		} as Relation,
+		relatedCollection: {
+			collection: 'related-collection',
+			meta: {
+				excluded: false,
+			},
+		} as Collection,
+		relatedPrimaryKeyField: { field: 'id' } as Field,
+		junctionCollection: {
+			collection: 'junction-collection',
+			meta: null,
+		} as Collection,
+		junctionPrimaryKeyField: { field: 'id' } as Field,
+		junctionField: { field: 'related_id' } as Field,
+		reverseJunctionField: { field: 'item_id' } as Field,
+		junction: {
+			collection: 'junction-collection',
+			field: 'item_id',
+			related_collection: 'test-collection',
+			schema: null,
+			meta: null,
+		} as Relation,
+		type: 'm2m',
+	};
+});
+
 const global: GlobalMountOptions = {
 	stubs: {
 		VIcon: true,
 		VListItem: {
 			template: '<div class="v-list-item"><slot /></div>',
 		},
-		VNotice: true,
+		VNotice: {
+			template: '<div class="v-notice"><slot /></div>',
+		},
 		VRemove: true,
 		VSkeletonLoader: true,
 		VButton: true,
@@ -186,6 +198,23 @@ describe('list-m2m', () => {
 		});
 
 		expect(wrapper.exists()).toBe(true);
+	});
+
+	it('should show inactive related collection warning when related collection is unavailable at runtime', () => {
+		relationInfo.value = {
+			...relationInfo.value,
+			relatedCollection: {
+				collection: 'related-collection',
+				meta: null,
+			} as Collection,
+		};
+
+		const wrapper = mount(ListM2M, {
+			props: listProps,
+			global,
+		});
+
+		expect(wrapper.text()).toContain('No active related collection is available.');
 	});
 
 	describe('list layout', () => {

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { isSystemCollection } from '@directus/system-data';
 import type { ContentVersion, Filter } from '@directus/types';
 import { deepMap, getFieldsFromTemplate } from '@directus/utils';
 import { clamp, get, isEmpty, isNil, merge, set } from 'lodash';
@@ -27,6 +28,7 @@ import { addRelatedPrimaryKeyToFields } from '@/utils/add-related-primary-key-to
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
 import { formatItemsCountPaginated } from '@/utils/format-items-count';
 import { getItemRoute } from '@/utils/get-route';
+import { isExcludedCollection } from '@/utils/is-excluded-collection';
 import { parseFilter } from '@/utils/parse-filter';
 import DrawerBatch from '@/views/private/components/drawer-batch.vue';
 import DrawerCollection from '@/views/private/components/drawer-collection.vue';
@@ -82,6 +84,21 @@ const { t, n } = useI18n();
 const { collection, field, primaryKey, version } = toRefs(props);
 const { relationInfo } = useRelationM2M(collection, field);
 const fieldsStore = useFieldsStore();
+
+const hasInactiveRelatedCollection = computed(() => {
+	const relatedCollection = relationInfo.value?.relatedCollection;
+
+	return (
+		!!relatedCollection &&
+		!isSystemCollection(relatedCollection.collection) &&
+		(!relatedCollection.meta || isExcludedCollection(relatedCollection))
+	);
+});
+
+const activeRelationInfo = computed(() => {
+	if (hasInactiveRelatedCollection.value) return undefined;
+	return relationInfo.value;
+});
 
 const value = computed({
 	get: () => props.value,
@@ -192,9 +209,9 @@ const {
 	isItemSelected,
 	isLocalItem,
 	getItemEdits,
-} = useRelationMultiple(value, query, relationInfo, primaryKey, version);
+} = useRelationMultiple(value, query, activeRelationInfo, primaryKey, version);
 
-const { createAllowed, updateAllowed, deleteAllowed, selectAllowed } = useRelationPermissionsM2M(relationInfo);
+const { createAllowed, updateAllowed, deleteAllowed, selectAllowed } = useRelationPermissionsM2M(activeRelationInfo);
 
 const pageCount = computed(() => Math.ceil(totalItemCount.value / limit.value));
 
@@ -488,6 +505,9 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 <template>
 	<VNotice v-if="!relationInfo" type="warning">
 		{{ $t('relationship_not_setup') }}
+	</VNotice>
+	<VNotice v-else-if="hasInactiveRelatedCollection" type="warning">
+		{{ $t('no_active_related_collection') }}
 	</VNotice>
 	<VNotice v-else-if="relationInfo.relatedCollection.meta?.singleton" type="warning">
 		{{ $t('no_singleton_relations') }}

--- a/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
+++ b/app/src/interfaces/list-o2m-tree-view/list-o2m-tree-view.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { isSystemCollection } from '@directus/system-data';
 import type { ContentVersion, Filter } from '@directus/types';
 import { deepMap, getFieldsFromTemplate } from '@directus/utils';
 import { render } from 'micromustache';
@@ -9,6 +10,7 @@ import { ChangesItem } from '@/composables/use-relation-multiple';
 import { useRelationO2M } from '@/composables/use-relation-o2m';
 import { addRelatedPrimaryKeyToFields } from '@/utils/add-related-primary-key-to-fields';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
+import { isExcludedCollection } from '@/utils/is-excluded-collection';
 import { parseFilter } from '@/utils/parse-filter';
 
 const props = withDefaults(
@@ -95,6 +97,16 @@ function map<T>(item: ChangesItem | undefined, fn: (v: Record<string, any> | str
 
 const { relationInfo } = useRelationO2M(collection, field);
 
+const hasInactiveRelatedCollection = computed(() => {
+	const relatedCollection = relationInfo.value?.relatedCollection;
+
+	return (
+		!!relatedCollection &&
+		!isSystemCollection(relatedCollection.collection) &&
+		(!relatedCollection.meta || isExcludedCollection(relatedCollection))
+	);
+});
+
 const template = computed(() => {
 	return (
 		props.displayTemplate ||
@@ -123,6 +135,9 @@ const menuActive = computed(() => addNewOpen.value || selectOpen.value);
 <template>
 	<VNotice v-if="!relationInfo || collection !== relationInfo?.relatedCollection.collection" type="warning">
 		{{ $t('interfaces.list-o2m-tree-view.recursive_only') }}
+	</VNotice>
+	<VNotice v-else-if="hasInactiveRelatedCollection" type="warning">
+		{{ $t('no_active_related_collection') }}
 	</VNotice>
 	<VNotice v-else-if="relationInfo.relatedCollection.meta?.singleton" type="warning">
 		{{ $t('no_singleton_relations') }}

--- a/app/src/interfaces/list-o2m/list-o2m.test.ts
+++ b/app/src/interfaces/list-o2m/list-o2m.test.ts
@@ -9,23 +9,11 @@ import { i18n } from '@/lang';
 import { Collection } from '@/types/collections';
 import { LAYOUTS } from '@/types/interfaces';
 
+const relationInfo = vi.hoisted(() => ({ value: null as any }));
+
 vi.mock('@/composables/use-relation-o2m', () => ({
 	useRelationO2M: () => ({
-		relationInfo: computed(() => ({
-			relation: {
-				collection: 'related-collection',
-				field: 'parent_id',
-				related_collection: 'test-collection',
-				schema: null,
-				meta: null,
-			} as Relation,
-			relatedCollection: {
-				collection: 'related-collection',
-			} as Collection,
-			relatedPrimaryKeyField: { field: 'id' } as Field,
-			reverseJunctionField: { field: 'parent_id' } as Field,
-			type: 'o2m',
-		})),
+		relationInfo: computed(() => relationInfo.value),
 	}),
 }));
 
@@ -83,13 +71,36 @@ afterEach(() => {
 	vi.clearAllMocks();
 });
 
+beforeEach(() => {
+	relationInfo.value = {
+		relation: {
+			collection: 'related-collection',
+			field: 'parent_id',
+			related_collection: 'test-collection',
+			schema: null,
+			meta: null,
+		} as Relation,
+		relatedCollection: {
+			collection: 'related-collection',
+			meta: {
+				excluded: false,
+			},
+		} as Collection,
+		relatedPrimaryKeyField: { field: 'id' } as Field,
+		reverseJunctionField: { field: 'parent_id' } as Field,
+		type: 'o2m',
+	};
+});
+
 const global: GlobalMountOptions = {
 	stubs: {
 		VIcon: true,
 		VListItem: {
 			template: '<div class="v-list-item"><slot /></div>',
 		},
-		VNotice: true,
+		VNotice: {
+			template: '<div class="v-notice"><slot /></div>',
+		},
 		VRemove: true,
 		VSkeletonLoader: true,
 		VButton: true,
@@ -173,6 +184,23 @@ describe('list-o2m', () => {
 		});
 
 		expect(wrapper.exists()).toBe(true);
+	});
+
+	it('should show inactive related collection warning when related collection is unavailable at runtime', () => {
+		relationInfo.value = {
+			...relationInfo.value,
+			relatedCollection: {
+				collection: 'related-collection',
+				meta: null,
+			} as Collection,
+		};
+
+		const wrapper = mount(ListO2M, {
+			props: listProps,
+			global,
+		});
+
+		expect(wrapper.text()).toContain('No active related collection is available.');
 	});
 
 	describe('list layout', () => {

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { isSystemCollection } from '@directus/system-data';
 import type { ContentVersion, Filter } from '@directus/types';
 import { deepMap, getFieldsFromTemplate } from '@directus/utils';
 import { clamp, get, isEmpty, isNil } from 'lodash';
@@ -27,6 +28,7 @@ import { addRelatedPrimaryKeyToFields } from '@/utils/add-related-primary-key-to
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
 import { formatItemsCountPaginated } from '@/utils/format-items-count';
 import { getItemRoute } from '@/utils/get-route';
+import { isExcludedCollection } from '@/utils/is-excluded-collection';
 import { parseFilter } from '@/utils/parse-filter';
 import DrawerBatch from '@/views/private/components/drawer-batch.vue';
 import DrawerCollection from '@/views/private/components/drawer-collection.vue';
@@ -79,6 +81,21 @@ const { t, n } = useI18n();
 const { collection, field, primaryKey, version } = toRefs(props);
 const { relationInfo } = useRelationO2M(collection, field);
 const fieldsStore = useFieldsStore();
+
+const hasInactiveRelatedCollection = computed(() => {
+	const relatedCollection = relationInfo.value?.relatedCollection;
+
+	return (
+		!!relatedCollection &&
+		!isSystemCollection(relatedCollection.collection) &&
+		(!relatedCollection.meta || isExcludedCollection(relatedCollection))
+	);
+});
+
+const activeRelationInfo = computed(() => {
+	if (hasInactiveRelatedCollection.value) return undefined;
+	return relationInfo.value;
+});
 
 const { getWidth, updateWidths } = useColumnWidths(
 	() => `directus-o2m-column-widths-${collection.value}-${field.value}`,
@@ -167,9 +184,9 @@ const {
 	isItemSelected,
 	isLocalItem,
 	getItemEdits,
-} = useRelationMultiple(value, query, relationInfo, primaryKey, version);
+} = useRelationMultiple(value, query, activeRelationInfo, primaryKey, version);
 
-const { createAllowed, deleteAllowed, updateAllowed } = useRelationPermissionsO2M(relationInfo);
+const { createAllowed, deleteAllowed, updateAllowed } = useRelationPermissionsO2M(activeRelationInfo);
 
 const pageCount = computed(() => Math.ceil(totalItemCount.value / limit.value));
 
@@ -451,6 +468,9 @@ const menuActive = computed(() => Boolean(currentlyEditing.value) || selectModal
 <template>
 	<VNotice v-if="!relationInfo" type="warning">
 		{{ $t('relationship_not_setup') }}
+	</VNotice>
+	<VNotice v-else-if="hasInactiveRelatedCollection" type="warning">
+		{{ $t('no_active_related_collection') }}
 	</VNotice>
 	<VNotice v-else-if="relationInfo.relatedCollection.meta?.singleton" type="warning">
 		{{ $t('no_singleton_relations') }}

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -791,6 +791,7 @@ no_collections_copy_admin: You don’t have any Collections yet. Click the butto
 no_collections_copy: You don’t have any Collections yet. Please contact your system administrator.
 relationship_not_setup: The relationship is not configured properly or you don't have permission to access it
 no_singleton_relations: Relationships to Singletons are not supported
+no_active_related_collection: No active related collection is available.
 display_template_not_setup: The display template option is misconfigured
 collection_field_not_setup: The collection field option is misconfigured
 select_a_collection: Select a Collection
@@ -928,6 +929,9 @@ all_users: All Users
 delete_collection: Delete Collection
 update_collection_success: Updated Collection
 delete_collection_success: Deleted Collection
+exclude_collection: Exclude Collection
+excluded_click_to_include: 'Excluded: Click to Include'
+include_collection: Include Collection
 make_collection_visible: Make Collection Visible
 make_collection_hidden: Make Collection Hidden
 make_folder_visible: Make Folder Visible
@@ -1406,6 +1410,9 @@ license:
   manage_addon: Manage
   purchase: Purchase
   addon_packages: Add-on Packages
+  limit_dialog:
+    title: You have reached the max limit allowed for your plan.
+    text: Update your plan to increase your limits.
   addon_dialog:
     title: Manage Add-on
     confirm_purchase: Confirm Purchase
@@ -1827,6 +1834,7 @@ field_options:
       "Override the collection's display name in the app based on the user's language."
     note_placeholder: A description of this collection...
     hidden_label: Hide within the App
+    excluded_label: Exclude from usage
     singleton: Treat as single object
     language: Language
     translation: Translation

--- a/app/src/layouts/tabular/index.ts
+++ b/app/src/layouts/tabular/index.ts
@@ -16,6 +16,7 @@ import { useFieldsStore } from '@/stores/fields';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
 import { formatItemsCountPaginated } from '@/utils/format-items-count';
 import { getDefaultDisplayForType } from '@/utils/get-default-display-for-type';
+import { getLocalTypeForField } from '@/utils/get-local-type';
 import { hideDragImage } from '@/utils/hide-drag-image';
 import { saveAsCSV } from '@/utils/save-as-csv';
 import { syncRefProperty } from '@/utils/sync-ref-property';
@@ -169,6 +170,24 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 			const page = syncRefProperty(layoutQuery, 'page', 1);
 			const limit = syncRefProperty(layoutQuery, 'limit', 25);
 
+			const isAvailableDefaultField = (field: Field) => {
+				const fieldCollection = collection.value;
+
+				if (!fieldCollection) return false;
+
+				const localType = getLocalTypeForField(fieldCollection, field.field);
+
+				if (!localType || localType === 'standard' || localType === 'group' || localType === 'presentation') {
+					return true;
+				}
+
+				if (localType === 'm2o' || localType === 'file') {
+					return true;
+				}
+
+				return false;
+			};
+
 			const defaultSort = computed(() => {
 				const field = sortField.value ?? primaryKeyField.value?.field;
 				return field ? [field] : [];
@@ -178,7 +197,10 @@ export default defineLayout<LayoutOptions, LayoutQuery>({
 
 			const fieldsDefaultValue = computed(() => {
 				return fieldsInCollection.value
-					.filter((field) => !field.meta?.hidden && !field.meta?.special?.includes('no-data'))
+					.filter(
+						(field) =>
+							!field.meta?.hidden && !field.meta?.special?.includes('no-data') && isAvailableDefaultField(field),
+					)
 					.slice(0, 4)
 					.map(({ field }) => field)
 					.sort();

--- a/app/src/modules/content/components/NavigationItem.vue
+++ b/app/src/modules/content/components/NavigationItem.vue
@@ -18,6 +18,7 @@ import { usePresetsStore } from '@/stores/presets';
 import { useUserStore } from '@/stores/user';
 import { Collection } from '@/types/collections';
 import { getCollectionRoute } from '@/utils/get-route';
+import { isExcludedCollection } from '@/utils/is-excluded-collection';
 
 const props = defineProps<{
 	collection: Collection;
@@ -80,7 +81,8 @@ const hasContextMenu = computed(() => isAdmin && props.collection.type === 'tabl
 
 function getChildCollections(collection: Collection) {
 	let collections = collectionsStore.sortedCollections.filter(
-		(childCollection) => childCollection.meta?.group === collection.collection,
+		(childCollection) =>
+			childCollection.meta?.group === collection.collection && !isExcludedCollection(childCollection),
 	);
 
 	if (props.showHidden === false) {

--- a/app/src/modules/content/components/navigation.vue
+++ b/app/src/modules/content/components/navigation.vue
@@ -27,8 +27,10 @@ const search = ref('');
 const collectionsStore = useCollectionsStore();
 const userStore = useUserStore();
 
+const navigableCollections = computed(() => collectionsStore.activeCollections);
+
 const rootItems = computed(() => {
-	const shownCollections = showHidden.value ? collectionsStore.allCollections : collectionsStore.visibleCollections;
+	const shownCollections = showHidden.value ? navigableCollections.value : collectionsStore.visibleCollections;
 	return orderBy(
 		shownCollections.filter((collection) => {
 			return isNil(collection?.meta?.group);
@@ -41,7 +43,7 @@ const dense = computed(() => collectionsStore.visibleCollections.length > 5);
 const showSearch = computed(() => collectionsStore.visibleCollections.length > 20);
 
 const hasHiddenCollections = computed(
-	() => collectionsStore.allCollections.length > collectionsStore.visibleCollections.length,
+	() => navigableCollections.value.length > collectionsStore.visibleCollections.length,
 );
 </script>
 
@@ -62,7 +64,7 @@ const hasHiddenCollections = computed(
 			:dense="dense"
 		>
 			<VButton
-				v-if="userStore.isAdmin && collectionsStore.allCollections.length === 0"
+				v-if="userStore.isAdmin && navigableCollections.length === 0"
 				full-width
 				outlined
 				dashed

--- a/app/src/modules/content/index.ts
+++ b/app/src/modules/content/index.ts
@@ -18,6 +18,7 @@ const checkForSystem: NavigationGuard = (to, from) => {
 	if (!to.params?.collection) return;
 
 	if (typeof to.params.collection === 'string') {
+		const collectionsStore = useCollectionsStore();
 		const route = getSystemCollectionRoute(to.params.collection);
 
 		if (route) {
@@ -26,6 +27,13 @@ const checkForSystem: NavigationGuard = (to, from) => {
 			} else {
 				return route;
 			}
+		}
+
+		if (!collectionsStore.activeCollections.find((collection) => collection.collection === to.params.collection)) {
+			return {
+				name: 'content-item-not-found',
+				params: { _: to.path.split('/').slice(1) },
+			};
 		}
 	}
 

--- a/app/src/modules/settings/index.ts
+++ b/app/src/modules/settings/index.ts
@@ -31,6 +31,7 @@ import api from '@/api';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
 import { useFlowsStore } from '@/stores/flows';
+import { useRelationsStore } from '@/stores/relations';
 import RouterPass from '@/utils/router-passthrough';
 
 export default defineModule({
@@ -89,6 +90,8 @@ export default defineModule({
 					component: Fields,
 					async beforeEnter(to) {
 						const collectionsStore = useCollectionsStore();
+						const fieldsStore = useFieldsStore();
+						const relationsStore = useRelationsStore();
 						const info = collectionsStore.getCollection(to.params.collection as string);
 
 						if (!info) {
@@ -100,10 +103,10 @@ export default defineModule({
 
 						if (!info?.meta) {
 							await api.patch(`/collections/${to.params.collection}`, { meta: {} });
+							await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate(), relationsStore.hydrate()]);
+						} else {
+							await Promise.all([fieldsStore.hydrate(), relationsStore.hydrate()]);
 						}
-
-						const fieldsStore = useFieldsStore();
-						fieldsStore.hydrate();
 					},
 					props: (route) => ({
 						collection: route.params.collection,

--- a/app/src/modules/settings/routes/data-model/collections/collections.vue
+++ b/app/src/modules/settings/routes/data-model/collections/collections.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { saveAs } from 'file-saver';
-import { merge } from 'lodash';
+import { merge, orderBy } from 'lodash';
 import { computed, ref } from 'vue';
 import { RouterLink, RouterView } from 'vue-router';
 import Draggable from 'vuedraggable';
@@ -20,7 +20,10 @@ import VListItemIcon from '@/components/v-list-item-icon.vue';
 import VListItem from '@/components/v-list-item.vue';
 import VList from '@/components/v-list.vue';
 import { useCollectionsStore } from '@/stores/collections';
+import { useFieldsStore } from '@/stores/fields';
+import { useRelationsStore } from '@/stores/relations';
 import { Collection } from '@/types/collections';
+import { isExcludedCollection } from '@/utils/is-excluded-collection';
 import { translate } from '@/utils/translate-object-values';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { PrivateViewHeaderBarActionButton } from '@/views/private';
@@ -33,10 +36,18 @@ const collectionDialogActive = ref(false);
 const editCollection = ref<Collection | null>();
 
 const collectionsStore = useCollectionsStore();
+const fieldsStore = useFieldsStore();
+const relationsStore = useRelationsStore();
 const { collapsedIds, hasExpandableCollections, expandAll, collapseAll, toggleCollapse } = useExpandCollapse();
 
+function sortConfiguredCollections(collections: Collection[]) {
+	return orderBy(collections, [(collection) => (isExcludedCollection(collection) ? 1 : 0), 'meta.sort', 'collection']);
+}
+
 const collections = computed(() => {
-	return translate(collectionsStore.allCollections.filter((collection) => collection.meta)).map((collection) => ({
+	return sortConfiguredCollections(
+		translate(collectionsStore.allCollections.filter((collection) => collection.meta)),
+	).map((collection) => ({
 		...collection,
 		isCollapsed: collapsedIds.value?.includes(collection.collection),
 	}));
@@ -140,6 +151,16 @@ async function onSort(updates: Collection[], removeGroup = false) {
 	}
 }
 
+async function onExcludeCollection(collectionKey: string) {
+	await collectionsStore.updateCollection(collectionKey, { meta: { excluded: true } });
+	await Promise.all([fieldsStore.hydrate(), relationsStore.hydrate()]);
+}
+
+async function onIncludeCollection(collectionKey: string) {
+	await collectionsStore.updateCollection(collectionKey, { meta: { excluded: false } });
+	await Promise.all([fieldsStore.hydrate(), relationsStore.hydrate()]);
+}
+
 async function downloadSnapshot() {
 	const snapshot = await api.get(`/schema/snapshot`);
 
@@ -223,6 +244,8 @@ async function downloadSnapshot() {
 							:is-collapsed="element.isCollapsed"
 							:visibility-tree="findVisibilityChild(element.collection)!"
 							@edit-collection="editCollection = $event"
+							@exclude-collection="onExcludeCollection"
+							@include-collection="onIncludeCollection"
 							@set-nested-sort="onSort"
 							@toggle-collapse="toggleCollapse"
 						/>
@@ -250,7 +273,12 @@ async function downloadSnapshot() {
 						<span class="collection-name">{{ collection.name }}</span>
 					</RouterLink>
 
-					<CollectionOptions :collection="collection" :has-nested-collections="false" />
+					<CollectionOptions
+						:collection="collection"
+						:has-nested-collections="false"
+						@exclude-collection="onExcludeCollection"
+						@include-collection="onIncludeCollection"
+					/>
 				</VListItem>
 			</VList>
 

--- a/app/src/modules/settings/routes/data-model/collections/components/CollectionItem.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/CollectionItem.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { orderBy } from 'lodash';
 import { computed } from 'vue';
 import Draggable from 'vuedraggable';
 import { CollectionTree } from '../collections.vue';
@@ -9,6 +10,7 @@ import VIcon from '@/components/v-icon/v-icon.vue';
 import VListItemIcon from '@/components/v-list-item-icon.vue';
 import VListItem from '@/components/v-list-item.vue';
 import { Collection } from '@/types/collections';
+import { isExcludedCollection } from '@/utils/is-excluded-collection';
 
 const props = defineProps<{
 	collection: Collection;
@@ -18,15 +20,25 @@ const props = defineProps<{
 	disableDrag?: boolean;
 }>();
 
-const emit = defineEmits(['setNestedSort', 'editCollection', 'toggleCollapse']);
+const emit = defineEmits([
+	'setNestedSort',
+	'editCollection',
+	'toggleCollapse',
+	'excludeCollection',
+	'includeCollection',
+]);
+
+const isExcluded = computed(() => isExcludedCollection(props.collection));
 
 const toggleCollapse = () => {
 	emit('toggleCollapse', props.collection.collection);
 };
 
-const nestedCollections = computed(() =>
-	props.collections.filter((collection) => collection.meta?.group === props.collection.collection),
-);
+const nestedCollections = computed(() => {
+	const nested = props.collections.filter((collection) => collection.meta?.group === props.collection.collection);
+
+	return orderBy(nested, [(collection) => (isExcludedCollection(collection) ? 1 : 0), 'meta.sort', 'collection']);
+});
 
 function onGroupSortChange(collections: Collection[]) {
 	const updates = collections.map((collection) => ({
@@ -38,28 +50,43 @@ function onGroupSortChange(collections: Collection[]) {
 
 	emit('setNestedSort', updates);
 }
+
+function onListItemClick() {
+	if (isExcluded.value) {
+		emit('includeCollection', props.collection.collection);
+		return;
+	}
+
+	if (!props.collection.schema) {
+		emit('editCollection', props.collection);
+	}
+}
 </script>
 
 <template>
 	<div v-show="visibilityTree.visible" class="collection-item">
 		<VListItem
+			v-tooltip="isExcluded ? $t('excluded_click_to_include') : undefined"
 			block
 			dense
 			clickable
-			:class="{ hidden: collection.meta?.hidden }"
-			:to="collection.schema ? `/settings/data-model/${collection.collection}` : undefined"
-			@click.self="!collection.schema ? $emit('editCollection', collection) : null"
+			:class="{ hidden: collection.meta?.hidden, excluded: isExcluded }"
+			:to="collection.schema && !isExcluded ? `/settings/data-model/${collection.collection}` : undefined"
+			@click="onListItemClick"
 		>
 			<VListItemIcon>
-				<VIcon v-if="!disableDrag" class="drag-handle" name="drag_handle" />
+				<VIcon v-if="isExcluded" name="add" />
+				<VIcon v-else-if="!disableDrag" class="drag-handle" name="drag_handle" />
 			</VListItemIcon>
 			<div class="collection-item-detail">
 				<VIcon
 					:color="
-						collection.meta?.hidden ? 'var(--theme--foreground-subdued)' : (collection.color ?? 'var(--theme--primary)')
+						collection.meta?.hidden || isExcluded
+							? 'var(--theme--foreground-subdued)'
+							: (collection.color ?? 'var(--theme--primary)')
 					"
 					class="collection-icon"
-					:name="collection.meta?.hidden ? 'visibility_off' : collection.icon"
+					:name="isExcluded ? 'diamond' : collection.meta?.hidden ? 'visibility_off' : collection.icon"
 				/>
 				<VHighlight
 					ref="collectionName"
@@ -82,6 +109,8 @@ function onGroupSortChange(collections: Collection[]) {
 				:has-nested-collections="nestedCollections.length > 0"
 				:collection="collection"
 				@collection-toggle="toggleCollapse"
+				@exclude-collection="$emit('excludeCollection', $event)"
+				@include-collection="$emit('includeCollection', $event)"
 			/>
 		</VListItem>
 
@@ -106,6 +135,8 @@ function onGroupSortChange(collections: Collection[]) {
 						@edit-collection="$emit('editCollection', $event)"
 						@set-nested-sort="$emit('setNestedSort', $event)"
 						@toggle-collapse="$emit('toggleCollapse', $event)"
+						@exclude-collection="$emit('excludeCollection', $event)"
+						@include-collection="$emit('includeCollection', $event)"
 					/>
 				</template>
 			</Draggable>
@@ -123,6 +154,11 @@ function onGroupSortChange(collections: Collection[]) {
 	margin-block-end: 0.4375rem;
 }
 
+.hidden,
+.excluded {
+	--v-list-item-color: var(--theme--foreground-subdued);
+}
+
 .collection-item-detail {
 	display: flex;
 	flex-grow: 1;
@@ -137,7 +173,8 @@ function onGroupSortChange(collections: Collection[]) {
 	flex-shrink: 0;
 }
 
-.hidden .collection-name {
+.hidden .collection-name,
+.excluded .collection-name {
 	color: var(--theme--foreground-subdued);
 }
 

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
@@ -21,6 +21,7 @@ import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
 import { Collection } from '@/types/collections';
 import { getCollectionRoute } from '@/utils/get-route';
+import { isExcludedCollection } from '@/utils/is-excluded-collection';
 
 type Props = {
 	collection: Collection;
@@ -28,6 +29,11 @@ type Props = {
 };
 
 const props = withDefaults(defineProps<Props>(), {});
+
+const emit = defineEmits<{
+	excludeCollection: [collectionKey: string];
+	includeCollection: [collectionKey: string];
+}>();
 
 const collectionsStore = useCollectionsStore();
 const fieldsStore = useFieldsStore();
@@ -80,13 +86,44 @@ async function update(updates: DeepPartial<Collection>) {
 </script>
 
 <template>
-	<div v-if="isSystemCollection(collection.collection) === false">
+	<div v-if="isSystemCollection(collection.collection) === false || isExcludedCollection(collection)">
 		<VMenu placement="left-start" show-arrow>
 			<template #activator="{ toggle }">
-				<VIcon name="more_vert" clickable class="ctx-toggle" @click.prevent="toggle" />
+				<VIcon name="more_vert" clickable class="ctx-toggle" @click.stop.prevent="toggle" />
 			</template>
 			<VList>
-				<VListItem v-if="collection.schema" clickable :to="getCollectionRoute(collection.collection)">
+				<VListItem
+					v-if="collection.schema && !isExcludedCollection(collection) && !isSystemCollection(collection.collection)"
+					clickable
+					class="warning"
+					@click="emit('excludeCollection', collection.collection)"
+				>
+					<VListItemIcon>
+						<VIcon name="remove_circle_outline" />
+					</VListItemIcon>
+					<VListItemContent>
+						{{ $t('exclude_collection') }}
+					</VListItemContent>
+				</VListItem>
+
+				<VListItem
+					v-if="isExcludedCollection(collection)"
+					clickable
+					@click="emit('includeCollection', collection.collection)"
+				>
+					<VListItemIcon>
+						<VIcon name="add" />
+					</VListItemIcon>
+					<VListItemContent>
+						{{ $t('include_collection') }}
+					</VListItemContent>
+				</VListItem>
+
+				<VListItem
+					v-if="collection.meta && !isExcludedCollection(collection)"
+					clickable
+					:to="getCollectionRoute(collection.collection)"
+				>
 					<VListItemIcon>
 						<VIcon name="box" />
 					</VListItemIcon>
@@ -218,7 +255,10 @@ async function update(updates: DeepPartial<Collection>) {
 .v-list-item.warning {
 	--v-list-item-color: var(--theme--warning);
 	--v-list-item-color-hover: var(--theme--warning);
+	--v-list-item-color-active: var(--theme--warning);
+	--v-list-item-color-active-hover: var(--theme--warning);
 	--v-list-item-icon-color: var(--theme--warning);
+	--v-list-item-icon-color-active: var(--theme--warning);
 }
 
 .delete-dependencies {

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-relationship-m2a.vue
@@ -39,7 +39,7 @@ const currentPrimaryKey = computed(() => fieldsStore.getPrimaryKeyFieldForCollec
 
 const availableCollections = computed(() => {
 	return [
-		...collectionsStore.databaseCollections.filter((collection) => collection.meta),
+		...collectionsStore.configuredDatabaseCollections,
 		{
 			divider: true,
 		},

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/relationship-configuration.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/relationship-configuration.vue
@@ -23,7 +23,7 @@ const oneAllowedCollections = syncFieldDetailStoreProperty('relations.m2o.meta.o
 
 const availableCollections = computed(() => {
 	return [
-		...collectionsStore.databaseCollections.filter((collection) => collection.meta),
+		...collectionsStore.configuredDatabaseCollections,
 		{
 			divider: true,
 		},

--- a/app/src/modules/settings/routes/data-model/field-detail/shared/related-collection-select.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/shared/related-collection-select.vue
@@ -24,7 +24,8 @@ const collectionExists = computed(() => {
 	return !!collectionsStore.getCollection(props.modelValue);
 });
 
-const availableCollections = collectionsStore.databaseCollections.filter((collection) => collection.meta);
+const availableCollections = computed(() => collectionsStore.configuredDatabaseCollections);
+
 const systemCollections = collectionsStore.crudSafeSystemCollections;
 </script>
 

--- a/app/src/stores/collections.test.ts
+++ b/app/src/stores/collections.test.ts
@@ -83,3 +83,37 @@ test('parseField action should translate field name when all translations are re
 	expect(collectionsStore.collections[0].name).toEqual('A');
 	expect(i18n.global.te(`collection_names.${mockCollection.collection}`)).toBe(false);
 });
+
+test('configuredDatabaseCollections includes excluded configured database collections, but excludes db-only and folder entries', () => {
+	const collectionsStore = useCollectionsStore();
+
+	collectionsStore.collections = [
+		{
+			collection: 'active_collection',
+			meta: {},
+			schema: {},
+		},
+		{
+			collection: 'excluded_collection',
+			meta: {
+				excluded: true,
+			},
+			schema: {},
+		},
+		{
+			collection: 'db_only_collection',
+			meta: null,
+			schema: {},
+		},
+		{
+			collection: 'folder_collection',
+			meta: {},
+			schema: null,
+		},
+	] as Collection[];
+
+	expect(collectionsStore.configuredDatabaseCollections.map((collection) => collection.collection)).toEqual([
+		'active_collection',
+		'excluded_collection',
+	]);
+});

--- a/app/src/stores/collections.ts
+++ b/app/src/stores/collections.ts
@@ -13,6 +13,7 @@ import { i18n } from '@/lang';
 import { Collection } from '@/types/collections';
 import { flattenGroupedCollections } from '@/utils/flatten-grouped-collections';
 import { getLiteralInterpolatedTranslation } from '@/utils/get-literal-interpolated-translation';
+import { isExcludedCollection } from '@/utils/is-excluded-collection';
 import { notify } from '@/utils/notify';
 import { unexpectedError } from '@/utils/unexpected-error';
 
@@ -49,16 +50,30 @@ export const useCollectionsStore = defineStore('collectionsStore', () => {
 	const configuredCollections = computed(() => allCollections.value.filter((collection) => collection.meta));
 
 	/**
-	 * All non-system collections that are configured and visible (not hidden)
+	 * All non-system collections that are configured and included in Directus
+	 */
+	const activeCollections = computed(() =>
+		configuredCollections.value.filter((collection) => !isExcludedCollection(collection)),
+	);
+
+	/**
+	 * All non-system collections that are configured, included, and visible (not hidden)
 	 */
 	const visibleCollections = computed(() =>
-		configuredCollections.value.filter((collection) => collection.meta?.hidden !== true),
+		activeCollections.value.filter((collection) => collection.meta?.hidden !== true),
 	);
 
 	/**
 	 * All non-system collections that are configured and have a corresponding database table
 	 */
 	const databaseCollections = computed(() => allCollections.value.filter((collection) => collection.schema));
+
+	/**
+	 * All non-system collections that are configured and have a corresponding database table
+	 */
+	const configuredDatabaseCollections = computed(() =>
+		databaseCollections.value.filter((collection) => collection.meta),
+	);
 
 	/**
 	 * All system collections that are safe to CRUD
@@ -71,9 +86,11 @@ export const useCollectionsStore = defineStore('collectionsStore', () => {
 		collections,
 		sortedCollections,
 		allCollections,
+		activeCollections,
 		visibleCollections,
 		configuredCollections,
 		databaseCollections,
+		configuredDatabaseCollections,
 		systemCollections,
 		crudSafeSystemCollections,
 		hydrate,

--- a/app/src/utils/is-excluded-collection.ts
+++ b/app/src/utils/is-excluded-collection.ts
@@ -1,0 +1,3 @@
+export function isExcludedCollection(collection: { meta: { excluded?: boolean } | null }): boolean {
+	return collection.meta?.excluded === true;
+}

--- a/app/src/views/private/components/notification-dialogs.vue
+++ b/app/src/views/private/components/notification-dialogs.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
+import type { DirectusError } from '@directus/sdk';
 import { render } from 'micromustache';
 import { storeToRefs } from 'pinia';
 import { computed } from 'vue';
-import { useRoute } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+import { useRoute, useRouter } from 'vue-router';
+import type { RequestError } from '@/api';
 import VButton from '@/components/v-button.vue';
 import VCardActions from '@/components/v-card-actions.vue';
 import VCardText from '@/components/v-card-text.vue';
@@ -14,11 +17,14 @@ import { DEFAULT_REPORT_BUG_URL } from '@/constants';
 import { useNotificationsStore } from '@/stores/notifications';
 import { useSettingsStore } from '@/stores/settings';
 import { useUserStore } from '@/stores/user';
+import type { APIError } from '@/types/error';
 import { Snackbar } from '@/types/notifications';
 
 const notificationsStore = useNotificationsStore();
 const { isAdmin, currentUser } = useUserStore();
 const { settings } = storeToRefs(useSettingsStore());
+const { t } = useI18n();
+const router = useRouter();
 
 const notifications = computed(() => notificationsStore.dialogs);
 
@@ -76,20 +82,59 @@ const done = async (notification: Snackbar) => {
 
 	notificationsStore.remove(notification.id);
 };
+
+function isLicenseLimitNotification(notification: Snackbar) {
+	if (isAdmin !== true) return false;
+	if (notification.code !== 'LIMIT_EXCEEDED') return false;
+
+	const extensions =
+		(notification.error as RequestError | undefined)?.response?.data?.errors?.[0]?.extensions ||
+		(notification.error as DirectusError | undefined)?.errors?.[0]?.extensions ||
+		(notification.error as APIError | undefined)?.extensions;
+
+	return extensions?.limit_type === 'license';
+}
+
+function getNotificationTitle(notification: Snackbar) {
+	if (isLicenseLimitNotification(notification)) {
+		return t('license.limit_dialog.title');
+	}
+
+	return notification.title;
+}
+
+function getNotificationText(notification: Snackbar) {
+	if (isLicenseLimitNotification(notification)) {
+		return t('license.limit_dialog.text');
+	}
+
+	return notification.text;
+}
+
+async function managePlan(notification: Snackbar) {
+	notificationsStore.remove(notification.id);
+	await router.push('/settings/license');
+}
 </script>
 
 <template>
 	<div class="notification-dialogs">
 		<VDialog v-for="notification in notifications" :key="notification.id" model-value persist>
 			<VCard :class="[notification.type]">
-				<VCardTitle>{{ notification.title }}</VCardTitle>
-				<VCardText v-if="notification.text || notification.error" class="notification-text">
-					{{ notification.text }}
+				<VCardTitle>{{ getNotificationTitle(notification) }}</VCardTitle>
+				<VCardText
+					v-if="getNotificationText(notification) || (notification.error && !isLicenseLimitNotification(notification))"
+					class="notification-text"
+				>
+					{{ getNotificationText(notification) }}
 
-					<VError v-if="notification.error" :error="notification.error" />
+					<VError v-if="notification.error && !isLicenseLimitNotification(notification)" :error="notification.error" />
 				</VCardText>
 				<VCardActions>
-					<VButton v-if="notification.type === 'error' && isAdmin && notification.code === 'UNKNOWN'" secondary>
+					<VButton v-if="isLicenseLimitNotification(notification)" secondary @click="managePlan(notification)">
+						{{ $t('license.manage_plan') }}
+					</VButton>
+					<VButton v-else-if="notification.type === 'error' && isAdmin && notification.code === 'UNKNOWN'" secondary>
 						<a target="_blank" :href="getErrorUrl(notification.error)">
 							{{ $t('report_error') }}
 						</a>

--- a/packages/errors/src/errors/limit-exceeded.ts
+++ b/packages/errors/src/errors/limit-exceeded.ts
@@ -2,6 +2,7 @@ import { createError, type DirectusErrorConstructor, ErrorCode } from '../index.
 
 export interface LimitExceededErrorExtensions {
 	category: string;
+	limit_type?: 'license';
 }
 
 export const messageConstructor = ({ category }: LimitExceededErrorExtensions) => {

--- a/packages/system-data/src/collections/collections.yaml
+++ b/packages/system-data/src/collections/collections.yaml
@@ -3,6 +3,7 @@ table: directus_collections
 defaults:
   collection: null
   hidden: false
+  excluded: false
   singleton: false
   icon: null
   note: null

--- a/packages/system-data/src/fields/collections.yaml
+++ b/packages/system-data/src/fields/collections.yaml
@@ -49,6 +49,14 @@ fields:
       label: $t:field_options.directus_collections.hidden_label
     width: half
 
+  - field: excluded
+    special:
+      - cast-boolean
+    interface: boolean
+    options:
+      label: $t:field_options.directus_collections.excluded_label
+    width: half
+
   - field: singleton
     special:
       - cast-boolean

--- a/packages/system-data/src/types.ts
+++ b/packages/system-data/src/types.ts
@@ -24,6 +24,7 @@ export type CollectionMeta = {
 	collection: string;
 	note: string | null;
 	hidden: boolean;
+	excluded: boolean;
 	singleton: boolean;
 	icon: string | null;
 	color: string | null;
@@ -49,6 +50,7 @@ export type BaseCollectionMeta = Pick<
 	| 'collection'
 	| 'note'
 	| 'hidden'
+	| 'excluded'
 	| 'singleton'
 	| 'icon'
 	| 'translations'

--- a/packages/types/src/collection.ts
+++ b/packages/types/src/collection.ts
@@ -11,6 +11,7 @@ type Translations = {
 export type CollectionMeta = {
 	collection: string;
 	note: string | null;
+	excluded: boolean;
 	hidden: boolean;
 	singleton: boolean;
 	icon: string | null;
@@ -51,6 +52,7 @@ export type BaseCollectionMeta = Pick<
 	CollectionMeta,
 	| 'collection'
 	| 'note'
+	| 'excluded'
 	| 'hidden'
 	| 'singleton'
 	| 'icon'

--- a/sdk/src/schema/collection.ts
+++ b/sdk/src/schema/collection.ts
@@ -10,6 +10,7 @@ export type DirectusCollection<Schema = any> = {
 			icon: string | null;
 			note: string | null;
 			display_template: string | null;
+			excluded: boolean;
 			hidden: boolean;
 			singleton: boolean;
 			translations: CollectionMetaTranslationType[] | null;


### PR DESCRIPTION
## Scope

What's changed:

- Added excluded collections as a first-class concept, including schema support, types, SDK exposure, and service logic so excluded collections do not count against collection limits.
- Added backend enforcement to prevent relational traversal into excluded collections during AST processing, field parsing, path validation, payload handling, and item operations.
- Updated collection creation and bulk-creation flows to validate collection-limit entitlements before adding new non-excluded collections, using the new numeric entitlement gate helper.
- Added a cached excluded-collection lookup helper and wired it into schema-dependent read paths and collection stores to keep the gating behavior consistent.
- Updated the data model and relation UIs so admins can exclude/include collections, see excluded collections sorted separately, and get warnings when related collections are inactive.

## Potential Risks / Drawbacks

- The excluded-collection guardrails now sit in several query and relation-processing paths, so regressions could surface as unexpected validation failures on nested reads and writes.
- Collection counting now depends on `meta.excluded`, which changes how limits behave for existing projects and bulk operations.
- Excluding a collection affects stores, relation widgets, and tabular layouts, so stale client state after toggling exclusion is a likely area to watch.

## Tested Scenarios

- Added coverage for field parsing and AST processing with excluded relations.
- Added dedicated validation tests for blocked relation paths into excluded collections.
- Added service tests for collections, items, payload handling, and fields behavior under the new gating rules.
- Added app tests around relation widgets, collection stores, and add-collection flows that now account for excluded collections.

## Review Notes / Questions

- Special attention should be paid to snapshot/export and schema-driven tooling, since excluded collections are still real tables but are intentionally hidden from licensed usage.
- The include/exclude toggle hydrates fields and relations stores after mutation; it is worth checking for any remaining views that still rely on stale relation metadata.
- The classification of system, DB-only, grouped, and excluded collections now affects ordering in the data model UI, so reviewer eyes on UX consistency would help.

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #\<num\>
