### PR TITLE
xiiui → Prevent layout shift when navigating away from visual editor

### DIFF
--- a/app/src/views/private/components/live-preview.vue
+++ b/app/src/views/private/components/live-preview.vue
@@ -581,6 +581,7 @@ function useUrls() {
 	container-type: inline-size;
 	inline-size: 100%;
 	block-size: 100%;
+	overflow: hidden;
 
 	&.header-expanded {
 		--preview--header--height: var(--header-bar-height);


### PR DESCRIPTION
## Scope

What's changed:

- Add `overflow: hidden` to `.live-preview` in `live-preview.vue` to contain layout overflow caused by the split panel's resize handle

## Potential Risks / Drawbacks

- None identified — `VMenu` and other dropdowns in the live preview header teleport to `#menu-outlet` outside `.live-preview`, so they are not clipped

## Tested Scenarios

- Navigate from the visual editor (AI sidebar closed) to the content module and confirm the module bar no longer shifts ~1.5px
- Navigate from the visual editor (AI sidebar open) to the content module and confirm no regression

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes [CMS-2180](https://linear.app/directus/issue/CMS-2180/jumpy-behavior-when-switching-between-visual-editor-module-and-other)
