### PR TITLE
Add custom policy limits

### DIFF
--- a/api/src/permissions/lib/with-app-minimal-permissions.test.ts
+++ b/api/src/permissions/lib/with-app-minimal-permissions.test.ts
@@ -35,3 +35,13 @@ it('should merge with filtered app minimal permissions if role has app access', 
 	expect(filterItems).toHaveBeenCalledWith(mocks.appAccessMinimalPermissions, filter);
 	expect(result).toEqual(filteredPermissions);
 });
+
+it('should accept projected permission rows', () => {
+	const accountability = { app: false } as Accountability;
+	const permissions: Partial<Permission>[] = [{ id: 1 }];
+	const filter: Query['filter'] = null;
+
+	const result = withAppMinimalPermissions(accountability, permissions, filter);
+
+	expect(result).toBe(permissions);
+});

--- a/api/src/permissions/lib/with-app-minimal-permissions.ts
+++ b/api/src/permissions/lib/with-app-minimal-permissions.ts
@@ -7,7 +7,17 @@ export function withAppMinimalPermissions(
 	accountability: Pick<Accountability, 'app'> | null,
 	permissions: Permission[],
 	filter: Query['filter'],
-): Permission[] {
+): Permission[];
+export function withAppMinimalPermissions(
+	accountability: Pick<Accountability, 'app'> | null,
+	permissions: Partial<Permission>[],
+	filter: Query['filter'],
+): Partial<Permission>[];
+export function withAppMinimalPermissions(
+	accountability: Pick<Accountability, 'app'> | null,
+	permissions: Partial<Permission>[],
+	filter: Query['filter'],
+): Partial<Permission>[] {
 	if (accountability?.app === true) {
 		const filteredAppMinimalPermissions = cloneDeep(filterItems(appAccessMinimalPermissions, filter));
 		return [...permissions, ...filteredAppMinimalPermissions];

--- a/api/src/services/permissions.test.ts
+++ b/api/src/services/permissions.test.ts
@@ -1,0 +1,298 @@
+import { SchemaBuilder } from '@directus/schema-builder';
+import type { Permission, Query } from '@directus/types';
+import knex from 'knex';
+import { MockClient } from 'knex-mock-client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getLicenseEntitlements } from '../license/summary.js';
+import { withAppMinimalPermissions } from '../permissions/lib/with-app-minimal-permissions.js';
+import { ItemsService } from './items.js';
+import { PermissionsService } from './permissions.js';
+
+vi.mock('../../src/database/index', () => ({
+	default: vi.fn(),
+}));
+
+vi.mock('../license/summary.js', async () => {
+	const actual = await vi.importActual<typeof import('../license/summary.js')>('../license/summary.js');
+	return {
+		...actual,
+		getLicenseEntitlements: vi.fn(),
+	};
+});
+
+vi.mock('../permissions/lib/with-app-minimal-permissions.js', async () => {
+	const actual = await vi.importActual<typeof import('../permissions/lib/with-app-minimal-permissions.js')>(
+		'../permissions/lib/with-app-minimal-permissions.js',
+	);
+
+	return {
+		...actual,
+		withAppMinimalPermissions: vi.fn((_accountability, permissions) => permissions),
+	};
+});
+
+const schema = new SchemaBuilder()
+	.collection('directus_permissions', (collection) => {
+		collection.field('id').integer().primary();
+		collection.field('policy').string();
+		collection.field('collection').string();
+		collection.field('action').string();
+		collection.field('permissions').json();
+		collection.field('validation').json();
+		collection.field('presets').json();
+		collection.field('fields').json();
+	})
+	.build();
+
+describe('PermissionsService', () => {
+	const db = vi.mocked(knex.default({ client: MockClient }));
+
+	beforeEach(() => {
+		vi.mocked(withAppMinimalPermissions).mockImplementation((_accountability, permissions) => permissions);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('returns custom permissions unchanged when the entitlement is enabled', async () => {
+		vi.mocked(getLicenseEntitlements).mockResolvedValue({
+			custom_policy_rules_enabled: true,
+		} as any);
+
+		const readByQuerySpy = vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([
+			{
+				id: 1,
+				fields: ['name'],
+				presets: null,
+				permissions: null,
+				validation: null,
+			},
+		] as Permission[]);
+
+		const service = new PermissionsService({
+			knex: db,
+			schema,
+		});
+
+		const query: Query = { filter: { policy: { _eq: 'policy-1' } } };
+		const result = await service.readByQuery(query);
+
+		expect(readByQuerySpy).toHaveBeenCalledWith(query, undefined);
+		expect(withAppMinimalPermissions).toHaveBeenCalledWith(service.accountability, result, query.filter);
+		expect(result).toHaveLength(1);
+	});
+
+	it('filters non-system custom permission rows when the entitlement is disabled', async () => {
+		vi.mocked(getLicenseEntitlements).mockResolvedValue({
+			custom_policy_rules_enabled: false,
+		} as any);
+
+		vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([
+			{
+				id: 1,
+				fields: ['*'],
+				presets: null,
+				permissions: null,
+				validation: null,
+			},
+			{
+				id: 2,
+				fields: ['name'],
+				presets: null,
+				permissions: null,
+				validation: null,
+			},
+		] as Permission[]);
+
+		const service = new PermissionsService({
+			knex: db,
+			schema,
+		});
+
+		const result = await service.readByQuery({});
+
+		expect(result).toStrictEqual([
+			{
+				id: 1,
+				fields: ['*'],
+				presets: null,
+				permissions: null,
+				validation: null,
+			},
+		]);
+	});
+
+	it('filters using classifier fields while preserving the requested projection', async () => {
+		vi.mocked(getLicenseEntitlements).mockResolvedValue({
+			custom_policy_rules_enabled: false,
+		} as any);
+
+		const readByQuerySpy = vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([
+			{
+				id: 1,
+				fields: ['*'],
+				presets: null,
+				permissions: null,
+				validation: null,
+			},
+			{
+				id: 2,
+				fields: ['name'],
+				presets: null,
+				permissions: null,
+				validation: null,
+			},
+		] as Permission[]);
+
+		const service = new PermissionsService({
+			knex: db,
+			schema,
+		});
+
+		const result = await service.readByQuery({
+			fields: ['id'],
+		});
+
+		expect(readByQuerySpy).toHaveBeenCalledWith(
+			{
+				fields: ['id', 'fields', 'permissions', 'validation', 'presets'],
+			},
+			undefined,
+		);
+
+		expect(result).toStrictEqual([{ id: 1 }]);
+	});
+
+	it('removes only injected classifier fields when restoring the requested shape', async () => {
+		vi.mocked(getLicenseEntitlements).mockResolvedValue({
+			custom_policy_rules_enabled: false,
+		} as any);
+
+		vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([
+			{
+				id: 1,
+				policy: {
+					id: 'policy-1',
+					name: 'Policy 1',
+				},
+				fields: ['*'],
+				presets: null,
+				permissions: null,
+				validation: null,
+			},
+		] as any);
+
+		const service = new PermissionsService({
+			knex: db,
+			schema,
+		});
+
+		const result = await service.readByQuery({
+			fields: ['id', 'policy.*'],
+		});
+
+		expect(result).toStrictEqual([
+			{
+				id: 1,
+				policy: {
+					id: 'policy-1',
+					name: 'Policy 1',
+				},
+			},
+		]);
+	});
+
+	it('preserves system permission rows even when they are custom-shaped', async () => {
+		vi.mocked(getLicenseEntitlements).mockResolvedValue({
+			custom_policy_rules_enabled: false,
+		} as any);
+
+		vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([
+			{
+				id: 1,
+				system: true,
+				fields: ['name'],
+				presets: { status: 'draft' },
+				permissions: null,
+				validation: null,
+			},
+		] as Permission[]);
+
+		const service = new PermissionsService({
+			knex: db,
+			schema,
+		});
+
+		const result = await service.readByQuery({});
+
+		expect(result).toStrictEqual([
+			{
+				id: 1,
+				system: true,
+				fields: ['name'],
+				presets: { status: 'draft' },
+				permissions: null,
+				validation: null,
+			},
+		]);
+	});
+
+	it('treats presets-only permission rows as custom', async () => {
+		vi.mocked(getLicenseEntitlements).mockResolvedValue({
+			custom_policy_rules_enabled: false,
+		} as any);
+
+		vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([
+			{
+				id: 1,
+				fields: ['*'],
+				presets: { status: 'draft' },
+				permissions: null,
+				validation: null,
+			},
+		] as Permission[]);
+
+		const service = new PermissionsService({
+			knex: db,
+			schema,
+		});
+
+		const result = await service.readByQuery({});
+
+		expect(result).toStrictEqual([]);
+	});
+
+	it('treats wildcard rows with no other custom state as full access', async () => {
+		vi.mocked(getLicenseEntitlements).mockResolvedValue({
+			custom_policy_rules_enabled: false,
+		} as any);
+
+		vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([
+			{
+				id: 1,
+				fields: ['*', 'title'],
+				presets: null,
+				permissions: null,
+				validation: null,
+			},
+		] as Permission[]);
+
+		const service = new PermissionsService({
+			knex: db,
+			schema,
+		});
+
+		const result = await service.readByQuery({});
+
+		expect(result).toStrictEqual([
+			{
+				id: 1,
+				fields: ['*', 'title'],
+				presets: null,
+				permissions: null,
+				validation: null,
+			},
+		]);
+	});
+});

--- a/api/src/services/permissions.ts
+++ b/api/src/services/permissions.ts
@@ -9,8 +9,9 @@ import type {
 	Query,
 	QueryOptions,
 } from '@directus/types';
-import { uniq } from 'lodash-es';
+import { omit, uniq } from 'lodash-es';
 import { clearSystemCache } from '../cache.js';
+import { getLicenseEntitlements } from '../license/summary.js';
 import { fetchPermissions } from '../permissions/lib/fetch-permissions.js';
 import { fetchPolicies } from '../permissions/lib/fetch-policies.js';
 import { withAppMinimalPermissions } from '../permissions/lib/with-app-minimal-permissions.js';
@@ -31,10 +32,50 @@ export class PermissionsService extends ItemsService {
 		}
 	}
 
-	override async readByQuery(query: Query, opts?: QueryOptions): Promise<Partial<Item>[]> {
-		const result = (await super.readByQuery(query, opts)) as Permission[];
+	private isCustomPermission(permission: Partial<Permission>): boolean {
+		if (permission.system === true) return false;
 
-		return withAppMinimalPermissions(this.accountability, result, query.filter);
+		return (
+			permission.fields?.includes('*') !== true ||
+			Object.keys(permission.permissions ?? {}).length > 0 ||
+			Object.keys(permission.validation ?? {}).length > 0 ||
+			Object.keys(permission.presets ?? {}).length > 0
+		);
+	}
+
+	override async readByQuery(query: Query, opts?: QueryOptions): Promise<Partial<Item>[]> {
+		const entitlements = await getLicenseEntitlements(this.knex);
+
+		if (entitlements.custom_policy_rules_enabled === true) {
+			const result = (await super.readByQuery(query, opts)) as Permission[];
+			return withAppMinimalPermissions(this.accountability, result, query.filter);
+		}
+
+		const requestedFields = query.fields;
+		const gatingFields = ['fields', 'permissions', 'validation', 'presets'];
+
+		const gatedQuery =
+			requestedFields && requestedFields.includes('*') === false
+				? {
+						...query,
+						fields: uniq([...requestedFields, ...gatingFields]),
+					}
+				: query;
+
+		const result = (await super.readByQuery(gatedQuery, opts)) as Permission[];
+
+		const extraGatingFields = requestedFields
+			? gatingFields.filter((field) => requestedFields.includes(field) === false)
+			: [];
+
+		const permissions =
+			gatedQuery === query || !requestedFields
+				? result.filter((permission) => !this.isCustomPermission(permission))
+				: result
+						.filter((permission) => !this.isCustomPermission(permission))
+						.map((permission) => omit(permission, extraGatingFields));
+
+		return withAppMinimalPermissions(this.accountability, permissions, query.filter);
 	}
 
 	override async createOne(data: Partial<Item>, opts?: MutationOptions) {

--- a/app/src/interfaces/_system/system-permissions/permissions-toggle.test.ts
+++ b/app/src/interfaces/_system/system-permissions/permissions-toggle.test.ts
@@ -1,0 +1,194 @@
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+import { createI18n } from 'vue-i18n';
+import PermissionsToggle from './permissions-toggle.vue';
+
+const i18n = createI18n({
+	legacy: false,
+	locale: 'en',
+	messages: {
+		en: {
+			read: 'Read',
+			all_access: 'All Access',
+			no_access: 'No Access',
+			use_custom: 'Use Custom',
+			required_for_app_access: 'Required for app access',
+			permissionsLevel: {
+				all: '{action} all',
+				none: '{action} none',
+				custom: '{action} custom',
+			},
+		},
+	},
+});
+
+const VChipStub = defineComponent({
+	inheritAttrs: false,
+	setup(_props, { attrs, slots }) {
+		return () => h('button', { ...attrs, 'data-test': 'chip' }, slots.default?.());
+	},
+});
+
+const VMenuStub = defineComponent({
+	setup(_props, { slots }) {
+		return () =>
+			h('div', [
+				slots.activator?.({
+					toggle: vi.fn(),
+					active: false,
+				}),
+				slots.default?.(),
+			]);
+	},
+});
+
+const VListItemStub = defineComponent({
+	props: {
+		disabled: Boolean,
+		clickable: Boolean,
+	},
+	emits: ['click'],
+	setup(props, { slots, emit }) {
+		return () =>
+			h(
+				'button',
+				{
+					'data-test': 'list-item',
+					disabled: props.disabled,
+					onClick: () => emit('click'),
+				},
+				slots.default?.(),
+			);
+	},
+});
+
+const VIconStub = defineComponent({
+	props: {
+		name: {
+			type: String,
+			required: true,
+		},
+	},
+	setup(props) {
+		return () => h('i', { 'data-test': 'icon', 'data-name': props.name });
+	},
+});
+
+function mountComponent(customPolicyRulesEnabled: boolean, permission?: Record<string, unknown>) {
+	return mount(PermissionsToggle, {
+		props: {
+			collection: {
+				collection: 'articles',
+				meta: null,
+				schema: null,
+			} as any,
+			action: 'read',
+			permission: permission as any,
+		},
+		global: {
+			plugins: [
+				i18n,
+				createTestingPinia({
+					createSpy: vi.fn,
+					initialState: {
+						serverStore: {
+							info: {
+								license: {
+									custom_policy_rules_enabled: customPolicyRulesEnabled,
+								},
+							},
+						},
+					},
+				}),
+			],
+			stubs: {
+				VChip: VChipStub,
+				VDivider: true,
+				VIcon: VIconStub,
+				VListItemContent: defineComponent({
+					setup(_props, { slots }) {
+						return () => h('span', slots.default?.());
+					},
+				}),
+				VListItemIcon: defineComponent({
+					setup(_props, { slots }) {
+						return () => h('span', slots.default?.());
+					},
+				}),
+				VListItem: VListItemStub,
+				VList: defineComponent({
+					setup(_props, { slots }) {
+						return () => h('div', slots.default?.());
+					},
+				}),
+				VMenu: VMenuStub,
+				VProgressCircular: true,
+			},
+			directives: {
+				tooltip: () => {},
+			},
+		},
+	});
+}
+
+describe('PermissionsToggle', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('emits edit when custom rules are enabled', async () => {
+		const wrapper = mountComponent(true, {
+			fields: ['*'],
+			presets: null,
+			permissions: null,
+			validation: null,
+		});
+
+		await wrapper.findAll('[data-test="list-item"]')[2]!.trigger('click');
+
+		expect(wrapper.emitted('edit')).toHaveLength(1);
+		expect(wrapper.findAll('[data-test="icon"]').at(-1)?.attributes('data-name')).toBe('launch');
+	});
+
+	it('disables custom edit and shows the diamond icon when custom rules are disabled', async () => {
+		const wrapper = mountComponent(false, {
+			fields: ['*'],
+			presets: null,
+			permissions: null,
+			validation: null,
+		});
+
+		const customAction = wrapper.findAll('[data-test="list-item"]')[2]!;
+
+		expect(customAction.attributes('disabled')).toBeDefined();
+		expect(wrapper.findAll('[data-test="icon"]').at(-1)?.attributes('data-name')).toBe('diamond');
+
+		await customAction.trigger('click');
+
+		expect(wrapper.emitted('edit')).toBeUndefined();
+	});
+
+	it('marks presets-only permissions as custom', () => {
+		const wrapper = mountComponent(true, {
+			fields: ['*'],
+			presets: { status: 'draft' },
+			permissions: null,
+			validation: null,
+		});
+
+		expect(wrapper.get('[data-test="chip"]').classes()).toContain('custom');
+	});
+
+	it('treats wildcard fields with no other custom state as all access', () => {
+		const wrapper = mountComponent(true, {
+			fields: ['*', 'id'],
+			presets: null,
+			permissions: null,
+			validation: null,
+		});
+
+		expect(wrapper.get('[data-test="chip"]').classes()).toContain('all');
+	});
+});

--- a/app/src/interfaces/_system/system-permissions/permissions-toggle.vue
+++ b/app/src/interfaces/_system/system-permissions/permissions-toggle.vue
@@ -10,6 +10,7 @@ import VListItem from '@/components/v-list-item.vue';
 import VList from '@/components/v-list.vue';
 import VMenu from '@/components/v-menu.vue';
 import VProgressCircular from '@/components/v-progress-circular.vue';
+import { useServerStore } from '@/stores/server';
 
 const props = defineProps<{
 	collection: Collection;
@@ -26,15 +27,14 @@ const emit = defineEmits<{
 }>();
 
 const { permission } = toRefs(props);
+const serverStore = useServerStore();
+
+const customPolicyRulesEnabled = computed(() => serverStore.info.license?.custom_policy_rules_enabled === true);
 
 const permissionLevel = computed<'all' | 'none' | 'custom'>(() => {
 	if (permission.value === undefined) return 'none';
 
-	if (
-		permission.value.fields?.includes('*') &&
-		Object.keys(permission.value.permissions || {}).length === 0 &&
-		Object.keys(permission.value.validation || {}).length === 0
-	) {
+	if (isFullAccessPermission(permission.value)) {
 		return 'all';
 	}
 
@@ -46,15 +46,19 @@ const saving = ref(false);
 const appMinimalLevel = computed(() => {
 	if (!props.appMinimal) return null;
 
-	if (
-		props.appMinimal.fields?.includes('*') &&
-		Object.keys(props.appMinimal.permissions || {}).length === 0 &&
-		Object.keys(props.appMinimal.validation || {}).length === 0
-	)
-		return 'full';
+	if (isFullAccessPermission(props.appMinimal)) return 'full';
 
 	return 'partial';
 });
+
+function isFullAccessPermission(permission: Partial<Permission>): boolean {
+	return (
+		permission.fields?.includes('*') === true &&
+		Object.keys(permission.permissions || {}).length === 0 &&
+		Object.keys(permission.validation || {}).length === 0 &&
+		Object.keys(permission.presets || {}).length === 0
+	);
+}
 </script>
 
 <template>
@@ -100,7 +104,7 @@ const appMinimalLevel = computed(() => {
 
 				<VDivider />
 
-				<VListItem clickable @click="emit('edit')">
+				<VListItem :disabled="!customPolicyRulesEnabled" :clickable="customPolicyRulesEnabled" @click="emit('edit')">
 					<VListItemIcon>
 						<VIcon name="rule" />
 					</VListItemIcon>
@@ -108,7 +112,7 @@ const appMinimalLevel = computed(() => {
 						{{ $t('use_custom') }}
 					</VListItemContent>
 					<VListItemIcon>
-						<VIcon name="launch" />
+						<VIcon :name="customPolicyRulesEnabled ? 'launch' : 'diamond'" />
 					</VListItemIcon>
 				</VListItem>
 			</VList>


### PR DESCRIPTION
## Scope

What's changed:

- Added license gating to `PermissionsService.readByQuery`, so custom-shaped permission rows are filtered out when `custom_policy_rules_enabled` is not available.
- Preserved full-access and system permission rows while treating presets, validation, and non-wildcard field sets as custom policy-rule usage.
- Updated the system permissions toggle UI to disable the "Use Custom" action when the entitlement is absent and to show the licensing state directly in the menu.
- Tightened the permission-level classifier in the UI through `isFullAccessPermission()`, so presets-only rules render as custom rather than incorrectly looking like full access.
- Added backend and frontend test coverage for the filtering rules, field projection restoration, and disabled custom-rule affordances.

## Potential Risks / Drawbacks

- The permission read path now injects extra classifier fields and removes them again when needed, so callers that depend on a specific projection shape are worth checking.
- This branch focuses on read/edit affordances; if reviewers expect hard blocking on create or update mutations too, that follow-up may still be needed.
- The distinction between full access and custom access now treats presets as custom behavior, which could reclassify some existing policy rows in the UI.

## Tested Scenarios

- Added comprehensive `PermissionsService` coverage for enabled and disabled entitlement states, projection handling, and classification edge cases.
- Added component tests for the permissions toggle to verify disabled custom-rule access, icon changes, and permission-level classification.
- Updated the minimal-app-permissions test surface to keep filtered permissions compatible with existing app-access handling.

## Review Notes / Questions

- Special attention should be paid to how we classify "custom" rules, especially rows that only use presets or partially wildcard field sets.
- The current implementation filters on read rather than rewriting stored data, which keeps upgrades reversible but means stale data remains in the database by design.
- It would be useful to confirm that all admin surfaces that expose permission rows go through `PermissionsService.readByQuery`.

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #\<num\>
