### PR TITLE
Add activity and revision limits

### DIFF
--- a/api/src/controllers/activity.ts
+++ b/api/src/controllers/activity.ts
@@ -21,6 +21,8 @@ const readHandler = asyncHandler(async (req, res, next) => {
 		schema: req.schema,
 	});
 
+	const historyQuery = await service.getHistoryQuery(req.sanitizedQuery);
+
 	let result;
 
 	if (req.singleton) {
@@ -31,7 +33,7 @@ const readHandler = asyncHandler(async (req, res, next) => {
 		result = await service.readByQuery(req.sanitizedQuery);
 	}
 
-	const meta = await metaService.getMetaForQuery('directus_activity', req.sanitizedQuery);
+	const meta = await metaService.getMetaForQuery('directus_activity', historyQuery);
 
 	res.locals['payload'] = {
 		data: result,

--- a/api/src/controllers/revisions.ts
+++ b/api/src/controllers/revisions.ts
@@ -21,8 +21,10 @@ const readHandler = asyncHandler(async (req, res, next) => {
 		schema: req.schema,
 	});
 
+	const historyQuery = await service.getHistoryQuery(req.sanitizedQuery);
+
 	const records = await service.readByQuery(req.sanitizedQuery);
-	const meta = await metaService.getMetaForQuery('directus_revisions', req.sanitizedQuery);
+	const meta = await metaService.getMetaForQuery('directus_revisions', historyQuery);
 
 	res.locals['payload'] = { data: records || null, meta };
 	return next();

--- a/api/src/services/activity.test.ts
+++ b/api/src/services/activity.test.ts
@@ -1,0 +1,144 @@
+import { SchemaBuilder } from '@directus/schema-builder';
+import type { Query } from '@directus/types';
+import knex from 'knex';
+import { MockClient } from 'knex-mock-client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getLicenseEntitlements } from '../license/summary.js';
+import { ActivityService } from './activity.js';
+import { ItemsService } from './items.js';
+
+vi.mock('../../src/database/index', () => ({
+	default: vi.fn(),
+}));
+
+vi.mock('../license/summary.js', async () => {
+	const actual = await vi.importActual<typeof import('../license/summary.js')>('../license/summary.js');
+	return {
+		...actual,
+		getLicenseEntitlements: vi.fn(),
+	};
+});
+
+const schema = new SchemaBuilder()
+	.collection('directus_activity', (collection) => {
+		collection.field('id').integer().primary();
+		collection.field('timestamp').dateTime();
+	})
+	.build();
+
+describe('ActivityService', () => {
+	const db = vi.mocked(knex.default({ client: MockClient }));
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-04-11T00:00:00.000Z'));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it('applies the history filter and merges it with the existing query filter', async () => {
+		vi.mocked(getLicenseEntitlements).mockResolvedValue({
+			activity_history_days: { limit: 30 },
+		} as any);
+
+		const readByQuerySpy = vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([]);
+
+		const service = new ActivityService({
+			knex: db,
+			schema,
+		});
+
+		const query: Query = {
+			filter: {
+				user: {
+					_eq: 'test-user',
+				},
+			},
+		};
+
+		await service.readByQuery(query);
+
+		expect(readByQuerySpy).toHaveBeenCalledWith(
+			{
+				filter: {
+					_and: [
+						{
+							timestamp: {
+								_gte: '2026-03-12T00:00:00.000Z',
+							},
+						},
+						query.filter,
+					],
+				},
+			},
+			undefined,
+		);
+	});
+
+	it('leaves the query unchanged when the history limit is invalid', async () => {
+		vi.mocked(getLicenseEntitlements).mockResolvedValue({
+			activity_history_days: { limit: -1 },
+		} as any);
+
+		const readByQuerySpy = vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([]);
+
+		const service = new ActivityService({
+			knex: db,
+			schema,
+		});
+
+		const query: Query = {
+			filter: {
+				user: {
+					_eq: 'test-user',
+				},
+			},
+		};
+
+		await service.readByQuery(query);
+
+		expect(readByQuerySpy).toHaveBeenCalledWith(query, undefined);
+	});
+
+	it('denies all history when the limit is zero', async () => {
+		vi.mocked(getLicenseEntitlements).mockResolvedValue({
+			activity_history_days: { limit: 0 },
+		} as any);
+
+		const readByQuerySpy = vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([]);
+
+		const service = new ActivityService({
+			knex: db,
+			schema,
+		});
+
+		const query: Query = {
+			filter: {
+				user: {
+					_eq: 'test-user',
+				},
+			},
+		};
+
+		await service.readByQuery(query);
+
+		expect(readByQuerySpy).toHaveBeenCalledWith(
+			{
+				filter: {
+					_and: [
+						{
+							id: {
+								_null: true,
+							},
+						},
+						query.filter,
+					],
+				},
+			},
+			undefined,
+		);
+	});
+});

--- a/api/src/services/activity.ts
+++ b/api/src/services/activity.ts
@@ -1,8 +1,25 @@
-import type { AbstractServiceOptions } from '@directus/types';
+import type { AbstractServiceOptions, Query, QueryOptions } from '@directus/types';
+import { createHistoryQueryResolver } from '../utils/get-history-filter-query.js';
 import { ItemsService } from './items.js';
 
 export class ActivityService extends ItemsService {
+	private readonly resolveHistoryQuery = createHistoryQueryResolver('activity_history_days', (sinceDate) => ({
+		timestamp: {
+			_gte: sinceDate.toISOString(),
+		},
+	}));
+
 	constructor(options: AbstractServiceOptions) {
 		super('directus_activity', options);
+	}
+
+	async getHistoryQuery(query: Query): Promise<Query> {
+		return this.resolveHistoryQuery(query, this.knex);
+	}
+
+	override async readByQuery(query: Query, opts?: QueryOptions) {
+		const historyQuery = await this.getHistoryQuery(query);
+
+		return super.readByQuery(historyQuery, opts);
 	}
 }

--- a/api/src/services/revisions.test.ts
+++ b/api/src/services/revisions.test.ts
@@ -1,0 +1,145 @@
+import { SchemaBuilder } from '@directus/schema-builder';
+import type { Query } from '@directus/types';
+import knex from 'knex';
+import { MockClient } from 'knex-mock-client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getLicenseEntitlements } from '../license/summary.js';
+import { ItemsService } from './items.js';
+import { RevisionsService } from './revisions.js';
+
+vi.mock('../../src/database/index', () => ({
+	default: vi.fn(),
+}));
+
+vi.mock('../license/summary.js', async () => {
+	const actual = await vi.importActual<typeof import('../license/summary.js')>('../license/summary.js');
+	return {
+		...actual,
+		getLicenseEntitlements: vi.fn(),
+	};
+});
+
+const schema = new SchemaBuilder()
+	.collection('directus_revisions', (collection) => {
+		collection.field('id').integer().primary();
+	})
+	.build();
+
+describe('RevisionsService', () => {
+	const db = vi.mocked(knex.default({ client: MockClient }));
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-04-11T00:00:00.000Z'));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it('applies the nested activity history filter and merges it with the existing query filter', async () => {
+		vi.mocked(getLicenseEntitlements).mockResolvedValue({
+			revisions_history_days: { limit: 14 },
+		} as any);
+
+		const readByQuerySpy = vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([]);
+
+		const service = new RevisionsService({
+			knex: db,
+			schema,
+		});
+
+		const query: Query = {
+			filter: {
+				collection: {
+					_eq: 'posts',
+				},
+			},
+		};
+
+		await service.readByQuery(query);
+
+		expect(readByQuerySpy).toHaveBeenCalledWith(
+			{
+				filter: {
+					_and: [
+						{
+							activity: {
+								timestamp: {
+									_gte: '2026-03-28T00:00:00.000Z',
+								},
+							},
+						},
+						query.filter,
+					],
+				},
+			},
+			undefined,
+		);
+	});
+
+	it('leaves the query unchanged when the history limit is invalid', async () => {
+		vi.mocked(getLicenseEntitlements).mockResolvedValue({
+			revisions_history_days: { limit: -1 },
+		} as any);
+
+		const readByQuerySpy = vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([]);
+
+		const service = new RevisionsService({
+			knex: db,
+			schema,
+		});
+
+		const query: Query = {
+			filter: {
+				collection: {
+					_eq: 'posts',
+				},
+			},
+		};
+
+		await service.readByQuery(query);
+
+		expect(readByQuerySpy).toHaveBeenCalledWith(query, undefined);
+	});
+
+	it('denies all history when the limit is zero', async () => {
+		vi.mocked(getLicenseEntitlements).mockResolvedValue({
+			revisions_history_days: { limit: 0 },
+		} as any);
+
+		const readByQuerySpy = vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([]);
+
+		const service = new RevisionsService({
+			knex: db,
+			schema,
+		});
+
+		const query: Query = {
+			filter: {
+				collection: {
+					_eq: 'posts',
+				},
+			},
+		};
+
+		await service.readByQuery(query);
+
+		expect(readByQuerySpy).toHaveBeenCalledWith(
+			{
+				filter: {
+					_and: [
+						{
+							id: {
+								_null: true,
+							},
+						},
+						query.filter,
+					],
+				},
+			},
+			undefined,
+		);
+	});
+});

