### PR TITLE
Add LLM limits

### DIFF
--- a/api/src/ai/chat/middleware/load-settings.test.ts
+++ b/api/src/ai/chat/middleware/load-settings.test.ts
@@ -214,6 +214,45 @@ describe('loadSettings', () => {
 		expect(nextFunction).toHaveBeenCalledTimes(1);
 	});
 
+	test('should preserve redacted custom provider values from SettingsService', async () => {
+		mockReadSingleton.mockResolvedValue({
+			ai_openai_api_key: 'test-openai-key',
+			ai_anthropic_api_key: 'test-anthropic-key',
+			ai_google_api_key: 'test-google-key',
+			ai_openai_compatible_api_key: null,
+			ai_openai_compatible_base_url: null,
+			ai_openai_compatible_name: null,
+			ai_openai_compatible_models: null,
+			ai_openai_compatible_headers: null,
+			ai_openai_allowed_models: ['gpt-5'],
+			ai_anthropic_allowed_models: ['claude-sonnet-4-5'],
+			ai_google_allowed_models: ['gemini-2.5-pro'],
+			ai_system_prompt: 'You are Directus.',
+		});
+
+		await loadSettings(mockRequest as Request, mockResponse as Response, nextFunction);
+
+		expect(mockResponse.locals).toEqual({
+			ai: {
+				settings: {
+					openaiApiKey: 'test-openai-key',
+					anthropicApiKey: 'test-anthropic-key',
+					googleApiKey: 'test-google-key',
+					openaiCompatibleApiKey: null,
+					openaiCompatibleBaseUrl: null,
+					openaiCompatibleName: null,
+					openaiCompatibleModels: null,
+					openaiCompatibleHeaders: null,
+					openaiAllowedModels: ['gpt-5'],
+					anthropicAllowedModels: ['claude-sonnet-4-5'],
+					googleAllowedModels: ['gemini-2.5-pro'],
+					systemPrompt: 'You are Directus.',
+				},
+				systemPrompt: 'You are Directus.',
+			},
+		});
+	});
+
 	test('should throw error if database fails', async () => {
 		const error = new Error('Database error');
 		mockReadSingleton.mockRejectedValue(error);

--- a/api/src/services/settings.test.ts
+++ b/api/src/services/settings.test.ts
@@ -1,0 +1,127 @@
+import { SchemaBuilder } from '@directus/schema-builder';
+import knex from 'knex';
+import { MockClient } from 'knex-mock-client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getLicenseEntitlements } from '../license/summary.js';
+import { ItemsService } from './items.js';
+import { SettingsService } from './settings.js';
+
+vi.mock('../../src/database/index', () => ({
+	default: vi.fn(),
+}));
+
+vi.mock('../license/summary.js', async () => {
+	const actual = await vi.importActual<typeof import('../license/summary.js')>('../license/summary.js');
+	return {
+		...actual,
+		getLicenseEntitlements: vi.fn(),
+	};
+});
+
+const schema = new SchemaBuilder()
+	.collection('directus_settings', (collection) => {
+		collection.field('id').integer().primary();
+		collection.field('ai_openai_api_key').text();
+		collection.field('ai_openai_compatible_api_key').text();
+		collection.field('ai_openai_compatible_base_url').text();
+		collection.field('ai_openai_compatible_name').text();
+		collection.field('ai_openai_compatible_models').json();
+		collection.field('ai_openai_compatible_headers').json();
+	})
+	.build();
+
+describe('SettingsService', () => {
+	const db = vi.mocked(knex.default({ client: MockClient }));
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('redacts custom LLM provider settings when the entitlement is disabled', async () => {
+		vi.mocked(getLicenseEntitlements).mockResolvedValue({
+			custom_llm_enabled: false,
+		} as any);
+
+		const readSingletonSpy = vi.spyOn(ItemsService.prototype, 'readSingleton').mockResolvedValue({
+			ai_openai_api_key: 'openai-key',
+			ai_openai_compatible_api_key: 'custom-key',
+			ai_openai_compatible_base_url: 'http://localhost:11434/v1',
+		});
+
+		const service = new SettingsService({
+			knex: db,
+			schema,
+		});
+
+		const query = {
+			fields: ['ai_openai_api_key', 'ai_openai_compatible_api_key', 'ai_openai_compatible_base_url'],
+		};
+
+		const result = await service.readSingleton(query);
+
+		expect(readSingletonSpy).toHaveBeenCalledWith(query, undefined);
+
+		expect(result).toStrictEqual({
+			ai_openai_api_key: 'openai-key',
+			ai_openai_compatible_api_key: null,
+			ai_openai_compatible_base_url: null,
+		});
+
+		expect(result).not.toHaveProperty('ai_openai_compatible_name');
+		expect(result).not.toHaveProperty('ai_openai_compatible_models');
+		expect(result).not.toHaveProperty('ai_openai_compatible_headers');
+	});
+
+	it('returns custom LLM provider settings unchanged when the entitlement is enabled', async () => {
+		vi.mocked(getLicenseEntitlements).mockResolvedValue({
+			custom_llm_enabled: true,
+		} as any);
+
+		const readSingletonSpy = vi.spyOn(ItemsService.prototype, 'readSingleton').mockResolvedValue({
+			ai_openai_compatible_api_key: 'custom-key',
+			ai_openai_compatible_base_url: 'http://localhost:11434/v1',
+		});
+
+		const service = new SettingsService({
+			knex: db,
+			schema,
+		});
+
+		const query = {
+			fields: ['ai_openai_compatible_api_key', 'ai_openai_compatible_base_url'],
+		};
+
+		const result = await service.readSingleton(query);
+
+		expect(readSingletonSpy).toHaveBeenCalledWith(query, undefined);
+
+		expect(result).toStrictEqual({
+			ai_openai_compatible_api_key: 'custom-key',
+			ai_openai_compatible_base_url: 'http://localhost:11434/v1',
+		});
+	});
+
+	it('skips entitlement lookup when the query does not include custom LLM fields', async () => {
+		const readSingletonSpy = vi.spyOn(ItemsService.prototype, 'readSingleton').mockResolvedValue({
+			ai_openai_api_key: 'openai-key',
+		});
+
+		const service = new SettingsService({
+			knex: db,
+			schema,
+		});
+
+		const query = {
+			fields: ['ai_openai_api_key'],
+		};
+
+		const result = await service.readSingleton(query);
+
+		expect(readSingletonSpy).toHaveBeenCalledWith(query, undefined);
+		expect(getLicenseEntitlements).not.toHaveBeenCalled();
+
+		expect(result).toStrictEqual({
+			ai_openai_api_key: 'openai-key',
+		});
+	});
+});

--- a/api/src/services/settings.ts
+++ b/api/src/services/settings.ts
@@ -1,11 +1,44 @@
-import type { AbstractServiceOptions, OwnerInformation } from '@directus/types';
+import type { AbstractServiceOptions, Item, OwnerInformation, Query, QueryOptions } from '@directus/types';
 import { version } from 'directus/version';
+import { getLicenseEntitlements } from '../license/summary.js';
 import { sendReport } from '../telemetry/index.js';
 import { ItemsService } from './items.js';
+
+const customLLMFields = [
+	'ai_openai_compatible_api_key',
+	'ai_openai_compatible_base_url',
+	'ai_openai_compatible_name',
+	'ai_openai_compatible_models',
+	'ai_openai_compatible_headers',
+] as const;
 
 export class SettingsService extends ItemsService {
 	constructor(options: AbstractServiceOptions) {
 		super('directus_settings', options);
+	}
+
+	override async readSingleton(query: Query, opts?: QueryOptions): Promise<Partial<Item>> {
+		const settings = await super.readSingleton(query, opts);
+
+		if (customLLMFields.some((field) => Object.hasOwn(settings, field)) === false) {
+			return settings;
+		}
+
+		const entitlements = await getLicenseEntitlements(this.knex);
+
+		if (entitlements.custom_llm_enabled === true) {
+			return settings;
+		}
+
+		const redactedSettings = { ...settings };
+
+		for (const field of customLLMFields) {
+			if (Object.hasOwn(redactedSettings, field)) {
+				redactedSettings[field] = null;
+			}
+		}
+
+		return redactedSettings;
 	}
 
 	async setOwner(data: OwnerInformation) {

--- a/app/src/modules/settings/routes/ai/overview.vue
+++ b/app/src/modules/settings/routes/ai/overview.vue
@@ -24,12 +24,49 @@ const router = useRouter();
 
 const settingsStore = useSettingsStore();
 const serverStore = useServerStore();
+const customLLMEnabled = computed(() => serverStore.info.license?.custom_llm_enabled === true);
 
 const { fields: allFields } = useCollection('directus_settings');
 
-const aiFields = computed(() =>
-	unref(allFields).filter((field) => field.meta?.group === 'ai_group' || field.field === 'ai_group'),
-);
+const customLLMFields = new Set([
+	'ai_openai_compatible_name',
+	'ai_openai_compatible_base_url',
+	'ai_openai_compatible_api_key',
+	'ai_openai_compatible_headers',
+	'ai_openai_compatible_models',
+	'ai_openai_compatible_divider',
+]);
+
+const aiFields = computed(() => {
+	return unref(allFields)
+		.filter((field) => field.meta?.group === 'ai_group' || field.field === 'ai_group')
+		.map((field) => {
+			if (customLLMEnabled.value === true || customLLMFields.has(field.field) === false) {
+				return field;
+			}
+
+			if (field.field === 'ai_openai_compatible_divider') {
+				return {
+					...field,
+					meta: {
+						...field.meta,
+						options: {
+							...(field.meta?.options ?? {}),
+							icon: 'diamond',
+						},
+					},
+				};
+			}
+
+			return {
+				...field,
+				meta: {
+					...field.meta,
+					readonly: true,
+				},
+			};
+		});
+});
 
 const mcpFields = computed(() =>
 	unref(allFields).filter((field) => field.meta?.group === 'mcp_group' || field.field === 'mcp_group'),


### PR DESCRIPTION
## Scope

What's changed:

- Added entitlement-aware redaction to `SettingsService.readSingleton`, so custom OpenAI-compatible provider settings are nulled out unless `custom_llm_enabled` is available.
- Left standard AI settings intact while specifically targeting the custom provider fields for redaction, preserving the broader AI configuration surface.
- Short-circuited the redaction path when custom-provider fields are not requested, avoiding unnecessary entitlement lookups on unrelated settings reads.
- Updated the AI settings screen so custom provider fields remain visible but become read-only when the feature is unavailable, with divider styling that makes the upsell state explicit.
- Added tests to ensure redacted values are preserved correctly through settings reads and that the chat settings middleware still forwards the expected values.

## Potential Risks / Drawbacks

- Because redaction happens on reads, stale client state or save payloads could accidentally overwrite custom-provider values if the UI submits disabled fields unexpectedly.
- The new behavior distinguishes between standard AI provider settings and custom-provider settings, so field-list drift in future schema changes could create gaps.
- Middleware and settings consumers now rely on the service-level redaction contract instead of each caller handling this independently.

## Tested Scenarios

- Added `SettingsService` tests for redacted and entitled reads of custom LLM provider fields.
- Added middleware tests for AI settings loading, including cases where redacted and non-redacted fields are returned together.
- Updated the AI settings UI behavior so the locked state is represented directly in the rendered form configuration.

## Review Notes / Questions

- Special attention should be paid to downgrade and re-upgrade behavior, since the goal is to hide custom provider settings without destroying stored values.
- The UI keeps these fields visible but read-only, so it is worth checking that disabled inputs do not leak into save payloads.
- Reviewer eyes on the exact field list for `customLLMFields` would help, since future additions need to stay in sync with the service redaction list.

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #\<num\>
