### PR TITLE
Fix unintended role and permission creation when admin data is missing

### DIFF
--- a/.changeset/eager-shrimps-tan.md
+++ b/.changeset/eager-shrimps-tan.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fix unintended role and permission creation when admin data is missing

--- a/api/src/utils/create-admin.ts
+++ b/api/src/utils/create-admin.ts
@@ -34,6 +34,11 @@ export async function createAdmin(
 	const logger = useLogger();
 	const env = useEnv();
 
+	if (!admin || !admin.email || !admin.password) {
+		logger.info('Skipping admin user creation');
+		return;
+	}
+
 	logger.info('Setting up first admin role...');
 	const accessService = new AccessService({ schema });
 	const policiesService = new PoliciesService({ schema });

--- a/contributors.yml
+++ b/contributors.yml
@@ -273,3 +273,4 @@
 - yogeshwaran-c
 - sanskar-soni-9
 - kropsi
+- sourav-18


### PR DESCRIPTION
## 🐛 Problem

During initial setup, the `createAdmin` function was executed even when no admin data was provided. This resulted in unintended creation of roles and permissions without an associated admin user.

As a result, extra roles appeared in the database and were returned by the `/roles` API, causing unexpected entries in the frontend.

## ✅ Solution

Added validation to ensure that admin data is present before executing the admin setup logic. If required fields (e.g., email or password) are missing, the function exits early and skips role and permission creation.

## ⚠️ Note

If the `directus_roles` table already contains multiple role entries (for example due to previous unintended creations), the `/roles` API will return all records. This may result in duplicate "Administrator" entries being displayed in the frontend.

This change prevents further unintended role creation, but does not automatically clean up existing duplicate records in the database.
fix: #27333 