### PR TITLE
fix sdk singleton core exclusion

### DIFF
--- a/.changeset/fix-sdk-singleton-core-exclusion.md
+++ b/.changeset/fix-sdk-singleton-core-exclusion.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Fixed `SingletonCollections` incorrectly including core schema collections

--- a/sdk/src/rest/commands/create/items.ts
+++ b/sdk/src/rest/commands/create/items.ts
@@ -27,7 +27,7 @@ export const createItems =
 	): RestCommand<CreateItemOutput<Schema, Collection, TQuery>[], Schema> =>
 	() => {
 		throwIfEmpty(String(collection), 'Collection cannot be empty');
-		throwIfCoreCollection(collection, 'Cannot use createItems for core collections')
+		throwIfCoreCollection(collection, 'Cannot use createItems for core collections');
 
 		return {
 			path: `/items/${collection as string}`,
@@ -56,7 +56,7 @@ export const createItem =
 	): RestCommand<CreateItemOutput<Schema, Collection, TQuery>, Schema> =>
 	() => {
 		throwIfEmpty(String(collection), 'Collection cannot be empty');
-		throwIfCoreCollection(collection, 'Cannot use createItem for core collections')
+		throwIfCoreCollection(collection, 'Cannot use createItem for core collections');
 
 		return {
 			path: `/items/${collection as string}`,

--- a/sdk/src/rest/commands/create/items.ts
+++ b/sdk/src/rest/commands/create/items.ts
@@ -1,6 +1,6 @@
 import type { ApplyQueryFields, CollectionType, NestedPartial, Query, UnpackList } from '../../../types/index.js';
 import type { RestCommand } from '../../types.js';
-import { isSystemCollection } from '../../utils/is-system-collection.js';
+import { throwIfCoreCollection, throwIfEmpty } from '../../utils/index.js';
 
 export type CreateItemOutput<
 	Schema,
@@ -16,6 +16,8 @@ export type CreateItemOutput<
  * @param query Optional return data query
  *
  * @returns Returns the item objects of the item that were created.
+ * @throws Will throw if collection is a core collection
+ * @throws Will throw if collection is empty
  */
 export const createItems =
 	<Schema, Collection extends keyof Schema, const TQuery extends Query<Schema, Schema[Collection]>>(
@@ -24,14 +26,11 @@ export const createItems =
 		query?: TQuery,
 	): RestCommand<CreateItemOutput<Schema, Collection, TQuery>[], Schema> =>
 	() => {
-		const _collection = String(collection);
-
-		if (isSystemCollection(_collection)) {
-			throw new Error('Cannot use createItems for core collections');
-		}
+		throwIfEmpty(String(collection), 'Collection cannot be empty');
+		throwIfCoreCollection(collection, 'Cannot use createItems for core collections')
 
 		return {
-			path: `/items/${_collection}`,
+			path: `/items/${collection as string}`,
 			params: query ?? {},
 			body: JSON.stringify(items),
 			method: 'POST',
@@ -46,6 +45,8 @@ export const createItems =
  * @param query Optional return data query
  *
  * @returns Returns the item objects of the item that were created.
+ * @throws Will throw if collection is a core collection
+ * @throws Will throw if collection is empty
  */
 export const createItem =
 	<Schema, Collection extends keyof Schema, const TQuery extends Query<Schema, Schema[Collection]>>(
@@ -54,14 +55,11 @@ export const createItem =
 		query?: TQuery,
 	): RestCommand<CreateItemOutput<Schema, Collection, TQuery>, Schema> =>
 	() => {
-		const _collection = String(collection);
-
-		if (isSystemCollection(_collection)) {
-			throw new Error('Cannot use createItem for core collections');
-		}
+		throwIfEmpty(String(collection), 'Collection cannot be empty');
+		throwIfCoreCollection(collection, 'Cannot use createItem for core collections')
 
 		return {
-			path: `/items/${_collection}`,
+			path: `/items/${collection as string}`,
 			params: query ?? {},
 			body: JSON.stringify(item),
 			method: 'POST',

--- a/sdk/src/types/schema.ts
+++ b/sdk/src/types/schema.ts
@@ -24,11 +24,14 @@ export type CollectionType<Schema, Collection> = IfAny<
 >;
 
 /**
- * Returns a list of singleton collections in the schema
+ * Returns a list of regular singleton collections in the schema (CoreSchema singleton collections excluded)
  */
-export type SingletonCollections<Schema> = {
-	[Key in keyof Schema]: Schema[Key] extends any[] ? never : Key;
-}[keyof Schema];
+export type SingletonCollections<Schema> = Exclude<
+	{
+		[Key in keyof Schema]: Schema[Key] extends any[] ? never : Key;
+	}[keyof Schema],
+	keyof CoreSchema<Schema>
+>;
 
 /**
  * Returns a list of regular collections in the schema

--- a/sdk/tests/merge-collection.test-d.ts
+++ b/sdk/tests/merge-collection.test-d.ts
@@ -39,9 +39,9 @@ describe('MergeCoreCollection', () => {
 	test('builtin fields cannot be overriden by custom core collection fields', () => {
 		type MergedUser = MergeCoreCollection<TestSchema, 'directus_users', { id: string; email: string | null }>;
 
-		expectTypeOf<MergedUser['id']>().toEqualTypeOf<string>()
-		expectTypeOf<MergedUser['custom_field']>().toEqualTypeOf<boolean | undefined>()
-	})
+		expectTypeOf<MergedUser['id']>().toEqualTypeOf<string>();
+		expectTypeOf<MergedUser['custom_field']>().toEqualTypeOf<boolean | undefined>();
+	});
 
 	test('custom fields absent when schema has no extension for that collection', () => {
 		type SchemaWithoutUsers = { articles: { id: number }[] };

--- a/sdk/tests/merge-collection.test-d.ts
+++ b/sdk/tests/merge-collection.test-d.ts
@@ -1,48 +1,47 @@
 import { assertType, describe, expectTypeOf, test } from 'vitest';
 import type { MergeCoreCollection, RegularCollections, SingletonCollections } from '../src/index.js';
-
-// https://directus.io/docs/tutorials/tips-and-tricks/advanced-types-with-the-directus-sdk#custom-fields-on-core-collections
-type CustomUser = { loyalty_points: number };
-
-type MySchema = {
-	articles: { id: number; title: string }[];
-	site_settings: { logo_url: string };
-	directus_users: CustomUser; // singular = custom fields only
-};
+import type { TestSchema } from './schema.js';
 
 describe('SingletonCollections', () => {
 	test('includes user-defined singleton collections', () => {
-		expectTypeOf<SingletonCollections<MySchema>>().toEqualTypeOf<'site_settings'>();
+		expectTypeOf<SingletonCollections<TestSchema>>().toEqualTypeOf<'user_defined_singleton'>();
 	});
 
 	test('excludes regular array collections', () => {
 		// @ts-expect-error
-		assertType<SingletonCollections<MySchema>>('articles');
+		assertType<SingletonCollections<TestSchema>>('collection_a');
 	});
 
 	test('excludes core collections defined as singular custom-field types', () => {
 		// @ts-expect-error
-		assertType<SingletonCollections<MySchema>>('directus_users');
+		assertType<SingletonCollections<TestSchema>>('directus_users');
 	});
 });
 
 describe('RegularCollections', () => {
 	test('includes user-defined array collections', () => {
-		expectTypeOf<'articles'>().toExtend<RegularCollections<MySchema>>();
+		expectTypeOf<'collection_a'>().toExtend<RegularCollections<TestSchema>>();
 	});
 
 	test('excludes user-defined singleton collections', () => {
 		// @ts-expect-error
-		assertType<RegularCollections<MySchema>>('site_settings');
+		assertType<RegularCollections<TestSchema>>('user_defined_singleton');
 	});
 });
 
 describe('MergeCoreCollection', () => {
 	test('merges custom fields onto the builtin collection', () => {
-		type MergedUser = MergeCoreCollection<MySchema, 'directus_users', { id: string; email: string | null }>;
+		type MergedUser = MergeCoreCollection<TestSchema, 'directus_users', { id: string; email: string | null }>;
 
-		assertType<MergedUser>({ id: '1', email: 'a@b.com', loyalty_points: 42 });
+		assertType<MergedUser>({ id: '1', email: 'a@b.com', custom_field: true });
 	});
+
+	test('builtin fields cannot be overriden by custom core collection fields', () => {
+		type MergedUser = MergeCoreCollection<TestSchema, 'directus_users', { id: string; email: string | null }>;
+
+		expectTypeOf<MergedUser['id']>().toEqualTypeOf<string>()
+		expectTypeOf<MergedUser['custom_field']>().toEqualTypeOf<boolean | undefined>()
+	})
 
 	test('custom fields absent when schema has no extension for that collection', () => {
 		type SchemaWithoutUsers = { articles: { id: number }[] };

--- a/sdk/tests/merge-collection.test-d.ts
+++ b/sdk/tests/merge-collection.test-d.ts
@@ -1,0 +1,59 @@
+import { assertType, describe, expectTypeOf, test } from 'vitest';
+import type { MergeCoreCollection, RegularCollections, SingletonCollections } from '../src/index.js';
+
+// https://directus.io/docs/tutorials/tips-and-tricks/advanced-types-with-the-directus-sdk#custom-fields-on-core-collections
+type CustomUser = { loyalty_points: number };
+
+type MySchema = {
+	articles: { id: number; title: string }[];
+	site_settings: { logo_url: string };
+	directus_users: CustomUser; // singular = custom fields only
+};
+
+describe('SingletonCollections', () => {
+	test('includes user-defined singleton collections', () => {
+		expectTypeOf<SingletonCollections<MySchema>>().toEqualTypeOf<'site_settings'>();
+	});
+
+	test('excludes regular array collections', () => {
+		// @ts-expect-error
+		assertType<SingletonCollections<MySchema>>('articles');
+	});
+
+	test('excludes core collections defined as singular custom-field types', () => {
+		// @ts-expect-error
+		assertType<SingletonCollections<MySchema>>('directus_users');
+	});
+});
+
+describe('RegularCollections', () => {
+	test('includes user-defined array collections', () => {
+		expectTypeOf<'articles'>().toExtend<RegularCollections<MySchema>>();
+	});
+
+	test('excludes user-defined singleton collections', () => {
+		// @ts-expect-error
+		assertType<RegularCollections<MySchema>>('site_settings');
+	});
+});
+
+describe('MergeCoreCollection', () => {
+	test('merges custom fields onto the builtin collection', () => {
+		type MergedUser = MergeCoreCollection<MySchema, 'directus_users', { id: string; email: string | null }>;
+
+		assertType<MergedUser>({ id: '1', email: 'a@b.com', loyalty_points: 42 });
+	});
+
+	test('custom fields absent when schema has no extension for that collection', () => {
+		type SchemaWithoutUsers = { articles: { id: number }[] };
+		type BaseUser = MergeCoreCollection<SchemaWithoutUsers, 'directus_users', { id: string; email: string | null }>;
+
+		assertType<BaseUser>({ id: '1', email: 'a@b.com' });
+	});
+
+	test('falls back to builtin type when schema is any', () => {
+		type AnyUser = MergeCoreCollection<any, 'directus_users', { id: string; email: string | null }>;
+
+		assertType<AnyUser>({ id: '1', email: null });
+	});
+});

--- a/sdk/tests/rest/create-items.test.ts
+++ b/sdk/tests/rest/create-items.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest';
+import { createItem, createItems } from '../../src/index.js';
+import type { TestSchema } from '../schema.js';
+
+describe('createItem', () => {
+	test('creates single item for non-core collections', () => {
+		const request = createItem<TestSchema, 'collection_a', any>('collection_a', { string_field: 'test' })();
+
+		expect(request.method).toBe('POST');
+		expect(request.path).toBe('/items/collection_a');
+	});
+
+	test('defaults params to empty object when query is omitted', () => {
+		const request = createItem<TestSchema, 'collection_a', any>('collection_a', { string_field: 'test' })();
+
+		expect(request.params).toEqual({});
+	});
+
+	test('throws when using core collections', () => {
+		expect(() => createItem<TestSchema, 'directus_users', any>('directus_users', { custom_field: false })()).toThrow(
+			'Cannot use createItem for core collections',
+		);
+	});
+});
+
+describe('createItems', () => {
+	test('creates items for non-core collections', () => {
+		const request = createItems<TestSchema, 'collection_a', any>('collection_a', [{ string_field: 'test' }])();
+
+		expect(request).toEqual({
+			path: '/items/collection_a',
+			method: 'POST',
+			params: {},
+			body: JSON.stringify([{ string_field: 'test' }]),
+		});
+	});
+
+	test('defaults params to empty object when query is omitted', () => {
+		const request = createItems<TestSchema, 'collection_a', any>('collection_a', [{ string_field: 'test' }])();
+
+		expect(request.params).toEqual({});
+	});
+
+	test('throws when using core collections', () => {
+		expect(() => createItems<TestSchema, 'directus_users', any>('directus_users', [{ custom_field: false }])()).toThrow(
+			'Cannot use createItems for core collections',
+		);
+	});
+});

--- a/sdk/tests/rest/read-users.test.ts
+++ b/sdk/tests/rest/read-users.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest';
+import { readMe, readUser, readUsers } from '../../src/index.js';
+import type { TestSchema } from '../schema.js';
+
+describe('readMe', () => {
+	test('returns request object', async () => {
+		const request = readMe<TestSchema, any>()();
+
+		expect(request.method).toBe('GET');
+		expect(request.path).toBe('/users/me');
+	});
+
+	test('defaults params to empty object when query is omitted', () => {
+		const request = readMe<TestSchema, any>()();
+
+		expect(request.params).toEqual({});
+	});
+});
+
+describe('readUser', () => {
+	test('returns request object with key', async () => {
+		const request = readUser<TestSchema, any>('uuid')();
+
+		expect(request.method).toBe('GET');
+		expect(request.path).toBe('/users/uuid');
+	});
+
+	test('defaults params to empty object when query is omitted', () => {
+		const request = readUser<TestSchema, any>('uuid')();
+
+		expect(request.params).toEqual({});
+	});
+
+	test('throws when key is empty', () => {
+		expect(() => readUser<TestSchema, any>('')()).toThrow('Key cannot be empty');
+	});
+});
+
+describe('readUsers', () => {
+	test('returns request object for users', async () => {
+		const request = readUsers<TestSchema, any>()();
+
+		expect(request).toEqual({
+			path: '/users',
+			params: {},
+			method: 'GET',
+		});
+	});
+});

--- a/sdk/tests/schema.ts
+++ b/sdk/tests/schema.ts
@@ -3,14 +3,16 @@ export type TestSchema = {
 	collection_b: CollectionB[];
 	collection_c: CollectionC[];
 	// singleton
-	collection_d: CollectionD[];
+	// https://directus.com/docs/tutorials/tips-and-tricks/advanced-types-with-the-directus-sdk#setting-up-a-schema
+	user_defined_singleton: CollectionD;
 	// junction collections
 	collection_a_b_m2m: CollectionAB_Many[];
 	collection_a_b_m2a: CollectionAB_Any[];
-	// directus_users: object; // workaround
+	// extend the provided DirectusUser type
+	// https://directus.com/docs/tutorials/tips-and-tricks/advanced-types-with-the-directus-sdk#custom-fields-on-core-collections
+	directus_users: CustomUser
 };
 
-// Collection A
 export type CollectionA = {
 	id: number;
 	string_field: string;
@@ -36,14 +38,12 @@ export type CollectionAB_Any = {
 	item: string | CollectionB | CollectionC;
 };
 
-// Collection B
 export type CollectionB = {
 	id: number;
 	json_field: 'json' | null;
 	csv_field: 'csv' | null;
 };
 
-// Collection C
 export type CollectionC = {
 	id: number;
 	parent_id: number | CollectionA;
@@ -57,4 +57,10 @@ export type CollectionC = {
 // Singleton collection
 export type CollectionD = {
 	id: number;
+};
+
+// Used to extend directus_users collection, cannot modify core fields
+export type CustomUser = {
+	custom_field?: boolean;
+	id: number; // core collection type is string (uuid), number will not be accepted as a valid modification
 };

--- a/sdk/tests/schema.ts
+++ b/sdk/tests/schema.ts
@@ -10,7 +10,7 @@ export type TestSchema = {
 	collection_a_b_m2a: CollectionAB_Any[];
 	// extend the provided DirectusUser type
 	// https://directus.com/docs/tutorials/tips-and-tricks/advanced-types-with-the-directus-sdk#custom-fields-on-core-collections
-	directus_users: CustomUser
+	directus_users: CustomUser;
 };
 
 export type CollectionA = {

--- a/sdk/vitest.config.ts
+++ b/sdk/vitest.config.ts
@@ -1,0 +1,8 @@
+import { systemCollectionNames } from '@directus/system-data';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	define: {
+		__SYSTEM_COLLECTION_NAMES__: JSON.stringify(systemCollectionNames),
+	},
+});


### PR DESCRIPTION
## Scope

  What's changed:

  - `SingletonCollections<Schema>` now excludes core schema collections via `Exclude<..., keyof CoreSchema<Schema>>` to prevent readSingleton from accepting core collections when custom fields are applied to them https://directus.io/docs/tutorials/tips-and-tricks/advanced-types-with-the-directus-sdk#custom-fields-on-core-collections
  - Added type tests for `SingletonCollections`, `RegularCollections`, and `MergeCoreCollection` in `sdk/tests/merge-collection.test-d.ts`

  ## Potential Risks / Drawbacks

  - Low/None - Consumers who were (incorrectly) putting core collections in `readSingleton()` will now see a type error. Before they would get a runtime error.

  ## Tested Scenarios

  - User-defined singleton collections are correctly included in `SingletonCollections`
  - Core collections defined as singular custom-field extensions (e.g. `directus_users: CustomUser`) are excluded from `SingletonCollections`
  - `MergeCoreCollection` merges custom fields onto the builtin collection type as expected

  ## Review Notes / Questions

  - This is a type-only change with no runtime impact

  ## Checklist

  - [x] Added or updated tests
  - [x] Documentation PR  not required
  - [x] OpenAPI package PR not required

  ---

 - Fixes #27195


([here's a minimal reproduction of the issue](https://github.com/kheiner/directus-sdk-customized-core-type-singleton-should-not-suggest-core-collections))