### PR TITLE
Add max capacity modal on user creation

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1439,6 +1439,12 @@ batch_delete_confirm: >-
   No items have been selected | Are you sure you want to delete this item? This action can not be undone. | Are you sure
   you want to delete these {count} items? This action can not be undone.
 cancel: Cancel
+license:
+  reached: You have reached the max limit allowed for your plan.
+  manage_plan_body: You will need to purchase additional add-ons or upgrade.
+  contact_sales_body: Contact sales to purchase more feature add-ons.
+  manage_plan: Manage Plan
+  contact_sales: Contact Sales
 no_upscale: Don't upscale images
 no_extensions: No Extensions
 no_extensions_copy: No extensions have been installed yet.

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1440,10 +1440,9 @@ batch_delete_confirm: >-
   you want to delete these {count} items? This action can not be undone.
 cancel: Cancel
 license:
-license:
-  reached: You have reached the max user limit allowed for your plan.
-  manage_plan_body: You will need to purchase additional user seats or upgrade.
-  contact_sales_body: Contact sales to purchase more feature add-ons.
+  seats_reached: You have reached the max user limit allowed for your plan.
+  manage_plan_copy: You will need to purchase additional user seats or upgrade your plan.
+  contact_sales_copy: Contact sales to purchase more feature add-ons.
   manage_plan: Manage Plan
   contact_sales: Contact Sales
 no_upscale: Don't upscale images

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1440,8 +1440,9 @@ batch_delete_confirm: >-
   you want to delete these {count} items? This action can not be undone.
 cancel: Cancel
 license:
-  reached: You have reached the max limit allowed for your plan.
-  manage_plan_body: You will need to purchase additional add-ons or upgrade.
+license:
+  reached: You have reached the max user limit allowed for your plan.
+  manage_plan_body: You will need to purchase additional user seats or upgrade.
   contact_sales_body: Contact sales to purchase more feature add-ons.
   manage_plan: Manage Plan
   contact_sales: Contact Sales

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -120,13 +120,17 @@ const confirmDiscard = ref(false);
 const licenseStore = useLicenseStore();
 const seatsLimitModalOpen = ref(false);
 
-const seatsLimitVariant = computed(() => (licenseStore.info?.plan === 'enterprise' ? 'contact-sales' : 'manage-plan'));
+function canSaveNewUser() {
+	if (!isNew.value) return true;
+	if (licenseStore.hasRemainingSeats) return true;
+
+	seatsLimitModalOpen.value = true;
+	return false;
+}
 
 watchEffect(() => {
 	if (!isNew.value) return;
-	const info = licenseStore.info;
-	if (!info) return;
-	seatsLimitModalOpen.value = (info.usage?.seats ?? 0) >= info.entitlements.seats;
+	seatsLimitModalOpen.value = !licenseStore.hasRemainingSeats;
 });
 
 // Provide the discard functionality to field interfaces
