### PR TITLE
fix(app): support field-name translations on repeater sub-fields

### DIFF
--- a/.changeset/repeater-field-translations.md
+++ b/.changeset/repeater-field-translations.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed repeater interface ignoring per-field translations and `$t:` keys on sub-field labels, and added a "Field Name Translations" section to the sub-field configuration UI

--- a/app/src/interfaces/list/list.test.ts
+++ b/app/src/interfaces/list/list.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { resolveFieldName } from './resolve-field-name';
+import { i18n } from '@/lang';
+
+describe('resolveFieldName', () => {
+	beforeEach(() => {
+		i18n.global.locale.value = 'en-US';
+	});
+
+	it('formats the field key when no name or translations are provided', () => {
+		expect(resolveFieldName({ field: 'title' }, 'en-US')).toBe('Title');
+		expect(resolveFieldName({ field: 'created_at' }, 'en-US')).toBe('Created At');
+	});
+
+	it('uses the provided name when no translations are configured', () => {
+		expect(resolveFieldName({ field: 'title', name: 'Custom Label' }, 'en-US')).toBe('Custom Label');
+	});
+
+	it('returns the matching meta.translations entry for the active locale', () => {
+		const field = {
+			field: 'title',
+			name: 'Fallback',
+			meta: {
+				translations: [
+					{ language: 'en-US', translation: 'Title (EN)' },
+					{ language: 'de-DE', translation: 'Titel (DE)' },
+				],
+			},
+		};
+
+		expect(resolveFieldName(field, 'en-US')).toBe('Title (EN)');
+		expect(resolveFieldName(field, 'de-DE')).toBe('Titel (DE)');
+	});
+
+	it('falls back to the provided name when no translation matches the active locale', () => {
+		const field = {
+			field: 'title',
+			name: 'Fallback',
+			meta: {
+				translations: [{ language: 'en-US', translation: 'Title (EN)' }],
+			},
+		};
+
+		expect(resolveFieldName(field, 'fr-FR')).toBe('Fallback');
+	});
+
+	it('falls back when the matched translation is empty', () => {
+		const field = {
+			field: 'title',
+			name: 'Fallback',
+			meta: {
+				translations: [{ language: 'en-US', translation: '' }],
+			},
+		};
+
+		expect(resolveFieldName(field, 'en-US')).toBe('Fallback');
+	});
+
+	it('falls back to the formatted field key when name is missing entirely', () => {
+		const field = {
+			field: 'created_at',
+			meta: {
+				translations: [{ language: 'fr-FR', translation: 'Créé le' }],
+			},
+		};
+
+		expect(resolveFieldName(field, 'en-US')).toBe('Created At');
+		expect(resolveFieldName(field, 'fr-FR')).toBe('Créé le');
+	});
+
+	it('resolves a $t: prefixed name through vue-i18n', () => {
+		i18n.global.mergeLocaleMessage('en-US', { custom: { sub_label: 'Resolved Label' } });
+
+		expect(resolveFieldName({ field: 'title', name: '$t:custom.sub_label' }, 'en-US')).toBe('Resolved Label');
+	});
+
+	it('prefers meta.translations over a $t: prefixed name', () => {
+		const field = {
+			field: 'title',
+			name: '$t:custom.sub_label',
+			meta: {
+				translations: [{ language: 'en-US', translation: 'From translations' }],
+			},
+		};
+
+		i18n.global.mergeLocaleMessage('en-US', { custom: { sub_label: 'Resolved Label' } });
+
+		expect(resolveFieldName(field, 'en-US')).toBe('From translations');
+	});
+});

--- a/app/src/interfaces/list/list.vue
+++ b/app/src/interfaces/list/list.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import formatTitle from '@directus/format-title';
 import { DeepPartial, Field, FieldMeta } from '@directus/types';
 import { isEqual, sortBy } from 'lodash';
 import { computed, ref, toRefs } from 'vue';
+import { useI18n } from 'vue-i18n';
 import Draggable from 'vuedraggable';
+import { resolveFieldName } from './resolve-field-name';
 import VButton from '@/components/v-button.vue';
 import VCardActions from '@/components/v-card-actions.vue';
 import VCardText from '@/components/v-card-text.vue';
@@ -91,11 +92,13 @@ const defaults = computed(() => {
 	return values;
 });
 
+const { locale } = useI18n();
+
 const fieldsWithNames = computed(() =>
 	props.fields?.map((field) => {
 		return {
 			...field,
-			name: formatTitle(field.name ?? field.field!),
+			name: resolveFieldName(field, locale.value),
 		};
 	}),
 );

--- a/app/src/interfaces/list/options.vue
+++ b/app/src/interfaces/list/options.vue
@@ -7,6 +7,7 @@ import VInput from '@/components/v-input.vue';
 import VSelect from '@/components/v-select/v-select.vue';
 import { FIELD_TYPES_SELECT } from '@/constants';
 import InterfaceSystemInputTranslatedString from '@/interfaces/_system/system-input-translated-string/input-translated-string.vue';
