### PR TITLE
fix(app): clear selection after manual flow

### DIFF
--- a/.changeset/clear-flow-selection.md
+++ b/.changeset/clear-flow-selection.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed selection not being cleared after running a manual flow from the collection list view sidebar

--- a/app/src/composables/use-flows.test.ts
+++ b/app/src/composables/use-flows.test.ts
@@ -399,6 +399,56 @@ describe('runManualFlow', () => {
 		expect(mockOnRefresh).toHaveBeenCalledOnce();
 	});
 
+	test('clears selection after successfully running flow', async () => {
+		const mockFlowsStore = {
+			getManualFlowsForCollection: vi.fn().mockReturnValue(mockFlows),
+		};
+
+		vi.mocked(useFlowsStore).mockReturnValue(mockFlowsStore as any);
+
+		vi.mocked(api.post).mockResolvedValue({});
+
+		const selection = ref([{ id: 'item1' }, { id: 'item2' }]);
+
+		const testOptions = {
+			...useFlowsOptions,
+			primaryKey: undefined,
+			selection,
+			hasEdits: ref(false),
+		};
+
+		const { runManualFlow } = useFlows(testOptions);
+
+		await runManualFlow(mockFlows[4]!.id);
+
+		expect(selection.value).toEqual([]);
+	});
+
+	test('does not clear selection if flow API call fails', async () => {
+		const mockFlowsStore = {
+			getManualFlowsForCollection: vi.fn().mockReturnValue(mockFlows),
+		};
+
+		vi.mocked(useFlowsStore).mockReturnValue(mockFlowsStore as any);
+
+		vi.mocked(api.post).mockRejectedValue(new Error('flow failed'));
+
+		const selection = ref([{ id: 'item1' }, { id: 'item2' }]);
+
+		const testOptions = {
+			...useFlowsOptions,
+			primaryKey: undefined,
+			selection,
+			hasEdits: ref(false),
+		};
+
+		const { runManualFlow } = useFlows(testOptions);
+
+		await runManualFlow(mockFlows[4]!.id);
+
+		expect(selection.value).toEqual([{ id: 'item1' }, { id: 'item2' }]);
+	});
+
 	test('resets confirm state after flow API error, showing dialog again on next trigger', async () => {
 		const flowWithConfirm = {
 			id: 'flow-confirm',

--- a/app/src/composables/use-flows.ts
+++ b/app/src/composables/use-flows.ts
@@ -241,6 +241,7 @@ export function useFlows(options: UseFlowsOptions) {
 				});
 			}
 
+			selection.value = [];
 			onRefreshCallback();
 
 			notify({

--- a/contributors.yml
+++ b/contributors.yml
@@ -272,3 +272,4 @@
 - om-singh-D
 - yogeshwaran-c
 - sanskar-soni-9
+- kropsi


### PR DESCRIPTION
## Scope

What's changed:

- Restored selection clear after a manual flow runs from the collection list view sidebar (regressed in #25962 /
  v11.13.0)
- Selection is cleared after the trigger request resolves; if the trigger request itself fails (network / 4xx / 5xx) the
  selection is preserved so the user can retry. Note: this matches what the trigger endpoint reports — operation-level
  rejections inside the flow still return HTTP 200, so they are treated as success here, same as pre-v11.13.0 behavior
- Added two unit tests covering the new behavior

## Potential Risks / Drawbacks

- None identified — single-line additive change on the success path, gated by the existing `try`

## Tested Scenarios

- Manual flow with selection on collection list view → selection cleared after the trigger request resolves
- Trigger request rejection (mocked) → selection preserved (user can retry)
- Existing 15 tests in `use-flows.test.ts` continue to pass; full suite is 17/17
- Manual end-to-end test against a local Directus instance (sqlite, seeded `test_items` collection, manual flow with
  `requireSelection: true`) confirmed the clear

## Review Notes / Questions

- The fix mirrors the pre-v11.13.0 ordering from `batchRefresh` in `collection.vue`: clear, then refresh
- Placed inside `useFlows` rather than each caller's `onRefreshCallback`, since the composable owns the `selection` ref
- On the item view, `selection` defaults to an empty ref in `useFlows`, so the new line is a no-op there
- `keys` for the API call is captured before the clear, so the trigger still uses the right selection

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created here or not required
- [x] OpenAPI package PR created here or not required

---

Fixes #27323
