### PR TITLE
Fix icon flash in navigation sidebar for bookmarks without an icon

### DIFF
--- a/.changeset/happy-otters-carry.md
+++ b/.changeset/happy-otters-carry.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed icon flash in navigation sidebar for bookmarks without an icon

--- a/app/src/components/v-icon/v-icon.vue
+++ b/app/src/components/v-icon/v-icon.vue
@@ -58,12 +58,14 @@ const sizeClass = computed<string | null>(() => {
 });
 
 const customIconName = computed(() => {
+	if (!props.name) return null;
 	const name = `CustomIcon${upperFirst(camelCase(props.name.replace(/_/g, '-')))}`;
 	if (name in components) return components[name];
 	return null;
 });
 
 const socialIconName = computed<IconName | null>(() => {
+	if (!props.name) return null;
 	if (socialIcons.includes(props.name)) return props.name.replace(/_/g, '-') as IconName;
 	return null;
 });
@@ -88,7 +90,7 @@ function emitClick(event: MouseEvent) {
 	>
 		<component :is="customIconName" v-if="customIconName" class="custom-icon-svg" />
 		<SocialIcon v-else-if="socialIconName" :name="socialIconName" />
-		<i v-else :class="{ filled }" :data-icon="name"></i>
+		<i v-else-if="name" :class="{ filled }" :data-icon="name"></i>
 	</component>
 </template>
 


### PR DESCRIPTION
## Scope

What's changed:

- Fix `VIcon` throwing a `TypeError` when `name` is `null` or `undefined` by guarding the `customIconName` and `socialIconName` computeds with an early return
- Prevent rendering a `<i data-icon="null">` element when no icon name is provided by changing the fallback `v-else` to `v-else-if="name"`

## Potential Risks / Drawbacks

- None identified — the change is purely defensive; existing behavior for valid icon names is unchanged

## Tested Scenarios

- Bookmark with no icon set no longer flashes when switching between singleton and non-singleton collections in the navigation sidebar
- Bookmarks with a valid icon continue to render correctly

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #27328 