--- a/api/src/services/revisions.ts
+++ b/api/src/services/revisions.ts
@@ -1,8 +1,17 @@
 import { ForbiddenError, InvalidPayloadError } from '@directus/errors';
-import type { AbstractServiceOptions, Item, MutationOptions, PrimaryKey } from '@directus/types';
+import type { AbstractServiceOptions, Item, MutationOptions, PrimaryKey, Query, QueryOptions } from '@directus/types';
+import { createHistoryQueryResolver } from '../utils/get-history-filter-query.js';
 import { ItemsService } from './items.js';
 
 export class RevisionsService extends ItemsService {
+	private readonly resolveHistoryQuery = createHistoryQueryResolver('revisions_history_days', (sinceDate) => ({
+		activity: {
+			timestamp: {
+				_gte: sinceDate.toISOString(),
+			},
+		},
+	}));
+
 	constructor(options: AbstractServiceOptions) {
 		super('directus_revisions', options);
 	}
@@ -53,5 +62,15 @@ export class RevisionsService extends ItemsService {
 
 	override async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]> {
 		return super.updateMany(keys, data, this.setDefaultOptions(opts));
+	}
+
+	async getHistoryQuery(query: Query): Promise<Query> {
+		return this.resolveHistoryQuery(query, this.knex);
+	}
+
+	override async readByQuery(query: Query, opts?: QueryOptions) {
+		const historyQuery = await this.getHistoryQuery(query);
+
+		return super.readByQuery(historyQuery, opts);
 	}
 }

