### PR TITLE
Add SSO limits

### DIFF
--- a/api/src/auth/constants/sso.ts
+++ b/api/src/auth/constants/sso.ts
@@ -1,0 +1,17 @@
+import { createError } from '@directus/errors';
+
+export const SSO_DRIVERS = ['oauth2', 'openid', 'saml'] as const;
+export const EXTERNAL_AUTH_DRIVERS = [...SSO_DRIVERS, 'ldap'] as const;
+
+export const SSO_DISABLED_REASON = 'SSO_DISABLED';
+export const SSO_NON_ADMIN_REASON = 'SSO_NON_ADMIN';
+
+export const SsoNonAdminError = createError(SSO_NON_ADMIN_REASON, 'SSO is only available for administrators.', 403);
+
+export function isSSODriver(driver: string | undefined): driver is (typeof SSO_DRIVERS)[number] {
+	return typeof driver === 'string' && SSO_DRIVERS.includes(driver as (typeof SSO_DRIVERS)[number]);
+}
+
+export function isExternalAuthDriver(driver: string | undefined): driver is (typeof EXTERNAL_AUTH_DRIVERS)[number] {
+	return typeof driver === 'string' && EXTERNAL_AUTH_DRIVERS.includes(driver as (typeof EXTERNAL_AUTH_DRIVERS)[number]);
+}

