### PR TITLE
fix(app): make item link clickable on readonly relational fields

### DIFF
--- a/.changeset/sunny-foxes-jump.md
+++ b/.changeset/sunny-foxes-jump.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed "Navigate to Item" link being non-clickable on readonly relational fields (M2O, O2M, M2M)

--- a/app/src/interfaces/list-m2m/list-m2m.test.ts
+++ b/app/src/interfaces/list-m2m/list-m2m.test.ts
@@ -227,13 +227,13 @@ describe('list-m2m', () => {
 				expect(wrapper.find('.item-actions .item-link').exists()).toBe(true);
 			});
 
-			it('should render non-clickable icon when disabled is true and nonEditable is false', () => {
+			it('should render clickable navigate link when disabled is true and nonEditable is false', () => {
 				const wrapper = mount(ListM2M, {
 					props: { ...listProps, enableLink: true, nonEditable: false, disabled: true },
 					global: globalWithRouterLink,
 				});
 
-				expect(wrapper.find('.item-actions .item-link').exists()).toBe(false);
+				expect(wrapper.find('.item-actions .item-link').exists()).toBe(true);
 			});
 		});
 
@@ -292,13 +292,13 @@ describe('list-m2m', () => {
 				expect(wrapper.find('.item-actions .item-link').exists()).toBe(true);
 			});
 
-			it('should render non-clickable icon when disabled is true and nonEditable is false', () => {
+			it('should render clickable navigate link when disabled is true and nonEditable is false', () => {
 				const wrapper = mount(ListM2M, {
 					props: { ...listProps, layout: LAYOUTS.TABLE, enableLink: true, nonEditable: false, disabled: true },
 					global: tableGlobalWithRouterLink,
 				});
 
-				expect(wrapper.find('.item-actions .item-link').exists()).toBe(false);
+				expect(wrapper.find('.item-actions .item-link').exists()).toBe(true);
 			});
 		});
 

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -578,7 +578,7 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 				<template v-if="!nonEditable || enableLink" #item-append="{ item }">
 					<div class="item-actions">
 						<RouterLink v-if="enableLink" v-slot="{ href, navigate }" :to="getLinkForItem(item)!" custom>
-							<VIcon v-if="(disabled && !nonEditable) || item.$type === 'created'" name="launch" />
+							<VIcon v-if="item.$type === 'created'" name="launch" />
 
 							<a
 								v-else
@@ -657,7 +657,7 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 
 							<div v-if="!nonEditable || enableLink" class="item-actions" @click.stop>
 								<RouterLink v-if="enableLink" v-slot="{ href, navigate }" :to="getLinkForItem(element)!" custom>
-									<VIcon v-if="(disabled && !nonEditable) || element.$type === 'created'" name="launch" />
+									<VIcon v-if="element.$type === 'created'" name="launch" />
 
 									<a
 										v-else

--- a/app/src/interfaces/list-o2m/list-o2m.test.ts
+++ b/app/src/interfaces/list-o2m/list-o2m.test.ts
@@ -214,13 +214,13 @@ describe('list-o2m', () => {
 				expect(wrapper.find('.item-actions .item-link').exists()).toBe(true);
 			});
 
-			it('should render non-clickable icon when disabled is true and nonEditable is false', () => {
+			it('should render clickable navigate link when disabled is true and nonEditable is false', () => {
 				const wrapper = mount(ListO2M, {
 					props: { ...listProps, enableLink: true, nonEditable: false, disabled: true },
 					global: globalWithRouterLink,
 				});
 
-				expect(wrapper.find('.item-actions .item-link').exists()).toBe(false);
+				expect(wrapper.find('.item-actions .item-link').exists()).toBe(true);
 			});
 		});
 
@@ -279,13 +279,13 @@ describe('list-o2m', () => {
 				expect(wrapper.find('.item-actions .item-link').exists()).toBe(true);
 			});
 