+import { useUserStore } from '@/stores/user';
 import { translate } from '@/utils/translate-object-values';
 
 const props = defineProps<{
@@ -19,6 +20,7 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
+const userStore = useUserStore();
 
 const repeaterValue = computed({
 	get() {
@@ -118,6 +120,52 @@ const repeaterFields: DeepPartial<Field>[] = [
 		},
 	},
 	{
+		name: t('field_name_translations'),
+		field: 'translations',
+		type: 'json',
+		meta: {
+			interface: 'list',
+			width: 'full',
+			sort: 7,
+			options: {
+				template: '[{{ language }}] {{ translation }}',
+				fields: [
+					{
+						field: 'language',
+						type: 'string',
+						name: t('language'),
+						meta: {
+							interface: 'system-language',
+							width: 'full',
+							required: true,
+							display: 'formatted-value',
+							display_options: {
+								font: 'monospace',
+								color: 'var(--theme--foreground-subdued)',
+							},
+						},
+						schema: {
+							default_value: userStore.language,
+						},
+					},
+					{
+						field: 'translation',
+						type: 'string',
+						name: t('translation'),
+						meta: {
+							interface: 'input-multiline',
+							width: 'full',
+							required: true,
+							options: {
+								placeholder: t('translation_placeholder'),
+							},
+						},
+					},
+				],
+			},
+		},
+	},
+	{
 		name: t('interfaces.list.interface_group'),
 		field: 'group-interface',
 		type: 'alias',
@@ -125,7 +173,7 @@ const repeaterFields: DeepPartial<Field>[] = [
 			interface: 'group-detail',
 			field: 'group-interface',
 			width: 'full',
-			sort: 7,
+			sort: 8,
 			options: {
 				start: 'open',
 			},
@@ -140,7 +188,7 @@ const repeaterFields: DeepPartial<Field>[] = [
 		meta: {
 			interface: 'system-interface',
 			width: 'half',
-			sort: 8,
+			sort: 9,
 			group: 'group-interface',
 			options: {
 				typeField: 'type',
@@ -154,7 +202,7 @@ const repeaterFields: DeepPartial<Field>[] = [
 		meta: {
 			interface: 'system-interface-options',
 			width: 'full',
-			sort: 9,
+			sort: 10,
 			group: 'group-interface',
 			options: {
 				interfaceField: 'interface',
@@ -169,7 +217,7 @@ const repeaterFields: DeepPartial<Field>[] = [
 			interface: 'group-detail',
 			field: 'group-display',
 			width: 'full',
-			sort: 10,
+			sort: 11,
 			options: {
 				start: 'closed',
 			},
@@ -185,7 +233,7 @@ const repeaterFields: DeepPartial<Field>[] = [
 			interface: 'system-display',
 			width: 'half',
 			group: 'group-display',
-			sort: 11,
+			sort: 12,
 			options: {
 				typeField: 'type',
 			},
@@ -199,7 +247,7 @@ const repeaterFields: DeepPartial<Field>[] = [
 			interface: 'system-display-options',
 			width: 'full',
 			group: 'group-display',
-			sort: 12,
+			sort: 13,
 			options: {
 				displayField: 'display',
 			},

--- a/app/src/interfaces/list/resolve-field-name.ts
+++ b/app/src/interfaces/list/resolve-field-name.ts
@@ -1,0 +1,18 @@
+import formatTitle from '@directus/format-title';
+import { DeepPartial, Field } from '@directus/types';
+import { translate } from '@/utils/translate-literal';
+
+export function resolveFieldName(field: DeepPartial<Field>, locale: string): string {
+	const translations = field.meta?.translations;
+
+	if (Array.isArray(translations)) {
+		const match = translations.find((entry) => entry?.language === locale && entry.translation);
+		if (match?.translation) return match.translation;
+	}
+
+	if (typeof field.name === 'string' && field.name.startsWith('$t:')) {
+		return translate(field.name);
+	}
+
+	return formatTitle(field.name ?? field.field!);
+}


### PR DESCRIPTION
## Scope

What's changed:

- Add `resolve-field-name.ts` that resolves a sub-field's display label, in order: matching `meta.translations` entry → `$t:` prefix via vue-i18n → `formatTitle(name ?? field)` fallback.
- Wire the resolver into `list.vue` via a computed bound to `useI18n()`'s `locale` ref so labels react to language switches.
- Extend the repeater sub-field configuration UI (`options.vue`) with a "Field Name Translations" section, mirroring the top-level field-detail advanced screen — translations can now be entered through the UI instead of raw JSON edits.
- Add unit tests for the resolver.
- Add a changeset.

## Potential Risks / Drawbacks

- Behavior change is intentional: a sub-field with a populated `meta.translations` will now switch labels with the UI locale instead of always rendering `formatTitle(name ?? field)`. Existing repeaters that have no translations configured render identically.
- Sub-field configuration UI gains one extra section; cosmetic only.
- No changes to top-level field handling.

## Tested Scenarios

Manually verified on a local instance:

- Repeater sub-field with multiple `meta.translations` entries → label uses the entry matching the active locale, falls back to `name`/`formatTitle` when no entry matches ✅
- `"name": "$t:custom.key"` on a sub-field → resolves to translated string ✅
- Switching the UI language re-renders labels reactively ✅
- New "Field Name Translations" section appears between the Note and Interface group when editing a repeater sub-field, matches the field-detail advanced layout ✅
- No regression for repeaters without translations configured ✅

Unit tests (`app/src/interfaces/list/list.test.ts`) cover all branches of `resolveFieldName`:

```
Test Files  1 passed (1)
     Tests  8 passed (8)
```

## Review Notes / Questions

- The resolver is intentionally render-time and per-component, not a global vue-i18n registration like top-level fields. Repeater sub-fields are config (live inside the parent's `meta.options.fields[]`), not real schema fields, so synthesizing global i18n keys for them would risk collisions and add registration/unregistration churn on every schema edit. Keeping the resolution local is simpler and avoids touching `stores/fields.ts`.
- The same gap may exist for other interfaces that render sub-field labels from inline config (e.g. block-editor). That's out of scope here; can be addressed in a follow-up if reported.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #27373