### PR TITLE
feat(sdk): add realtime lifecycle state

### DIFF
--- a/.changeset/bright-bugs-explain.md
+++ b/.changeset/bright-bugs-explain.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': minor
+---
+
+Added authenticated and ready lifecycle tracking to the realtime SDK.

--- a/contributors.yml
+++ b/contributors.yml
@@ -279,3 +279,4 @@
 - Prateet-Github
 - sourav-18
 - valerkahere
+- PuneetKumar1790

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -45,6 +45,9 @@ export function realtime(config: WebSocketConfig = {}) {
 	return <Schema>(client: DirectusClient<Schema>) => {
 		config = { ...defaultRealTimeConfig, ...config };
 		let uid = generateUid();
+		let connected = false;
+		let authenticated = false;
+		let readyEmitted = false;
 
 		let state: ConnectionState = {
 			code: 'closed',
@@ -143,6 +146,36 @@ export function realtime(config: WebSocketConfig = {}) {
 			error: new Set<WebSocketEventHandler>([]),
 			close: new Set<WebSocketEventHandler>([]),
 			message: new Set<WebSocketEventHandler>([]),
+			connected: new Set<WebSocketEventHandler>([]),
+			authenticated: new Set<WebSocketEventHandler>([]),
+			ready: new Set<WebSocketEventHandler>([]),
+		};
+
+		const emit = (event: WebSocketEvents, ws: WebSocketInterface, payload: Event | CloseEvent | any = new Event(event)) => {
+			eventHandlers[event].forEach((handler) => handler.call(ws, payload));
+		};
+
+		const resetLifecycleState = () => {
+			connected = false;
+			authenticated = false;
+			readyEmitted = false;
+		};
+
+		const markConnected = (ws: WebSocketInterface, payload?: Event) => {
+			connected = true;
+			emit('connected', ws, payload ?? new Event('connected'));
+		};
+
+		const markAuthenticated = (ws: WebSocketInterface, payload?: Event) => {
+			if (authenticated === false) {
+				authenticated = true;
+				emit('authenticated', ws, payload ?? new Event('authenticated'));
+			}
+
+			if (connected && authenticated && readyEmitted === false) {
+				readyEmitted = true;
+				emit('ready', ws, payload ?? new Event('ready'));
+			}
 		};
 
 		function isAuthError(message: Record<string, any> | MessageEvent<string>): message is WebSocketAuthError {
@@ -206,7 +239,22 @@ export function realtime(config: WebSocketConfig = {}) {
 
 				if (!message) continue;
 
+					if (
+						'type' in message &&
+						'status' in message &&
+						message['type'] === 'auth' &&
+						message['status'] === 'ok' &&
+						state.firstMessage === false
+					) {
+						markAuthenticated(state.connection);
+					}
+
 				if (isAuthError(message)) {
+						if (message.error.code === 'TOKEN_EXPIRED') {
+							authenticated = false;
+							readyEmitted = false;
+						}
+
 					await handleAuthError(message, currentClient);
 					state.firstMessage = false;
 					continue;
@@ -240,7 +288,13 @@ export function realtime(config: WebSocketConfig = {}) {
 					}
 				}
 
-				return state.code === 'open';
+				return connected;
+			},
+			isAuthenticated() {
+				return authenticated;
+			},
+			isReady() {
+				return connected && authenticated;
 			},
 			async connect() {
 				wasManuallyDisconnected = false;
@@ -295,6 +349,7 @@ export function realtime(config: WebSocketConfig = {}) {
 					debug('info', `Connection open.`);
 
 					state = { code: 'open', connection: ws, firstMessage: true };
+					markConnected(ws);
 					reconnectState.attempts = 0;
 					reconnectState.active = false;
 					clearTimeout(connectTimeout);
@@ -324,7 +379,18 @@ export function realtime(config: WebSocketConfig = {}) {
 							return reject('Authentication failed while opening websocket connection');
 						} else {
 							debug('info', 'Authentication successful!');
+							authenticated = true;
+							readyEmitted = false;
+							state.firstMessage = false;
+							emit('authenticated', ws, new Event('authenticated'));
+							emit('ready', ws, new Event('ready'));
+							readyEmitted = true;
 						}
+					} else if (config.authMode === 'strict' && hasAuth(self)) {
+						authenticated = true;
+						emit('authenticated', ws, new Event('authenticated'));
+						emit('ready', ws, new Event('ready'));
+						readyEmitted = true;
 					}
 
 					eventHandlers['open'].forEach((handler) => handler.call(ws, evt));
@@ -343,6 +409,7 @@ export function realtime(config: WebSocketConfig = {}) {
 
 				ws.addEventListener('close', (evt: CloseEvent) => {
 					debug('info', `Connection closed.`);
+					resetLifecycleState();
 					eventHandlers['close'].forEach((handler) => handler.call(ws, evt));
 					uid = generateUid();
 					state = { code: 'closed' };
@@ -354,6 +421,7 @@ export function realtime(config: WebSocketConfig = {}) {
 			},
 			disconnect() {
 				wasManuallyDisconnected = true;
+				resetLifecycleState();
 
 				if (state.code === 'open') {
 					state.connection.close();

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -151,7 +151,11 @@ export function realtime(config: WebSocketConfig = {}) {
 			ready: new Set<WebSocketEventHandler>([]),
 		};
 
-		const emit = (event: WebSocketEvents, ws: WebSocketInterface, payload: Event | CloseEvent | any = new Event(event)) => {
+		const emit = (
+			event: WebSocketEvents,
+			ws: WebSocketInterface,
+			payload: Event | CloseEvent | any = new Event(event),
+		) => {
 			eventHandlers[event].forEach((handler) => handler.call(ws, payload));
 		};
 
@@ -239,21 +243,21 @@ export function realtime(config: WebSocketConfig = {}) {
 
 				if (!message) continue;
 
-					if (
-						'type' in message &&
-						'status' in message &&
-						message['type'] === 'auth' &&
-						message['status'] === 'ok' &&
-						state.firstMessage === false
-					) {
-						markAuthenticated(state.connection);
-					}
+				if (
+					'type' in message &&
+					'status' in message &&
+					message['type'] === 'auth' &&
+					message['status'] === 'ok' &&
+					state.firstMessage === false
+				) {
+					markAuthenticated(state.connection);
+				}
 
 				if (isAuthError(message)) {
-						if (message.error.code === 'TOKEN_EXPIRED') {
-							authenticated = false;
-							readyEmitted = false;
-						}
+					if (message.error.code === 'TOKEN_EXPIRED') {
+						authenticated = false;
+						readyEmitted = false;
+					}
 
 					await handleAuthError(message, currentClient);
 					state.firstMessage = false;

--- a/sdk/src/realtime/types.ts
+++ b/sdk/src/realtime/types.ts
@@ -27,12 +27,14 @@ export interface SubscribeOptions<Schema, Collection extends keyof Schema> {
 	uid?: string;
 }
 
-export type WebSocketEvents = 'open' | 'close' | 'error' | 'message';
+export type WebSocketEvents = 'open' | 'close' | 'error' | 'message' | 'connected' | 'authenticated' | 'ready';
 export type RemoveEventHandler = () => void;
 export type WebSocketEventHandler = (this: WebSocketInterface, ev: Event | CloseEvent | any) => any;
 
 export interface WebSocketClient<Schema> {
 	isConnected(): Promise<boolean>;
+	isAuthenticated(): boolean;
+	isReady(): boolean;
 	connect(): Promise<WebSocketInterface>;
 	disconnect(): void;
 	onWebSocket(event: 'open', callback: (this: WebSocketInterface, ev: Event) => any): RemoveEventHandler;

--- a/sdk/tests/realtime.test.ts
+++ b/sdk/tests/realtime.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest';
+import { realtime } from '../src/realtime/index.js';
+
+class MockWebSocket {
+	static instances: MockWebSocket[] = [];
+
+	readonly url: string;
+	readonly sent: string[] = [];
+	readyState = 0;
+	private closed = false;
+	private listeners = new Map<string, Set<(this: MockWebSocket, ev: any) => any>>();
+
+	constructor(url: string) {
+		this.url = url;
+		MockWebSocket.instances.push(this);
+
+		queueMicrotask(() => {
+			this.readyState = 1;
+			this.dispatch('open', new Event('open'));
+		});
+	}
+
+	addEventListener(type: string, listener: (this: MockWebSocket, ev: any) => any) {
+		if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+		this.listeners.get(type)?.add(listener);
+	}
+
+	removeEventListener(type: string, listener: (this: MockWebSocket, ev: any) => any) {
+		this.listeners.get(type)?.delete(listener);
+	}
+
+	send(data: string) {
+		this.sent.push(data);
+
+		try {
+			const parsed = JSON.parse(data);
+
+			if (parsed?.type === 'auth') {
+				queueMicrotask(() => {
+					this.dispatch('message', { data: JSON.stringify({ type: 'auth', status: 'ok' }) });
+				});
+			}
+		} catch {
+			/* ignore */
+		}
+	}
+
+	close() {
+		if (this.closed) return;
+
+		this.closed = true;
+		this.readyState = 3;
+		this.dispatch('close', new Event('close'));
+	}
+
+	private dispatch(type: string, ev: any) {
+		for (const listener of this.listeners.get(type) ?? []) {
+			listener.call(this, ev);
+		}
+	}
+}
+
+describe('realtime lifecycle', () => {
+	it('tracks connected, authenticated, and ready state', async () => {
+		MockWebSocket.instances = [];
+
+		const lifecycleEvents: string[] = [];
+		const baseClient = {
+			url: new URL('https://example.com'),
+			getToken: vi.fn().mockResolvedValue('token'),
+			globals: {
+				URL,
+				WebSocket: MockWebSocket as any,
+				fetch: vi.fn() as any,
+				logger: {
+					log: vi.fn(),
+					info: vi.fn(),
+					warn: vi.fn(),
+					error: vi.fn(),
+				},
+			},
+			with<Extension extends object>(extension: (client: any) => Extension) {
+				return Object.assign(this, extension(this as any));
+			},
+		} as any;
+
+		const sdk = baseClient.with(
+			realtime({
+			authMode: 'handshake',
+			connect: false,
+			reconnect: false,
+			}),
+		);
+
+		sdk.onWebSocket('connected', () => lifecycleEvents.push('connected'));
+		sdk.onWebSocket('authenticated', () => lifecycleEvents.push('authenticated'));
+		sdk.onWebSocket('ready', () => lifecycleEvents.push('ready'));
+
+		await sdk.connect();
+
+		expect(await sdk.isConnected()).toBe(true);
+		expect(sdk.isAuthenticated()).toBe(true);
+		expect(sdk.isReady()).toBe(true);
+		expect(lifecycleEvents).toEqual(['connected', 'authenticated', 'ready']);
+
+		sdk.disconnect();
+		expect(await sdk.isConnected()).toBe(false);
+		expect(sdk.isAuthenticated()).toBe(false);
+		expect(sdk.isReady()).toBe(false);
+	});
+
+	it('re-emits the lifecycle after reconnect', async () => {
+		MockWebSocket.instances = [];
+
+		const lifecycleEvents: string[] = [];
+		const baseClient = {
+			url: new URL('https://example.com'),
+			getToken: vi.fn().mockResolvedValue('token'),
+			globals: {
+				URL,
+				WebSocket: MockWebSocket as any,
+				fetch: vi.fn() as any,
+				logger: {
+					log: vi.fn(),
+					info: vi.fn(),
+					warn: vi.fn(),
+					error: vi.fn(),
+				},
+			},
+			with<Extension extends object>(extension: (client: any) => Extension) {
+				return Object.assign(this, extension(this as any));
+			},
+		} as any;
+
+		const sdk = baseClient.with(
+			realtime({
+			authMode: 'handshake',
+			connect: false,
+			reconnect: false,
+			}),
+		);
+
+		sdk.onWebSocket('connected', () => lifecycleEvents.push('connected'));
+		sdk.onWebSocket('authenticated', () => lifecycleEvents.push('authenticated'));
+		sdk.onWebSocket('ready', () => lifecycleEvents.push('ready'));
+
+		await sdk.connect();
+		sdk.disconnect();
+
+		expect(sdk.isReady()).toBe(false);
+
+		await sdk.connect();
+
+		expect(lifecycleEvents).toEqual(['connected', 'authenticated', 'ready', 'connected', 'authenticated', 'ready']);
+		expect(sdk.isReady()).toBe(true);
+	});
+});

--- a/sdk/tests/realtime.test.ts
+++ b/sdk/tests/realtime.test.ts
@@ -3,6 +3,8 @@ import { realtime } from '../src/realtime/index.js';
 
 class MockWebSocket {
 	static instances: MockWebSocket[] = [];
+	static authResponse: Record<string, any> | undefined = { type: 'auth', status: 'ok' };
+	static autoOpen = true;
 
 	readonly url: string;
 	readonly sent: string[] = [];
@@ -14,10 +16,9 @@ class MockWebSocket {
 		this.url = url;
 		MockWebSocket.instances.push(this);
 
-		queueMicrotask(() => {
-			this.readyState = 1;
-			this.dispatch('open', new Event('open'));
-		});
+		if (MockWebSocket.autoOpen) {
+			queueMicrotask(() => this.open());
+		}
 	}
 
 	addEventListener(type: string, listener: (this: MockWebSocket, ev: any) => any) {
@@ -35,9 +36,9 @@ class MockWebSocket {
 		try {
 			const parsed = JSON.parse(data);
 
-			if (parsed?.type === 'auth') {
+			if (parsed?.type === 'auth' && MockWebSocket.authResponse) {
 				queueMicrotask(() => {
-					this.dispatch('message', { data: JSON.stringify({ type: 'auth', status: 'ok' }) });
+					this.dispatch('message', { data: JSON.stringify(MockWebSocket.authResponse) });
 				});
 			}
 		} catch {
@@ -53,7 +54,20 @@ class MockWebSocket {
 		this.dispatch('close', new Event('close'));
 	}
 
-	private dispatch(type: string, ev: any) {
+	open() {
+		this.readyState = 1;
+		this.dispatch('open', new Event('open'));
+	}
+
+	message(message: Record<string, any> | string) {
+		this.dispatch('message', { data: typeof message === 'string' ? message : JSON.stringify(message) });
+	}
+
+	error() {
+		this.dispatch('error', new Event('error'));
+	}
+
+	dispatch(type: string, ev: any) {
 		for (const listener of this.listeners.get(type) ?? []) {
 			listener.call(this, ev);
 		}
@@ -61,10 +75,10 @@ class MockWebSocket {
 }
 
 describe('realtime lifecycle', () => {
-	it('tracks connected, authenticated, and ready state', async () => {
+	const createClient = (config = {}, overrides = {}) => {
 		MockWebSocket.instances = [];
-
-		const lifecycleEvents: string[] = [];
+		MockWebSocket.authResponse = { type: 'auth', status: 'ok' };
+		MockWebSocket.autoOpen = true;
 
 		const baseClient = {
 			url: new URL('https://example.com'),
@@ -83,15 +97,22 @@ describe('realtime lifecycle', () => {
 			with<Extension extends object>(extension: (client: any) => Extension) {
 				return Object.assign(this, extension(this as any));
 			},
+			...overrides,
 		} as any;
 
-		const sdk = baseClient.with(
+		return baseClient.with(
 			realtime({
 				authMode: 'handshake',
 				connect: false,
 				reconnect: false,
+				...config,
 			}),
 		);
+	};
+
+	it('tracks connected, authenticated, and ready state', async () => {
+		const lifecycleEvents: string[] = [];
+		const sdk = createClient();
 
 		sdk.onWebSocket('connected', () => lifecycleEvents.push('connected'));
 		sdk.onWebSocket('authenticated', () => lifecycleEvents.push('authenticated'));
@@ -111,36 +132,8 @@ describe('realtime lifecycle', () => {
 	});
 
 	it('re-emits the lifecycle after reconnect', async () => {
-		MockWebSocket.instances = [];
-
 		const lifecycleEvents: string[] = [];
-
-		const baseClient = {
-			url: new URL('https://example.com'),
-			getToken: vi.fn().mockResolvedValue('token'),
-			globals: {
-				URL,
-				WebSocket: MockWebSocket as any,
-				fetch: vi.fn() as any,
-				logger: {
-					log: vi.fn(),
-					info: vi.fn(),
-					warn: vi.fn(),
-					error: vi.fn(),
-				},
-			},
-			with<Extension extends object>(extension: (client: any) => Extension) {
-				return Object.assign(this, extension(this as any));
-			},
-		} as any;
-
-		const sdk = baseClient.with(
-			realtime({
-				authMode: 'handshake',
-				connect: false,
-				reconnect: false,
-			}),
-		);
+		const sdk = createClient();
 
 		sdk.onWebSocket('connected', () => lifecycleEvents.push('connected'));
 		sdk.onWebSocket('authenticated', () => lifecycleEvents.push('authenticated'));
@@ -155,5 +148,112 @@ describe('realtime lifecycle', () => {
 
 		expect(lifecycleEvents).toEqual(['connected', 'authenticated', 'ready', 'connected', 'authenticated', 'ready']);
 		expect(sdk.isReady()).toBe(true);
+	});
+
+	it('marks public connections ready after receiving an auth confirmation', async () => {
+		const lifecycleEvents: string[] = [];
+		const sdk = createClient({ authMode: 'public' });
+
+		sdk.onWebSocket('authenticated', () => lifecycleEvents.push('authenticated'));
+		sdk.onWebSocket('ready', () => lifecycleEvents.push('ready'));
+
+		await sdk.connect();
+
+		expect(sdk.isAuthenticated()).toBe(false);
+		expect(sdk.isReady()).toBe(false);
+
+		MockWebSocket.instances[0]!.message({ type: 'ping' });
+		await vi.waitFor(() => expect(MockWebSocket.instances[0]!.sent).toContain(JSON.stringify({ type: 'pong' })));
+		MockWebSocket.instances[0]!.message({ type: 'auth', status: 'ok' });
+		await vi.waitFor(() => expect(sdk.isReady()).toBe(true));
+
+		MockWebSocket.instances[0]!.message({ type: 'auth', status: 'ok' });
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(lifecycleEvents).toEqual(['authenticated', 'ready']);
+	});
+
+	it('resets readiness and re-authenticates after token expiration', async () => {
+		const sdk = createClient({ authMode: 'public' });
+
+		await sdk.connect();
+		MockWebSocket.instances[0]!.message({ type: 'ping' });
+		await vi.waitFor(() => expect(MockWebSocket.instances[0]!.sent).toContain(JSON.stringify({ type: 'pong' })));
+		MockWebSocket.instances[0]!.message({ type: 'auth', status: 'ok' });
+		await vi.waitFor(() => expect(sdk.isReady()).toBe(true));
+
+		MockWebSocket.instances[0]!.message({
+			type: 'auth',
+			status: 'error',
+			error: {
+				code: 'TOKEN_EXPIRED',
+				message: 'Token expired',
+			},
+		});
+
+		await vi.waitFor(() =>
+			expect(MockWebSocket.instances[0]!.sent).toContain(JSON.stringify({ access_token: 'token', type: 'auth' })),
+		);
+
+		MockWebSocket.instances[0]!.message({ type: 'auth', status: 'ok' });
+		await vi.waitFor(() => expect(sdk.isReady()).toBe(true));
+	});
+
+	it('emits authenticated and ready immediately for strict auth clients', async () => {
+		const lifecycleEvents: string[] = [];
+		const sdk = createClient({ authMode: 'strict' });
+
+		sdk.onWebSocket('authenticated', () => lifecycleEvents.push('authenticated'));
+		sdk.onWebSocket('ready', () => lifecycleEvents.push('ready'));
+
+		await sdk.connect();
+
+		expect(MockWebSocket.instances[0]!.url).toBe('wss://example.com/websocket?access_token=token');
+		expect(sdk.isAuthenticated()).toBe(true);
+		expect(sdk.isReady()).toBe(true);
+		expect(lifecycleEvents).toEqual(['authenticated', 'ready']);
+	});
+
+	it('waits for an in-flight connection when checking connected state', async () => {
+		const sdk = createClient();
+		MockWebSocket.autoOpen = false;
+
+		const connectPromise = sdk.connect();
+		const connectedPromise = sdk.isConnected();
+
+		await vi.waitFor(() => expect(MockWebSocket.instances[0]).toBeDefined());
+		MockWebSocket.instances[0]!.open();
+
+		await connectPromise;
+		await expect(connectedPromise).resolves.toBe(true);
+	});
+
+	it('rejects when handshake authentication cannot confirm', async () => {
+		const sdk = createClient();
+
+		MockWebSocket.authResponse = {
+			type: 'auth',
+			status: 'error',
+			error: {
+				code: 'AUTH_FAILED',
+				message: 'Auth failed',
+			},
+		};
+
+		await expect(sdk.connect()).rejects.toBe('Authentication failed while opening websocket connection');
+	});
+
+	it('rejects and resets connected state when a connection errors before opening', async () => {
+		const sdk = createClient();
+		MockWebSocket.autoOpen = false;
+
+		const connectPromise = sdk.connect();
+		await vi.waitFor(() => expect(MockWebSocket.instances[0]).toBeDefined());
+		MockWebSocket.instances[0]!.error();
+
+		await expect(connectPromise).rejects.toBeInstanceOf(Event);
+		await expect(sdk.isConnected()).resolves.toBe(false);
+		expect(sdk.isAuthenticated()).toBe(false);
+		expect(sdk.isReady()).toBe(false);
 	});
 });

--- a/sdk/tests/realtime.test.ts
+++ b/sdk/tests/realtime.test.ts
@@ -65,6 +65,7 @@ describe('realtime lifecycle', () => {
 		MockWebSocket.instances = [];
 
 		const lifecycleEvents: string[] = [];
+
 		const baseClient = {
 			url: new URL('https://example.com'),
 			getToken: vi.fn().mockResolvedValue('token'),
@@ -86,9 +87,9 @@ describe('realtime lifecycle', () => {
 
 		const sdk = baseClient.with(
 			realtime({
-			authMode: 'handshake',
-			connect: false,
-			reconnect: false,
+				authMode: 'handshake',
+				connect: false,
+				reconnect: false,
 			}),
 		);
 
@@ -113,6 +114,7 @@ describe('realtime lifecycle', () => {
 		MockWebSocket.instances = [];
 
 		const lifecycleEvents: string[] = [];
+
 		const baseClient = {
 			url: new URL('https://example.com'),
 			getToken: vi.fn().mockResolvedValue('token'),
@@ -134,9 +136,9 @@ describe('realtime lifecycle', () => {
 
 		const sdk = baseClient.with(
 			realtime({
-			authMode: 'handshake',
-			connect: false,
-			reconnect: false,
+				authMode: 'handshake',
+				connect: false,
+				reconnect: false,
 			}),
 		);
 


### PR DESCRIPTION
## Scope
- Added realtime connection/authentication lifecycle tracking in the SDK
- Added `isAuthenticated()` and `isReady()` to the realtime client
- Emitted `connected`, `authenticated`, and `ready` events
- Added lifecycle coverage tests and a changeset

## Tested Scenarios
- connect -> authenticate -> ready
- disconnect -> reset -> reconnect
- Verified `sdk/tests/realtime.test.ts` passes

## Notes
- Existing `isConnected()` behavior remains available

--
Fixes: https://github.com/directus/directus/pull/26555