-			it('should render non-clickable icon when disabled is true and nonEditable is false', () => {
+			it('should render clickable navigate link when disabled is true and nonEditable is false', () => {
 				const wrapper = mount(ListO2M, {
 					props: { ...listProps, layout: LAYOUTS.TABLE, enableLink: true, nonEditable: false, disabled: true },
 					global: tableGlobalWithRouterLink,
 				});
 
-				expect(wrapper.find('.item-actions .item-link').exists()).toBe(false);
+				expect(wrapper.find('.item-actions .item-link').exists()).toBe(true);
 			});
 		});
 

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -541,7 +541,7 @@ const menuActive = computed(() => Boolean(currentlyEditing.value) || selectModal
 				<template v-if="!nonEditable || enableLink" #item-append="{ item }">
 					<div class="item-actions">
 						<RouterLink v-if="enableLink" v-slot="{ href, navigate }" :to="getLinkForItem(item)!" custom>
-							<VIcon v-if="(disabled && !nonEditable) || item.$type === 'created'" name="launch" />
+							<VIcon v-if="item.$type === 'created'" name="launch" />
 
 							<a
 								v-else
@@ -620,7 +620,7 @@ const menuActive = computed(() => Boolean(currentlyEditing.value) || selectModal
 
 							<div v-if="!nonEditable || enableLink" class="item-actions" @click.stop>
 								<RouterLink v-if="enableLink" v-slot="{ href, navigate }" :to="getLinkForItem(element)!" custom>
-									<VIcon v-if="(disabled && !nonEditable) || element.$type === 'created'" name="launch" />
+									<VIcon v-if="element.$type === 'created'" name="launch" />
 
 									<a
 										v-else

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.test.ts
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.test.ts
@@ -200,7 +200,7 @@ describe('Interface', () => {
 		expect(wrapper.find('.item-actions .item-link').exists()).toBe(true);
 	});
 
-	it('should render non-clickable icon when disabled is true and nonEditable is false', () => {
+	it('should render clickable navigate link when disabled is true and nonEditable is false', () => {
 		const wrapper = mount(SelectDropdownM2O, {
 			props: {
 				value: '1',
@@ -213,7 +213,7 @@ describe('Interface', () => {
 			global: globalWithRouterLink,
 		});
 
-		expect(wrapper.find('.item-actions .item-link').exists()).toBe(false);
+		expect(wrapper.find('.item-actions .item-link').exists()).toBe(true);
 	});
 
 	describe('on click', () => {

--- a/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
+++ b/app/src/interfaces/select-dropdown-m2o/select-dropdown-m2o.vue
@@ -216,16 +216,7 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 			<div v-if="!nonEditable || (enableLink && displayItem)" class="item-actions" @click.stop>
 				<template v-if="displayItem">
 					<RouterLink v-if="enableLink" v-slot="{ href, navigate }" :to="getLinkForItem()" custom>
-						<VIcon v-if="disabled && !nonEditable" name="launch" />
-
-						<a
-							v-else
-							v-tooltip="$t('navigate_to_item')"
-							:href="href"
-							class="item-link"
-							@click.stop="navigate"
-							@keydown.stop
-						>
+						<a v-tooltip="$t('navigate_to_item')" :href="href" class="item-link" @click.stop="navigate" @keydown.stop>
 							<VIcon name="launch" />
 						</a>
 					</RouterLink>


### PR DESCRIPTION
## Scope

What's changed:

- Drop the `disabled && !nonEditable` guard on the launch / "Navigate to Item" icon in the M2O, O2M, and M2M interfaces, so the link stays clickable when the field is set to Readonly.
- Keep the `$type === 'created'` guard for unsaved rows in O2M / M2M list layouts (those genuinely can't be navigated to yet).
- Update the corresponding unit tests to assert the link is rendered (was asserting the buggy non-clickable variant).
- Adds a changeset.

## Potential Risks / Drawbacks

- Behavior change is intentional: a readonly relational field now exposes the navigate link if "Item link" is enabled. This was the pre-v11.15 behavior and what users expect — navigation is read-only.
- No change for users without edit permissions (`nonEditable`); that path was already fixed in #26711.

## Tested Scenarios

Manually reproduced and verified the fix on a local instance with two collections (`posts`, `comments`) and an M2O on `comments → posts`:

- M2O field, Item link enabled, Readonly = on → launch icon now navigates ✅
- O2M list, Item link enabled, Readonly = on → launch icon on each row navigates ✅
- M2M list, Item link enabled, Readonly = on → launch icon on each row navigates ✅
- Newly added (unsaved) row in O2M / M2M still shows a non-clickable icon (correct — no route to navigate to yet) ✅
- Editable (non-readonly) cases unaffected ✅

Unit tests updated and passing locally:
```
Test Files  3 passed (3)
     Tests  45 passed (45)
```
(`select-dropdown-m2o.test.ts`, `list-o2m.test.ts`, `list-m2m.test.ts`)

## Review Notes / Questions

- This is a follow-up to #26711, which fixed the same regression for the `nonEditable` (no edit permission) path but missed the plain `disabled` / Readonly path. See #27361 for the full repro.
- The previously-closed reports of this exact bug are #26689 (closed by #26711) and #26838 (closed as duplicate of #26689). This PR completes the fix.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #27361