### PR TITLE
dp ← add missing @vitest/coverage-v8 dep and prettier fixes

### DIFF
--- a/app/src/layouts/map/components/map.vue
+++ b/app/src/layouts/map/components/map.vue
@@ -193,9 +193,10 @@ function updateStyle(style: any) {
 
 function startWatchers() {
 	unwatchers.push(
-		watch(() => [props.source, props.featureId],
+		watch(
+			() => [props.source, props.featureId],
 			([newSource, _newFeatureId]) => updateSource(newSource as GeoJSONSource),
-			{ immediate: true }
+			{ immediate: true },
 		),
 		watch(() => props.selection, updateSelection, { immediate: true }),
 		watch(() => props.layers, updateLayers),

--- a/app/src/utils/get-route.test.ts
+++ b/app/src/utils/get-route.test.ts
@@ -105,44 +105,38 @@ describe('getItemRoute', async () => {
 		const versionId = 'abc-123';
 
 		expect(getItemRoute(collection, primaryKey, versionKey, versionId)).toBe(
-		  `${collectionRoute}/+?version=${versionKey}&versionId=${versionId}`,
+			`${collectionRoute}/+?version=${versionKey}&versionId=${versionId}`,
 		);
-	  });
+	});
 
-	  it('Returns route with only version when primaryKey is "+" and versionId is omitted', () => {
+	it('Returns route with only version when primaryKey is "+" and versionId is omitted', () => {
 		const primaryKey = '+';
 		const versionKey = 'draft';
 
-		expect(getItemRoute(collection, primaryKey, versionKey)).toBe(
-		  `${collectionRoute}/+?version=${versionKey}`,
-		);
-	  });
+		expect(getItemRoute(collection, primaryKey, versionKey)).toBe(`${collectionRoute}/+?version=${versionKey}`);
+	});
 
-	  it('Returns route with only version (no versionId) when primaryKey is not "+" even if versionId is provided', () => {
+	it('Returns route with only version (no versionId) when primaryKey is not "+" even if versionId is provided', () => {
 		const primaryKey = 123;
 		const versionKey = 'draft';
 		const versionId = 'abc-123';
 
 		expect(getItemRoute(collection, primaryKey, versionKey, versionId)).toBe(
-		  `${collectionRoute}/${primaryKey}?version=${versionKey}`,
+			`${collectionRoute}/${primaryKey}?version=${versionKey}`,
 		);
-	  });
+	});
 
-	  it('Returns base route when only versionId is provided without versionKey', () => {
+	it('Returns base route when only versionId is provided without versionKey', () => {
 		const primaryKey = 123;
 		const versionId = 'abc-123';
 
-		expect(getItemRoute(collection, primaryKey, undefined, versionId)).toBe(
-		  `${collectionRoute}/${primaryKey}`,
-		);
-	  });
+		expect(getItemRoute(collection, primaryKey, undefined, versionId)).toBe(`${collectionRoute}/${primaryKey}`);
+	});
 
-	  it('Returns base route when primaryKey is "+" but only versionId is provided without versionKey', () => {
+	it('Returns base route when primaryKey is "+" but only versionId is provided without versionKey', () => {
 		const primaryKey = '+';
 		const versionId = 'abc-123';
 
-		expect(getItemRoute(collection, primaryKey, undefined, versionId)).toBe(
-		  `${collectionRoute}/+`,
-		);
-	  });
+		expect(getItemRoute(collection, primaryKey, undefined, versionId)).toBe(`${collectionRoute}/+`);
+	});
 });

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -29,6 +29,7 @@
 	},
 	"devDependencies": {
 		"@directus/tsconfig": "catalog:",
+		"@vitest/coverage-v8": "catalog:",
 		"tsdown": "catalog:",
 		"typescript": "catalog:",
 		"vitest": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2053,6 +2053,9 @@ importers:
       '@directus/tsconfig':
         specifier: 'catalog:'
         version: 4.0.0
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 3.2.4(vitest@3.2.4)
       tsdown:
         specifier: 'catalog:'
         version: 0.15.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@5.9.3)(vue-tsc@3.1.3(typescript@5.9.3))


### PR DESCRIPTION
## Scope

What's changed:

- Add missing `@vitest/coverage-v8` devDependency to `packages/constants` so `pnpm test:coverage` no longer fails with `Cannot find package '@vitest/coverage-v8'` (every other package with `test:coverage` already had it)
- Apply Prettier fixes to `app/src/layouts/map/components/map.vue` and `app/src/utils/get-route.test.ts` to unblock the format check
- Refresh `pnpm-lock.yaml` accordingly

## Potential Risks / Drawbacks

- Pure CI/tooling fixes; no runtime behavior changes
- Formatting-only edits to the two affected files

## Tested Scenarios

- `pnpm --filter @directus/constants test:coverage --passWithNoTests` passes locally with v8 coverage report
- `pnpm exec prettier --check app/src/layouts/map/components/map.vue app/src/utils/get-route.test.ts` reports clean

## Review Notes / Questions

- Targeting `directus-version-12` since the failing workflow runs originated from PR #27394 against that branch

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required