--- a/api/src/auth/drivers/ldap.test.ts
+++ b/api/src/auth/drivers/ldap.test.ts
@@ -1,4 +1,5 @@
 import {
+	ForbiddenError,
 	InvalidCredentialsError,
 	InvalidProviderConfigError,
 	InvalidProviderError,
@@ -13,6 +14,7 @@ import {
 } from 'ldapts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import emitter from '../../emitter.js';
+import { getSSOState } from '../utils/get-sso-state.js';
 import { createLDAPAuthRouter, LDAPAuthDriver } from './ldap.js';
 
 const mockAuthenticationService = {
@@ -109,6 +111,14 @@ vi.mock('../../utils/get-schema.js', () => ({
 	getSchema: vi.fn().mockResolvedValue({}),
 }));
 
+vi.mock('../utils/get-sso-state.js', () => ({
+	getSSOState: vi.fn().mockResolvedValue({
+		enabled: true,
+		disabled: false,
+		transitional: false,
+	}),
+}));
+
 // Create mock functions for UsersService
 const mockCreateOne = vi.fn().mockResolvedValue('new-user-id');
 const mockUpdateOne = vi.fn().mockResolvedValue(undefined);
@@ -177,6 +187,12 @@ describe('LDAP Auth Driver', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockKnexInstance = createMockKnex();
+
+		vi.mocked(getSSOState).mockResolvedValue({
+			enabled: true,
+			disabled: false,
+			transitional: false,
+		});
 	});
 
 	afterEach(() => {
@@ -1094,6 +1110,37 @@ describe('LDAP Auth Driver', () => {
 			});
 
 			expect(mockNext).toHaveBeenCalled();
+		});
+
+		it('should reject direct ldap login when external auth is disabled', async () => {
+			vi.mocked(getSSOState).mockResolvedValue({
+				enabled: false,
+				disabled: true,
+				transitional: false,
+			});
+
+			const router = createLDAPAuthRouter('ldap');
+			const postLayer = router.stack.find((layer: any) => layer.route?.methods?.post);
+			const handler = postLayer.route.stack[0].handle;
+
+			const mockReq = {
+				body: {
+					identifier: 'testuser',
+					password: 'testpass',
+					mode: 'json',
+				},
+				schema: {},
+				get: vi.fn(),
+			};
+
+			const mockRes = {
+				cookie: vi.fn(),
+				json: vi.fn(),
+				locals: {},
+			};
+
+			await expect(handler(mockReq, mockRes, vi.fn())).rejects.toBeInstanceOf(ForbiddenError);
+			expect(mockAuthenticationService.login).not.toHaveBeenCalled();
 		});
 
 		it('should set cookie in cookie mode', async () => {

--- a/api/src/auth/drivers/ldap.ts
+++ b/api/src/auth/drivers/ldap.ts
@@ -1,6 +1,7 @@
 import { useEnv } from '@directus/env';
 import {
 	ErrorCode,
+	ForbiddenError,
 	InvalidCredentialsError,
 	InvalidPayloadError,
 	InvalidProviderConfigError,
@@ -31,6 +32,7 @@ import asyncHandler from '../../utils/async-handler.js';
 import { getIPFromReq } from '../../utils/get-ip-from-req.js';
 import { getSchema } from '../../utils/get-schema.js';
 import { AuthDriver } from '../auth.js';
+import { getSSOState } from '../utils/get-sso-state.js';
 
 interface UserInfo {
 	dn: string;
@@ -437,6 +439,11 @@ export function createLDAPAuthRouter(provider: string): Router {
 		'/',
 		asyncHandler(async (req, res, next) => {
 			const env = useEnv();
+			const ssoState = await getSSOState();
+
+			if (ssoState.disabled) {
+				throw new ForbiddenError();
+			}
 
 			const accountability: Accountability = createDefaultAccountability({
 				ip: getIPFromReq(req),

--- a/api/src/auth/drivers/oauth2.test.ts
+++ b/api/src/auth/drivers/oauth2.test.ts
@@ -12,6 +12,11 @@ import type { Logger } from 'pino';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { getAuthProvider } from '../../auth.js';
 import { useLogger } from '../../logger/index.js';
+import { getSSOState } from '../utils/get-sso-state.js';
+import {
+	resolveBlockedSSORedirect,
+	resolveBlockedSSORedirectFromStateCookie,
+} from '../utils/resolve-blocked-sso-redirect.js';
 import { createOAuth2AuthRouter, OAuth2AuthDriver } from './oauth2.js';
 
 vi.mock('@directus/env', () => ({
@@ -30,6 +35,19 @@ vi.mock('../../utils/get-secret.js', () => ({
 
 vi.mock('../utils/generate-callback-url.js', () => ({
 	generateCallbackUrl: vi.fn(() => 'http://localhost:8055/auth/login/test/callback'),
+}));
+
+vi.mock('../utils/get-sso-state.js', () => ({
+	getSSOState: vi.fn().mockResolvedValue({
+		enabled: true,
+		disabled: false,
+		transitional: false,
+	}),
+}));
+
+vi.mock('../utils/resolve-blocked-sso-redirect.js', () => ({
+	resolveBlockedSSORedirect: vi.fn(),
+	resolveBlockedSSORedirectFromStateCookie: vi.fn(),
 }));
 
 vi.mock('../utils/is-login-redirect-allowed.js', () => ({
@@ -124,6 +142,15 @@ beforeEach(() => {
 	mockAuthorizationUrl.mockClear();
 
 	codeChallengelengeSpy = vi.spyOn(generators, 'codeChallenge');
+
+	vi.mocked(getSSOState).mockResolvedValue({
+		enabled: true,
+		disabled: false,
+		transitional: false,
+	});
+
+	vi.mocked(resolveBlockedSSORedirect).mockReturnValue(undefined);
+	vi.mocked(resolveBlockedSSORedirectFromStateCookie).mockReturnValue(undefined);
 });
 
 afterEach(() => {
@@ -662,7 +689,7 @@ describe('OAuth2AuthDriver', () => {
 
 				await driver.getUserID(payload);
 
-				expect(fetchUserIdSpy).toHaveBeenCalledWith('user_id_test');
+				expect(fetchUserIdSpy).toHaveBeenCalledWith('user_id_test', provider);
 			});
 
 			test('falls back to email when identifierKey not found', async () => {
@@ -688,7 +715,7 @@ describe('OAuth2AuthDriver', () => {
 
 				await driver.getUserID(payload);
 
-				expect(fetchUserIdSpy).toHaveBeenCalledWith('fallback@test.com');
+				expect(fetchUserIdSpy).toHaveBeenCalledWith('fallback@test.com', provider);
 			});
 
 			test('throws InvalidCredentialsError when no identifier found', async () => {
@@ -735,7 +762,7 @@ describe('OAuth2AuthDriver', () => {
 
 				await driver.getUserID(payload);
 
-				expect(fetchUserIdSpy).toHaveBeenCalledWith('custom-email@test.com');
+				expect(fetchUserIdSpy).toHaveBeenCalledWith('custom-email@test.com', provider);
 			});
 		});
 
@@ -1307,6 +1334,7 @@ describe('createOAuth2AuthRouter', () => {
 	function createMockReqRes() {
 		const req: any = {
 			query: {},
+			cookies: {},
 			protocol: 'http',
 			get: vi.fn((header: string) => {
 				if (header === 'host') return 'localhost:8055';
@@ -1316,13 +1344,14 @@ describe('createOAuth2AuthRouter', () => {
 
 		const res: any = {
 			cookie: vi.fn(),
+			clearCookie: vi.fn(),
 			redirect: vi.fn(),
 		};
 
 		return { req, res };
 	}
 
-	test('sets secure cookie option to true when AUTH_TEST_COOKIE_SECURE is true', () => {
+	test('sets secure cookie option to true when AUTH_TEST_COOKIE_SECURE is true', async () => {
 		vi.mocked(useEnv).mockReturnValue({
 			EMAIL_TEMPLATES_PATH: './templates',
 			AUTH_TEST_COOKIE_SECURE: true,
@@ -1340,7 +1369,7 @@ describe('createOAuth2AuthRouter', () => {
 
 		const { req, res } = createMockReqRes();
 
-		handler(req, res);
+		await handler(req, res);
 
 		expect(res.cookie).toHaveBeenCalledWith(
 			'oauth2.test',
@@ -1349,7 +1378,7 @@ describe('createOAuth2AuthRouter', () => {
 		);
 	});
 
-	test('sets secure cookie option to false when AUTH_TEST_COOKIE_SECURE is false', () => {
+	test('sets secure cookie option to false when AUTH_TEST_COOKIE_SECURE is false', async () => {
 		vi.mocked(useEnv).mockReturnValue({
 			EMAIL_TEMPLATES_PATH: './templates',
 			AUTH_TEST_COOKIE_SECURE: false,
@@ -1367,12 +1396,33 @@ describe('createOAuth2AuthRouter', () => {
 
 		const { req, res } = createMockReqRes();
 
-		handler(req, res);
+		await handler(req, res);
 
 		expect(res.cookie).toHaveBeenCalledWith(
 			'oauth2.test',
 			expect.any(String),
 			expect.objectContaining({ secure: false }),
 		);
+	});
+
+	test('clears the oauth state cookie and redirects when sso is disabled during callback', async () => {
+		vi.mocked(getSSOState).mockResolvedValue({
+			enabled: false,
+			disabled: true,
+			transitional: false,
+		});
+
+		vi.mocked(resolveBlockedSSORedirectFromStateCookie).mockReturnValue('/admin/login');
+
+		const router = createOAuth2AuthRouter('test');
+		const handler = getRouteHandler(router, 'get', '/callback');
+
+		const { req, res } = createMockReqRes();
+		req.cookies['oauth2.test'] = 'cookie';
+
+		await handler(req, res, vi.fn());
+
+		expect(res.clearCookie).toHaveBeenCalledWith('oauth2.test');
+		expect(res.redirect).toHaveBeenCalledWith('/admin/login?reason=SSO_DISABLED');
 	});
 });

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -1,6 +1,7 @@
 import { useEnv } from '@directus/env';
 import {
 	ErrorCode,
+	ForbiddenError,
 	InvalidCredentialsError,
 	InvalidPayloadError,
 	InvalidProviderConfigError,
@@ -33,7 +34,13 @@ import { getSchema } from '../../utils/get-schema.js';
 import { getSecret } from '../../utils/get-secret.js';
 import { verifyJWT } from '../../utils/jwt.js';
 import { Url } from '../../utils/url.js';
+import { SSO_DISABLED_REASON } from '../constants/sso.js';
 import { generateCallbackUrl } from '../utils/generate-callback-url.js';
+import { getSSOState } from '../utils/get-sso-state.js';
+import {
+	resolveBlockedSSORedirect,
+	resolveBlockedSSORedirectFromStateCookie,
+} from '../utils/resolve-blocked-sso-redirect.js';
 import { resolveLoginRedirect } from '../utils/resolve-login-redirect.js';
 import { LocalAuthDriver } from './local.js';
 
@@ -125,10 +132,11 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 		}
 	}
 
-	private async fetchUserId(identifier: string): Promise<string | undefined> {
+	private async fetchUserId(identifier: string, provider: string): Promise<string | undefined> {
 		const user = await this.knex
 			.select('id')
 			.from('directus_users')
+			.where({ provider })
 			.whereRaw('LOWER(??) = ?', ['external_identifier', identifier.toLowerCase()])
 			.first();
 
@@ -204,7 +212,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			auth_data: tokenSet.refresh_token && JSON.stringify({ refreshToken: tokenSet.refresh_token }),
 		};
 
-		const userId = await this.fetchUserId(identifier);
+		const userId = await this.fetchUserId(identifier, provider);
 
 		if (userId) {
 			// Run hook so the end user has the chance to augment the
@@ -282,7 +290,7 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			throw e;
 		}
 
-		return (await this.fetchUserId(identifier)) as string;
+		return (await this.fetchUserId(identifier, provider)) as string;
 	}
 
 	override async login(user: User): Promise<void> {
@@ -353,7 +361,19 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 
 	router.get(
 		'/',
-		(req, res) => {
+		asyncHandler(async (req, res) => {
+			const ssoState = await getSSOState();
+
+			if (ssoState.disabled) {
+				const redirect = resolveBlockedSSORedirect(req.query['redirect'], providerName);
+
+				if (redirect) {
+					return res.redirect(`${redirect.split('?')[0]}?reason=${SSO_DISABLED_REASON}`);
+				}
+
+				throw new ForbiddenError();
+			}
+
 			const provider = getAuthProvider(providerName) as OAuth2AuthDriver;
 			const codeVerifier = provider.generateCodeVerifier();
 			const prompt = !!req.query['prompt'];
@@ -391,16 +411,30 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 			});
 
 			return res.redirect(provider.generateAuthUrl(codeVerifier, prompt, callbackUrl));
-		},
+		}),
 		respond,
 	);
 
 	router.post(
 		'/callback',
 		express.urlencoded({ extended: false }),
-		(req, res) => {
+		asyncHandler(async (req, res) => {
+			const ssoState = await getSSOState();
+
+			if (ssoState.disabled) {
+				const redirect = resolveBlockedSSORedirectFromStateCookie(req.cookies[`oauth2.${providerName}`], providerName);
+
+				res.clearCookie(`oauth2.${providerName}`);
+
+				if (redirect) {
+					return res.redirect(`${redirect.split('?')[0]}?reason=${SSO_DISABLED_REASON}`);
+				}
+
+				throw new ForbiddenError();
+			}
+
 			res.redirect(303, `./callback?${new URLSearchParams(req.body)}`);
-		},
+		}),
 		respond,
 	);
 
@@ -408,6 +442,19 @@ export function createOAuth2AuthRouter(providerName: string): Router {
 		'/callback',
 		asyncHandler(async (req, res, next) => {
 			const logger = useLogger();
+			const ssoState = await getSSOState();
+
+			if (ssoState.disabled) {
+				const redirect = resolveBlockedSSORedirectFromStateCookie(req.cookies[`oauth2.${providerName}`], providerName);
+
+				res.clearCookie(`oauth2.${providerName}`);
+
+				if (redirect) {
+					return res.redirect(`${redirect.split('?')[0]}?reason=${SSO_DISABLED_REASON}`);
+				}
+
+				throw new ForbiddenError();
+			}
 
 			let tokenData;
 

--- a/api/src/auth/drivers/openid.test.ts
+++ b/api/src/auth/drivers/openid.test.ts
@@ -12,6 +12,11 @@ import type { Logger } from 'pino';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { getAuthProvider } from '../../auth.js';
 import { useLogger } from '../../logger/index.js';
+import { getSSOState } from '../utils/get-sso-state.js';
+import {
+	resolveBlockedSSORedirect,
+	resolveBlockedSSORedirectFromStateCookie,
+} from '../utils/resolve-blocked-sso-redirect.js';
 import { createOpenIDAuthRouter, OpenIDAuthDriver } from './openid.js';
 
 vi.mock('@directus/env', () => ({
@@ -30,6 +35,19 @@ vi.mock('../../utils/get-secret.js', () => ({
 
 vi.mock('../utils/generate-callback-url.js', () => ({
 	generateCallbackUrl: vi.fn(() => 'http://localhost:8055/auth/login/test/callback'),
+}));
+
+vi.mock('../utils/get-sso-state.js', () => ({
+	getSSOState: vi.fn().mockResolvedValue({
+		enabled: true,
+		disabled: false,
+		transitional: false,
+	}),
+}));
+
+vi.mock('../utils/resolve-blocked-sso-redirect.js', () => ({
+	resolveBlockedSSORedirect: vi.fn(),
+	resolveBlockedSSORedirectFromStateCookie: vi.fn(),
 }));
 
 vi.mock('../utils/is-login-redirect-allowed.js', () => ({
@@ -128,6 +146,15 @@ beforeEach(() => {
 	} as unknown as Logger;
 
 	vi.mocked(useLogger).mockReturnValue(mockLogger);
+
+	vi.mocked(getSSOState).mockResolvedValue({
+		enabled: true,
+		disabled: false,
+		transitional: false,
+	});
+
+	vi.mocked(resolveBlockedSSORedirect).mockReturnValue(undefined);
+	vi.mocked(resolveBlockedSSORedirectFromStateCookie).mockReturnValue(undefined);
 });
 
 afterEach(() => {
@@ -589,7 +616,7 @@ describe('OpenIDAuthDriver', () => {
 
 				await driver.getUserID(payload);
 
-				expect(fetchUserIdSpy).toHaveBeenCalledWith('user_id_test');
+				expect(fetchUserIdSpy).toHaveBeenCalledWith('user_id_test', provider);
 			});
 
 			test('throws InvalidCredentialsError when no identifier found', async () => {
@@ -1243,6 +1270,7 @@ describe('createOpenIDAuthRouter', () => {
 	function createMockReqRes() {
 		const req: any = {
 			query: {},
+			cookies: {},
 			protocol: 'http',
 			get: vi.fn((header: string) => {
 				if (header === 'host') return 'localhost:8055';
@@ -1252,6 +1280,7 @@ describe('createOpenIDAuthRouter', () => {
 
 		const res: any = {
 			cookie: vi.fn(),
+			clearCookie: vi.fn(),
 			redirect: vi.fn(),
 		};
 
@@ -1310,5 +1339,26 @@ describe('createOpenIDAuthRouter', () => {
 			expect.any(String),
 			expect.objectContaining({ secure: false }),
 		);
+	});
+
+	test('clears the openid state cookie and redirects when sso is disabled during callback', async () => {
+		vi.mocked(getSSOState).mockResolvedValue({
+			enabled: false,
+			disabled: true,
+			transitional: false,
+		});
+
+		vi.mocked(resolveBlockedSSORedirectFromStateCookie).mockReturnValue('/admin/login');
+
+		const router = createOpenIDAuthRouter('test');
+		const handler = getRouteHandler(router, 'get', '/callback');
+
+		const { req, res } = createMockReqRes();
+		req.cookies['openid.test'] = 'cookie';
+
+		await handler(req, res, vi.fn());
+
+		expect(res.clearCookie).toHaveBeenCalledWith('openid.test');
+		expect(res.redirect).toHaveBeenCalledWith('/admin/login?reason=SSO_DISABLED');
 	});
 });

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -1,6 +1,7 @@
 import { useEnv } from '@directus/env';
 import {
 	ErrorCode,
+	ForbiddenError,
 	InvalidCredentialsError,
 	InvalidPayloadError,
 	InvalidProviderConfigError,
@@ -34,7 +35,13 @@ import { getSchema } from '../../utils/get-schema.js';
 import { getSecret } from '../../utils/get-secret.js';
 import { verifyJWT } from '../../utils/jwt.js';
 import { Url } from '../../utils/url.js';
+import { SSO_DISABLED_REASON } from '../constants/sso.js';
 import { generateCallbackUrl } from '../utils/generate-callback-url.js';
+import { getSSOState } from '../utils/get-sso-state.js';
+import {
+	resolveBlockedSSORedirect,
+	resolveBlockedSSORedirectFromStateCookie,
+} from '../utils/resolve-blocked-sso-redirect.js';
 import { resolveLoginRedirect } from '../utils/resolve-login-redirect.js';
 import { LocalAuthDriver } from './local.js';
 
@@ -197,10 +204,11 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 		}
 	}
 
-	private async fetchUserId(identifier: string): Promise<string | undefined> {
+	private async fetchUserId(identifier: string, provider: string): Promise<string | undefined> {
 		const user = await this.knex
 			.select('id')
 			.from('directus_users')
+			.where({ provider })
 			.whereRaw('LOWER(??) = ?', ['external_identifier', identifier.toLowerCase()])
 			.first();
 
@@ -285,7 +293,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			auth_data: tokenSet.refresh_token && JSON.stringify({ refreshToken: tokenSet.refresh_token }),
 		};
 
-		const userId = await this.fetchUserId(identifier);
+		const userId = await this.fetchUserId(identifier, provider);
 
 		if (userId) {
 			// Run hook so the end user has the chance to augment the
@@ -365,7 +373,7 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			throw e;
 		}
 
-		return (await this.fetchUserId(identifier)) as string;
+		return (await this.fetchUserId(identifier, provider)) as string;
 	}
 
 	override async login(user: User): Promise<void> {
@@ -438,6 +446,18 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 	router.get(
 		'/',
 		asyncHandler(async (req, res) => {
+			const ssoState = await getSSOState();
+
+			if (ssoState.disabled) {
+				const redirect = resolveBlockedSSORedirect(req.query['redirect'], providerName);
+
+				if (redirect) {
+					return res.redirect(`${redirect.split('?')[0]}?reason=${SSO_DISABLED_REASON}`);
+				}
+
+				throw new ForbiddenError();
+			}
+
 			const provider = getAuthProvider(providerName) as OpenIDAuthDriver;
 			const codeVerifier = provider.generateCodeVerifier();
 			const prompt = !!req.query['prompt'];
@@ -491,9 +511,23 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 	router.post(
 		'/callback',
 		express.urlencoded({ extended: false }),
-		(req, res) => {
+		asyncHandler(async (req, res) => {
+			const ssoState = await getSSOState();
+
+			if (ssoState.disabled) {
+				const redirect = resolveBlockedSSORedirectFromStateCookie(req.cookies[`openid.${providerName}`], providerName);
+
+				res.clearCookie(`openid.${providerName}`);
+
+				if (redirect) {
+					return res.redirect(`${redirect.split('?')[0]}?reason=${SSO_DISABLED_REASON}`);
+				}
+
+				throw new ForbiddenError();
+			}
+
 			res.redirect(303, `./callback?${new URLSearchParams(req.body)}`);
-		},
+		}),
 		respond,
 	);
 
@@ -502,6 +536,19 @@ export function createOpenIDAuthRouter(providerName: string): Router {
 		asyncHandler(async (req, res, next) => {
 			const env = useEnv();
 			const logger = useLogger();
+			const ssoState = await getSSOState();
+
+			if (ssoState.disabled) {
+				const redirect = resolveBlockedSSORedirectFromStateCookie(req.cookies[`openid.${providerName}`], providerName);
+
+				res.clearCookie(`openid.${providerName}`);
+
+				if (redirect) {
+					return res.redirect(`${redirect.split('?')[0]}?reason=${SSO_DISABLED_REASON}`);
+				}
+
+				throw new ForbiddenError();
+			}
 
 			let tokenData;
 

--- a/api/src/auth/drivers/saml.test.ts
+++ b/api/src/auth/drivers/saml.test.ts
@@ -1,0 +1,141 @@
+import { ForbiddenError } from '@directus/errors';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { getAuthProvider } from '../../auth.js';
+import { getSSOState } from '../utils/get-sso-state.js';
+import { resolveBlockedSSORedirect } from '../utils/resolve-blocked-sso-redirect.js';
+import { createSAMLAuthRouter } from './saml.js';
+
+vi.mock('@directus/env', () => ({
+	useEnv: vi.fn(() => ({
+		SESSION_COOKIE_NAME: 'session',
+		REFRESH_TOKEN_COOKIE_NAME: 'refresh_token',
+	})),
+}));
+
+vi.mock('@authenio/samlify-node-xmllint', () => ({}));
+
+vi.mock('samlify', () => ({
+	setSchemaValidator: vi.fn(),
+	ServiceProvider: vi.fn(),
+	IdentityProvider: vi.fn(),
+}));
+
+vi.mock('../../auth.js', () => ({
+	getAuthProvider: vi.fn(),
+}));
+
+vi.mock('../../logger/index.js', () => ({
+	useLogger: vi.fn(() => ({
+		error: vi.fn(),
+		warn: vi.fn(),
+		debug: vi.fn(),
+	})),
+}));
+
+vi.mock('../../middleware/respond.js', () => ({
+	respond: vi.fn(),
+}));
+
+vi.mock('../../services/authentication.js', () => ({
+	AuthenticationService: vi.fn(),
+}));
+
+vi.mock('../../utils/async-handler.js', () => ({
+	default: (fn: any) => fn,
+}));
+
+vi.mock('../utils/get-sso-state.js', () => ({
+	getSSOState: vi.fn().mockResolvedValue({
+		enabled: true,
+		disabled: false,
+		transitional: false,
+	}),
+}));
+
+vi.mock('../utils/resolve-blocked-sso-redirect.js', () => ({
+	resolveBlockedSSORedirect: vi.fn(),
+}));
+
+vi.mock('./local.js', () => ({
+	LocalAuthDriver: class {},
+}));
+
+describe('createSAMLAuthRouter', () => {
+	beforeEach(() => {
+		vi.mocked(getAuthProvider).mockReturnValue({
+			sp: {
+				getMetadata: vi.fn(() => '<xml />'),
+				createLoginRequest: vi.fn(() => ({ context: 'https://idp.test/login' })),
+			},
+			idp: {},
+		} as any);
+
+		vi.mocked(getSSOState).mockResolvedValue({
+			enabled: true,
+			disabled: false,
+			transitional: false,
+		});
+
+		vi.mocked(resolveBlockedSSORedirect).mockReturnValue(undefined);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('keeps metadata public even when sso is disabled', async () => {
+		vi.mocked(getSSOState).mockResolvedValue({
+			enabled: false,
+			disabled: true,
+			transitional: false,
+		});
+
+		const router = createSAMLAuthRouter('sso') as any;
+		const metadataRoute = router.stack.find((layer: any) => layer.route?.path === '/metadata');
+		const handler = metadataRoute.route.stack[0].handle;
+
+		const header = vi.fn().mockReturnThis();
+		const send = vi.fn();
+		const res = { header, send } as any;
+
+		await handler({}, res);
+
+		expect(header).toHaveBeenCalledWith('Content-Type', 'text/xml');
+		expect(send).toHaveBeenCalledWith('<xml />');
+	});
+
+	test('redirects disabled entry route when a valid blocked-path redirect exists', async () => {
+		vi.mocked(getSSOState).mockResolvedValue({
+			enabled: false,
+			disabled: true,
+			transitional: false,
+		});
+
+		vi.mocked(resolveBlockedSSORedirect).mockReturnValue('/admin/login');
+
+		const router = createSAMLAuthRouter('sso') as any;
+		const loginRoute = router.stack.find((layer: any) => layer.route?.path === '/');
+		const handler = loginRoute.route.stack[0].handle;
+		const redirect = vi.fn();
+
+		await handler({ query: { redirect: '/admin/login' } }, { redirect } as any);
+
+		expect(redirect).toHaveBeenCalledWith('/admin/login?reason=SSO_DISABLED');
+	});
+
+	test('returns forbidden for disabled acs route without a valid redirect target', async () => {
+		vi.mocked(getSSOState).mockResolvedValue({
+			enabled: false,
+			disabled: true,
+			transitional: false,
+		});
+
+		vi.mocked(resolveBlockedSSORedirect).mockReturnValue(undefined);
+
+		const router = createSAMLAuthRouter('sso') as any;
+		const acsRoute = router.stack.find((layer: any) => layer.route?.path === '/acs');
+		const handler = acsRoute.route.stack[1].handle;
+
+		await expect(handler({ body: {} }, {} as any, vi.fn())).rejects.toBeInstanceOf(ForbiddenError);
+	});
+});

--- a/api/src/auth/drivers/saml.ts
+++ b/api/src/auth/drivers/saml.ts
@@ -2,6 +2,7 @@ import * as validator from '@authenio/samlify-node-xmllint';
 import { useEnv } from '@directus/env';
 import {
 	ErrorCode,
+	ForbiddenError,
 	InvalidCredentialsError,
 	InvalidPayloadError,
 	InvalidProviderError,
@@ -20,6 +21,9 @@ import type { AuthDriverOptions, User } from '../../types/index.js';
 import asyncHandler from '../../utils/async-handler.js';
 import { getConfigFromEnv } from '../../utils/get-config-from-env.js';
 import { getSchema } from '../../utils/get-schema.js';
+import { SSO_DISABLED_REASON } from '../constants/sso.js';
+import { getSSOState } from '../utils/get-sso-state.js';
+import { resolveBlockedSSORedirect } from '../utils/resolve-blocked-sso-redirect.js';
 import { resolveLoginRedirect } from '../utils/resolve-login-redirect.js';
 import { LocalAuthDriver } from './local.js';
 
@@ -40,10 +44,11 @@ export class SAMLAuthDriver extends LocalAuthDriver {
 		this.idp = samlify.IdentityProvider(getConfigFromEnv(`AUTH_${config['provider'].toUpperCase()}_IDP`));
 	}
 
-	async fetchUserID(identifier: string) {
+	async fetchUserID(identifier: string, provider: string) {
 		const user = await this.knex
 			.select('id')
 			.from('directus_users')
+			.where({ provider })
 			.whereRaw('LOWER(??) = ?', ['external_identifier', identifier.toLowerCase()])
 			.first();
 
@@ -63,7 +68,7 @@ export class SAMLAuthDriver extends LocalAuthDriver {
 			throw new InvalidCredentialsError();
 		}
 
-		const userID = await this.fetchUserID(identifier);
+		const userID = await this.fetchUserID(identifier, provider);
 
 		if (userID) return userID;
 
@@ -129,6 +134,18 @@ export function createSAMLAuthRouter(providerName: string) {
 	router.get(
 		'/',
 		asyncHandler(async (req, res) => {
+			const ssoState = await getSSOState();
+
+			if (ssoState.disabled) {
+				const redirect = resolveBlockedSSORedirect(req.query['redirect'], providerName);
+
+				if (redirect) {
+					return res.redirect(`${redirect.split('?')[0]}?reason=${SSO_DISABLED_REASON}`);
+				}
+
+				throw new ForbiddenError();
+			}
+
 			const { sp, idp } = getAuthProvider(providerName) as SAMLAuthDriver;
 			const { context: url } = sp.createLoginRequest(idp, 'redirect');
 			const parsedUrl = new URL(url);
@@ -173,8 +190,19 @@ export function createSAMLAuthRouter(providerName: string) {
 		express.urlencoded({ extended: false }),
 		asyncHandler(async (req, res, next) => {
 			const logger = useLogger();
+			const ssoState = await getSSOState();
 
 			let redirect: string | undefined = req.body?.RelayState;
+
+			if (ssoState.disabled) {
+				redirect = resolveBlockedSSORedirect(redirect, providerName);
+
+				if (redirect) {
+					return res.redirect(`${redirect.split('?')[0]}?reason=${SSO_DISABLED_REASON}`);
+				}
+
+				throw new ForbiddenError();
+			}
 
 			const authMode = (env[`AUTH_${providerName.toUpperCase()}_MODE`] ?? 'session') as string;
 

--- a/api/src/auth/utils/get-sso-state.ts
+++ b/api/src/auth/utils/get-sso-state.ts
@@ -1,0 +1,28 @@
+import { toBoolean } from '@directus/utils';
+import type { Knex } from 'knex';
+import getDatabase from '../../database/index.js';
+import { getLicenseEntitlements } from '../../license/summary.js';
+
+type SSOState = {
+	enabled: boolean;
+	disabled: boolean;
+	transitional: boolean;
+};
+
+export async function getSSOState(knexArg?: Knex): Promise<SSOState> {
+	const knex = knexArg ?? getDatabase();
+
+	const [entitlements, settings] = await Promise.all([
+		getLicenseEntitlements(knex),
+		knex.select('sso_disabled').from('directus_settings').first(),
+	]);
+
+	const enabled = entitlements.sso_enabled === true;
+	const disabled = toBoolean(settings?.['sso_disabled']);
+
+	return {
+		enabled,
+		disabled,
+		transitional: enabled === false && disabled === false,
+	};
+}

--- a/api/src/auth/utils/resolve-blocked-sso-redirect.test.ts
+++ b/api/src/auth/utils/resolve-blocked-sso-redirect.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test, vi } from 'vitest';
+import { resolveBlockedSSORedirect, resolveBlockedSSORedirectFromStateCookie } from './resolve-blocked-sso-redirect.js';
+
+vi.mock('../../utils/get-secret.js', () => ({
+	getSecret: vi.fn(() => 'test-secret'),
+}));
+
+vi.mock('../../utils/jwt.js', () => ({
+	verifyJWT: vi.fn(),
+}));
+
+vi.mock('./resolve-login-redirect.js', () => ({
+	resolveLoginRedirect: vi.fn(),
+}));
+
+describe('resolveBlockedSSORedirect', () => {
+	test('returns undefined when no redirect source is provided', async () => {
+		await expect(resolveBlockedSSORedirect(undefined, 'test')).toBeUndefined();
+	});
+
+	test('returns undefined when redirect validation fails', async () => {
+		const { resolveLoginRedirect } = await import('./resolve-login-redirect.js');
+
+		vi.mocked(resolveLoginRedirect).mockImplementation(() => {
+			throw new Error('invalid');
+		});
+
+		await expect(resolveBlockedSSORedirect('/admin/login', 'test')).toBeUndefined();
+	});
+
+	test('returns a validated redirect for direct query or relay state sources', async () => {
+		const { resolveLoginRedirect } = await import('./resolve-login-redirect.js');
+		vi.mocked(resolveLoginRedirect).mockReturnValue('/admin/login');
+
+		await expect(resolveBlockedSSORedirect('/admin/login', 'test')).toBe('/admin/login');
+	});
+});
+
+describe('resolveBlockedSSORedirectFromStateCookie', () => {
+	test('returns undefined when no cookie is present', async () => {
+		await expect(resolveBlockedSSORedirectFromStateCookie(undefined, 'test')).toBeUndefined();
+	});
+
+	test('returns undefined when the signed state cookie cannot be verified', async () => {
+		const { verifyJWT } = await import('../../utils/jwt.js');
+
+		vi.mocked(verifyJWT).mockImplementation(() => {
+			throw new Error('invalid');
+		});
+
+		await expect(resolveBlockedSSORedirectFromStateCookie('bad-cookie', 'test')).toBeUndefined();
+	});
+
+	test('returns a validated redirect from the signed state cookie', async () => {
+		const { verifyJWT } = await import('../../utils/jwt.js');
+		const { resolveLoginRedirect } = await import('./resolve-login-redirect.js');
+
+		vi.mocked(verifyJWT).mockReturnValue({ redirect: '/admin/login' } as any);
+		vi.mocked(resolveLoginRedirect).mockReturnValue('/admin/login');
+
+		await expect(resolveBlockedSSORedirectFromStateCookie('valid-cookie', 'test')).toBe('/admin/login');
+	});
+});

--- a/api/src/auth/utils/resolve-blocked-sso-redirect.ts
+++ b/api/src/auth/utils/resolve-blocked-sso-redirect.ts
@@ -1,0 +1,27 @@
+import { getSecret } from '../../utils/get-secret.js';
+import { verifyJWT } from '../../utils/jwt.js';
+import { resolveLoginRedirect } from './resolve-login-redirect.js';
+
+export function resolveBlockedSSORedirect(redirect: unknown, provider: string): string | undefined {
+	if (!redirect) return undefined;
+
+	try {
+		return resolveLoginRedirect(redirect, { provider });
+	} catch {
+		return undefined;
+	}
+}
+
+export function resolveBlockedSSORedirectFromStateCookie(
+	cookie: string | undefined,
+	provider: string,
+): string | undefined {
+	if (!cookie) return undefined;
+
+	try {
+		const tokenData = verifyJWT(cookie, getSecret()) as { redirect?: unknown };
+		return resolveBlockedSSORedirect(tokenData.redirect, provider);
+	} catch {
+		return undefined;
+	}
+}

--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -3,6 +3,7 @@ import { ErrorCode, InvalidPayloadError, isDirectusError } from '@directus/error
 import type { Accountability } from '@directus/types';
 import type { Request } from 'express';
 import { Router } from 'express';
+import { isExternalAuthDriver } from '../auth/constants/sso.js';
 import {
 	createLDAPAuthRouter,
 	createLocalAuthRouter,
@@ -10,6 +11,7 @@ import {
 	createOpenIDAuthRouter,
 	createSAMLAuthRouter,
 } from '../auth/drivers/index.js';
+import { getSSOState } from '../auth/utils/get-sso-state.js';
 import { DEFAULT_AUTH_PROVIDER, REFRESH_COOKIE_OPTIONS, SESSION_COOKIE_OPTIONS } from '../constants.js';
 import { useLogger } from '../logger/index.js';
 import { respond } from '../middleware/respond.js';
@@ -255,8 +257,11 @@ router.get(
 		const sessionOnly =
 			'sessionOnly' in req.query && (req.query['sessionOnly'] === '' || Boolean(req.query['sessionOnly']));
 
+		const providers = getAuthProviders({ sessionOnly });
+		const ssoState = await getSSOState();
+
 		res.locals['payload'] = {
-			data: getAuthProviders({ sessionOnly }),
+			data: ssoState.disabled ? providers.filter((provider) => !isExternalAuthDriver(provider.driver)) : providers,
 			disableDefault: env['AUTH_DISABLE_DEFAULT'],
 		};
 

--- a/api/src/database/migrations/20260219C-add-sso-disabled.ts
+++ b/api/src/database/migrations/20260219C-add-sso-disabled.ts
@@ -1,0 +1,13 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_settings', (table) => {
+		table.boolean('sso_disabled').defaultTo(false).notNullable();
+	});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_settings', (table) => {
+		table.dropColumn('sso_disabled');
+	});
+}

--- a/api/src/services/authentication.ts
+++ b/api/src/services/authentication.ts
@@ -12,6 +12,8 @@ import jwt from 'jsonwebtoken';
 import type { Knex } from 'knex';
 import { clone, cloneDeep } from 'lodash-es';
 import type { StringValue } from 'ms';
+import { isSSODriver, SsoNonAdminError } from '../auth/constants/sso.js';
+import { getSSOState } from '../auth/utils/get-sso-state.js';
 import { getAuthProvider } from '../auth.js';
 import { DEFAULT_AUTH_PROVIDER } from '../constants.js';
 import getDatabase from '../database/index.js';
@@ -20,6 +22,7 @@ import { fetchRolesTree } from '../permissions/lib/fetch-roles-tree.js';
 import { fetchGlobalAccess } from '../permissions/modules/fetch-global-access/fetch-global-access.js';
 import { createRateLimiter, RateLimiterRes } from '../rate-limiter.js';
 import type { DirectusTokenPayload, Session, User } from '../types/index.js';
+import { getAuthProviders } from '../utils/get-auth-providers.js';
 import { getMilliseconds } from '../utils/get-milliseconds.js';
 import { getSecret } from '../utils/get-secret.js';
 import { stall } from '../utils/stall.js';
@@ -135,6 +138,30 @@ export class AuthenticationService {
 			schema: this.schema,
 		});
 
+		const authProvider = getAuthProviders().find((provider) => provider.name === providerName);
+		let globalAccess: Awaited<ReturnType<typeof fetchGlobalAccess>> | null = null;
+
+		if (authProvider && isSSODriver(authProvider.driver)) {
+			const ssoState = await getSSOState(this.knex);
+
+			if (ssoState.transitional) {
+				const roles = await fetchRolesTree(user.role, { knex: this.knex });
+
+				globalAccess = await fetchGlobalAccess(
+					{ roles, user: user.id, ip: this.accountability?.ip ?? null },
+					{ knex: this.knex },
+				);
+
+				if (globalAccess.admin !== true) {
+					const loginError = new SsoNonAdminError();
+
+					emitStatus('fail', updatedPayload, user, loginError);
+					await stall(STALL_TIME, timeStart);
+					throw loginError;
+				}
+			}
+		}
+
 		const { auth_login_attempts: allowedAttempts } = await settingsService.readSingleton({
 			fields: ['auth_login_attempts'],
 		});
@@ -216,12 +243,14 @@ export class AuthenticationService {
 			}
 		}
 
-		const roles = await fetchRolesTree(user.role, { knex: this.knex });
+		if (!globalAccess) {
+			const roles = await fetchRolesTree(user.role, { knex: this.knex });
 
-		const globalAccess = await fetchGlobalAccess(
-			{ roles, user: user.id, ip: this.accountability?.ip ?? null },
-			{ knex: this.knex },
-		);
+			globalAccess = await fetchGlobalAccess(
+				{ roles, user: user.id, ip: this.accountability?.ip ?? null },
+				{ knex: this.knex },
+			);
+		}
 
 		const tokenPayload: DirectusTokenPayload = {
 			id: user.id,

--- a/api/src/services/settings.test.ts
+++ b/api/src/services/settings.test.ts
@@ -1,3 +1,4 @@
+import { ForbiddenError } from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import knex from 'knex';
 import { MockClient } from 'knex-mock-client';
@@ -27,6 +28,7 @@ const schema = new SchemaBuilder()
 		collection.field('ai_openai_compatible_name').text();
 		collection.field('ai_openai_compatible_models').json();
 		collection.field('ai_openai_compatible_headers').json();
+		collection.field('sso_disabled').boolean();
 	})
 	.build();
 
@@ -123,5 +125,27 @@ describe('SettingsService', () => {
 		expect(result).toStrictEqual({
 			ai_openai_api_key: 'openai-key',
 		});
+	});
+
+	it('rejects re-enabling sso when the entitlement is disabled and the project is already sso-disabled', async () => {
+		vi.mocked(getLicenseEntitlements).mockResolvedValue({
+			sso_enabled: false,
+		} as any);
+
+		const upsertSingletonSpy = vi.spyOn(ItemsService.prototype, 'upsertSingleton');
+
+		const service = new SettingsService({
+			knex: {
+				select: vi.fn(() => ({
+					from: vi.fn(() => ({
+						first: vi.fn().mockResolvedValue({ sso_disabled: true }),
+					})),
+				})),
+			} as any,
+			schema,
+		});
+
+		await expect(service.upsertSingleton({ sso_disabled: false })).rejects.toBeInstanceOf(ForbiddenError);
+		expect(upsertSingletonSpy).not.toHaveBeenCalled();
 	});
 });

--- a/api/src/services/settings.ts
+++ b/api/src/services/settings.ts
@@ -1,4 +1,14 @@
-import type { AbstractServiceOptions, Item, OwnerInformation, Query, QueryOptions } from '@directus/types';
+import { ForbiddenError } from '@directus/errors';
+import type {
+	AbstractServiceOptions,
+	Item,
+	MutationOptions,
+	OwnerInformation,
+	PrimaryKey,
+	Query,
+	QueryOptions,
+} from '@directus/types';
+import { toBoolean } from '@directus/utils';
 import { version } from 'directus/version';
 import { getLicenseEntitlements } from '../license/summary.js';
 import { sendReport } from '../telemetry/index.js';
@@ -39,6 +49,24 @@ export class SettingsService extends ItemsService {
 		}
 
 		return redactedSettings;
+	}
+
+	override async upsertSingleton(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
+		if (Object.hasOwn(data, 'sso_disabled')) {
+			const entitlements = await getLicenseEntitlements(this.knex);
+
+			if (entitlements.sso_enabled !== true) {
+				const currentSettings = await this.knex.select('sso_disabled').from('directus_settings').first();
+				const currentDisabled = toBoolean(currentSettings?.['sso_disabled']);
+				const nextDisabled = toBoolean(data['sso_disabled']);
+
+				if (currentDisabled === true && nextDisabled === false) {
+					throw new ForbiddenError();
+				}
+			}
+		}
+
+		return await super.upsertSingleton(data, opts);
 	}
 
 	async setOwner(data: OwnerInformation) {

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -876,6 +876,8 @@ errors:
   INVALID_PROVIDER: User belongs to a different auth provider
   INVALID_PROVIDER_CONFIG: Invalid provider configuration
   INVALID_QUERY: Invalid query
+  SSO_DISABLED: SSO has been disabled for this project
+  SSO_NON_ADMIN: SSO is only available for administrators
   INVALID_TOKEN: Invalid token
   INVALID_USER: Failed to authenticate user
   ITEM_LIMIT_REACHED: Item limit reached
@@ -1699,6 +1701,8 @@ fields:
     public_registration_verify_email: Verify Email
     public_registration_verify_email_note:
       Sends an email to the registering user asking them to click on a verification link before they can sign in.
+    sso_disabled: SSO Disabled
+    sso_disabled_note: Hides and blocks SSO for this project.
     visual_editor_urls: Visual Editor URLs
     report_feature_url: Report Feature URL
     report_bug_url: Report Bug URL

--- a/app/src/modules/settings/routes/project/project.vue
+++ b/app/src/modules/settings/routes/project/project.vue
@@ -28,6 +28,14 @@ const { fields: allFields } = useCollection('directus_settings');
 
 const EXCLUDED_GROUPS = ['theming_group', 'ai_group', 'mcp_group'] as const;
 
+const canEditSSODisabled = computed(() => {
+	if (serverStore.info.license?.sso_enabled === true) {
+		return true;
+	}
+
+	return settingsStore.settings?.sso_disabled !== true;
+});
+
 const fields = computed(() => {
 	return allFields.value
 		.map((field) => {
@@ -35,6 +43,16 @@ const fields = computed(() => {
 				field.field === 'collaborative_editing_enabled' &&
 				(serverStore.info.websocket === false || serverStore.info.websocket?.collaborativeEditing === false)
 			) {
+				return {
+					...field,
+					meta: {
+						...field.meta,
+						readonly: true,
+					},
+				} as any;
+			}
+
+			if (field.field === 'sso_disabled' && canEditSSODisabled.value === false) {
 				return {
 					...field,
 					meta: {

--- a/app/src/routes/login/components/sso-links.test.ts
+++ b/app/src/routes/login/components/sso-links.test.ts
@@ -1,0 +1,93 @@
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import SsoLinks from './sso-links.vue';
+import { i18n } from '@/lang';
+
+const mockRoute = vi.hoisted(() => ({
+	query: {} as Record<string, unknown>,
+}));
+
+vi.mock('vue-router', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('vue-router')>();
+
+	return {
+		...actual,
+		useRoute: () => mockRoute,
+	};
+});
+
+const VTextOverflowStub = defineComponent({
+	name: 'VTextOverflow',
+	props: {
+		text: {
+			type: String,
+			required: true,
+		},
+	},
+	template: '<span>{{ text }}</span>',
+});
+
+describe('SsoLinks', () => {
+	beforeEach(() => {
+		mockRoute.query = {};
+		localStorage.clear();
+		sessionStorage.clear();
+	});
+
+	function mountComponent() {
+		return mountWithProviders([{ name: 'okta', driver: 'openid', label: 'Okta', icon: 'lock' }]);
+	}
+
+	function mountWithProviders(providers: { name: string; driver: string; label: string; icon: string }[]) {
+		return mount(SsoLinks, {
+			props: {
+				providers,
+			},
+			global: {
+				plugins: [i18n],
+				stubs: {
+					TransitionExpand: defineComponent({ template: '<div><slot /></div>' }),
+					VDivider: true,
+					VIcon: true,
+					VInput: true,
+					VNotice: defineComponent({ template: '<div><slot /></div>' }),
+					VProgressCircular: true,
+					VTextOverflow: VTextOverflowStub,
+				},
+			},
+		});
+	}
+
+	test('shows the explicit sso non-admin message before falling back to api error translations', () => {
+		mockRoute.query = { reason: 'SSO_NON_ADMIN' };
+
+		const wrapper = mountComponent();
+
+		expect(wrapper.text()).toContain(i18n.global.t('errors.SSO_NON_ADMIN'));
+	});
+
+	test('shows the explicit sso disabled message before falling back to api error translations', () => {
+		mockRoute.query = { reason: 'SSO_DISABLED' };
+
+		const wrapper = mountComponent();
+
+		expect(wrapper.text()).toContain(i18n.global.t('errors.SSO_DISABLED'));
+	});
+
+	test('shows the sso disabled message even when no sso providers are available', () => {
+		mockRoute.query = { reason: 'SSO_DISABLED' };
+
+		const wrapper = mountWithProviders([]);
+
+		expect(wrapper.text()).toContain(i18n.global.t('errors.SSO_DISABLED'));
+	});
+
+	test('does not show generic api errors when no sso providers are available', () => {
+		mockRoute.query = { reason: 'INVALID_CREDENTIALS' };
+
+		const wrapper = mountWithProviders([]);
+
+		expect(wrapper.text()).not.toContain(i18n.global.t('errors.INVALID_CREDENTIALS'));
+	});
+});

--- a/app/src/routes/login/components/sso-links.vue
+++ b/app/src/routes/login/components/sso-links.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import formatTitle from '@directus/format-title';
 import { computed, onMounted, ref, toRefs, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 import TransitionExpand from '@/components/transition/expand.vue';
 import VDivider from '@/components/v-divider.vue';
@@ -19,6 +20,7 @@ const props = defineProps<{
 }>();
 
 const route = useRoute();
+const { t } = useI18n();
 
 const { providers } = toRefs(props);
 const ssoProviders = ref<{ name: string; label: string; link: string; icon: string }[]>([]);
@@ -127,16 +129,35 @@ watch(
 const errorFormatted = computed(() => {
 	const validReasons = ['SIGN_OUT', 'SESSION_EXPIRED'];
 
+	const customReasons = {
+		SSO_DISABLED: t('errors.SSO_DISABLED'),
+		SSO_NON_ADMIN: t('errors.SSO_NON_ADMIN'),
+	} as const;
+
 	const reason = Array.isArray(route.query.reason) ? route.query.reason[0] : route.query.reason;
 
 	// When requiring TFA, don't show the error banner; render the OTP input instead
 	if (requiresTFA.value) return null;
+
+	if (reason && Object.hasOwn(customReasons, reason)) {
+		return customReasons[reason as keyof typeof customReasons];
+	}
 
 	if (reason && !validReasons.includes(reason)) {
 		return translateAPIError(reason);
 	}
 
 	return null;
+});
+
+const showStandaloneSSONotice = computed(() => {
+	const reason = Array.isArray(route.query.reason) ? route.query.reason[0] : route.query.reason;
+
+	return reason === 'SSO_DISABLED' || reason === 'SSO_NON_ADMIN';
+});
+
+const showErrorNotice = computed(() => {
+	return !!errorFormatted.value && (ssoProviders.value.length > 0 || showStandaloneSSONotice.value);
 });
 
 function handleSSOClick(provider: { name: string; link: string }) {
@@ -169,12 +190,12 @@ watch(selectedProviderName, (val) => {
 
 <template>
 	<div class="sso-links">
+		<VNotice v-if="showErrorNotice" type="warning">
+			{{ errorFormatted }}
+		</VNotice>
+
 		<template v-if="ssoProviders.length > 0">
 			<VDivider />
-
-			<VNotice v-if="errorFormatted" type="warning">
-				{{ errorFormatted }}
-			</VNotice>
 
 			<template v-for="provider in ssoProviders" :key="provider.name">
 				<a class="sso-link" @click.prevent="() => handleSSOClick(provider)">
@@ -219,7 +240,7 @@ watch(selectedProviderName, (val) => {
 }
 
 .v-notice {
-	margin-block-end: 1.125rem;
+	margin-block: 1.125rem;
 }
 
 .otp-input {

--- a/packages/system-data/src/fields/settings.yaml
+++ b/packages/system-data/src/fields/settings.yaml
@@ -151,6 +151,15 @@ fields:
       placeholder: $t:unlimited
     width: half
 
+  - field: sso_disabled
+    interface: boolean
+    note: $t:fields.directus_settings.sso_disabled_note
+    width: half
+    options:
+      label: $t:disabled
+    special:
+      - cast-boolean
+
   - field: public_registration_divider
     interface: presentation-divider
     options:

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -50,6 +50,7 @@ export type Settings = {
 	public_note: string | null;
 	visual_editor_urls: Array<{ url: string }> | null;
 	auth_login_attempts: number;
+	sso_disabled: boolean;
 	auth_password_policy: string | null;
 	storage_asset_transform: string;
 	storage_asset_presets: SettingsStorageAssetPreset[] | null;


### PR DESCRIPTION
## Scope

What's changed:

- Added shared SSO and external-auth state helpers, including `sso_disabled` project state, driver classification utilities, and transitional-state resolution based on current entitlements and settings.
- Updated OAuth2, OpenID, SAML, and LDAP entry points so SSO can be explicitly disabled, with redirect-preserving blocked-login flows for OAuth2/OpenID/SAML and direct login blocking for LDAP.
- Updated OAuth2 and OpenID user matching to scope external-identifier lookups by provider before falling back to registration or other user-resolution paths.
- Updated central authentication to support transitional mode where SSO remains temporarily available only to admins until remediation is completed.
- Added login messaging and project-settings form behavior so end users see explicit `SSO_DISABLED` and `SSO_NON_ADMIN` messages and admins can only edit `sso_disabled` when licensing state allows it.
- Added schema support for the new `sso_disabled` setting and broadened auth-driver coverage for the new gating behavior.

## Potential Risks / Drawbacks

- This branch changes both provider-specific routers and the shared authentication service, so regressions could block legitimate sign-ins across several auth providers at once.
- Transitional SSO mode adds extra global-access resolution during login, which increases complexity and may have performance or edge-case implications.
- LDAP is now treated as an external-auth dependency for licensing fallback purposes, which is intentional here but worth validating against product expectations.
- Redirect preservation is now provider-specific, so regressions may show up differently between OAuth2/OpenID/SAML callback flows and LDAP login blocking.

## Tested Scenarios

- Added or expanded auth-driver tests for LDAP, OAuth2, OpenID, and SAML under the new SSO gating rules.
- Added tests for blocked SSO redirect resolution and shared SSO-state helpers.
- Added frontend tests for SSO login-link messaging, plus settings-service coverage for the disabled-SSO project setting.

## Review Notes / Questions

- Special attention should be paid to the `enabled`, `disabled`, and `transitional` state model, since later remediation flows rely on these exact semantics.
- The admin-only transitional login path is the sharpest behavior change in this PR and deserves a close pass.
- Reviewer eyes on redirect preservation would help, especially when users hit blocked SSO entry points from a deep-linked login redirect.

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #\<num\>
