### PR TITLE
Add STORAGE_<LOCATION>_HEALTHCHECK_WRITE_INTERVAL to throttle healthcheck writes

### DIFF
--- a/.changeset/throttle-healthcheck-writes.md
+++ b/.changeset/throttle-healthcheck-writes.md
@@ -1,0 +1,7 @@
+---
+'@directus/api': minor
+---
+
+Added optional `STORAGE_<LOCATION>_HEALTHCHECK_WRITE_INTERVAL` environment variable to throttle healthcheck writes (PUT)
+to object storage. When set, health checks only perform lightweight reads (GET) within the interval, dramatically
+reducing PUT operations and helping stay within free tier limits

--- a/api/src/services/server.ts
+++ b/api/src/services/server.ts
@@ -21,6 +21,8 @@ import { SettingsService } from './settings.js';
 const env = useEnv();
 const logger = useLogger();
 
+const lastDiskWriteTimestamps = new Map<string, number>();
+
 export class ServerService {
 	knex: Knex;
 	accountability: Accountability | null;
@@ -419,6 +421,7 @@ export class ServerService {
 			for (const location of toArray(env['STORAGE_LOCATIONS'] as string)) {
 				const disk = storage.location(location);
 				const envThresholdKey = `STORAGE_${location}_HEALTHCHECK_THRESHOLD`.toUpperCase();
+				const envWriteIntervalKey = `STORAGE_${location}_HEALTHCHECK_WRITE_INTERVAL`.toUpperCase();
 
 				checks[`storage:${location}:responseTime`] = [
 					{
@@ -430,23 +433,55 @@ export class ServerService {
 					},
 				];
 
-				const startTime = performance.now();
+				const writeInterval = env[envWriteIntervalKey] ? +(env[envWriteIntervalKey] as string) : 0;
+				const lastWrite = lastDiskWriteTimestamps.get(location) || 0;
+				let startTime = performance.now();
+				let shouldWrite = !writeInterval || startTime - lastWrite >= writeInterval;
 
-				try {
-					await disk.write('directus-health-file', Readable.from([checkID]));
-				} catch (err: any) {
-					checks[`storage:${location}:responseTime`]![0]!.status = 'error';
-					checks[`storage:${location}:responseTime`]![0]!.output = err;
-				} finally {
-					const endTime = performance.now();
-					checks[`storage:${location}:responseTime`]![0]!.observedValue = +(endTime - startTime).toFixed(3);
+				if (!shouldWrite) {
+					try {
+						const stream = await disk.read('directus-health-file');
 
-					if (
-						Number(checks[`storage:${location}:responseTime`]![0]!.observedValue!) >
-							checks[`storage:${location}:responseTime`]![0]!.threshold! &&
-						checks[`storage:${location}:responseTime`]![0]!.status !== 'error'
-					) {
-						checks[`storage:${location}:responseTime`]![0]!.status = 'warn';
+						// Поглощаем поток, чтобы убедиться в доступности объекта
+						await new Promise<void>((resolve, reject) => {
+							stream.resume();
+							stream.on('end', resolve);
+							stream.on('error', reject);
+						});
+
+						if (
+							+(performance.now() - startTime).toFixed(3) > checks[`storage:${location}:responseTime`]![0]!.threshold!
+						) {
+							shouldWrite = true;
+						}
+					} catch {
+						shouldWrite = true;
+					}
+				}
+
+				if (shouldWrite) {
+					startTime = performance.now();
+
+					try {
+						await disk.write('directus-health-file', Readable.from([checkID]));
+					} catch (err: any) {
+						checks[`storage:${location}:responseTime`]![0]!.status = 'error';
+						checks[`storage:${location}:responseTime`]![0]!.output = err;
+					} finally {
+						const endTime = performance.now();
+						checks[`storage:${location}:responseTime`]![0]!.observedValue = +(endTime - startTime).toFixed(3);
+
+						if (
+							Number(checks[`storage:${location}:responseTime`]![0]!.observedValue!) >
+								checks[`storage:${location}:responseTime`]![0]!.threshold! &&
+							checks[`storage:${location}:responseTime`]![0]!.status !== 'error'
+						) {
+							checks[`storage:${location}:responseTime`]![0]!.status = 'warn';
+						}
+
+						if (checks[`storage:${location}:responseTime`]![0]!.status === 'ok') {
+							lastDiskWriteTimestamps.set(location, endTime);
+						}
 					}
 				}
 			}

--- a/contributors.yml
+++ b/contributors.yml
@@ -273,3 +273,4 @@
 - yogeshwaran-c
 - sanskar-soni-9
 - kropsi
+- NickNovoselov


### PR DESCRIPTION
## Throttle healthcheck writes with `STORAGE_<LOCATION>_HEALTHCHECK_WRITE_INTERVAL`

### Scope

What's changed:

- Introduced an optional environment variable `STORAGE_<LOCATION>_HEALTHCHECK_WRITE_INTERVAL` (value in milliseconds) that controls how often a full write (`PUT`) is performed during storage health checks.
- When the interval is set and the time since the last write is less than the interval, the health check performs a lightweight read (`GET`) on the existing `directus-health-file`. If the read fails **or takes too long**, it automatically falls back to a full write (`PUT`) – no `warn` status is returned for slow reads.
- If the fallback write also fails, the check reports an error.
- Behaviour remains fully backward‑compatible – without the variable, health checks write on every invocation.

**Motivation:**  
S3 providers typically offer far lower free limits for `PUT` operations compared to `GET`. Even when storage is used almost exclusively for reads, the health check (which runs every few seconds via Docker’s `HEALTHCHECK`) can easily exhaust the monthly `PUT` quota. This change ensures that `PUT` calls are made only at a configurable interval, while the vast majority of checks become lightweight `GET` requests that stay within the free tier.

### Potential Risks / Drawbacks

- The last‑write timestamp is stored in memory (a `Map`). With multiple Directus instances, each instance tracks its own interval independently. Total `PUT` requests are still drastically reduced, but strict global periodicity is not guaranteed.
- The recovery write after a failed or slow read may cause a short spike in response time for that particular health check.
- The `stream.resume()` approach for consuming the read stream may behave differently across storage drivers. Testing with non‑S3 drivers (GCS, Azure, etc.) is advised.

### Tested Scenarios

- `STORAGE_S3_HEALTHCHECK_WRITE_INTERVAL=60000` (1 minute):  
  * First `/server/health` call performs a `PUT` and creates the file.  
  * Subsequent calls within 1 minute perform only `GET`.  
  * After the interval elapses another `PUT` is executed.
- Manual deletion of `directus-health-file` from the bucket:  
  * The next health check fails on `GET`, automatically triggers a `PUT` (recovery), and returns `ok`/`warn` based on the write response time.
- Variable not set: behaviour is identical to the current implementation (always `PUT`).
- S3 connection failure: both `GET` and fallback `PUT` fail, health check correctly returns `status: error`.

### Review Notes / Questions

- The current implementation uses `stream.resume()` to consume the read stream. This should be validated with storage drivers other than `@directus/storage-driver-s3`; a `stream.on('data', ...)` approach may be more universal.
- Should we consider a global default (e.g., `HEALTHCHECK_STORAGE_WRITE_INTERVAL`) to avoid configuring each location separately?
- No tests exist for `server.ts` and I do not plan to add them as part of this PR. Integration testing with real storage backends would be useful but is out of scope.

### Checklist

- [ ] Added or updated tests – **Not applicable (no existing test coverage for server.ts)**
- [x] Documentation PR created [here](https://github.com/directus/docs/pull/670)
- [ ] OpenAPI package PR not required

---

Fixes #<num>