### PR TITLE
Switch to env vars

### DIFF
--- a/.github/workflows/preview-webhook.yml
+++ b/.github/workflows/preview-webhook.yml
@@ -23,8 +23,13 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Call NF deploy webhook
+        env:
+          NEXT_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PREVIEW_TOKEN: ${{ secrets.NORTHFLANK_PREVIEW_TOKEN }}
+          PULL_REQUEST_ID: ${{ github.event.pull_request.number }}
+          REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
         run: |
-          curl -G "https://webhooks.northflank.com/previews/${{ secrets.NORTHFLANK_PREVIEW_TOKEN }}" \
-          --data-urlencode "preview-source.pullRequestId=${{ github.event.pull_request.number }}" \
-          --data-urlencode "preview-source.repoUrl=${{ github.event.pull_request.head.repo.clone_url }}" \
-          --data-urlencode "next.branch=${{ github.event.pull_request.head.ref }}"
+          curl -G "https://webhooks.northflank.com/previews/${PREVIEW_TOKEN}" \
+          --data-urlencode "preview-source.pullRequestId=${PULL_REQUEST_ID}" \
+          --data-urlencode "preview-source.repoUrl=${REPO_URL}" \
+          --data-urlencode "next.branch=${NEXT_BRANCH}"


### PR DESCRIPTION
Hardens the preview workflow 🤏 ever so slightly by using env vars for branch names instead of direct interpolation. Technically speaking a branch name can contain special characters, so there's a potential angle where a fork using a branch name with escape characters that somehow gets approved by the team _could_ read the preview-scope NF token. 