--- a/api/src/utils/get-history-filter-query.ts
+++ b/api/src/utils/get-history-filter-query.ts
@@ -1,0 +1,65 @@
+import type { Filter, Query } from '@directus/types';
+import { mergeFilters } from '@directus/utils';
+import type { Knex } from 'knex';
+import { getLicenseEntitlements } from '../license/summary.js';
+
+type HistoryEntitlement = 'activity_history_days' | 'revisions_history_days';
+
+type HistoryFilterBuilder = (sinceDate: Date) => Filter;
+
+const denyHistoryFilter: Filter = {
+	id: {
+		_null: true,
+	},
+};
+
+export function createHistoryQueryResolver(entitlement: HistoryEntitlement, buildFilter: HistoryFilterBuilder) {
+	const cache = new WeakMap<Query, Promise<Query>>();
+
+	return (query: Query, knex: Knex | undefined): Promise<Query> => {
+		const cachedQuery = cache.get(query);
+
+		if (cachedQuery) return cachedQuery;
+
+		const historyQuery = getHistoryFilterQuery(query, entitlement, knex, buildFilter);
+		cache.set(query, historyQuery);
+		return historyQuery;
+	};
+}
+
+export async function getHistoryFilterQuery(
+	query: Query,
+	entitlement: HistoryEntitlement,
+	knex: Knex | undefined,
+	buildFilter: HistoryFilterBuilder,
+): Promise<Query> {
+	const entitlements = await getLicenseEntitlements(knex);
+	const limit = entitlements[entitlement]?.limit;
+
+	if (limit === null) {
+		return query;
+	}
+
+	if (typeof limit !== 'number' || !Number.isFinite(limit) || limit < 0) {
+		return query;
+	}
+
+	if (limit === 0) {
+		return {
+			...query,
+			filter: mergeFilters(denyHistoryFilter, query.filter ?? null, 'and') ?? denyHistoryFilter,
+		};
+	}
+
+	const sinceDate = new Date(Date.now() - limit * 24 * 60 * 60 * 1000);
+	const filter = mergeFilters(buildFilter(sinceDate), query.filter ?? null, 'and');
+
+	if (!filter) {
+		return query;
+	}
+
+	return {
+		...query,
+		filter,
+	};
+}

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1439,6 +1439,7 @@ license:
   included: Included
   optional: Optional
   not_included: Not Included
