### PR TITLE
Prevent filter popup being closed when reordering filters

### DIFF
--- a/.changeset/four-ties-sneeze.md
+++ b/.changeset/four-ties-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Prevented filter popup being closed when reordering filters

--- a/app/src/views/private/components/search-input.test.ts
+++ b/app/src/views/private/components/search-input.test.ts
@@ -116,6 +116,15 @@ describe('Component', () => {
 				expect(search.classes()).not.toContain('active');
 				expect(search.classes()).not.toContain('filter-active');
 			});
+
+			it('should stay open when focusout has no relatedTarget while filter is active (drag operation)', async () => {
+				wrapper.find('input').element.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: null }));
+
+				await wrapper.vm.$nextTick();
+
+				expect(search.classes()).toContain('active');
+				expect(search.classes()).toContain('filter-active');
+			});
 		});
 
 		describe('when focus moves into v-menu-content', () => {

--- a/app/src/views/private/components/search-input.vue
+++ b/app/src/views/private/components/search-input.vue
@@ -126,6 +126,8 @@ function onFocusOut(event: FocusEvent) {
 
 	if (relatedTarget && searchElement?.contains(relatedTarget)) return;
 
+	if (filterActive.value && !relatedTarget) return;
+
 	disable();
 }
 


### PR DESCRIPTION
## Scope

What's changed:

- Fix filter popup closing automatically when dragging to reorder filters in the collection page
- Add guard in `onFocusOut` to skip `disable()` when the filter is active and `relatedTarget` is null (the signature of a drag-triggered focusout)
- Add regression test covering the drag-initiated focusout scenario

## Tested Scenarios

- Open filter panel, drag a filter to reorder it — popup stays open throughout the drag
- Open filter panel, press Tab to navigate away — popup closes correctly (relatedTarget is set)
- Open filter panel, click outside the search component on a non-focusable element — popup closes via `v-click-outside`
- Open filter panel, click a `v-menu-content` element (e.g. field selector dropdown) — popup stays open (existing behavior preserved)
 
## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #27193 