@@ -190,6 +194,8 @@ function useBreadcrumb() {
 }
 
 async function saveAndQuit() {
+	if (!canSaveNewUser()) return;
+
 	try {
 		const savedItem: Record<string, any> = await save();
 		await setLang(savedItem);
@@ -201,6 +207,8 @@ async function saveAndQuit() {
 }
 
 async function saveAndStay() {
+	if (!canSaveNewUser()) return;
+
 	try {
 		const savedItem: Record<string, any> = await save();
 		await setLang(savedItem);
@@ -219,6 +227,8 @@ async function saveAndStay() {
 }
 
 async function saveAndAddNew() {
+	if (!canSaveNewUser()) return;
+
 	try {
 		const savedItem: Record<string, any> = await save();
 		await setLang(savedItem);
@@ -518,7 +528,7 @@ function revert(values: Record<string, any>) {
 		<LicenseSeatsLimitModal
 			v-if="isNew"
 			v-model="seatsLimitModalOpen"
-			:variant="seatsLimitVariant"
+			persistent
 			@cancel="router.push({ name: 'users-active' })"
 		/>
 

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -2,7 +2,7 @@
 import { useCollection } from '@directus/composables';
 import { useShortcut } from '@directus/composables';
 import type { User } from '@directus/types';
-import { computed, provide, ref, toRefs } from 'vue';
+import { computed, provide, ref, toRefs, watchEffect } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import UsersNavigation from '../components/navigation.vue';
@@ -25,6 +25,7 @@ import { useEditsGuard } from '@/composables/use-edits-guard';
 import { useItem } from '@/composables/use-item';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
+import { useLicenseStore } from '@/stores/license';
 import { useServerStore } from '@/stores/server';
 import { useUserStore } from '@/stores/user';
 import { getAssetUrl } from '@/utils/get-asset-url';
@@ -34,6 +35,7 @@ import { PrivateViewHeaderBarActionButton } from '@/views/private';
 import CollabIndicatorHeader from '@/views/private/components/collab/CollabIndicatorHeader.vue';
 import CommentsSidebarDetail from '@/views/private/components/comments-sidebar-detail.vue';
 import ComparisonModal from '@/views/private/components/comparison/comparison-modal.vue';
+import LicenseSeatsLimitModal from '@/views/private/components/license-seats-limit-modal.vue';
 import RevisionsSidebarDetail from '@/views/private/components/revisions-sidebar-detail.vue';
 import SaveOptions from '@/views/private/components/save-options.vue';
 
@@ -114,6 +116,18 @@ const { confirmLeave, leaveTo } = useEditsGuard(hasEdits);
 const confirmDelete = ref(false);
 const confirmArchive = ref(false);
 const confirmDiscard = ref(false);
+
+const licenseStore = useLicenseStore();
+const seatsLimitModalOpen = ref(false);
+
+const seatsLimitVariant = computed(() => (licenseStore.info?.plan === 'enterprise' ? 'contact-sales' : 'manage-plan'));
+
+watchEffect(() => {
+	if (!isNew.value) return;
+	const info = licenseStore.info;
+	if (!info) return;
+	seatsLimitModalOpen.value = (info.usage?.seats ?? 0) >= info.entitlements.seats;
+});
 
 // Provide the discard functionality to field interfaces
 provide('discardAllChanges', discardAndStay);
@@ -499,6 +513,13 @@ function revert(values: Record<string, any>) {
 			:current-version="null"
 			@confirm="updateCollab"
 			@cancel="clearCollidingChanges"
+		/>
+
+		<LicenseSeatsLimitModal
+			v-if="isNew"
+			v-model="seatsLimitModalOpen"
+			:variant="seatsLimitVariant"
+			@cancel="router.push({ name: 'users-active' })"
 		/>
 
 		<template #sidebar>

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -120,13 +120,10 @@ const confirmDiscard = ref(false);
 const licenseStore = useLicenseStore();
 const seatsLimitModalOpen = ref(false);
 
-function canSaveNewUser() {
+const canSaveNewUser = computed(() => {
 	if (!isNew.value) return true;
-	if (licenseStore.hasRemainingSeats) return true;
-
-	seatsLimitModalOpen.value = true;
-	return false;
-}
+	return licenseStore.hasRemainingSeats;
+});
 
 watchEffect(() => {
 	if (!isNew.value) return;
@@ -194,7 +191,7 @@ function useBreadcrumb() {
 }
 
 async function saveAndQuit() {
-	if (!canSaveNewUser()) return;
+	if (!canSaveNewUser.value) return;
 
 	try {
 		const savedItem: Record<string, any> = await save();
@@ -207,7 +204,7 @@ async function saveAndQuit() {
 }
 
 async function saveAndStay() {
-	if (!canSaveNewUser()) return;
+	if (!canSaveNewUser.value) return;
 
 	try {
 		const savedItem: Record<string, any> = await save();
@@ -227,7 +224,7 @@ async function saveAndStay() {
 }
 
 async function saveAndAddNew() {
-	if (!canSaveNewUser()) return;
+	if (!canSaveNewUser.value) return;
 
 	try {
 		const savedItem: Record<string, any> = await save();

--- a/app/src/stores/license.ts
+++ b/app/src/stores/license.ts
@@ -22,6 +22,13 @@ export const useLicenseStore = defineStore('licenseStore', () => {
 		return null;
 	});
 
+	const seatsRemaining = computed<number | null>(() => {
+		if (!info.value) return null;
+		return info.value.entitlements.seats - (info.value.usage?.seats ?? 0);
+	});
+
+	const hasRemainingSeats = computed(() => seatsRemaining.value === null || seatsRemaining.value > 0);
+
 	function clearTimer() {
 		if (refreshTimer) {
 			clearTimeout(refreshTimer);
@@ -79,6 +86,8 @@ export const useLicenseStore = defineStore('licenseStore', () => {
 		loading,
 		error,
 		boundary,
+		seatsRemaining,
+		hasRemainingSeats,
 		hydrate,
 		dehydrate,
 	};

--- a/app/src/views/private/components/license-seats-limit-modal.test.ts
+++ b/app/src/views/private/components/license-seats-limit-modal.test.ts
@@ -1,0 +1,101 @@
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import LicenseSeatsLimitModal from './license-seats-limit-modal.vue';
+import { i18n } from '@/lang';
+import { useLicenseStore } from '@/stores/license';
+
+const mockPush = vi.fn();
+
+vi.mock('vue-router', () => ({
+	useRouter: () => ({ push: mockPush }),
+}));
+
+const global = {
+	stubs: {
+		VDialog: { template: '<div><slot /></div>' },
+		VCard: { template: '<div><slot /></div>' },
+		VCardTitle: { template: '<div><slot /></div>' },
+		VCardText: { template: '<div><slot /></div>' },
+		VCardActions: { template: '<div><slot /></div>' },
+		VButton: { template: '<button @click="$emit(\'click\')"><slot /></button>', emits: ['click'] },
+	},
+	plugins: [i18n, createTestingPinia({ createSpy: vi.fn })],
+};
+
+describe('LicenseSeatsLimitModal', () => {
+	let licenseStore: ReturnType<typeof useLicenseStore>;
+
+	beforeEach(() => {
+		mockPush.mockClear();
+		vi.spyOn(window, 'open').mockImplementation(() => null);
+
+		const wrapper = mount(LicenseSeatsLimitModal, { props: { modelValue: true }, global });
+		licenseStore = useLicenseStore();
+		wrapper.unmount();
+	});
+
+	describe('content based on plan type', () => {
+		it('shows manage plan text for non-enterprise plans', () => {
+			licenseStore.info = { plan: 'business' } as any;
+
+			const wrapper = mount(LicenseSeatsLimitModal, { props: { modelValue: true }, global });
+
+			expect(wrapper.text()).toContain(i18n.global.t('license.manage_plan_copy'));
+			expect(wrapper.text()).toContain(i18n.global.t('license.manage_plan'));
+			expect(wrapper.text()).not.toContain(i18n.global.t('license.contact_sales_copy'));
+		});
+
+		it('shows contact sales text for enterprise plan', () => {
+			licenseStore.info = { plan: 'enterprise' } as any;
+
+			const wrapper = mount(LicenseSeatsLimitModal, { props: { modelValue: true }, global });
+
+			expect(wrapper.text()).toContain(i18n.global.t('license.contact_sales_copy'));
+			expect(wrapper.text()).toContain(i18n.global.t('license.contact_sales'));
+			expect(wrapper.text()).not.toContain(i18n.global.t('license.manage_plan_copy'));
+		});
+
+		it('shows manage plan text when license info is null', () => {
+			licenseStore.info = null;
+
+			const wrapper = mount(LicenseSeatsLimitModal, { props: { modelValue: true }, global });
+
+			expect(wrapper.text()).toContain(i18n.global.t('license.manage_plan_copy'));
+		});
+	});
+
+	describe('primary action button', () => {
+		it('navigates to /settings/license for non-enterprise plans', async () => {
+			licenseStore.info = { plan: 'business' } as any;
+
+			const wrapper = mount(LicenseSeatsLimitModal, { props: { modelValue: true }, global });
+			const buttons = wrapper.findAll('button');
+			await buttons[buttons.length - 1]!.trigger('click');
+
+			expect(mockPush).toHaveBeenCalledWith('/settings/license');
+			expect(window.open).not.toHaveBeenCalled();
+		});
+
+		it('opens contact URL for enterprise plan', async () => {
+			licenseStore.info = { plan: 'enterprise' } as any;
+
+			const wrapper = mount(LicenseSeatsLimitModal, { props: { modelValue: true }, global });
+			const buttons = wrapper.findAll('button');
+			await buttons[buttons.length - 1]!.trigger('click');
+
+			expect(window.open).toHaveBeenCalledWith('https://directus.io/contact', '_blank', 'noopener,noreferrer');
+			expect(mockPush).not.toHaveBeenCalled();
+		});
+
+		it('emits update:modelValue false when action is taken', async () => {
+			licenseStore.info = { plan: 'business' } as any;
+
+			const wrapper = mount(LicenseSeatsLimitModal, { props: { modelValue: true }, global });
+			const buttons = wrapper.findAll('button');
+			await buttons[buttons.length - 1]!.trigger('click');
+
+			expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+		});
+	});
+});

--- a/app/src/views/private/components/license-seats-limit-modal.vue
+++ b/app/src/views/private/components/license-seats-limit-modal.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { useRouter } from 'vue-router';
+import VButton from '@/components/v-button.vue';
+import VCardActions from '@/components/v-card-actions.vue';
+import VCardText from '@/components/v-card-text.vue';
+import VCardTitle from '@/components/v-card-title.vue';
+import VCard from '@/components/v-card.vue';
+import VDialog from '@/components/v-dialog.vue';
+
+const props = defineProps<{
+	modelValue: boolean;
+	variant: 'manage-plan' | 'contact-sales';
+}>();
+
+const emit = defineEmits<{
+	(e: 'update:modelValue', value: boolean): void;
+	(e: 'cancel'): void;
+}>();
+
+const router = useRouter();
+
+function close() {
+	emit('update:modelValue', false);
+	emit('cancel');
+}
+
+function handleAction() {
+	close();
+
+	if (props.variant === 'manage-plan') {
+		router.push('/settings/license');
+	} else {
+		window.open('https://directus.io/contact', '_blank');
+	}
+}
+</script>
+
+<template>
+	<VDialog :model-value="modelValue" @update:model-value="$emit('update:modelValue', $event)" @esc="close">
+		<VCard>
+			<VCardTitle>{{ $t('license.reached') }}</VCardTitle>
+
+			<VCardText>
+				{{ variant === 'manage-plan' ? $t('license.manage_plan_body') : $t('license.contact_sales_body') }}
+			</VCardText>
+
+			<VCardActions>
+				<VButton secondary @click="close">{{ $t('cancel') }}</VButton>
+				<VButton @click="handleAction">
+					{{ variant === 'manage-plan' ? $t('license.manage_plan') : $t('license.contact_sales') }}
+				</VButton>
+			</VCardActions>
+		</VCard>
+	</VDialog>
+</template>

--- a/app/src/views/private/components/license-seats-limit-modal.vue
+++ b/app/src/views/private/components/license-seats-limit-modal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { useRouter } from 'vue-router';
 import VButton from '@/components/v-button.vue';
 import VCardActions from '@/components/v-card-actions.vue';
@@ -6,10 +7,11 @@ import VCardText from '@/components/v-card-text.vue';
 import VCardTitle from '@/components/v-card-title.vue';
 import VCard from '@/components/v-card.vue';
 import VDialog from '@/components/v-dialog.vue';
+import { useLicenseStore } from '@/stores/license';
 
-const props = defineProps<{
+defineProps<{
 	modelValue: boolean;
-	variant: 'manage-plan' | 'contact-sales';
+	persistent?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -18,6 +20,9 @@ const emit = defineEmits<{
 }>();
 
 const router = useRouter();
+const licenseStore = useLicenseStore();
+
+const isEnterprisePlan = computed(() => licenseStore.info?.plan === 'enterprise');
 
 function close() {
 	emit('update:modelValue', false);
@@ -27,27 +32,32 @@ function close() {
 function handleAction() {
 	close();
 
-	if (props.variant === 'manage-plan') {
-		router.push('/settings/license');
-	} else {
+	if (isEnterprisePlan.value) {
 		window.open('https://directus.io/contact', '_blank');
+	} else {
+		router.push('/settings/license');
 	}
 }
 </script>
 
 <template>
-	<VDialog :model-value="modelValue" @update:model-value="$emit('update:modelValue', $event)" @esc="close">
+	<VDialog
+		:model-value="modelValue"
+		:persistent="persistent"
+		@update:model-value="$emit('update:modelValue', $event)"
+		@esc="close"
+	>
 		<VCard>
 			<VCardTitle>{{ $t('license.reached') }}</VCardTitle>
 
 			<VCardText>
-				{{ variant === 'manage-plan' ? $t('license.manage_plan_body') : $t('license.contact_sales_body') }}
+				{{ isEnterprisePlan ? $t('license.contact_sales_body') : $t('license.manage_plan_body') }}
 			</VCardText>
 
 			<VCardActions>
 				<VButton secondary @click="close">{{ $t('cancel') }}</VButton>
 				<VButton @click="handleAction">
-					{{ variant === 'manage-plan' ? $t('license.manage_plan') : $t('license.contact_sales') }}
+					{{ isEnterprisePlan ? $t('license.contact_sales') : $t('license.manage_plan') }}
 				</VButton>
 			</VCardActions>
 		</VCard>

--- a/app/src/views/private/components/license-seats-limit-modal.vue
+++ b/app/src/views/private/components/license-seats-limit-modal.vue
@@ -30,10 +30,10 @@ function close() {
 }
 
 function handleAction() {
-	close();
+	emit('update:modelValue', false);
 
 	if (isEnterprisePlan.value) {
-		window.open('https://directus.io/contact', '_blank');
+		window.open('https://directus.io/contact', '_blank', 'noopener,noreferrer');
 	} else {
 		router.push('/settings/license');
 	}
@@ -48,10 +48,10 @@ function handleAction() {
 		@esc="close"
 	>
 		<VCard>
-			<VCardTitle>{{ $t('license.reached') }}</VCardTitle>
+			<VCardTitle>{{ $t('license.seats_reached') }}</VCardTitle>
 
 			<VCardText>
-				{{ isEnterprisePlan ? $t('license.contact_sales_body') : $t('license.manage_plan_body') }}
+				{{ isEnterprisePlan ? $t('license.contact_sales_copy') : $t('license.manage_plan_copy') }}
 			</VCardText>
 
 			<VCardActions>

--- a/app/src/views/private/components/users-invite.vue
+++ b/app/src/views/private/components/users-invite.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { Role } from '@directus/types';
 import { ref, watch } from 'vue';
-import LicenseSeatsLimitModal from './license-seats-limit-modal.vue';
 import api from '@/api';
 import VButton from '@/components/v-button.vue';
 import VCardActions from '@/components/v-card-actions.vue';
@@ -12,7 +11,6 @@ import VDialog from '@/components/v-dialog.vue';
 import VNotice from '@/components/v-notice.vue';
 import VSelect from '@/components/v-select/v-select.vue';
 import VTextarea from '@/components/v-textarea.vue';
-import { useLicenseStore } from '@/stores/license';
 import { APIError } from '@/types/error';
 import { unexpectedError } from '@/utils/unexpected-error';
 
@@ -25,13 +23,10 @@ const emit = defineEmits<{
 	(e: 'update:modelValue', value: boolean): void;
 }>();
 
-const licenseStore = useLicenseStore();
-
 const emails = ref<string>('');
 const roles = ref<Record<string, any>[]>([]);
 const roleSelected = ref<string | undefined>(props.role);
 const loading = ref(false);
-const seatsLimitModalOpen = ref(false);
 
 const uniqueValidationErrors = ref([]);
 
@@ -45,21 +40,14 @@ watch(
 async function inviteUsers() {
 	if (emails.value.length === 0 || loading.value) return;
 
-	const emailsParsed = emails.value
-		.split(/,|\n/)
-		.map((email) => email.trim())
-		.filter((email) => email);
-
-	if (emailsParsed.length === 0) return;
-
-	if (licenseStore.seatsRemaining !== null && emailsParsed.length > licenseStore.seatsRemaining) {
-		seatsLimitModalOpen.value = true;
-		return;
-	}
-
 	loading.value = true;
 
 	try {
+		const emailsParsed = emails.value
+			.split(/,|\n/)
+			.filter((e) => e)
+			.map((email) => email.trim());
+
 		await api.post('/users/invite', {
 			email: emailsParsed,
 			role: roleSelected.value,
@@ -144,8 +132,6 @@ async function loadRoles() {
 			</VCardActions>
 		</VCard>
 	</VDialog>
-
-	<LicenseSeatsLimitModal v-model="seatsLimitModalOpen" />
 </template>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/users-invite.vue
+++ b/app/src/views/private/components/users-invite.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Role } from '@directus/types';
-import { ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
+import LicenseSeatsLimitModal from './license-seats-limit-modal.vue';
 import api from '@/api';
 import VButton from '@/components/v-button.vue';
 import VCardActions from '@/components/v-card-actions.vue';
@@ -11,6 +12,7 @@ import VDialog from '@/components/v-dialog.vue';
 import VNotice from '@/components/v-notice.vue';
 import VSelect from '@/components/v-select/v-select.vue';
 import VTextarea from '@/components/v-textarea.vue';
+import { useLicenseStore } from '@/stores/license';
 import { APIError } from '@/types/error';
 import { unexpectedError } from '@/utils/unexpected-error';
 
@@ -23,12 +25,23 @@ const emit = defineEmits<{
 	(e: 'update:modelValue', value: boolean): void;
 }>();
 
+const licenseStore = useLicenseStore();
+
 const emails = ref<string>('');
 const roles = ref<Record<string, any>[]>([]);
 const roleSelected = ref<string | undefined>(props.role);
 const loading = ref(false);
+const seatsLimitModalOpen = ref(false);
 
 const uniqueValidationErrors = ref([]);
+
+const isAtSeatsLimit = computed(() => {
+	const info = licenseStore.info;
+	if (!info) return false;
+	return (info.usage?.seats ?? 0) >= info.entitlements.seats;
+});
+
+const seatsLimitVariant = computed(() => (licenseStore.info?.plan === 'enterprise' ? 'contact-sales' : 'manage-plan'));
 
 watch(
 	() => props.modelValue,
@@ -39,6 +52,11 @@ watch(
 
 async function inviteUsers() {
 	if (emails.value.length === 0 || loading.value) return;
+
+	if (isAtSeatsLimit.value) {
+		seatsLimitModalOpen.value = true;
+		return;
+	}
 
 	loading.value = true;
 
@@ -132,6 +150,8 @@ async function loadRoles() {
 			</VCardActions>
 		</VCard>
 	</VDialog>
+
+	<LicenseSeatsLimitModal v-model="seatsLimitModalOpen" :variant="seatsLimitVariant" />
 </template>
 
 <style lang="scss" scoped>

--- a/app/src/views/private/components/users-invite.vue
+++ b/app/src/views/private/components/users-invite.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Role } from '@directus/types';
-import { computed, ref, watch } from 'vue';
+import { ref, watch } from 'vue';
 import LicenseSeatsLimitModal from './license-seats-limit-modal.vue';
 import api from '@/api';
 import VButton from '@/components/v-button.vue';
@@ -35,14 +35,6 @@ const seatsLimitModalOpen = ref(false);
 
 const uniqueValidationErrors = ref([]);
 
-const isAtSeatsLimit = computed(() => {
-	const info = licenseStore.info;
-	if (!info) return false;
-	return (info.usage?.seats ?? 0) >= info.entitlements.seats;
-});
-
-const seatsLimitVariant = computed(() => (licenseStore.info?.plan === 'enterprise' ? 'contact-sales' : 'manage-plan'));
-
 watch(
 	() => props.modelValue,
 	() => {
@@ -53,7 +45,14 @@ watch(
 async function inviteUsers() {
 	if (emails.value.length === 0 || loading.value) return;
 
-	if (isAtSeatsLimit.value) {
+	const emailsParsed = emails.value
+		.split(/,|\n/)
+		.map((email) => email.trim())
+		.filter((email) => email);
+
+	if (emailsParsed.length === 0) return;
+
+	if (licenseStore.seatsRemaining !== null && emailsParsed.length > licenseStore.seatsRemaining) {
 		seatsLimitModalOpen.value = true;
 		return;
 	}
@@ -61,11 +60,6 @@ async function inviteUsers() {
 	loading.value = true;
 
 	try {
-		const emailsParsed = emails.value
-			.split(/,|\n/)
-			.filter((e) => e)
-			.map((email) => email.trim());
-
 		await api.post('/users/invite', {
 			email: emailsParsed,
 			role: roleSelected.value,
@@ -151,7 +145,7 @@ async function loadRoles() {
 		</VCard>
 	</VDialog>
 
-	<LicenseSeatsLimitModal v-model="seatsLimitModalOpen" :variant="seatsLimitVariant" />
+	<LicenseSeatsLimitModal v-model="seatsLimitModalOpen" />
 </template>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
To test this one, you can adjust the mock api data per the instruction below.
Note that I'm redirecting to the user list page if they cancel the modal.

Also, for the Manage Plan option, I'm redirecting to @HZooly's settings page which is not available in this PR. @gaetansenn this differs a bit from the spec that suggests to send to the stripe portal, so let me know if this seems like an issue.


## Scenario 1 — Seats limit modal on "Create User" (non-enterprise plan)
                                                                                                                                                   
  1. Configure the mock license so plan is not enterprise (e.g. pro) and usage.seats >= entitlements.seats.
  2. Log in as an admin and navigate to Users → Create User (/users/+).                                                                            
  3. Expected: The seats-limit modal opens immediately, showing the body text "You will need to purchase additional add-ons or upgrade." with a    
  Manage Plan button and a Cancel button.                                                                                                          
  4. Click Cancel → should navigate back to the active users list.                                                                                 
  5. Click Manage Plan → should navigate to /settings/license.                                                                                     
                                                         
  ## Scenario 2 — Seats limit modal on "Create User" (enterprise plan)                                                                                
                                                         
  1. Configure the mock license so plan is enterprise and usage.seats >= entitlements.seats.                                                       
  2. Navigate to Users → Create User.                    
  3. Expected: Modal opens with the body text "Contact sales to purchase more feature add-ons." and a Contact Sales button.                        
  4. Click Contact Sales → should open https://directus.io/contact in a new tab.                                                                   
                                                                                                                                                                                                                                                                                                                                                                          
 ## Scenario 3 — No modal when seats are available                                                                                                   
                                                                                                                                                   
  1. Configure the mock so usage.seats < entitlements.seats.                                                                                       
  2. Navigate to Users → Create User — modal should not appear.
  3. Open Invite Users and submit — the invite should proceed normally without the modal appearing.        
 
<img width="800" alt="Screenshot 2026-04-29 at 000221" src="https://github.com/user-attachments/assets/e08fb252-eda3-4e35-b0e6-c6740c663342" />

---

Fixes [cms-2255](https://linear.app/directus/issue/CMS-2235/add-max-capacity-modal-on-user-creationinvite)
