### PR TITLE
feat(sdk): add realtime lifecycle state

### DIFF
--- a/.changeset/bright-bugs-explain.md
+++ b/.changeset/bright-bugs-explain.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': minor
+---
+
+Added authenticated and ready lifecycle tracking to the realtime SDK.

--- a/.changeset/fix-password-policy-error.md
+++ b/.changeset/fix-password-policy-error.md
@@ -1,0 +1,6 @@
+---
+'@directus/errors': minor
+'@directus/api': patch
+'@directus/app': patch
+---
+Added descriptive error when password fails the configured Auth Password Policy.

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -1,4 +1,10 @@
-import { ForbiddenError, InvalidInviteError, InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
+import {
+	ForbiddenError,
+	InvalidInviteError,
+	InvalidPasswordError,
+	InvalidPayloadError,
+	RecordNotUniqueError,
+} from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import type { Accountability, MutationOptions } from '@directus/types';
 import { UserIntegrityCheckFlag } from '@directus/types';
@@ -114,6 +120,18 @@ describe('Integration Tests', () => {
 				await service.createOne({}, opts);
 
 				expect(opts.userIntegrityCheckFlags).toBe(UserIntegrityCheckFlag.UserLimits);
+			});
+
+			it('should set preMutationError to InvalidPasswordError when password fails policy', async () => {
+				vi.mocked(SettingsService.prototype.readSingleton).mockResolvedValue({
+					auth_password_policy: '^.{8,}$',
+				} as any);
+
+				const opts: MutationOptions = {};
+
+				await service.createOne({ password: 'short' }, opts);
+
+				expect(opts.preMutationError).toBeInstanceOf(InvalidPasswordError);
 			});
 		});
 

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -1,6 +1,12 @@
 import { performance } from 'perf_hooks';
 import { useEnv } from '@directus/env';
