### PR TITLE
 xiiui → Image Editor save button uses split button

### DIFF
--- a/.changeset/brave-pots-heal.md
+++ b/.changeset/brave-pots-heal.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Fixed Image Editor save button to use split button

--- a/app/src/components/__snapshots__/v-button.test.ts.snap
+++ b/app/src/components/__snapshots__/v-button.test.ts.snap
@@ -5,5 +5,7 @@ exports[`Mount component 1`] = `
     <div data-v-28d526fe="" class="spinner">
       <!--v-if-->
     </div>
-  </button></div>"
+  </button>
+  <!--v-if-->
+</div>"
 `;

--- a/app/src/components/v-button.test.ts
+++ b/app/src/components/v-button.test.ts
@@ -50,14 +50,14 @@ const splitMenuGlobal = () => ({
 	},
 });
 
-test('disables split-menu button when splitMenuDisabled is true', () => {
+test('disables split-menu button when button is disabled', () => {
 	const wrapper = mount(VButton, {
 		global: splitMenuGlobal(),
 		slots: {
 			'split-menu': '<div>Menu item</div>',
 		},
 		props: {
-			splitMenuDisabled: true,
+			disabled: true,
 		},
 	});
 

--- a/app/src/components/v-button.test.ts
+++ b/app/src/components/v-button.test.ts
@@ -35,3 +35,44 @@ test('Mount component', () => {
 
 	expect(wrapper.html()).toMatchSnapshot();
 });
+
+const splitMenuGlobal = () => ({
+	...global,
+	mocks: {
+		$t: (value: string) => value,
+	},
+	stubs: {
+		...Object.fromEntries((global.stubs as string[]).map((s) => [s, true])),
+		'v-menu': {
+			template: '<div><slot name="activator" :toggle="() => {}" :active="false" /><slot /></div>',
+		},
+		'v-icon': true,
+	},
+});
+
+test('disables split-menu button when splitMenuDisabled is true', () => {
+	const wrapper = mount(VButton, {
+		global: splitMenuGlobal(),
+		slots: {
+			'split-menu': '<div>Menu item</div>',
+		},
+		props: {
+			splitMenuDisabled: true,
+		},
+	});
+
+	const splitMenuButton = wrapper.find('.split-menu-button');
+	expect(splitMenuButton.attributes('disabled')).toBeDefined();
+});
+
+test('split-menu button is enabled by default when split-menu slot is provided', () => {
+	const wrapper = mount(VButton, {
+		global: splitMenuGlobal(),
+		slots: {
+			'split-menu': '<div>Menu item</div>',
+		},
+	});
+
+	const splitMenuButton = wrapper.find('.split-menu-button');
+	expect(splitMenuButton.attributes('disabled')).toBeUndefined();
+});

--- a/app/src/components/v-button.vue
+++ b/app/src/components/v-button.vue
@@ -296,18 +296,14 @@ async function onClick(event: MouseEvent) {
 	background-color: var(--v-button-background-color, var(--theme--primary));
 	border: var(--theme--border-width) solid var(--v-button-background-color, var(--theme--primary));
 	border-radius: var(--theme--border-radius);
+	transition: var(--fast) var(--transition);
+	transition-property: background-color, border, color;
 
 	&:hover {
 		color: var(--v-button-color-hover, var(--foreground-inverted));
 		background-color: var(--v-button-background-color-hover, var(--theme--primary-accent));
 		border-color: var(--v-button-background-color-hover, var(--theme--primary-accent));
 	}
-}
-
-.button,
-.split-menu-button {
-	transition: var(--fast) var(--transition);
-	transition-property: background-color, border, color;
 }
 
 .button {

--- a/app/src/components/v-button.vue
+++ b/app/src/components/v-button.vue
@@ -64,6 +64,8 @@ export interface VButtonProps {
 	xLarge?: boolean;
 	/** Tooltip text to show on hover */
 	tooltip?: string;
+	/** Disables the split-menu dropdown button */
+	splitMenuDisabled?: boolean;
 }
 
 export interface VButtonEmits {
@@ -196,6 +198,7 @@ async function onClick(event: MouseEvent) {
 						},
 						kind,
 					]"
+					:disabled="splitMenuDisabled"
 					:aria-label="$t('aria.more_options')"
 					@click.stop="toggleSplitMenu"
 				>
@@ -305,6 +308,12 @@ async function onClick(event: MouseEvent) {
 	}
 }
 
+.button,
+.split-menu-button {
+	transition: var(--fast) var(--transition);
+	transition-property: background-color, border, color;
+}
+
 .button {
 	position: relative;
 	display: flex;
@@ -317,8 +326,6 @@ async function onClick(event: MouseEvent) {
 	line-height: var(--v-button-line-height, 1.4286);
 	text-decoration: none;
 	cursor: pointer;
-	transition: var(--fast) var(--transition);
-	transition-property: background-color, border;
 
 	&.has-split-menu {
 		border-start-end-radius: 0;
@@ -359,7 +366,8 @@ async function onClick(event: MouseEvent) {
 	justify-content: flex-end;
 }
 
-.button:disabled {
+.button:disabled,
+.split-menu-button:disabled {
 	color: var(--v-button-color-disabled, var(--theme--foreground-subdued));
 	background-color: var(--v-button-background-color-disabled, var(--theme--background-normal));
 	border: var(--theme--border-width) solid var(--v-button-background-color-disabled, var(--theme--background-normal));

--- a/app/src/components/v-button.vue
+++ b/app/src/components/v-button.vue
@@ -64,8 +64,6 @@ export interface VButtonProps {
 	xLarge?: boolean;
 	/** Tooltip text to show on hover */
 	tooltip?: string;
-	/** Disables the split-menu dropdown button */
-	splitMenuDisabled?: boolean;
 }
 
 export interface VButtonEmits {
@@ -198,7 +196,7 @@ async function onClick(event: MouseEvent) {
 						},
 						kind,
 					]"
-					:disabled="splitMenuDisabled"
+					:disabled="disabled"
 					:aria-label="$t('aria.more_options')"
 					@click.stop="toggleSplitMenu"
 				>

--- a/app/src/views/private/components/image-editor.vue
+++ b/app/src/views/private/components/image-editor.vue
@@ -639,7 +639,6 @@ function setAspectRatio() {
 				:label="$t('save')"
 				:loading="saving"
 				:disabled="!hasEdits"
-				:split-menu-disabled="!hasEdits"
 				icon="check"
 				@click="save"
 			>

--- a/app/src/views/private/components/image-editor.vue
+++ b/app/src/views/private/components/image-editor.vue
@@ -645,7 +645,7 @@ function setAspectRatio() {
 			>
 				<template v-if="props.createAllowed" #split-menu>
 					<VList>
-						<VListItem :disabled="!hasEdits" clickable @click="saveAsNew">
+						<VListItem clickable @click="saveAsNew">
 							<VListItemIcon><VIcon name="add_photo_alternate" /></VListItemIcon>
 							<VListItemContent>{{ $t('save_as_new_file') }}</VListItemContent>
 						</VListItem>

--- a/app/src/views/private/components/image-editor.vue
+++ b/app/src/views/private/components/image-editor.vue
@@ -639,22 +639,17 @@ function setAspectRatio() {
 				:label="$t('save')"
 				:loading="saving"
 				:disabled="!hasEdits"
+				:split-menu-disabled="!hasEdits"
 				icon="check"
 				@click="save"
 			>
-				<template v-if="props.createAllowed" #append-outer>
-					<VMenu show-arrow placement="bottom-end">
-						<template #activator="{ toggle }">
-							<VIcon name="more_vert" clickable @click="toggle" />
-						</template>
-
-						<VList>
-							<VListItem :disabled="!hasEdits" clickable @click="saveAsNew">
-								<VListItemIcon><VIcon name="add_photo_alternate" /></VListItemIcon>
-								<VListItemContent>{{ $t('save_as_new_file') }}</VListItemContent>
-							</VListItem>
-						</VList>
-					</VMenu>
+				<template v-if="props.createAllowed" #split-menu>
+					<VList>
+						<VListItem :disabled="!hasEdits" clickable @click="saveAsNew">
+							<VListItemIcon><VIcon name="add_photo_alternate" /></VListItemIcon>
+							<VListItemContent>{{ $t('save_as_new_file') }}</VListItemContent>
+						</VListItem>
+					</VList>
 				</template>
 			</PrivateViewHeaderBarActionButton>
 		</template>

--- a/app/src/views/private/private-view/components/private-view-header-bar-action-button.vue
+++ b/app/src/views/private/private-view/components/private-view-header-bar-action-button.vue
@@ -25,6 +25,7 @@ const {
 	href?: VButtonProps['href'];
 	download?: VButtonProps['download'];
 	active?: VButtonProps['active'];
+	splitMenuDisabled?: VButtonProps['splitMenuDisabled'];
 }>();
 
 defineEmits<VButtonEmits>();
@@ -69,6 +70,7 @@ function useIcon() {
 		:download
 		:tooltip="activeTooltip"
 		:icon="showIcon"
+		:split-menu-disabled="splitMenuDisabled"
 		small
 		exact
 		@click="$emit('click', $event)"

--- a/app/src/views/private/private-view/components/private-view-header-bar-action-button.vue
+++ b/app/src/views/private/private-view/components/private-view-header-bar-action-button.vue
@@ -25,7 +25,6 @@ const {
 	href?: VButtonProps['href'];
 	download?: VButtonProps['download'];
 	active?: VButtonProps['active'];
-	splitMenuDisabled?: VButtonProps['splitMenuDisabled'];
 }>();
 
 defineEmits<VButtonEmits>();
@@ -70,7 +69,6 @@ function useIcon() {
 		:download
 		:tooltip="activeTooltip"
 		:icon="showIcon"
-		:split-menu-disabled="splitMenuDisabled"
 		small
 		exact
 		@click="$emit('click', $event)"


### PR DESCRIPTION
## Scope

What's changed:

- Replace the 3-dots icon menu on the Image Editor save button with a proper split button using the `#split-menu` slot
- Add `splitMenuDisabled` prop to `VButton` to allow disabling the split-menu arrow independently of the main button
- Propagate `splitMenuDisabled` through `PrivateViewHeaderBarActionButton`
- Align transition behavior between the main button and split-menu button (shared `transition-property` including `color`)

## Tested Scenarios

- Save button with no edits: both main button and split-menu arrow are disabled
- Save button with edits: both buttons are enabled, split-menu opens with "Save as new file" option
- Disabled state transitions animate consistently between the two buttons

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes [CMS-2185
](https://linear.app/directus/issue/CMS-2185/primary-action-button-not-using-split-button-in-image-editor)