### PR TITLE
dp ← fix: correct useItems test counts and refactor trackLastAccessedCollection typing

### DIFF
--- a/app/src/modules/content/index.ts
+++ b/app/src/modules/content/index.ts
@@ -3,7 +3,7 @@ import { defineModule } from '@directus/extensions';
 import { Collection } from '@directus/types';
 import { useLocalStorage } from '@vueuse/core';
 import { isNil, orderBy } from 'lodash';
-import { LocationQuery, NavigationGuard } from 'vue-router';
+import { LocationQuery, NavigationGuard, RouteLocationNormalized } from 'vue-router';
 import { useNavigation } from './composables/use-navigation';
 import CollectionRoute from './routes/collection.vue';
 import Item from './routes/item.vue';
@@ -46,7 +46,7 @@ export const redirectSingleton: NavigationGuard = (to) => {
 	return { name: 'content-singleton', params: to.params, query: to.query };
 };
 
-export const trackLastAccessedCollection: NavigationGuard = (to) => {
+export const trackLastAccessedCollection = (to: RouteLocationNormalized) => {
 	const collection = typeof to.params.collection === 'string' ? to.params.collection : undefined;
 	if (!collection) return;
 

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -93,7 +93,7 @@ onBeforeRouteUpdate((to, from) => {
 	if (to.params.collection === from.params.collection) return;
 
 	// `beforeEnter` doesn’t re-fire on sibling/param-only navigation. Auto-draft for pristine singletons is handled by the post-load watcher below, since sync route guards can’t detect existing items.
-	trackLastAccessedCollection(to);
+	trackLastAccessedCollection(to, from, () => {});
 });
 
 const { collectionRoute, backRoute } = useItemNavigation();

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -93,7 +93,7 @@ onBeforeRouteUpdate((to, from) => {
 	if (to.params.collection === from.params.collection) return;
 
 	// `beforeEnter` doesn’t re-fire on sibling/param-only navigation. Auto-draft for pristine singletons is handled by the post-load watcher below, since sync route guards can’t detect existing items.
-	trackLastAccessedCollection(to, from, () => {});
+	trackLastAccessedCollection(to);
 });
 
 const { collectionRoute, backRoute } = useItemNavigation();

--- a/packages/composables/src/use-items.test.ts
+++ b/packages/composables/src/use-items.test.ts
@@ -514,8 +514,8 @@ describe('useItems', () => {
 				version,
 			});
 
-			// Initial: items + count + total = 3
-			expect(mockApiGet).toHaveBeenCalledTimes(3);
+			// Initial: items + 1 deduped aggregate (itemCount/totalCount share the same memoize key when filter and search are empty)
+			expect(mockApiGet).toHaveBeenCalledTimes(2);
 
 			// Switch to draft mode
 			version.value = 'draft';
@@ -523,8 +523,8 @@ describe('useItems', () => {
 			await vi.advanceTimersByTimeAsync(500);
 
 			// Should call getItems again (no separate count call since version is now set)
-			// items(2) + count(1) + total(1) = 4
-			expect(mockApiGet).toHaveBeenCalledTimes(4);
+			// items(2) + initial deduped aggregate(1) = 3
+			expect(mockApiGet).toHaveBeenCalledTimes(3);
 		});
 	});
 


### PR DESCRIPTION
## Scope

What's changed:

- Fixed failing assertions in `useItems > version query param > should refetch with count update when version value changes` to account for `useMemoize` deduplication of `getItemCount`/`getTotalCount` when filter and search are empty (both produce the same `{url}` key).
- Refactored `trackLastAccessedCollection` in `app/src/modules/content/index.ts` to type its parameter as `RouteLocationNormalized` instead of annotating the export as `NavigationGuard`. The function only uses `to`, so widening to a 3-arg guard signature was forcing callers to pass dummy `from`/`next` values. The `beforeEnter` registrations still type-check via subtyping (a `(to) => void` is assignable to `NavigationGuard`).
- Cleaned up the manual call site in `app/src/modules/content/routes/item.vue:96` from `trackLastAccessedCollection(to, from, () => {})` to `trackLastAccessedCollection(to)`, addressing the [review comment in #27394](https://github.com/directus/directus/pull/27394#discussion_r3202682797) without breaking types.

## Potential Risks / Drawbacks

- None. Test-only change for `useItems`. The `trackLastAccessedCollection` refactor preserves runtime behavior — vue-router still calls the guard with `(to, from, next)`; the function just declares it doesn't need the latter two.

## Tested Scenarios

- `pnpm --filter @directus/composables test src/use-items.test.ts` → 17/17 pass.
- `vue-tsc --noEmit` → no new errors at `item.vue:96` or in `content/index.ts`. `beforeEnter: [..., trackLastAccessedCollection, ...]` registrations at lines 237 and 247 still type-check.

## Review Notes / Questions

- The previous test author expected `items + count + total = 3` initial calls, missing that `getItemCount(filter={}, search='')` and `getTotalCount(filter=undefined, search=undefined)` both memoize to the same `{url}` key — see existing assertions at lines 61 and 90 which already establish the deduped count of 2.
- The Copilot bot's original suggestion (drop the trailing args from `trackLastAccessedCollection(to, from, () => {})`) was correct in spirit but broke types because the function was annotated as `NavigationGuard`. Fixed at the type declaration instead.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Refs #27394