+  days_count: '{count} days'
   deactivate: Deactivate License
   save_success: License key was saved successfully.
   deactivate_success: License was deactivated successfully.
@@ -1447,6 +1448,8 @@ license:
   locked_notice: This project is currently locked because its license grace period has been exhausted.
   feature:
     seats: Seats
+    activity_history: Activity History
+    revisions_history: Revision History
     sso: Single Sign-On
     policy_rules: Custom Policy Rules
     custom_llm: Custom LLM
@@ -1492,6 +1495,7 @@ show_x_axis: Show X Axis
 show_y_axis: Show Y Axis
 keep_editing: Keep Editing
 activity_feed: Activity Feed
+activity_history_notice: '{limit} days of Activity History is included in your current plan.'
 add_new: Add New
 create_new: Create New
 all: All
@@ -2141,6 +2145,7 @@ reset: Reset
 reset_password: Reset Password
 revisions: Revisions
 no_revisions: No Revisions Yet
+revisions_history_notice: '{limit} days of Revision History is included in your current plan.'
 no_logs: No Logs Yet
 show_failed_only: Show Failed Only
 no_logs_on_page: No logs on this page

--- a/app/src/modules/activity/routes/collection.test.ts
+++ b/app/src/modules/activity/routes/collection.test.ts
@@ -1,0 +1,158 @@
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, ref, shallowRef } from 'vue';
+import { createI18n } from 'vue-i18n';
+import ActivityCollection from './collection.vue';
+
+vi.mock('@directus/composables', () => ({
+	useLayout: () => ({
+		layoutWrapper: shallowRef(
+			defineComponent({
+				props: {
+					collection: {
+						type: String,
+						required: true,
+					},
+					layoutOptions: {
+						type: Object,
+						default: () => ({}),
+					},
+					layoutQuery: {
+						type: Object,
+						default: () => ({}),
+					},
+					filter: {
+						type: Object,
+						default: null,
+					},
+					filterUser: {
+						type: Object,
+						default: null,
+					},
+					filterSystem: {
+						type: Object,
+						default: null,
+					},
+					search: {
+						type: String,
+						default: null,
+					},
+					showSelect: {
+						type: String,
+						default: 'none',
+					},
+				},
+				setup(_props, { slots }) {
+					return () => slots.default?.({ layoutState: {} });
+				},
+			}),
+		),
+	}),
+}));
+
+vi.mock('@/composables/use-preset', () => ({
+	usePreset: () => ({
+		layout: ref('table'),
+		layoutOptions: ref({}),
+		layoutQuery: ref({}),
+		filter: ref(null),
+		search: ref(null),
+	}),
+}));
+
+const i18n = createI18n({
+	legacy: false,
+	locale: 'en',
+	messages: {
+		en: {
+			activity_feed: 'Activity Feed',
+			activity_history_notice: '{limit} days of Activity History is included in your current plan.',
+			no_results: 'No Results',
+			no_results_copy: 'No results copy',
+			item_count: '0 Items',
+			no_items_copy: 'No items copy',
+		},
+	},
+});
+
+const baseStubs = {
+	PrivateView: defineComponent({
+		setup(_props, { slots }) {
+			return () =>
+				h('div', [
+					slots['actions:prepend']?.(),
+					slots.actions?.(),
+					slots.navigation?.(),
+					slots.default?.(),
+					slots.sidebar?.(),
+				]);
+		},
+	}),
+	VNotice: defineComponent({
+		setup(_props, { slots }) {
+			return () => h('div', { 'data-test': 'activity-history-notice' }, slots.title?.());
+		},
+	}),
+	VInfo: true,
+	ActivityNavigation: true,
+	SearchInput: true,
+	RouterView: true,
+	LayoutSidebarDetail: true,
+	'layout-actions-table': true,
+	'layout-options-table': true,
+	'layout-sidebar-table': true,
+	'layout-table': defineComponent({
+		setup(_props, { slots }) {
+			return () => h('div', slots.default?.());
+		},
+	}),
+};
+
+function mountComponent(activityLimit: number | null | undefined) {
+	return mount(ActivityCollection, {
+		global: {
+			plugins: [
+				createTestingPinia({
+					createSpy: vi.fn,
+					initialState: {
+						serverStore: {
+							info: {
+								license:
+									activityLimit === undefined
+										? null
+										: {
+												activity_history_days: {
+													limit: activityLimit,
+												},
+											},
+							},
+						},
+					},
+				}),
+				i18n,
+			],
+			stubs: baseStubs,
+		},
+	});
+}
+
+describe('Activity history notice', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('shows the history notice when the limit is a positive number', () => {
+		const wrapper = mountComponent(30);
+
+		expect(wrapper.get('[data-test="activity-history-notice"]').text()).toContain(
+			'30 days of Activity History is included in your current plan.',
+		);
+	});
+
+	it('hides the history notice when the limit is not a positive number', () => {
+		const wrapper = mountComponent(0);
+
+		expect(wrapper.find('[data-test="activity-history-notice"]').exists()).toBe(false);
+	});
+});

