### PR TITLE
Add user limits

### DIFF
--- a/api/src/services/access.ts
+++ b/api/src/services/access.ts
@@ -1,6 +1,7 @@
 import type { AbstractServiceOptions, Item, MutationOptions, PrimaryKey } from '@directus/types';
 import { UserIntegrityCheckFlag } from '@directus/types';
 import { clearSystemCache } from '../cache.js';
+import { ensureUserCountBaseline } from '../utils/validate-user-count-integrity.js';
 import { ItemsService } from './items.js';
 
 export class AccessService extends ItemsService {
@@ -22,7 +23,17 @@ export class AccessService extends ItemsService {
 		opts.userIntegrityCheckFlags =
 			(opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None) | UserIntegrityCheckFlag.UserLimits;
 
-		opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags);
+		const userCountBaseline = await ensureUserCountBaseline({
+			flags: opts.userIntegrityCheckFlags,
+			knex: this.knex,
+			...(opts.userCountBaseline ? { userCountBaseline: opts.userCountBaseline } : {}),
+		});
+
+		if (userCountBaseline) {
+			opts.userCountBaseline = userCountBaseline;
+		}
+
+		opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags, opts.userCountBaseline);
 
 		const result = await super.createOne(data, opts);
 
@@ -39,7 +50,18 @@ export class AccessService extends ItemsService {
 	): Promise<PrimaryKey[]> {
 		// Updating policy attachments might affect the number of admin/app/api users
 		opts.userIntegrityCheckFlags = UserIntegrityCheckFlag.All;
-		opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags);
+
+		const userCountBaseline = await ensureUserCountBaseline({
+			flags: opts.userIntegrityCheckFlags,
+			knex: this.knex,
+			...(opts.userCountBaseline ? { userCountBaseline: opts.userCountBaseline } : {}),
+		});
+
+		if (userCountBaseline) {
+			opts.userCountBaseline = userCountBaseline;
+		}
+
+		opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags, opts.userCountBaseline);
 
 		const result = await super.updateMany(keys, data, { ...opts, userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
 
@@ -52,7 +74,18 @@ export class AccessService extends ItemsService {
 	override async deleteMany(keys: PrimaryKey[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
 		// Changes here can affect the number of admin/app/api users
 		opts.userIntegrityCheckFlags = UserIntegrityCheckFlag.All;
-		opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags);
+
+		const userCountBaseline = await ensureUserCountBaseline({
+			flags: opts.userIntegrityCheckFlags,
+			knex: this.knex,
+			...(opts.userCountBaseline ? { userCountBaseline: opts.userCountBaseline } : {}),
+		});
+
+		if (userCountBaseline) {
+			opts.userCountBaseline = userCountBaseline;
+		}
+
+		opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags, opts.userCountBaseline);
 
 		const result = await super.deleteMany(keys, opts);
 

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -328,9 +328,13 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 			if (userIntegrityCheckFlags) {
 				if (opts.onRequireUserIntegrityCheck) {
-					opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags);
+					opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags, opts.userCountBaseline);
 				} else {
-					await validateUserCountIntegrity({ flags: userIntegrityCheckFlags, knex: trx });
+					await validateUserCountIntegrity({
+						flags: userIntegrityCheckFlags,
+						knex: trx,
+						...(opts.userCountBaseline ? { userCountBaseline: opts.userCountBaseline } : {}),
+					});
 				}
 			}
 
@@ -455,6 +459,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			const service = this.fork({ knex });
 
 			let userIntegrityCheckFlags = opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None;
+			let userCountBaseline = opts.userCountBaseline;
 
 			const primaryKeys: PrimaryKey[] = [];
 			const nestedActionEvents: ActionEventParams[] = [];
@@ -473,7 +478,15 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				const primaryKey = await service.createOne(payload, {
 					...(opts || {}),
 					autoPurgeCache: false,
-					onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
+					...(userCountBaseline ? { userCountBaseline } : {}),
+					onRequireUserIntegrityCheck: (flags, nextUserCountBaseline) => {
+						userIntegrityCheckFlags |= flags;
+
+						if (nextUserCountBaseline) {
+							userCountBaseline ??= nextUserCountBaseline;
+							opts.userCountBaseline ??= nextUserCountBaseline;
+						}
+					},
 					bypassEmitAction: (params) => nestedActionEvents.push(params),
 					mutationTracker: opts.mutationTracker,
 					overwriteDefaults: opts.overwriteDefaults?.[index],
@@ -485,9 +498,13 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 			if (userIntegrityCheckFlags) {
 				if (opts.onRequireUserIntegrityCheck) {
-					opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags);
+					opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags, userCountBaseline);
 				} else {
-					await validateUserCountIntegrity({ flags: userIntegrityCheckFlags, knex });
+					await validateUserCountIntegrity({
+						flags: userIntegrityCheckFlags,
+						knex,
+						...(userCountBaseline ? { userCountBaseline } : {}),
+					});
 				}
 			}
 
@@ -700,6 +717,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				const service = this.fork({ knex });
 
 				let userIntegrityCheckFlags = opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None;
+				let userCountBaseline = opts.userCountBaseline;
 
 				for (const index in data) {
 					const item = data[index]!;
@@ -709,8 +727,16 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					const combinedOpts: MutationOptions = {
 						autoPurgeCache: false,
 						...opts,
+						...(userCountBaseline ? { userCountBaseline } : {}),
 						overwriteDefaults: opts.overwriteDefaults?.[index],
-						onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
+						onRequireUserIntegrityCheck: (flags, nextUserCountBaseline) => {
+							userIntegrityCheckFlags |= flags;
+
+							if (nextUserCountBaseline) {
+								userCountBaseline ??= nextUserCountBaseline;
+								opts.userCountBaseline ??= nextUserCountBaseline;
+							}
+						},
 					};
 
 					keys.push(await service.updateOne(primaryKey, omit(item, primaryKeyField), combinedOpts));
@@ -718,9 +744,13 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 				if (userIntegrityCheckFlags) {
 					if (opts.onRequireUserIntegrityCheck) {
-						opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags);
+						opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags, userCountBaseline);
 					} else {
-						await validateUserCountIntegrity({ flags: userIntegrityCheckFlags, knex });
+						await validateUserCountIntegrity({
+							flags: userIntegrityCheckFlags,
+							knex,
+							...(userCountBaseline ? { userCountBaseline } : {}),
+						});
 					}
 				}
 			});
@@ -874,11 +904,15 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 			if (userIntegrityCheckFlags) {
 				if (opts?.onRequireUserIntegrityCheck) {
-					opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags);
+					opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags, opts.userCountBaseline);
 				} else {
 					// Having no onRequireUserIntegrityCheck callback indicates that
 					// this is the top level invocation of the nested updates, so perform the user integrity check
-					await validateUserCountIntegrity({ flags: userIntegrityCheckFlags, knex: trx });
+					await validateUserCountIntegrity({
+						flags: userIntegrityCheckFlags,
+						knex: trx,
+						...(opts.userCountBaseline ? { userCountBaseline: opts.userCountBaseline } : {}),
+					});
 				}
 			}
 
