### PR TITLE
 xiiui → Calendar layout toolbar responsiveness

### DIFF
--- a/.changeset/soft-lizards-itch.md
+++ b/.changeset/soft-lizards-itch.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed calendar layout toolbar responsiveness

--- a/app/src/layouts/calendar/calendar.vue
+++ b/app/src/layouts/calendar/calendar.vue
@@ -76,14 +76,4 @@ const atLimit = computed(() => {
 .v-notice {
 	margin-block-end: 1.375rem;
 }
-
-:deep(.fc-header-toolbar) {
-	overflow-x: auto;
-	flex-wrap: nowrap;
-
-	.fc-toolbar-chunk {
-		flex-shrink: 0;
-		white-space: nowrap;
-	}
-}
 </style>

--- a/app/src/layouts/calendar/calendar.vue
+++ b/app/src/layouts/calendar/calendar.vue
@@ -76,4 +76,14 @@ const atLimit = computed(() => {
 .v-notice {
 	margin-block-end: 1.375rem;
 }
+
+:deep(.fc-header-toolbar) {
+	overflow-x: auto;
+	flex-wrap: nowrap;
+
+	.fc-toolbar-chunk {
+		flex-shrink: 0;
+		white-space: nowrap;
+	}
+}
 </style>

--- a/app/src/styles/lib/_fullcalendar.scss
+++ b/app/src/styles/lib/_fullcalendar.scss
@@ -118,9 +118,8 @@
 
 	.fc-toolbar {
 		&.fc-header-toolbar {
-			position: sticky;
-			inset-block-start: 0;
-			z-index: 4;
+			overflow-x: auto;
+			flex-wrap: nowrap;
 			block-size: calc(var(--sub-header-height) + var(--theme--border-width));
 			margin-block-end: var(--content-padding);
 			font-weight: inherit !important;
@@ -128,6 +127,11 @@
 			background-color: var(--theme--background);
 			border-block-end: var(--theme--border-width) solid var(--theme--border-color);
 			box-shadow: 0 0 0 2px var(--theme--background);
+
+			.fc-toolbar-chunk {
+				flex-shrink: 0;
+				white-space: nowrap;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Scope

What's changed:

- Make the FullCalendar header toolbar horizontally scrollable on small viewports
- Prevent toolbar chunks from shrinking or wrapping, keeping all controls in a single row

## Tested Scenarios

- Verified toolbar renders as a single scrollable row when the viewport is too narrow to display all controls
- Verified navigation arrows, title, and view switcher buttons (`Month`, `Week`, `Day`, `List`) remain accessible via horizontal scroll
- Verified layout is unaffected on wide viewports

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes [CMS-2181](https://linear.app/directus/issue/CMS-2181/ensure-responsiveness-for-calendar-layout)