-import { ForbiddenError, InvalidInviteError, InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
+import {
+	ForbiddenError,
+	InvalidInviteError,
+	InvalidPasswordError,
+	InvalidPayloadError,
+	RecordNotUniqueError,
+} from '@directus/errors';
 import type {
 	AbstractServiceOptions,
 	Item,
@@ -11,7 +17,7 @@ import type {
 } from '@directus/types';
 import { UserIntegrityCheckFlag } from '@directus/types';
 import { getSimpleHash, toArray, validatePayload } from '@directus/utils';
-import { FailedValidationError, joiValidationErrorItemToErrorExtensions } from '@directus/validation';
+import { FailedValidationError } from '@directus/validation';
 import Joi from 'joi';
 import jwt from 'jsonwebtoken';
 import { isEmpty } from 'lodash-es';
@@ -103,16 +109,7 @@ export class UsersService extends ItemsService {
 
 		for (const password of passwords) {
 			if (!regex.test(password)) {
-				throw new FailedValidationError(
-					joiValidationErrorItemToErrorExtensions({
-						message: `Provided password doesn't match password policy`,
-						path: ['password'],
-						type: 'custom.pattern.base',
-						context: {
-							value: password,
-						},
-					}),
-				);
+				throw new InvalidPasswordError();
 			}
 		}
 	}

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -866,6 +866,7 @@ errors:
   INVALID_IP: IP Address not allowed
   INVALID_OTP: Wrong one-time password
   INVALID_PAYLOAD: Invalid payload
+  INVALID_PASSWORD: Password doesn't match the configured password policy
   INVALID_PROVIDER: User belongs to a different auth provider
   INVALID_PROVIDER_CONFIG: Invalid provider configuration
   INVALID_QUERY: Invalid query

--- a/app/src/utils/translateAPIError.test.ts
+++ b/app/src/utils/translateAPIError.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { translateAPIError } from '@/lang';
+
+describe('translateAPIError', () => {
+	it('maps INVALID_PASSWORD to the configured translation', () => {
+		const apiError = {
+			response: {
+				data: {
+					errors: [{ extensions: { code: 'INVALID_PASSWORD' } }],
+				},
+			},
+		};
+
+		expect(translateAPIError(apiError as any)).toBe("Password doesn't match the configured password policy");
+	});
+});

--- a/contributors.yml
+++ b/contributors.yml
@@ -267,3 +267,4 @@
 - faizkhairi
 - eric-pennecot
 - om-singh-D
+- PuneetKumar1790

--- a/packages/errors/src/errors/invalid-password.ts
+++ b/packages/errors/src/errors/invalid-password.ts
@@ -1,0 +1,7 @@
+import { createError, type DirectusErrorConstructor, ErrorCode } from '../index.js';
+
+export const InvalidPasswordError: DirectusErrorConstructor<void> = createError(
+	ErrorCode.InvalidPassword,
+	`Provided password doesn't match the password policy.`,
+	400,
+);

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -45,6 +45,9 @@ export function realtime(config: WebSocketConfig = {}) {
 	return <Schema>(client: DirectusClient<Schema>) => {
 		config = { ...defaultRealTimeConfig, ...config };
 		let uid = generateUid();
+		let connected = false;
+		let authenticated = false;
+		let readyEmitted = false;
 
 		let state: ConnectionState = {
 			code: 'closed',
@@ -143,6 +146,36 @@ export function realtime(config: WebSocketConfig = {}) {
 			error: new Set<WebSocketEventHandler>([]),
 			close: new Set<WebSocketEventHandler>([]),
 			message: new Set<WebSocketEventHandler>([]),
+			connected: new Set<WebSocketEventHandler>([]),
+			authenticated: new Set<WebSocketEventHandler>([]),
+			ready: new Set<WebSocketEventHandler>([]),
+		};
+
+		const emit = (event: WebSocketEvents, ws: WebSocketInterface, payload: Event | CloseEvent | any = new Event(event)) => {
+			eventHandlers[event].forEach((handler) => handler.call(ws, payload));
+		};
+
+		const resetLifecycleState = () => {
+			connected = false;
+			authenticated = false;
+			readyEmitted = false;
+		};
+
+		const markConnected = (ws: WebSocketInterface, payload?: Event) => {
+			connected = true;
+			emit('connected', ws, payload ?? new Event('connected'));
+		};
+
+		const markAuthenticated = (ws: WebSocketInterface, payload?: Event) => {
+			if (authenticated === false) {
+				authenticated = true;
+				emit('authenticated', ws, payload ?? new Event('authenticated'));
+			}
+
+			if (connected && authenticated && readyEmitted === false) {
+				readyEmitted = true;
+				emit('ready', ws, payload ?? new Event('ready'));
+			}
 		};
 
 		function isAuthError(message: Record<string, any> | MessageEvent<string>): message is WebSocketAuthError {
@@ -206,7 +239,22 @@ export function realtime(config: WebSocketConfig = {}) {
 
 				if (!message) continue;
 
+					if (
+						'type' in message &&
+						'status' in message &&
+						message['type'] === 'auth' &&
+						message['status'] === 'ok' &&
+						state.firstMessage === false
+					) {
+						markAuthenticated(state.connection);
+					}
+
 				if (isAuthError(message)) {
+						if (message.error.code === 'TOKEN_EXPIRED') {
+							authenticated = false;
+							readyEmitted = false;
+						}
+
 					await handleAuthError(message, currentClient);
 					state.firstMessage = false;
 					continue;
@@ -240,7 +288,13 @@ export function realtime(config: WebSocketConfig = {}) {
 					}
 				}
 
-				return state.code === 'open';
+				return connected;
+			},
+			isAuthenticated() {
+				return authenticated;
+			},
+			isReady() {
+				return connected && authenticated;
 			},
 			async connect() {
 				wasManuallyDisconnected = false;
@@ -295,6 +349,7 @@ export function realtime(config: WebSocketConfig = {}) {
 					debug('info', `Connection open.`);
 
 					state = { code: 'open', connection: ws, firstMessage: true };
+					markConnected(ws);
 					reconnectState.attempts = 0;
 					reconnectState.active = false;
 					clearTimeout(connectTimeout);
@@ -324,7 +379,18 @@ export function realtime(config: WebSocketConfig = {}) {
 							return reject('Authentication failed while opening websocket connection');
 						} else {
 							debug('info', 'Authentication successful!');
+							authenticated = true;
+							readyEmitted = false;
+							state.firstMessage = false;
+							emit('authenticated', ws, new Event('authenticated'));
+							emit('ready', ws, new Event('ready'));
+							readyEmitted = true;
 						}
+					} else if (config.authMode === 'strict' && hasAuth(self)) {
+						authenticated = true;
+						emit('authenticated', ws, new Event('authenticated'));
+						emit('ready', ws, new Event('ready'));
+						readyEmitted = true;
 					}
 
 					eventHandlers['open'].forEach((handler) => handler.call(ws, evt));
@@ -343,6 +409,7 @@ export function realtime(config: WebSocketConfig = {}) {
 
 				ws.addEventListener('close', (evt: CloseEvent) => {
 					debug('info', `Connection closed.`);
+					resetLifecycleState();
 					eventHandlers['close'].forEach((handler) => handler.call(ws, evt));
 					uid = generateUid();
 					state = { code: 'closed' };
@@ -354,6 +421,7 @@ export function realtime(config: WebSocketConfig = {}) {
 			},
 			disconnect() {
 				wasManuallyDisconnected = true;
+				resetLifecycleState();
 
 				if (state.code === 'open') {
 					state.connection.close();

--- a/sdk/src/realtime/types.ts
+++ b/sdk/src/realtime/types.ts
@@ -27,12 +27,14 @@ export interface SubscribeOptions<Schema, Collection extends keyof Schema> {
 	uid?: string;
 }
 
-export type WebSocketEvents = 'open' | 'close' | 'error' | 'message';
+export type WebSocketEvents = 'open' | 'close' | 'error' | 'message' | 'connected' | 'authenticated' | 'ready';
 export type RemoveEventHandler = () => void;
 export type WebSocketEventHandler = (this: WebSocketInterface, ev: Event | CloseEvent | any) => any;
 
 export interface WebSocketClient<Schema> {
 	isConnected(): Promise<boolean>;
+	isAuthenticated(): boolean;
+	isReady(): boolean;
 	connect(): Promise<WebSocketInterface>;
 	disconnect(): void;
 	onWebSocket(event: 'open', callback: (this: WebSocketInterface, ev: Event) => any): RemoveEventHandler;

--- a/sdk/tests/realtime.test.ts
+++ b/sdk/tests/realtime.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest';
+import { realtime } from '../src/realtime/index.js';
+
+class MockWebSocket {
+	static instances: MockWebSocket[] = [];
+
+	readonly url: string;
+	readonly sent: string[] = [];
+	readyState = 0;
+	private closed = false;
+	private listeners = new Map<string, Set<(this: MockWebSocket, ev: any) => any>>();
+
+	constructor(url: string) {
+		this.url = url;
+		MockWebSocket.instances.push(this);
+
+		queueMicrotask(() => {
+			this.readyState = 1;
+			this.dispatch('open', new Event('open'));
+		});
+	}
+
+	addEventListener(type: string, listener: (this: MockWebSocket, ev: any) => any) {
+		if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+		this.listeners.get(type)?.add(listener);
+	}
+
+	removeEventListener(type: string, listener: (this: MockWebSocket, ev: any) => any) {
+		this.listeners.get(type)?.delete(listener);
+	}
+
+	send(data: string) {
+		this.sent.push(data);
+
+		try {
+			const parsed = JSON.parse(data);
+
+			if (parsed?.type === 'auth') {
+				queueMicrotask(() => {
+					this.dispatch('message', { data: JSON.stringify({ type: 'auth', status: 'ok' }) });
+				});
+			}
+		} catch {
+			/* ignore */
+		}
+	}
+
+	close() {
+		if (this.closed) return;
+
+		this.closed = true;
+		this.readyState = 3;
+		this.dispatch('close', new Event('close'));
+	}
+
+	private dispatch(type: string, ev: any) {
+		for (const listener of this.listeners.get(type) ?? []) {
+			listener.call(this, ev);
+		}
+	}
+}
+
+describe('realtime lifecycle', () => {
+	it('tracks connected, authenticated, and ready state', async () => {
+		MockWebSocket.instances = [];
+
+		const lifecycleEvents: string[] = [];
+		const baseClient = {
+			url: new URL('https://example.com'),
+			getToken: vi.fn().mockResolvedValue('token'),
+			globals: {
+				URL,
+				WebSocket: MockWebSocket as any,
+				fetch: vi.fn() as any,
+				logger: {
+					log: vi.fn(),
+					info: vi.fn(),
+					warn: vi.fn(),
+					error: vi.fn(),
+				},
+			},
+			with<Extension extends object>(extension: (client: any) => Extension) {
+				return Object.assign(this, extension(this as any));
+			},
+		} as any;
+
+		const sdk = baseClient.with(
+			realtime({
+			authMode: 'handshake',
+			connect: false,
+			reconnect: false,
+			}),
+		);
+
+		sdk.onWebSocket('connected', () => lifecycleEvents.push('connected'));
+		sdk.onWebSocket('authenticated', () => lifecycleEvents.push('authenticated'));
+		sdk.onWebSocket('ready', () => lifecycleEvents.push('ready'));
+
+		await sdk.connect();
+
+		expect(await sdk.isConnected()).toBe(true);
+		expect(sdk.isAuthenticated()).toBe(true);
+		expect(sdk.isReady()).toBe(true);
+		expect(lifecycleEvents).toEqual(['connected', 'authenticated', 'ready']);
+
+		sdk.disconnect();
+		expect(await sdk.isConnected()).toBe(false);
+		expect(sdk.isAuthenticated()).toBe(false);
+		expect(sdk.isReady()).toBe(false);
+	});
+
+	it('re-emits the lifecycle after reconnect', async () => {
+		MockWebSocket.instances = [];
+
+		const lifecycleEvents: string[] = [];
+		const baseClient = {
+			url: new URL('https://example.com'),
+			getToken: vi.fn().mockResolvedValue('token'),
+			globals: {
+				URL,
+				WebSocket: MockWebSocket as any,
+				fetch: vi.fn() as any,
+				logger: {
+					log: vi.fn(),
+					info: vi.fn(),
+					warn: vi.fn(),
+					error: vi.fn(),
+				},
+			},
+			with<Extension extends object>(extension: (client: any) => Extension) {
+				return Object.assign(this, extension(this as any));
+			},
+		} as any;
+
+		const sdk = baseClient.with(
+			realtime({
+			authMode: 'handshake',
+			connect: false,
+			reconnect: false,
+			}),
+		);
+
+		sdk.onWebSocket('connected', () => lifecycleEvents.push('connected'));
+		sdk.onWebSocket('authenticated', () => lifecycleEvents.push('authenticated'));
+		sdk.onWebSocket('ready', () => lifecycleEvents.push('ready'));
+
+		await sdk.connect();
+		sdk.disconnect();
+
+		expect(sdk.isReady()).toBe(false);
+
+		await sdk.connect();
+
+		expect(lifecycleEvents).toEqual(['connected', 'authenticated', 'ready', 'connected', 'authenticated', 'ready']);
+		expect(sdk.isReady()).toBe(true);
+	});
+});


### PR DESCRIPTION
## Scope
- Added realtime connection/authentication lifecycle tracking in the SDK
- Added `isAuthenticated()` and `isReady()` to the realtime client
- Emitted `connected`, `authenticated`, and `ready` events
- Added lifecycle coverage tests and a changeset

## Tested Scenarios
- connect -> authenticate -> ready
- disconnect -> reset -> reconnect
- Verified `sdk/tests/realtime.test.ts` passes

## Notes
- Existing `isConnected()` behavior remains available
