### PR TITLE
Ignore required for presentation fields in app layer validateItem

### DIFF
--- a/.changeset/some-ways-laugh.md
+++ b/.changeset/some-ways-laugh.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+ignore required for presentation fields

--- a/.changeset/some-ways-laugh.md
+++ b/.changeset/some-ways-laugh.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-ignore required for presentation fields
+Fixed presentation fields marked as required incorrectly blocking item save

--- a/app/src/utils/validate-item.test.ts
+++ b/app/src/utils/validate-item.test.ts
@@ -54,6 +54,28 @@ const fields: DeepPartial<Field>[] = [
 		},
 		schema: null,
 	},
+	{
+		field: 'divider_line',
+		collection: 'articles',
+		type: 'alias',
+		name: 'Divider',
+		meta: {
+			required: true,
+			special: ['alias', 'no-data'],
+		},
+		schema: null,
+	},
+	{
+		field: 'group_tabs',
+		collection: 'articles',
+		type: 'alias',
+		name: 'Tab Group',
+		meta: {
+			required: false,
+			special: ['alias', 'no-data', 'group'],
+		},
+		schema: null,
+	},
 ];
 
 beforeEach(() => {
@@ -125,5 +147,30 @@ test('Custom validation with $NOW dynamic variable does not throw', () => {
 
 	const result = validateItem({ publish_date: futureDate }, fieldsWithValidation as Field[], true, true);
 
+	expect(result.length).toEqual(0);
+});
+
+test('Presentation fields ignore required', () => {
+	let result = validateItem(
+		{
+			id: 1,
+			name: 'test',
+			email: 'test@test.com',
+		},
+		fields as Field[],
+		true,
+	);
+	expect(result.length).toEqual(1);
+
+	result = validateItem(
+		{
+			id: 1,
+			name: 'test',
+			email: 'test@test.com',
+			role: [1],
+		},
+		fields as Field[],
+		true,
+	);
 	expect(result.length).toEqual(0);
 });

--- a/app/src/utils/validate-item.test.ts
+++ b/app/src/utils/validate-item.test.ts
@@ -160,6 +160,7 @@ test('Presentation fields ignore required', () => {
 		fields as Field[],
 		true,
 	);
+
 	expect(result.length).toEqual(1);
 
 	result = validateItem(
@@ -172,5 +173,6 @@ test('Presentation fields ignore required', () => {
 		fields as Field[],
 		true,
 	);
+
 	expect(result.length).toEqual(0);
 });

--- a/app/src/utils/validate-item.ts
+++ b/app/src/utils/validate-item.ts
@@ -28,7 +28,9 @@ export function validateItem(
 		return conditionedField;
 	});
 
-	const requiredFields = fieldsWithConditions.filter((field) => field.meta?.required === true);
+	const requiredFields = fieldsWithConditions.filter(
+		(field) => field.meta?.required === true && !field.meta?.special?.includes('no-data'),
+	);
 
 	requiredFields.forEach((field) => {
 		applyRulesForRequiredFields(field.field, field, isNew);

--- a/contributors.yml
+++ b/contributors.yml
@@ -273,3 +273,4 @@
 - yogeshwaran-c
 - sanskar-soni-9
 - kropsi
+- sourav-18


### PR DESCRIPTION
## Problem

Presentation fields (divider, notice, button, etc.) store no data but currently allow `required: true` in settings. This causes validation errors when creating/updating items because the system expects a value for a field that doesn't exist in the database.

## Solution

Skip required validation for presentation/no‑data fields inside `validateItem` (app layer). If a field has `special` flags like `no-data` or is an alias field without a column, it is excluded from required validation.

## Why app layer instead of backend?

- Backend fix would need to override `required` value when fetching fields (force false for presentation types). This creates a mismatch between what the user sees in field settings (`required: true`) and what the app uses (`required: false`), leading to confusion.
- App‑layer fix keeps the field settings intact but simply does not enforce required validation on the frontend. The user can still set `required: true` in the UI, but it won't block saving.

fix #26961 