### PR TITLE
Fix decimal and float inputs rejecting locale decimal separator on Chromium

### DIFF
--- a/.changeset/locale-aware-decimal-inputs.md
+++ b/.changeset/locale-aware-decimal-inputs.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed decimal and float input fields rejecting the app locale's decimal separator (e.g. `,` in Dutch/German) on Chromium-based browsers. Float and decimal fields now use a text input with `inputmode="decimal"` so the separator is accepted uniformly across browsers, while integer fields continue to render as a native number input.

--- a/app/src/components/v-input.test.ts
+++ b/app/src/components/v-input.test.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import { afterEach, describe, expect, it, test, vi } from 'vitest';
+import { createI18n } from 'vue-i18n';
 import VInput from './v-input.vue';
 import { Focus } from '@/__utils__/focus';
 import { Tooltip } from '@/__utils__/tooltip';
@@ -251,6 +252,42 @@ describe('emitValue', () => {
 		await wrapper.find('input').trigger('input');
 
 		expect(wrapper.emitted()['update:modelValue']?.[0]).toEqual(['a_test_field']);
+	});
+});
+
+describe('locale-aware decimal handling', () => {
+	test('renders value with app locale decimal separator for float text inputs', () => {
+		const i18nWithCommaLocale = createI18n({ legacy: false, locale: 'nl-NL' });
+
+		const wrapper = mount(VInput, {
+			props: { type: 'text', modelValue: '300.44', float: true },
+			global: { ...global, plugins: [i18nWithCommaLocale] },
+		});
+
+		expect(wrapper.get('input').element.value).toBe('300,44');
+	});
+
+	test('leaves value untouched when app locale uses a period separator', () => {
+		const wrapper = mount(VInput, {
+			props: { type: 'text', modelValue: '300.44', float: true },
+			global,
+		});
+
+		expect(wrapper.get('input').element.value).toBe('300.44');
+	});
+
+	test('emits dot-normalized value when user types with a locale separator', async () => {
+		const i18nWithCommaLocale = createI18n({ legacy: false, locale: 'nl-NL' });
+
+		const wrapper = mount(VInput, {
+			props: { type: 'text', modelValue: '300.44', float: true },
+			global: { ...global, plugins: [i18nWithCommaLocale] },
+		});
+
+		await wrapper.find('input').setValue('300,45');
+		await wrapper.find('input').trigger('input');
+
+		expect(wrapper.emitted()['update:modelValue']?.[0]).toEqual(['300.45']);
 	});
 });
 

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -90,7 +90,7 @@ const emit = defineEmits(['click', 'keydown', 'update:modelValue', 'focus', 'key
 
 const attrs = useAttrs();
 
-const { t } = useI18n();
+const { t, locale } = useI18n();
 
 const input = ref<HTMLInputElement | null>(null);
 
@@ -108,6 +108,22 @@ const listeners = computed(() => ({
 }));
 
 const attributes = computed(() => omit(attrs, ['class']));
+
+const decimalSeparator = computed(
+	() => new Intl.NumberFormat(locale.value).formatToParts(1.1).find((p) => p.type === 'decimal')?.value ?? '.',
+);
+
+// Float fields are rendered as type="text" (see interfaces/input/input.vue) so we render
+// the stored dot-separated value with the app locale's decimal separator.
+const displayValue = computed(() => {
+	const raw = props.modelValue === undefined || props.modelValue === null ? '' : String(props.modelValue);
+
+	if (props.float && props.type !== 'number' && decimalSeparator.value !== '.') {
+		return raw.replace('.', decimalSeparator.value);
+	}
+
+	return raw;
+});
 
 const classes = computed(() => [
 	{
@@ -350,7 +366,7 @@ function useInlineWarning() {
 					:max="max"
 					:step="step"
 					:disabled="disabled"
-					:value="modelValue === undefined || modelValue === null ? '' : String(modelValue)"
+					:value="displayValue"
 					v-on="listeners"
 					@keydown.space="$emit('keydown:space', $event)"
 					@keydown.enter="$emit('keydown:enter', $event)"

--- a/app/src/interfaces/input/input.test.ts
+++ b/app/src/interfaces/input/input.test.ts
@@ -7,7 +7,19 @@ const mountOptions = {
 		stubs: {
 			'v-input': {
 				name: 'v-input',
-				props: ['modelValue', 'type', 'min', 'max', 'step', 'placeholder', 'disabled', 'trim', 'integer', 'float'],
+				props: [
+					'modelValue',
+					'type',
+					'inputmode',
+					'min',
+					'max',
+					'step',
+					'placeholder',
+					'disabled',
+					'trim',
+					'integer',
+					'float',
+				],
 				template: '<input />',
 				emits: ['update:model-value'],
 			},
@@ -53,7 +65,7 @@ describe('input interface', () => {
 			expect(input.props('type')).toBe('number');
 		});
 
-		test('sets inputType to "number" for float type', () => {
+		test('sets inputType to "text" for float type (so locale decimal separators work across browsers, issue #24803)', () => {
 			wrapper = mount(InputInterface, {
 				...mountOptions,
 				props: {
@@ -63,7 +75,36 @@ describe('input interface', () => {
 			});
 
 			const input = wrapper.findComponent({ name: 'v-input' });
+			expect(input.props('type')).toBe('text');
+			expect(input.props('inputmode')).toBe('decimal');
+		});
+
+		test('sets inputType to "text" for decimal type', () => {
+			wrapper = mount(InputInterface, {
+				...mountOptions,
+				props: {
+					value: 19.99,
+					type: 'decimal',
+				},
+			});
+
+			const input = wrapper.findComponent({ name: 'v-input' });
+			expect(input.props('type')).toBe('text');
+			expect(input.props('inputmode')).toBe('decimal');
+		});
+
+		test('does not set inputmode for integer type', () => {
+			wrapper = mount(InputInterface, {
+				...mountOptions,
+				props: {
+					value: 42,
+					type: 'integer',
+				},
+			});
+
+			const input = wrapper.findComponent({ name: 'v-input' });
 			expect(input.props('type')).toBe('number');
+			expect(input.props('inputmode')).toBeUndefined();
 		});
 
 		test('sets inputType to "text" for string type', () => {

--- a/app/src/interfaces/input/input.vue
+++ b/app/src/interfaces/input/input.vue
@@ -2,7 +2,6 @@
 import { computed } from 'vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
 import VInput from '@/components/v-input.vue';
-import { APP_NUMERIC_TYPES } from '@/constants';
 
 const props = withDefaults(
 	defineProps<{
@@ -58,9 +57,13 @@ const percentageRemaining = computed(() => {
 	return 100;
 });
 
+// Only integer-typed fields render as native type="number". Float/decimal fields render as
+// type="text" with inputmode="decimal" so the locale's decimal separator (e.g. comma) is
+// accepted across browsers — Chromium ignores `lang` on <input type="number"> and rejects
+// non-period decimal separators regardless of the app locale (see issue #24803).
 const inputType = computed(() => {
 	if (props.masked) return 'password';
-	if (APP_NUMERIC_TYPES.includes(props.type!)) return 'number';
+	if (props.type === 'integer') return 'number';
 	return 'text';
 });
 
@@ -78,6 +81,7 @@ const isFloat = computed(() => ['float', 'decimal'].includes(props.type!));
 		:non-editable="nonEditable"
 		:trim="trim"
 		:type="inputType"
+		:inputmode="isFloat ? 'decimal' : undefined"
 		:class="font"
 		:db-safe="dbSafe"
 		:slug="slug"

--- a/contributors.yml
+++ b/contributors.yml
@@ -271,3 +271,4 @@
 - eric-pennecot
 - om-singh-D
 - yogeshwaran-c
+- Tokonigeorge


### PR DESCRIPTION
## Scope

What's changed:

- Float and decimal field types now render as `<input type="text" inputmode="decimal">` instead of `<input type="number">`, so the app locale's decimal separator (e.g. `,` in `nl-NL`, `de-DE`) is accepted consistently across browsers.
- Stored values are displayed using the app locale's separator (via `Intl.NumberFormat`), and user input is normalised back to `.` before emission, matching the existing text+float path.
- Integer fields are unchanged, they still render as `<input type="number">` with native spinner arrows.

### Why the change

Chromium-based browsers (Chrome, Edge, Safari) ignore the `lang` attribute on `<input type="number">` and always require `.` as the decimal separator, regardless of the user's OS locale or any `lang` we set on the element (see Chromium issue [40593334](https://issues.chromium.org/issues/40593334)). Users on comma-locale browsers therefore couldn't enter `300,44` into a Decimal field, the browser rejected it with "not a number" before the value ever reached Directus code. Because the bug was in the browser's validity layer, a small fix in `v-input.vue` alone couldn't solve it; the field had to stop being `type="number"` altogether for float/decimal.

## Potential Risks / Drawbacks

- **No native spinner for float/decimal.** The up/down step buttons previously rendered by `v-input.vue` (gated on `type === 'number'`) are gone for these field types. Integer fields still have them.
- **Keyboard ↑/↓ no longer steps** float/decimal values, since that is a browser behaviour tied to `type="number"`. A JS-side handler could restore this; left as a possible follow-up to keep this PR focused on the bug.
- **Client-side HTML5 `min`/`max`/`step` validation** is no longer enforced by the browser for float/decimal. The existing keydown filter (`regexValidFloat`, non-numeric key blocking) still prevents junk input, and server-side validation is unaffected.
- **Emitted value type changed from `number` to `string`** for float/decimal. The API coerces string → numeric on insert/update for decimal/float columns, and the round-trip was verified end-to-end against SQLite.

## Tested Scenarios

### Repro (before fix)

1. Set Directus app language to Dutch (`nl-NL`) or German (`de-DE`).
2. Create a collection with a Decimal field.
3. Open the item form and type `300,44` into the field, the browser shows "Geen getal" ("not a number") and blocks input on Chrome/Safari/Edge.

### After fix — verified locally on Chrome with SQLite backend

1. **Dutch locale, Decimal field**: typed `300,44` → accepted, no warning → saved → DB stores `300.44` (numeric) → reopen shows `300,44` ✅
2. **Dutch locale, Float field**: same as above ✅
3. **English locale, Decimal field**: displays `300.44`, typing and saving works, DB stores `300.44` ✅
4. **DOM inspection**: float/decimal fields render as `<input type="text" inputmode="decimal">` with no `lang` attribute; integer fields still `<input type="number">` ✅
5. **Unit tests**: 66/66 pass across `v-input.test.ts` (46) and `input.test.ts` (20). New tests:
   - Float text input renders stored `300.44` as `300,44` under `nl-NL`.
   - Float text input leaves `300.44` as-is under `en-US`.
   - Float text input emits `'300.45'` when user types `300,45` under `nl-NL`.
   - Float/decimal field types pass `type="text"` and `inputmode="decimal"` through `input.vue`.
   - Integer field type still passes `type="number"` and no `inputmode`.

## Review Notes / Questions

- **Out of scope for this PR**: the list-view display of decimal values is not locale-aware (it still shows the raw stored `300.44` regardless of app locale). That would need changes to the display component and feels like a separate PR.
- **Possible follow-up**: a JS handler on `ArrowUp` / `ArrowDown` could restore keyboard stepping for float/decimal inputs. Not done here to keep the diff minimal and focused on the reported bug.
- `APP_NUMERIC_TYPES` (`['integer', 'float']`) is still used elsewhere (`get-js-type`, `slider`, `input/index.ts`) for semantic field-type checks and is intentionally left intact, only the render-time dispatch in `input.vue` was changed.

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required — **not required** (no user-facing docs describe the old decimal-input behaviour)
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required — **not required** (no API surface changes)

---

Fixes #24803