--- a/app/src/modules/activity/routes/collection.vue
+++ b/app/src/modules/activity/routes/collection.vue
@@ -2,11 +2,14 @@
 import { useLayout } from '@directus/composables';
 import { Filter } from '@directus/types';
 import { mergeFilters } from '@directus/utils';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { RouterView } from 'vue-router';
 import ActivityNavigation from '../components/navigation.vue';
 import VInfo from '@/components/v-info.vue';
+import VNotice from '@/components/v-notice.vue';
 import { usePreset } from '@/composables/use-preset';
+import { useServerStore } from '@/stores/server';
 import { PrivateView } from '@/views/private';
 import LayoutSidebarDetail from '@/views/private/components/layout-sidebar-detail.vue';
 import SearchInput from '@/views/private/components/search-input.vue';
@@ -18,8 +21,20 @@ defineProps<{
 const { layout, layoutOptions, layoutQuery, filter, search } = usePreset(ref('directus_activity'));
 
 const { layoutWrapper } = useLayout(layout);
+const { t } = useI18n();
+const serverStore = useServerStore();
 
 const roleFilter = ref<Filter | null>(null);
+
+const activityHistoryDays = computed(() => serverStore.info.license?.activity_history_days?.limit);
+
+const showActivityHistoryNotice = computed(
+	() => activityHistoryDays.value !== null && Number(activityHistoryDays.value) > 0,
+);
+
+const formattedActivityHistoryDays = computed(() =>
+	activityHistoryDays.value === null ? t('unlimited') : activityHistoryDays.value,
+);
 </script>
 
 <template>
@@ -48,6 +63,14 @@ const roleFilter = ref<Filter | null>(null);
 				<ActivityNavigation v-model:filter="roleFilter" />
 			</template>
 
+			<div v-if="showActivityHistoryNotice" class="notice-wrapper">
+				<VNotice type="info" icon="diamond">
+					<template #title>
+						{{ $t('activity_history_notice', { limit: formattedActivityHistoryDays }) }}
+					</template>
+				</VNotice>
+			</div>
+
 			<component :is="`layout-${layout}`" v-bind="layoutState">
 				<template #no-results>
 					<VInfo :title="$t('no_results')" icon="search" center>
@@ -75,6 +98,7 @@ const roleFilter = ref<Filter | null>(null);
 </template>
 
 <style lang="scss" scoped>
+.notice-wrapper,
 .content {
 	padding: var(--content-padding);
 }

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -268,6 +268,12 @@ function formatLicenseLimit(limit: number | null): string {
 	return limit === null ? t('unlimited') : String(limit);
 }
 
+function formatHistoryLimit(limit: number | null): string {
+	if (limit === null) return t('unlimited');
+	if (limit === 0) return t('license.not_included');
+	return t('license.days_count', { count: limit });
+}
+
 const usageRows = computed<LicenseUsageRow[]>(() => {
 	if (!license.value) return [];
 
@@ -294,12 +300,30 @@ const usageRows = computed<LicenseUsageRow[]>(() => {
 			},
 		},
 		{
+			key: 'activity-history',
+			icon: 'access_time',
+			label: t('license.feature.activity_history'),
+			value: {
+				type: 'text',
+				text: formatHistoryLimit(license.value.entitlements.activity_history_days.limit),
+			},
+		},
+		{
 			key: 'seats',
 			icon: 'group',
 			label: t('license.feature.seats'),
 			value: {
 				type: 'text',
 				text: `${license.value.usage.seats.current} / ${formatLicenseLimit(license.value.entitlements.seats.limit)}`,
+			},
+		},
+		{
+			key: 'revisions-history',
+			icon: 'change_history',
+			label: t('license.feature.revisions_history'),
+			value: {
+				type: 'text',
+				text: formatHistoryLimit(license.value.entitlements.revisions_history_days.limit),
 			},
 		},
 		{

--- a/app/src/views/private/components/revisions-sidebar-detail.test.ts
+++ b/app/src/views/private/components/revisions-sidebar-detail.test.ts
@@ -1,0 +1,144 @@
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { createI18n } from 'vue-i18n';
+import RevisionsSidebarDetail from './revisions-sidebar-detail.vue';
+
+const revisionsByDate = ref([
+	{
+		date: new Date('2026-04-11T00:00:00.000Z'),
+		dateFormatted: 'Today',
+		revisions: [{ id: 1 }],
+	},
+	{
+		date: new Date('2026-04-10T00:00:00.000Z'),
+		dateFormatted: 'Yesterday',
+		revisions: [{ id: 2 }],
+	},
+]);
+
+const useRevisionsMock = vi.fn(() => ({
+	revisions: ref([{ id: 1 }, { id: 2 }]),
+	revisionsByDate,
+	loading: ref(false),
+	refresh: vi.fn(),
+	revisionsCount: ref(2),
+	pagesCount: ref(1),
+	created: ref(undefined),
+	getRevisions: vi.fn(),
+	loadingCount: ref(false),
+	getRevisionsCount: vi.fn(),
+}));
+
+vi.mock('@directus/composables', () => ({
+	useGroupable: () => ({
+		active: ref(true),
+	}),
+}));
+
+vi.mock('@/composables/use-revisions', () => ({
+	useRevisions: () => useRevisionsMock(),
+}));
+
+vi.mock('../private-view/stores/sidebar', () => ({
+	useSidebarStore: () => ({
+		activeAccordionItem: null,
+	}),
+}));
+
+vi.mock('vue-router', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('vue-router')>();
+
+	return {
+		...actual,
+		useRoute: () => ({
+			fullPath: '/content/posts/1',
+		}),
+	};
+});
+
+const i18n = createI18n({
+	legacy: false,
+	locale: 'en',
+	messages: {
+		en: {
+			revisions: 'Revisions',
+			no_revisions: 'No Revisions Yet',
+			revisions_history_notice: '{limit} days of Revision History is included in your current plan.',
+			revision_delta_created_externally: 'Created externally',
+		},
+	},
+});
+
+function mountComponent(revisionsLimit: number | null | undefined) {
+	return mount(RevisionsSidebarDetail, {
+		props: {
+			collection: 'posts',
+			primaryKey: 1,
+			version: null,
+		},
+		global: {
+			plugins: [
+				createTestingPinia({
+					createSpy: vi.fn,
+					initialState: {
+						serverStore: {
+							info: {
+								license:
+									revisionsLimit === undefined
+										? null
+										: {
+												revisions_history_days: {
+													limit: revisionsLimit,
+												},
+											},
+							},
+						},
+					},
+				}),
+				i18n,
+			],
+			stubs: {
+				SidebarDetail: {
+					template: '<div><slot /></div>',
+				},
+				VNotice: {
+					template: '<div data-test="revisions-history-notice"><slot name="title" /></div>',
+				},
+				RevisionsDateGroup: {
+					template: '<div data-test="revisions-group" />',
+				},
+				VDivider: true,
+				VPagination: true,
+				VProgressLinear: true,
+				ComparisonModal: {
+					props: ['currentCollab'],
+					template: '<div />',
+				},
+			},
+		},
+	});
+}
+
+describe('Revisions history notice', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('shows a single history notice when the limit is a positive number', () => {
+		const wrapper = mountComponent(14);
+
+		expect(wrapper.findAll('[data-test="revisions-history-notice"]')).toHaveLength(1);
+
+		expect(wrapper.get('[data-test="revisions-history-notice"]').text()).toContain(
+			'14 days of Revision History is included in your current plan.',
+		);
+	});
+
+	it('hides the history notice when the limit is not a positive number', () => {
+		const wrapper = mountComponent(0);
+
+		expect(wrapper.find('[data-test="revisions-history-notice"]').exists()).toBe(false);
+	});
+});

--- a/app/src/views/private/components/revisions-sidebar-detail.vue
+++ b/app/src/views/private/components/revisions-sidebar-detail.vue
@@ -9,9 +9,11 @@ import { useSidebarStore } from '../private-view/stores/sidebar';
 import RevisionsDateGroup from './revisions-date-group.vue';
 import SidebarDetail from './sidebar-detail.vue';
 import VDivider from '@/components/v-divider.vue';
+import VNotice from '@/components/v-notice.vue';
 import VPagination from '@/components/v-pagination.vue';
 import VProgressLinear from '@/components/v-progress-linear.vue';
 import { useRevisions } from '@/composables/use-revisions';
+import { useServerStore } from '@/stores/server';
 import type { Revision } from '@/types/revisions';
 import type { ContentVersionMaybeNew, ContentVersionWithType } from '@/types/versions';
 import ComparisonModal from '@/views/private/components/comparison/comparison-modal.vue';
@@ -36,11 +38,22 @@ const { active: open } = useGroupable({
 const { collection, primaryKey, version } = toRefs(props);
 
 const sidebarStore = useSidebarStore();
+const serverStore = useServerStore();
 const route = useRoute();
 
 const comparisonModalActive = ref(false);
 const currentRevision = ref<Revision | null>(null);
 const page = ref<number>(1);
+
+const revisionsHistoryDays = computed(() => serverStore.info.license?.revisions_history_days?.limit);
+
+const showRevisionsHistoryNotice = computed(
+	() => revisionsHistoryDays.value !== null && Number(revisionsHistoryDays.value) > 0,
+);
+
+const formattedRevisionsHistoryDays = computed(() =>
+	revisionsHistoryDays.value === null ? t('unlimited') : revisionsHistoryDays.value,
+);
 
 const comparableVersion = computed(() => {
 	if (version.value === undefined || version.value === null) return version.value;
@@ -123,7 +136,16 @@ defineExpose({
 					{{ $t('revision_delta_created_externally') }}
 				</div>
 			</template>
+
 			<VPagination v-if="pagesCount > 1" v-model="page" :length="pagesCount" :total-visible="3" />
+
+			<div v-if="showRevisionsHistoryNotice" class="notice-wrapper">
+				<VNotice type="info" icon="diamond">
+					<template #title>
+						{{ $t('revisions_history_notice', { limit: formattedRevisionsHistoryDays }) }}
+					</template>
+				</VNotice>
+			</div>
 		</template>
 
 		<ComparisonModal
@@ -134,6 +156,7 @@ defineExpose({
 			:primary-key
 			mode="revision"
 			:current-version="comparableVersion"
+			:current-collab="undefined"
 			:revisions="revisions as Revision[]"
 			@confirm="$emit('revert', $event)"
 			@cancel="closeModal"
@@ -161,6 +184,14 @@ defineExpose({
 	margin-inline-start: 0.125rem;
 	color: var(--theme--foreground-subdued);
 	font-style: italic;
+}
+
+.notice-wrapper {
+	margin-block-start: 1.375rem;
+
+	.v-notice {
+		background-color: var(--theme--background-accent);
+	}
 }
 
 .external {


### PR DESCRIPTION
## Scope

What's changed:

- Added entitlement-driven history filtering for `directus_activity` and `directus_revisions`, so reads are automatically constrained by `activity_history_days` and `revisions_history_days`.
- Introduced a reusable history-query resolver that controllers and services use to merge license-derived date filters into incoming queries without replacing caller-provided filters.
- Applied revision-history limiting through the related activity timestamp, so revision reads inherit the same date window via `activity.timestamp`.
- Updated the activity feed UI to surface the current history window when a positive activity-history limit is present.
- Updated revisions-related UI and license usage display so reviewers can see history entitlements directly from the licensing screen.
- Added backend and frontend coverage around the new query filtering and messaging behavior.

## Potential Risks / Drawbacks

- The filter-merging logic sits in the read path for two system collections, so regressions could show up as missing history or unexpectedly empty result sets.
- A zero-day entitlement now intentionally denies all results, which is a sharp behavior change and worth verifying against product expectations.
- Time-window filtering depends on server time and inclusive `_gte` semantics, so off-by-one-day behavior near boundaries is something to watch.

## Tested Scenarios

- Added service tests for activity and revisions reads under different history-limit configurations.
- Added frontend tests for the activity route notice and the revisions sidebar detail behavior.
- Extended license-page coverage by surfacing the new history entitlements in the usage grid.

## Review Notes / Questions

- Special attention should be paid to whether every history-facing endpoint should use the same limiter semantics as `readByQuery`.
- The new helper caches resolved queries per query object; that is intentional, but it is worth a quick sanity check for unexpected reuse patterns.
- Reviewer eyes on the product copy for limited history would help, since it now appears in both activity and licensing contexts.

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #\<num\>
