### PR TITLE
Fixed vremove button not shown on vtable

### DIFF
--- a/.changeset/shiny-dogs-type.md
+++ b/.changeset/shiny-dogs-type.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed vremove button not shown on vtable

--- a/app/src/components/v-table/table-row.vue
+++ b/app/src/components/v-table/table-row.vue
@@ -85,7 +85,7 @@ function onKeydown(e: KeyboardEvent) {
 		</td>
 
 		<td class="spacer cell" />
-		<td v-if="$slots['item-append']" class="append cell" @click.stop>
+		<td class="append cell" @click.stop>
 			<slot name="item-append" />
 		</td>
 	</tr>


### PR DESCRIPTION
## Scope

What's changed:

- Made the slot existent by default

## Potential Risks / Drawbacks

- none

## Tested Scenarios

- Bug doesn't reproduce anymore after the change

## Review Notes / Questions

- I was first able to reproduce it on app in dev mode, but after not changing anything, the bug dissipated after a while. I then tried just removing the weird v-if on that slot and that seemed to fix the bug. But I honestly have 0 clue why this is the fix. Could be a race condition.

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes CMS-2151