@@ -1161,9 +1195,13 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 			if (opts.userIntegrityCheckFlags) {
 				if (opts.onRequireUserIntegrityCheck) {
-					opts.onRequireUserIntegrityCheck(opts.userIntegrityCheckFlags);
+					opts.onRequireUserIntegrityCheck(opts.userIntegrityCheckFlags, opts.userCountBaseline);
 				} else {
-					await validateUserCountIntegrity({ flags: opts.userIntegrityCheckFlags, knex: trx });
+					await validateUserCountIntegrity({
+						flags: opts.userIntegrityCheckFlags,
+						knex: trx,
+						...(opts.userCountBaseline ? { userCountBaseline: opts.userCountBaseline } : {}),
+					});
 				}
 			}
 

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -15,6 +15,7 @@ import type {
 	PrimaryKey,
 	Query,
 	SchemaOverview,
+	UserCountBaseline,
 } from '@directus/types';
 import { UserIntegrityCheckFlag } from '@directus/types';
 import { parseJSON, toArray } from '@directus/utils';
@@ -70,6 +71,35 @@ export class PayloadService {
 		this.overwriteDefaults = options.overwriteDefaults;
 
 		return this;
+	}
+
+	private getNestedMutationOptions(
+		opts: MutationOptions | undefined,
+		overwriteDefaults: DefaultOverwrite | undefined,
+		revisions: PrimaryKey[],
+		nestedActionEvents: ActionEventParams[],
+		onRequireUserIntegrityCheck: (flags: UserIntegrityCheckFlag, userCountBaseline?: UserCountBaseline) => void,
+	): MutationOptions {
+		return {
+			onRevisionCreate: (pk) => revisions.push(pk),
+			onRequireUserIntegrityCheck: (flags, userCountBaseline) => {
+				onRequireUserIntegrityCheck(flags, userCountBaseline);
+
+				if (opts && userCountBaseline) {
+					opts.userCountBaseline ??= userCountBaseline;
+				}
+			},
+			bypassEmitAction: (params) =>
+				opts?.bypassEmitAction ? opts.bypassEmitAction(params) : nestedActionEvents.push(params),
+			emitEvents: opts?.emitEvents,
+			autoPurgeCache: opts?.autoPurgeCache,
+			autoPurgeSystemCache: opts?.autoPurgeSystemCache,
+			skipTracking: opts?.skipTracking,
+			overwriteDefaults,
+			onItemCreate: opts?.onItemCreate,
+			mutationTracker: opts?.mutationTracker,
+			...(opts?.userCountBaseline ? { userCountBaseline: opts.userCountBaseline } : {}),
+		};
 	}
 
 	public transformers: Transformers = {
@@ -309,16 +339,12 @@ export class PayloadService {
 					if (key in item === false) continue;
 
 					const [operation, fieldName] = key.split('->') as [string, string];
+					const fieldEntry = fieldEntries[fieldName];
 
 					const aggregateResult = { [fieldName]: item[key] };
 
-					if (fieldEntries[fieldName]?.special?.length > 0) {
-						const newValue = await this.processField(
-							fieldEntries[fieldName],
-							aggregateResult,
-							'read',
-							this.accountability,
-						);
+					if (fieldEntry && fieldEntry.special?.length > 0) {
+						const newValue = await this.processField(fieldEntry, aggregateResult, 'read', this.accountability);
 
 						if (newValue !== undefined) aggregateResult[fieldName] = newValue;
 					}
@@ -629,32 +655,24 @@ export class PayloadService {
 
 				if (Object.keys(record).length > 0) {
 					await service.updateOne(relatedPrimaryKey, record, {
-						onRevisionCreate: (pk) => revisions.push(pk),
-						onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
-						bypassEmitAction: (params) =>
-							opts?.bypassEmitAction ? opts.bypassEmitAction(params) : nestedActionEvents.push(params),
-						emitEvents: opts?.emitEvents,
-						autoPurgeCache: opts?.autoPurgeCache,
-						autoPurgeSystemCache: opts?.autoPurgeSystemCache,
-						skipTracking: opts?.skipTracking,
-						overwriteDefaults: opts?.overwriteDefaults?.[relation.field],
-						onItemCreate: opts?.onItemCreate,
-						mutationTracker: opts?.mutationTracker,
+						...this.getNestedMutationOptions(
+							opts,
+							opts?.overwriteDefaults?.[relation.field],
+							revisions,
+							nestedActionEvents,
+							(flags) => (userIntegrityCheckFlags |= flags),
+						),
 					});
 				}
 			} else {
 				relatedPrimaryKey = await service.createOne(relatedRecord, {
-					onRevisionCreate: (pk) => revisions.push(pk),
-					onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
-					bypassEmitAction: (params) =>
-						opts?.bypassEmitAction ? opts.bypassEmitAction(params) : nestedActionEvents.push(params),
-					emitEvents: opts?.emitEvents,
-					autoPurgeCache: opts?.autoPurgeCache,
-					autoPurgeSystemCache: opts?.autoPurgeSystemCache,
-					skipTracking: opts?.skipTracking,
-					overwriteDefaults: opts?.overwriteDefaults?.[relation.field],
-					onItemCreate: opts?.onItemCreate,
-					mutationTracker: opts?.mutationTracker,
+					...this.getNestedMutationOptions(
+						opts,
+						opts?.overwriteDefaults?.[relation.field],
+						revisions,
+						nestedActionEvents,
+						(flags) => (userIntegrityCheckFlags |= flags),
+					),
 				});
 			}
 
@@ -736,32 +754,24 @@ export class PayloadService {
 
 				if (Object.keys(record).length > 0) {
 					await service.updateOne(relatedPrimaryKey, record, {
-						onRevisionCreate: (pk) => revisions.push(pk),
-						onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
-						bypassEmitAction: (params) =>
-							opts?.bypassEmitAction ? opts.bypassEmitAction(params) : nestedActionEvents.push(params),
-						emitEvents: opts?.emitEvents,
-						autoPurgeCache: opts?.autoPurgeCache,
-						autoPurgeSystemCache: opts?.autoPurgeSystemCache,
-						skipTracking: opts?.skipTracking,
-						overwriteDefaults: opts?.overwriteDefaults?.[relation.field],
-						onItemCreate: opts?.onItemCreate,
-						mutationTracker: opts?.mutationTracker,
+						...this.getNestedMutationOptions(
+							opts,
+							opts?.overwriteDefaults?.[relation.field],
+							revisions,
+							nestedActionEvents,
+							(flags) => (userIntegrityCheckFlags |= flags),
+						),
 					});
 				}
 			} else {
 				relatedPrimaryKey = await service.createOne(relatedRecord, {
-					onRevisionCreate: (pk) => revisions.push(pk),
-					onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
-					bypassEmitAction: (params) =>
-						opts?.bypassEmitAction ? opts.bypassEmitAction(params) : nestedActionEvents.push(params),
-					emitEvents: opts?.emitEvents,
-					autoPurgeCache: opts?.autoPurgeCache,
-					autoPurgeSystemCache: opts?.autoPurgeSystemCache,
-					skipTracking: opts?.skipTracking,
-					overwriteDefaults: opts?.overwriteDefaults?.[relation.field],
-					onItemCreate: opts?.onItemCreate,
-					mutationTracker: opts?.mutationTracker,
+					...this.getNestedMutationOptions(
+						opts,
+						opts?.overwriteDefaults?.[relation.field],
+						revisions,
+						nestedActionEvents,
+						(flags) => (userIntegrityCheckFlags |= flags),
+					),
 				});
 			}
 
@@ -885,17 +895,13 @@ export class PayloadService {
 
 				savedPrimaryKeys.push(
 					...(await service.upsertMany(recordsToUpsert, {
-						onRevisionCreate: (pk) => revisions.push(pk),
-						onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
-						bypassEmitAction: (params) =>
-							opts?.bypassEmitAction ? opts.bypassEmitAction(params) : nestedActionEvents.push(params),
-						emitEvents: opts?.emitEvents,
-						autoPurgeCache: opts?.autoPurgeCache,
-						autoPurgeSystemCache: opts?.autoPurgeSystemCache,
-						skipTracking: opts?.skipTracking,
-						overwriteDefaults: opts?.overwriteDefaults?.[relation.meta!.one_field!],
-						onItemCreate: opts?.onItemCreate,
-						mutationTracker: opts?.mutationTracker,
+						...this.getNestedMutationOptions(
+							opts,
+							opts?.overwriteDefaults?.[relation.meta!.one_field!],
+							revisions,
+							nestedActionEvents,
+							(flags) => (userIntegrityCheckFlags |= flags),
+						),
 					})),
 				);
 
@@ -921,33 +927,26 @@ export class PayloadService {
 				if (relation.meta.one_deselect_action === 'delete') {
 					// There's no revision for a deletion
 					await service.deleteByQuery(query, {
-						onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
-						bypassEmitAction: (params) =>
-							opts?.bypassEmitAction ? opts.bypassEmitAction(params) : nestedActionEvents.push(params),
-						emitEvents: opts?.emitEvents,
-						autoPurgeCache: opts?.autoPurgeCache,
-						autoPurgeSystemCache: opts?.autoPurgeSystemCache,
-						skipTracking: opts?.skipTracking,
-						overwriteDefaults: opts?.overwriteDefaults?.[relation.meta!.one_field!],
-						onItemCreate: opts?.onItemCreate,
-						mutationTracker: opts?.mutationTracker,
+						...this.getNestedMutationOptions(
+							opts,
+							opts?.overwriteDefaults?.[relation.meta!.one_field!],
+							revisions,
+							nestedActionEvents,
+							(flags) => (userIntegrityCheckFlags |= flags),
+						),
 					});
 				} else {
 					await service.updateByQuery(
 						query,
 						{ [relation.field]: null },
 						{
-							onRevisionCreate: (pk) => revisions.push(pk),
-							onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
-							bypassEmitAction: (params) =>
-								opts?.bypassEmitAction ? opts.bypassEmitAction(params) : nestedActionEvents.push(params),
-							emitEvents: opts?.emitEvents,
-							autoPurgeCache: opts?.autoPurgeCache,
-							autoPurgeSystemCache: opts?.autoPurgeSystemCache,
-							skipTracking: opts?.skipTracking,
-							overwriteDefaults: opts?.overwriteDefaults?.[relation.meta!.one_field!],
-							onItemCreate: opts?.onItemCreate,
-							mutationTracker: opts?.mutationTracker,
+							...this.getNestedMutationOptions(
+								opts,
+								opts?.overwriteDefaults?.[relation.meta!.one_field!],
+								revisions,
+								nestedActionEvents,
+								(flags) => (userIntegrityCheckFlags |= flags),
+							),
 						},
 					);
 				}
@@ -992,17 +991,13 @@ export class PayloadService {
 					}
 
 					await service.createMany(createPayload, {
-						onRevisionCreate: (pk) => revisions.push(pk),
-						onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
-						bypassEmitAction: (params) =>
-							opts?.bypassEmitAction ? opts.bypassEmitAction(params) : nestedActionEvents.push(params),
-						emitEvents: opts?.emitEvents,
-						autoPurgeCache: opts?.autoPurgeCache,
-						autoPurgeSystemCache: opts?.autoPurgeSystemCache,
-						skipTracking: opts?.skipTracking,
-						overwriteDefaults: opts?.overwriteDefaults?.[relation.meta!.one_field!]?.['create'],
-						onItemCreate: opts?.onItemCreate,
-						mutationTracker: opts?.mutationTracker,
+						...this.getNestedMutationOptions(
+							opts,
+							opts?.overwriteDefaults?.[relation.meta!.one_field!]?.['create'],
+							revisions,
+							nestedActionEvents,
+							(flags) => (userIntegrityCheckFlags |= flags),
+						),
 					});
 				}
 
@@ -1021,17 +1016,13 @@ export class PayloadService {
 						}
 
 						await service.updateOne(key, record, {
-							onRevisionCreate: (pk) => revisions.push(pk),
-							onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
-							bypassEmitAction: (params) =>
-								opts?.bypassEmitAction ? opts.bypassEmitAction(params) : nestedActionEvents.push(params),
-							emitEvents: opts?.emitEvents,
-							autoPurgeCache: opts?.autoPurgeCache,
-							autoPurgeSystemCache: opts?.autoPurgeSystemCache,
-							skipTracking: opts?.skipTracking,
-							overwriteDefaults: opts?.overwriteDefaults?.[relation.meta!.one_field!]?.['update'][index],
-							onItemCreate: opts?.onItemCreate,
-							mutationTracker: opts?.mutationTracker,
+							...this.getNestedMutationOptions(
+								opts,
+								opts?.overwriteDefaults?.[relation.meta!.one_field!]?.['update'][index],
+								revisions,
+								nestedActionEvents,
+								(flags) => (userIntegrityCheckFlags |= flags),
+							),
 						});
 					}
 				}
@@ -1057,33 +1048,26 @@ export class PayloadService {
 
 					if (relation.meta.one_deselect_action === 'delete') {
 						await service.deleteByQuery(query, {
-							onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
-							bypassEmitAction: (params) =>
-								opts?.bypassEmitAction ? opts.bypassEmitAction(params) : nestedActionEvents.push(params),
-							emitEvents: opts?.emitEvents,
-							autoPurgeCache: opts?.autoPurgeCache,
-							autoPurgeSystemCache: opts?.autoPurgeSystemCache,
-							skipTracking: opts?.skipTracking,
-							overwriteDefaults: opts?.overwriteDefaults?.[relation.meta!.one_field!]?.['delete'],
-							onItemCreate: opts?.onItemCreate,
-							mutationTracker: opts?.mutationTracker,
+							...this.getNestedMutationOptions(
+								opts,
+								opts?.overwriteDefaults?.[relation.meta!.one_field!]?.['delete'],
+								revisions,
+								nestedActionEvents,
+								(flags) => (userIntegrityCheckFlags |= flags),
+							),
 						});
 					} else {
 						await service.updateByQuery(
 							query,
 							{ [relation.field]: null },
 							{
-								onRevisionCreate: (pk) => revisions.push(pk),
-								onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
-								bypassEmitAction: (params) =>
-									opts?.bypassEmitAction ? opts.bypassEmitAction(params) : nestedActionEvents.push(params),
-								emitEvents: opts?.emitEvents,
-								autoPurgeCache: opts?.autoPurgeCache,
-								autoPurgeSystemCache: opts?.autoPurgeSystemCache,
-								skipTracking: opts?.skipTracking,
-								overwriteDefaults: opts?.overwriteDefaults?.[relation.meta!.one_field!]?.['delete'],
-								onItemCreate: opts?.onItemCreate,
-								mutationTracker: opts?.mutationTracker,
+								...this.getNestedMutationOptions(
+									opts,
+									opts?.overwriteDefaults?.[relation.meta!.one_field!]?.['delete'],
+									revisions,
+									nestedActionEvents,
+									(flags) => (userIntegrityCheckFlags |= flags),
+								),
 							},
 						);
 					}

--- a/api/src/services/policies.ts
+++ b/api/src/services/policies.ts
@@ -4,6 +4,7 @@ import { UserIntegrityCheckFlag } from '@directus/types';
 import { getMatch } from 'ip-matching';
 import { clearSystemCache } from '../cache.js';
 import { clearCache as clearPermissionsCache } from '../permissions/cache.js';
+import { ensureUserCountBaseline } from '../utils/validate-user-count-integrity.js';
 import { ItemsService } from './items.js';
 
 export class PoliciesService extends ItemsService<Policy> {
@@ -84,7 +85,19 @@ export class PoliciesService extends ItemsService<Policy> {
 				(opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None) | UserIntegrityCheckFlag.UserLimits;
 		}
 
-		if (opts.userIntegrityCheckFlags) opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags);
+		if (opts.userIntegrityCheckFlags) {
+			const userCountBaseline = await ensureUserCountBaseline({
+				flags: opts.userIntegrityCheckFlags,
+				knex: this.knex,
+				...(opts.userCountBaseline ? { userCountBaseline: opts.userCountBaseline } : {}),
+			});
+
+			if (userCountBaseline) {
+				opts.userCountBaseline = userCountBaseline;
+			}
+
+			opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags, opts.userCountBaseline);
+		}
 
 		const result = await super.updateMany(keys, data, opts);
 
@@ -98,7 +111,18 @@ export class PoliciesService extends ItemsService<Policy> {
 
 	override async deleteMany(keys: PrimaryKey[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
 		opts.userIntegrityCheckFlags = UserIntegrityCheckFlag.All;
-		opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags);
+
+		const userCountBaseline = await ensureUserCountBaseline({
+			flags: opts.userIntegrityCheckFlags,
+			knex: this.knex,
+			...(opts.userCountBaseline ? { userCountBaseline: opts.userCountBaseline } : {}),
+		});
+
+		if (userCountBaseline) {
+			opts.userCountBaseline = userCountBaseline;
+		}
+
+		opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags, opts.userCountBaseline);
 
 		const result = await super.deleteMany(keys, opts);
 

--- a/api/src/services/roles.test.ts
+++ b/api/src/services/roles.test.ts
@@ -4,11 +4,16 @@ import { UserIntegrityCheckFlag } from '@directus/types';
 import knex from 'knex';
 import { createTracker, MockClient } from 'knex-mock-client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ensureUserCountBaseline } from '../utils/validate-user-count-integrity.js';
 import { AccessService, ItemsService, PresetsService, RolesService, UsersService } from './index.js';
 
 vi.mock('../../src/database/index', () => ({
 	default: vi.fn(),
 	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+vi.mock('../utils/validate-user-count-integrity.js', () => ({
+	ensureUserCountBaseline: vi.fn().mockResolvedValue({ admin: 2, app: 3, api: 5 }),
 }));
 
 const schema = new SchemaBuilder()
@@ -52,6 +57,8 @@ describe('Integration Tests', () => {
 				await service.updateMany(['role-id-3'], { parent: 'parent-role-id-1' }, opts);
 
 				expect(opts.userIntegrityCheckFlags).toBe(UserIntegrityCheckFlag.All);
+				expect(opts.userCountBaseline).toEqual({ admin: 2, app: 3, api: 5 });
+				expect(ensureUserCountBaseline).toHaveBeenCalled();
 			});
 
 			it('should validate role nesting if parent is changed', async () => {
@@ -91,7 +98,13 @@ describe('Integration Tests', () => {
 
 				await service.deleteMany(keys);
 
-				const opts: MutationOptions = { userIntegrityCheckFlags: UserIntegrityCheckFlag.All, bypassLimits: true };
+				const opts: MutationOptions = {
+					userIntegrityCheckFlags: UserIntegrityCheckFlag.All,
+					userCountBaseline: { admin: 2, app: 3, api: 5 },
+					bypassLimits: true,
+				};
+
+				expect(ensureUserCountBaseline).toHaveBeenCalled();
 
 				expect(accessDeleteByQuerySpy).toHaveBeenCalledWith(
 					{
@@ -132,7 +145,10 @@ describe('Integration Tests', () => {
 					{ parent: null },
 				);
 
-				expect(itemsDeleteManySpy).toHaveBeenCalledWith(keys, { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
+				expect(itemsDeleteManySpy).toHaveBeenCalledWith(keys, {
+					userIntegrityCheckFlags: UserIntegrityCheckFlag.All,
+					userCountBaseline: { admin: 2, app: 3, api: 5 },
+				});
 			});
 
 			it('should clear caches', async () => {

--- a/api/src/services/roles.ts
+++ b/api/src/services/roles.ts
@@ -4,6 +4,7 @@ import { UserIntegrityCheckFlag } from '@directus/types';
 import { clearSystemCache } from '../cache.js';
 import { fetchRolesTree } from '../permissions/lib/fetch-roles-tree.js';
 import { transaction } from '../utils/transaction.js';
+import { ensureUserCountBaseline } from '../utils/validate-user-count-integrity.js';
 import { AccessService } from './access.js';
 import { ItemsService } from './items.js';
 import { PresetsService } from './presets.js';
@@ -27,7 +28,18 @@ export class RolesService extends ItemsService {
 			// If the parent of a role changed we need to make a full integrity check.
 			// Anything related to policies will be checked in the AccessService, where the policies are attached to roles
 			opts.userIntegrityCheckFlags = UserIntegrityCheckFlag.All;
-			opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags);
+
+			const userCountBaseline = await ensureUserCountBaseline({
+				flags: opts.userIntegrityCheckFlags,
+				knex: this.knex,
+				...(opts.userCountBaseline ? { userCountBaseline: opts.userCountBaseline } : {}),
+			});
+
+			if (userCountBaseline) {
+				opts.userCountBaseline = userCountBaseline;
+			}
+
+			opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags, opts.userCountBaseline);
 
 			await this.validateRoleNesting(keys as string[], data['parent']);
 		}
@@ -45,7 +57,18 @@ export class RolesService extends ItemsService {
 
 	override async deleteMany(keys: PrimaryKey[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
 		opts.userIntegrityCheckFlags = UserIntegrityCheckFlag.All;
-		opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags);
+
+		const userCountBaseline = await ensureUserCountBaseline({
+			flags: opts.userIntegrityCheckFlags,
+			knex: this.knex,
+			...(opts.userCountBaseline ? { userCountBaseline: opts.userCountBaseline } : {}),
+		});
+
+		if (userCountBaseline) {
+			opts.userCountBaseline = userCountBaseline;
+		}
+
+		opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags, opts.userCountBaseline);
 
 		await transaction(this.knex, async (trx) => {
 			const options: AbstractServiceOptions = {

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -2,12 +2,14 @@ import { ForbiddenError, InvalidInviteError, InvalidPayloadError, RecordNotUniqu
 import { SchemaBuilder } from '@directus/schema-builder';
 import type { Accountability, MutationOptions } from '@directus/types';
 import { UserIntegrityCheckFlag } from '@directus/types';
+import * as directusUtils from '@directus/utils';
 import knex from 'knex';
 import { createTracker, MockClient } from 'knex-mock-client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { validateRemainingAdminUsers } from '../permissions/modules/validate-remaining-admin/validate-remaining-admin-users.js';
 import { verifyJWT } from '../utils/jwt.js';
-import { ItemsService, MailService, UsersService } from './index.js';
+import { ensureUserCountBaseline } from '../utils/validate-user-count-integrity.js';
+import { ItemsService, MailService, SettingsService, UsersService } from './index.js';
 
 vi.mock('../../src/database/index', () => ({
 	default: vi.fn(),
@@ -34,6 +36,10 @@ vi.mock('../permissions/modules/validate-remaining-admin/validate-remaining-admi
 
 vi.mock('../utils/jwt.js', () => ({
 	verifyJWT: vi.fn(),
+}));
+
+vi.mock('../utils/validate-user-count-integrity.js', () => ({
+	ensureUserCountBaseline: vi.fn().mockResolvedValue({ admin: 1, app: 1, api: 2 }),
 }));
 
 vi.mock('../utils/get-secret.js', () => ({
@@ -114,6 +120,8 @@ describe('Integration Tests', () => {
 				await service.createOne({}, opts);
 
 				expect(opts.userIntegrityCheckFlags).toBe(UserIntegrityCheckFlag.UserLimits);
+				expect(opts.userCountBaseline).toEqual({ admin: 1, app: 1, api: 2 });
+				expect(ensureUserCountBaseline).toHaveBeenCalled();
 			});
 		});
 
@@ -150,6 +158,8 @@ describe('Integration Tests', () => {
 				await service.createMany([{}], opts);
 
 				expect(opts.userIntegrityCheckFlags).toBe(UserIntegrityCheckFlag.UserLimits);
+				expect(opts.userCountBaseline).toEqual({ admin: 1, app: 1, api: 2 });
+				expect(ensureUserCountBaseline).toHaveBeenCalled();
 			});
 		});
 
@@ -186,6 +196,7 @@ describe('Integration Tests', () => {
 				await service.updateMany(['user-id-6'], { status: 'active' }, opts);
 
 				expect(opts.userIntegrityCheckFlags).toBe(UserIntegrityCheckFlag.UserLimits);
+				expect(opts.userCountBaseline).toEqual({ admin: 1, app: 1, api: 2 });
 				expect(clearUserSessionsSpy).not.toBeCalled();
 			});
 
@@ -479,6 +490,119 @@ describe('Integration Tests', () => {
 				});
 
 				await expect(service.acceptInvite('fake-token', 'Password123!')).rejects.toThrow(ForbiddenError);
+			});
+
+			it('should activate invited users through updateOne', async () => {
+				vi.mocked(verifyJWT).mockReturnValueOnce({ email: 'test@example.com', scope: 'invite' });
+
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+					id: 'user-id-invite',
+					status: 'invited',
+					email: 'test@example.com',
+				});
+
+				const updateOneSpy = vi.spyOn(UsersService.prototype, 'updateOne').mockResolvedValue('user-id-invite');
+
+				const service = new UsersService({
+					knex: db,
+					schema,
+				});
+
+				await service.acceptInvite('fake-token', 'Password123!');
+
+				expect(updateOneSpy).toHaveBeenCalledWith('user-id-invite', { password: 'Password123!', status: 'active' });
+			});
+		});
+
+		describe('verifyRegistration', () => {
+			it('should activate unverified users through updateOne', async () => {
+				vi.mocked(verifyJWT).mockReturnValueOnce({ email: 'verify@example.com', scope: 'pending-registration' });
+
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+					id: 'user-id-verify',
+					status: 'unverified',
+					email: 'verify@example.com',
+				});
+
+				const updateOneSpy = vi.spyOn(UsersService.prototype, 'updateOne').mockResolvedValue('user-id-verify');
+
+				const service = new UsersService({
+					knex: db,
+					schema,
+				});
+
+				await service.verifyRegistration('fake-token');
+
+				expect(updateOneSpy).toHaveBeenCalledWith('user-id-verify', { status: 'active' });
+			});
+		});
+
+		describe('registerUser', () => {
+			it('should create active users when email verification is disabled', async () => {
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce(undefined);
+				const createOneSpy = vi.spyOn(UsersService.prototype, 'createOne').mockResolvedValue('user-id-register');
+
+				vi.spyOn(SettingsService.prototype, 'readSingleton').mockResolvedValueOnce({
+					public_registration: true,
+					public_registration_verify_email: false,
+					public_registration_role: 'public-role',
+					public_registration_email_filter: null,
+				} as any);
+
+				const service = new UsersService({
+					knex: db,
+					schema,
+				});
+
+				await service.registerUser({
+					email: 'register@example.com',
+					password: 'Password123!',
+				});
+
+				expect(createOneSpy).toHaveBeenCalledWith(
+					expect.objectContaining({
+						email: 'register@example.com',
+						status: 'active',
+						role: 'public-role',
+					}),
+				);
+			});
+		});
+
+		describe('resetPassword', () => {
+			it('should reset active users without changing the target status', async () => {
+				vi.mocked(verifyJWT).mockReturnValueOnce({
+					email: 'reset@example.com',
+					scope: 'password-reset',
+					hash: 'hash',
+				});
+
+				vi.spyOn(UsersService.prototype as any, 'checkPasswordPolicy').mockResolvedValueOnce(undefined);
+
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+					id: 'user-id-reset',
+					status: 'active',
+					email: 'reset@example.com',
+					password: 'hashed-password',
+				});
+
+				const updateOneSpy = vi.spyOn(UsersService.prototype, 'updateOne').mockResolvedValue('user-id-reset');
+				const hashSpy = vi.spyOn(directusUtils, 'getSimpleHash').mockReturnValue('hash');
+
+				const service = new UsersService({
+					knex: db,
+					schema,
+				});
+
+				await service.resetPassword('fake-token', 'Password123!');
+
+				expect(updateOneSpy).toHaveBeenCalledWith(
+					'user-id-reset',
+					{ password: 'Password123!', status: 'active' },
+					expect.any(Object),
+				);
+
+				hashSpy.mockRestore();
 			});
 		});
 	});

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -27,6 +27,7 @@ import isUrlAllowed from '../utils/is-url-allowed.js';
 import { verifyJWT } from '../utils/jwt.js';
 import { stall } from '../utils/stall.js';
 import { Url } from '../utils/url.js';
+import { ensureUserCountBaseline } from '../utils/validate-user-count-integrity.js';
 import { ItemsService } from './items.js';
 import { MailService } from './mail/index.js';
 import { SettingsService } from './settings.js';
@@ -206,7 +207,17 @@ export class UsersService extends ItemsService {
 			opts.userIntegrityCheckFlags =
 				(opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None) | UserIntegrityCheckFlag.UserLimits;
 
-			opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags);
+			const userCountBaseline = await ensureUserCountBaseline({
+				flags: opts.userIntegrityCheckFlags,
+				knex: this.knex,
+				...(opts.userCountBaseline ? { userCountBaseline: opts.userCountBaseline } : {}),
+			});
+
+			if (userCountBaseline) {
+				opts.userCountBaseline = userCountBaseline;
+			}
+
+			opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags, opts.userCountBaseline);
 		}
 
 		return await super.createOne(data, opts);
@@ -238,7 +249,17 @@ export class UsersService extends ItemsService {
 			opts.userIntegrityCheckFlags =
 				(opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None) | UserIntegrityCheckFlag.UserLimits;
 
-			opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags);
+			const userCountBaseline = await ensureUserCountBaseline({
+				flags: opts.userIntegrityCheckFlags,
+				knex: this.knex,
+				...(opts.userCountBaseline ? { userCountBaseline: opts.userCountBaseline } : {}),
+			});
+
+			if (userCountBaseline) {
+				opts.userCountBaseline = userCountBaseline;
+			}
+
+			opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags, opts.userCountBaseline);
 		}
 
 		// Use generic ItemsService to avoid calling `UserService.createOne` to avoid additional work of validating emails,
@@ -316,7 +337,17 @@ export class UsersService extends ItemsService {
 		}
 
 		if (opts.userIntegrityCheckFlags) {
-			opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags);
+			const userCountBaseline = await ensureUserCountBaseline({
+				flags: opts.userIntegrityCheckFlags,
+				knex: this.knex,
+				...(opts.userCountBaseline ? { userCountBaseline: opts.userCountBaseline } : {}),
+			});
+
+			if (userCountBaseline) {
+				opts.userCountBaseline = userCountBaseline;
+			}
+
+			opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags, opts.userCountBaseline);
 		}
 
 		const result = await super.updateMany(keys, data, opts);
@@ -340,7 +371,10 @@ export class UsersService extends ItemsService {
 	 */
 	override async deleteMany(keys: PrimaryKey[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
 		if (opts?.onRequireUserIntegrityCheck) {
-			opts.onRequireUserIntegrityCheck(opts?.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None);
+			opts.onRequireUserIntegrityCheck(
+				opts?.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None,
+				opts?.userCountBaseline,
+			);
 		} else {
 			try {
 				await validateRemainingAdminUsers({ excludeUsers: keys }, { knex: this.knex, schema: this.schema });

--- a/api/src/utils/validate-user-count-integrity.test.ts
+++ b/api/src/utils/validate-user-count-integrity.test.ts
@@ -1,3 +1,224 @@
-import { test } from 'vitest';
+import { InternalServerError, LimitExceededError } from '@directus/errors';
+import { UserIntegrityCheckFlag } from '@directus/types';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { getLicenseEntitlements } from '../license/summary.js';
+import { validateRemainingAdminCount } from '../permissions/modules/validate-remaining-admin/validate-remaining-admin-count.js';
+import { fetchUserCount } from './fetch-user-count/fetch-user-count.js';
+import { ensureUserCountBaseline, validateUserCountIntegrity } from './validate-user-count-integrity.js';
 
-test.todo('unimplemented test');
+const { mockedEnv } = vi.hoisted(() => ({
+	mockedEnv: {
+		USERS_ADMIN_ACCESS_LIMIT: 3,
+		USERS_APP_ACCESS_LIMIT: 3,
+		USERS_API_ACCESS_LIMIT: 3,
+	},
+}));
+
+vi.mock('@directus/env', () => ({
+	useEnv: vi.fn().mockReturnValue(mockedEnv),
+}));
+
+vi.mock('../license/summary.js', () => ({
+	getLicenseEntitlements: vi.fn(),
+}));
+
+vi.mock('../permissions/modules/validate-remaining-admin/validate-remaining-admin-count.js', () => ({
+	validateRemainingAdminCount: vi.fn(),
+}));
+
+vi.mock('./fetch-user-count/fetch-user-count.js', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('./fetch-user-count/fetch-user-count.js')>();
+
+	return {
+		...actual,
+		fetchUserCount: vi.fn(),
+	};
+});
+
+const mockedFetchUserCount = vi.mocked(fetchUserCount);
+const mockedGetLicenseEntitlements = vi.mocked(getLicenseEntitlements);
+const mockedValidateRemainingAdminCount = vi.mocked(validateRemainingAdminCount);
+
+afterEach(() => {
+	vi.clearAllMocks();
+	mockedEnv.USERS_ADMIN_ACCESS_LIMIT = 3;
+	mockedEnv.USERS_APP_ACCESS_LIMIT = 3;
+	mockedEnv.USERS_API_ACCESS_LIMIT = 3;
+});
+
+describe('ensureUserCountBaseline', () => {
+	test('returned undefined when user limits were not requested', async () => {
+		await expect(
+			ensureUserCountBaseline({ flags: UserIntegrityCheckFlag.RemainingAdmins, knex: {} as any }),
+		).resolves.toBeUndefined();
+
+		expect(mockedFetchUserCount).not.toHaveBeenCalled();
+	});
+
+	test('returns the provided counts', async () => {
+		await expect(
+			ensureUserCountBaseline({
+				flags: UserIntegrityCheckFlag.UserLimits,
+				knex: {} as any,
+				userCountBaseline: { admin: 1, app: 2, api: 3 },
+			}),
+		).resolves.toEqual({ admin: 1, app: 2, api: 3 });
+
+		expect(mockedFetchUserCount).not.toHaveBeenCalled();
+	});
+
+	test('loads the full user counts', async () => {
+		mockedFetchUserCount.mockResolvedValue({ admin: 2, app: 3, api: 99 });
+
+		await expect(
+			ensureUserCountBaseline({ flags: UserIntegrityCheckFlag.UserLimits, knex: {} as any }),
+		).resolves.toEqual({ admin: 2, app: 3, api: 99 });
+	});
+});
+
+describe('validateUserCountIntegrity', () => {
+	test('no-oped when no integrity checks were requested', async () => {
+		await validateUserCountIntegrity({ flags: UserIntegrityCheckFlag.None, knex: {} as any });
+
+		expect(mockedFetchUserCount).not.toHaveBeenCalled();
+		expect(mockedGetLicenseEntitlements).not.toHaveBeenCalled();
+	});
+
+	test('validated user seats using admin and app users only', async () => {
+		mockedEnv.USERS_ADMIN_ACCESS_LIMIT = Infinity;
+		mockedEnv.USERS_APP_ACCESS_LIMIT = Infinity;
+		mockedEnv.USERS_API_ACCESS_LIMIT = Infinity;
+
+		mockedFetchUserCount.mockResolvedValue({ admin: 2, app: 2, api: 500 });
+
+		mockedGetLicenseEntitlements.mockResolvedValue({
+			seats: { limit: 3, hard_limit: 3, is_overage_allowed: false },
+		} as any);
+
+		const promise = validateUserCountIntegrity({
+			flags: UserIntegrityCheckFlag.UserLimits,
+			knex: {} as any,
+			userCountBaseline: { admin: 1, app: 2, api: 500 },
+		});
+
+		await expect(promise).rejects.toMatchObject({
+			message: 'Users limit exceeded.',
+			extensions: {
+				category: 'Users',
+				limit_type: 'license',
+			},
+		});
+	});
+
+	test('allowed neutral seat usage while already over limit', async () => {
+		mockedFetchUserCount.mockResolvedValue({ admin: 2, app: 2, api: 0 });
+
+		mockedGetLicenseEntitlements.mockResolvedValue({
+			seats: { limit: 3, hard_limit: 3, is_overage_allowed: false },
+		} as any);
+
+		await expect(
+			validateUserCountIntegrity({
+				flags: UserIntegrityCheckFlag.UserLimits,
+				knex: {} as any,
+				userCountBaseline: { admin: 2, app: 2, api: 0 },
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	test('fails closed when user limits are requested without a baseline', async () => {
+		mockedFetchUserCount.mockResolvedValue({ admin: 2, app: 2, api: 0 });
+
+		mockedGetLicenseEntitlements.mockResolvedValue({
+			seats: { limit: 3, hard_limit: 3, is_overage_allowed: false },
+		} as any);
+
+		await expect(
+			validateUserCountIntegrity({
+				flags: UserIntegrityCheckFlag.UserLimits,
+				knex: {} as any,
+			}),
+		).rejects.toBeInstanceOf(InternalServerError);
+	});
+
+	test('allowed decreasing seat usage while already over limit', async () => {
+		mockedFetchUserCount.mockResolvedValue({ admin: 1, app: 1, api: 0 });
+
+		mockedGetLicenseEntitlements.mockResolvedValue({
+			seats: { limit: 1, hard_limit: 1, is_overage_allowed: false },
+		} as any);
+
+		await expect(
+			validateUserCountIntegrity({
+				flags: UserIntegrityCheckFlag.UserLimits,
+				knex: {} as any,
+				userCountBaseline: { admin: 2, app: 2, api: 0 },
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	test('enforced the configured admin env limit on increases', async () => {
+		mockedFetchUserCount.mockResolvedValue({ admin: 4, app: 0, api: 0 });
+
+		mockedGetLicenseEntitlements.mockResolvedValue({
+			seats: { limit: 10, hard_limit: 10, is_overage_allowed: false },
+		} as any);
+
+		await expect(
+			validateUserCountIntegrity({
+				flags: UserIntegrityCheckFlag.UserLimits,
+				knex: {} as any,
+				userCountBaseline: { admin: 3, app: 0, api: 0 },
+			}),
+		).rejects.toBeInstanceOf(LimitExceededError);
+	});
+
+	test('allowed api decreases while current usage stayed over the configured env limit', async () => {
+		mockedFetchUserCount.mockResolvedValue({ admin: 0, app: 0, api: 4 });
+
+		mockedGetLicenseEntitlements.mockResolvedValue({
+			seats: { limit: 10, hard_limit: 10, is_overage_allowed: false },
+		} as any);
+
+		await expect(
+			validateUserCountIntegrity({
+				flags: UserIntegrityCheckFlag.UserLimits,
+				knex: {} as any,
+				userCountBaseline: { admin: 0, app: 0, api: 5 },
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	test('validated remaining admins with the admin-only query when seat checks were not requested', async () => {
+		mockedFetchUserCount.mockResolvedValue({ admin: 1, app: 0, api: 0 });
+
+		await validateUserCountIntegrity({
+			flags: UserIntegrityCheckFlag.RemainingAdmins,
+			knex: {} as any,
+		});
+
+		expect(mockedFetchUserCount).toHaveBeenCalledWith({
+			flags: UserIntegrityCheckFlag.RemainingAdmins,
+			knex: {} as any,
+			adminOnly: true,
+		});
+
+		expect(mockedValidateRemainingAdminCount).toHaveBeenCalledWith(1);
+	});
+
+	test('ran both seat and remaining-admin validation when both flags were requested', async () => {
+		mockedFetchUserCount.mockResolvedValue({ admin: 1, app: 1, api: 0 });
+
+		mockedGetLicenseEntitlements.mockResolvedValue({
+			seats: { limit: 3, hard_limit: 3, is_overage_allowed: false },
+		} as any);
+
+		await validateUserCountIntegrity({
+			flags: UserIntegrityCheckFlag.All,
+			knex: {} as any,
+			userCountBaseline: { admin: 1, app: 0, api: 0 },
+		});
+
+		expect(mockedValidateRemainingAdminCount).toHaveBeenCalledWith(1);
+	});
+});

--- a/api/src/utils/validate-user-count-integrity.ts
+++ b/api/src/utils/validate-user-count-integrity.ts
@@ -1,28 +1,100 @@
-import { UserIntegrityCheckFlag } from '@directus/types';
+import { useEnv } from '@directus/env';
+import { InternalServerError, LimitExceededError } from '@directus/errors';
+import { type UserCountBaseline, UserIntegrityCheckFlag } from '@directus/types';
+import { validateNumericEntitlementLimit } from '../license/numeric-gate.js';
+import { getLicenseEntitlements } from '../license/summary.js';
 import { validateRemainingAdminCount } from '../permissions/modules/validate-remaining-admin/validate-remaining-admin-count.js';
-import { checkUserLimits } from '../telemetry/utils/check-user-limits.js';
-import { shouldCheckUserLimits } from '../telemetry/utils/should-check-user-limits.js';
-import { fetchUserCount, type FetchUserCountOptions } from './fetch-user-count/fetch-user-count.js';
+import { fetchUserCount, type FetchUserCountOptions, getUserSeatsCount } from './fetch-user-count/fetch-user-count.js';
+
+const env = useEnv();
 
 export interface ValidateUserCountIntegrityOptions extends Omit<FetchUserCountOptions, 'adminOnly'> {
 	flags: UserIntegrityCheckFlag;
+	userCountBaseline?: UserCountBaseline;
+}
+
+export async function ensureUserCountBaseline(
+	options: Pick<ValidateUserCountIntegrityOptions, 'flags' | 'knex' | 'userCountBaseline'>,
+): Promise<UserCountBaseline | undefined> {
+	const validateUserLimits = (options.flags & UserIntegrityCheckFlag.UserLimits) !== 0;
+
+	if (!validateUserLimits || options.userCountBaseline !== undefined) {
+		return options.userCountBaseline;
+	}
+
+	return await fetchUserCount({ knex: options.knex });
+}
+
+function validateIncreaseOnlyUserLimit(
+	current: number,
+	baseline: number,
+	limit: number,
+	category: 'Active Admin users' | 'Active App users' | 'Active API users',
+) {
+	if (limit === Infinity) return;
+	if (current <= baseline) return;
+	if (current <= limit) return;
+
+	throw new LimitExceededError({ category });
+}
+
+function validateConfiguredUserLimits(userCountBaseline: UserCountBaseline, userCountCurrent: UserCountBaseline) {
+	validateIncreaseOnlyUserLimit(
+		userCountCurrent.admin,
+		userCountBaseline.admin,
+		Number(env['USERS_ADMIN_ACCESS_LIMIT']),
+		'Active Admin users',
+	);
+
+	validateIncreaseOnlyUserLimit(
+		userCountCurrent.admin + userCountCurrent.app,
+		userCountBaseline.admin + userCountBaseline.app,
+		Number(env['USERS_APP_ACCESS_LIMIT']),
+		'Active App users',
+	);
+
+	validateIncreaseOnlyUserLimit(
+		userCountCurrent.api,
+		userCountBaseline.api,
+		Number(env['USERS_API_ACCESS_LIMIT']),
+		'Active API users',
+	);
 }
 
 export async function validateUserCountIntegrity(options: ValidateUserCountIntegrityOptions) {
 	const validateUserLimits = (options.flags & UserIntegrityCheckFlag.UserLimits) !== 0;
 	const validateRemainingAdminUsers = (options.flags & UserIntegrityCheckFlag.RemainingAdmins) !== 0;
 
-	const limitCheck = validateUserLimits && shouldCheckUserLimits();
-
-	if (!validateRemainingAdminUsers && !limitCheck) {
+	if (!validateRemainingAdminUsers && !validateUserLimits) {
 		return;
 	}
 
-	const adminOnly = validateRemainingAdminUsers && !limitCheck;
+	const adminOnly = validateRemainingAdminUsers && !validateUserLimits;
 	const userCounts = await fetchUserCount({ ...options, adminOnly });
 
-	if (limitCheck) {
-		await checkUserLimits(userCounts);
+	if (validateUserLimits) {
+		const entitlements = await getLicenseEntitlements(options.knex);
+		const userCountBaseline = options.userCountBaseline;
+
+		if (userCountBaseline === undefined) {
+			throw new InternalServerError();
+		}
+
+		validateConfiguredUserLimits(userCountBaseline, userCounts);
+
+		const userSeatsBaseline = getUserSeatsCount(userCountBaseline);
+		const userSeatsCurrent = getUserSeatsCount(userCounts);
+		const userSeatsDelta = userSeatsCurrent - userSeatsBaseline;
+
+		if (userSeatsDelta > 0) {
+			validateNumericEntitlementLimit({
+				entitlement: entitlements.seats,
+				current: userSeatsBaseline,
+				delta: userSeatsDelta,
+				category: 'Users',
+				limit_type: 'license',
+			});
+		}
 	}
 
 	if (validateRemainingAdminUsers) {

--- a/packages/types/src/items.ts
+++ b/packages/types/src/items.ts
@@ -1,7 +1,7 @@
 import type { DirectusError } from './error.js';
 import type { EventContext } from './events.js';
 import type { PermissionsAction } from './permissions.js';
-import type { UserIntegrityCheckFlag } from './users.js';
+import type { UserCountBaseline, UserIntegrityCheckFlag } from './users.js';
 
 export type Item = Record<string, any>;
 
@@ -103,9 +103,16 @@ export type MutationOptions = {
 	userIntegrityCheckFlags?: UserIntegrityCheckFlag;
 
 	/**
+	 * Baseline user counts captured before a top-level mutation so nested mutations can enforce increase-only seat rules.
+	 */
+	userCountBaseline?: UserCountBaseline;
+
+	/**
 	 * Callback function that is called whenever a mutation requires a user integrity check to be made
 	 */
-	onRequireUserIntegrityCheck?: ((flags: UserIntegrityCheckFlag) => void) | undefined;
+	onRequireUserIntegrityCheck?:
+		| ((flags: UserIntegrityCheckFlag, userCountBaseline?: UserCountBaseline) => void)
+		| undefined;
 };
 
 export type FieldMutationOptions = MutationOptions & {

--- a/packages/types/src/users.ts
+++ b/packages/types/src/users.ts
@@ -53,6 +53,12 @@ export type RegisterUserInput = {
 	last_name?: User['last_name'];
 };
 
+export type UserCountBaseline = {
+	admin: number;
+	app: number;
+	api: number;
+};
+
 export enum UserIntegrityCheckFlag {
 	None = 0,
 	/** Check if the number of remaining admin users is greater than 0 */


### PR DESCRIPTION
## Scope

What's changed:

- Added user-count baseline propagation so seat-limit and remaining-admin validation can reuse a consistent snapshot across nested mutations instead of recalculating mid-operation.
- Updated `UsersService`, `AccessService`, `RolesService`, `PoliciesService`, and related mutation paths to capture and pass that baseline whenever user limits or role/admin integrity checks are required.
- Updated payload relation handling so nested creates and updates preserve the same user-integrity context and baseline as the top-level mutation.
- Tightened activation-related flows so invite acceptance and registration verification use shared user mutation paths that participate in the same integrity checks, while registration creation keeps the same baseline-aware limit handling.
- Extended user-count integrity utilities and shared types, including the mutation callback contract, to support the baseline-aware checks across admin, app, and API seat calculations.

## Potential Risks / Drawbacks

- This changes the mutation-options contract used by several services, so nested write paths are a likely place for subtle regressions.
- Activation flows now depend more heavily on shared update logic, which may change when sessions are cleared and when integrity checks fire.
- Access, roles, policies, and user-status changes all feed into licensed seat counts now, which increases coupling between permission updates and licensing checks.

## Tested Scenarios

- Added and expanded service tests for user creation, activation, status changes, access updates, and user-integrity baseline handling.
- Added coverage for invite acceptance and registration verification activation behavior alongside baseline-aware registration handling.
- Added focused tests for the user-count integrity utility to confirm baseline-aware behavior across seat and admin checks.

## Review Notes / Questions

- Special attention should be paid to nested mutations that activate users indirectly, since they now rely on the propagated baseline being preserved correctly.
- The baseline is optional and only attached when limits matter, so it is worth checking there are no remaining paths that request integrity checks without forwarding it.
- This branch is mostly behavioral plumbing, so reviewer focus on side effects like session clearing and role/cache invalidation would be helpful.

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #\<num\>
