### PR TITLE
Cleanup inconsistent secret read

### DIFF
--- a/.changeset/fuzzy-secrets-protect.md
+++ b/.changeset/fuzzy-secrets-protect.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed registration email verification tokens to use the configured secret fallback when `SECRET` is missing.

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -2,12 +2,13 @@ import { ForbiddenError, InvalidInviteError, InvalidPayloadError, RecordNotUniqu
 import { SchemaBuilder } from '@directus/schema-builder';
 import type { Accountability, MutationOptions } from '@directus/types';
 import { UserIntegrityCheckFlag } from '@directus/types';
+import jwt from 'jsonwebtoken';
 import knex from 'knex';
 import { createTracker, MockClient } from 'knex-mock-client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { validateRemainingAdminUsers } from '../permissions/modules/validate-remaining-admin/validate-remaining-admin-users.js';
 import { verifyJWT } from '../utils/jwt.js';
-import { ItemsService, MailService, UsersService } from './index.js';
+import { ItemsService, MailService, SettingsService, UsersService } from './index.js';
 
 vi.mock('../../src/database/index', () => ({
 	default: vi.fn(),
@@ -24,6 +25,8 @@ vi.mock('./mail', () => {
 vi.mock('@directus/env', () => ({
 	useEnv: vi.fn().mockReturnValue({
 		EMAIL_TEMPLATES_PATH: './templates',
+		EMAIL_VERIFICATION_TOKEN_TTL: '1d',
+		REGISTER_STALL_TIME: 0,
 		USERS_ADMIN_ACCESS_LIMIT: 3,
 		USERS_APP_ACCESS_LIMIT: 3,
 		USERS_API_ACCESS_LIMIT: 3,
@@ -65,6 +68,7 @@ describe('Integration Tests', () => {
 		});
 
 		const superCreateOneSpy = vi.spyOn(ItemsService.prototype, 'createOne').mockResolvedValue('user-id-1');
+		const superUpdateOneSpy = vi.spyOn(ItemsService.prototype, 'updateOne').mockResolvedValue('user-id-1');
 		const superUpdateManySpy = vi.spyOn(ItemsService.prototype, 'updateMany').mockResolvedValue(['user-id-2']);
 
 		const checkUniqueEmailsSpy = vi
@@ -479,6 +483,66 @@ describe('Integration Tests', () => {
 				});
 
 				await expect(service.acceptInvite('fake-token', 'Password123!')).rejects.toThrow(ForbiddenError);
+			});
+		});
+
+		describe('registerUser', () => {
+			it('should sign email verification tokens with the resolved secret', async () => {
+				vi.spyOn(SettingsService.prototype, 'readSingleton').mockResolvedValueOnce({
+					public_registration: true,
+					public_registration_verify_email: true,
+					public_registration_role: 'role-id',
+				});
+
+				const signSpy = vi.spyOn(jwt, 'sign');
+
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce(undefined);
+
+				const mailService = new MailService({ schema });
+
+				const service = new UsersService({
+					knex: db,
+					schema,
+				});
+
+				await service.registerUser({
+					email: 'test@example.com',
+					password: 'Password123!',
+					verification_url: 'https://example.com/verify',
+				});
+
+				expect(signSpy).toHaveBeenCalledWith(
+					{ email: 'test@example.com', scope: 'pending-registration' },
+					'test-secret',
+					{
+						expiresIn: '1d',
+						issuer: 'directus',
+					},
+				);
+
+				expect(mailService.send).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		describe('verifyRegistration', () => {
+			it('should verify registration tokens with the resolved secret', async () => {
+				vi.mocked(verifyJWT).mockReturnValueOnce({ email: 'test@example.com', scope: 'pending-registration' });
+
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+					id: 'user-id-18',
+					status: 'unverified',
+					email: 'test@example.com',
+				});
+
+				const service = new UsersService({
+					knex: db,
+					schema,
+				});
+
+				await service.verifyRegistration('fake-token');
+
+				expect(verifyJWT).toHaveBeenCalledWith('fake-token', 'test-secret');
+				expect(superUpdateOneSpy).toHaveBeenCalledWith('user-id-18', { status: 'active' });
 			});
 		});
 	});

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -5,8 +5,9 @@ import { UserIntegrityCheckFlag } from '@directus/types';
 import jwt from 'jsonwebtoken';
 import knex from 'knex';
 import { createTracker, MockClient } from 'knex-mock-client';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { validateRemainingAdminUsers } from '../permissions/modules/validate-remaining-admin/validate-remaining-admin-users.js';
+import { _cache } from '../utils/get-secret.js';
 import { verifyJWT } from '../utils/jwt.js';
 import { ItemsService, MailService, SettingsService, UsersService } from './index.js';
 
@@ -37,10 +38,6 @@ vi.mock('../permissions/modules/validate-remaining-admin/validate-remaining-admi
 
 vi.mock('../utils/jwt.js', () => ({
 	verifyJWT: vi.fn(),
-}));
-
-vi.mock('../utils/get-secret.js', () => ({
-	getSecret: vi.fn().mockReturnValue('test-secret'),
 }));
 
 const testRoleId = '4ccdb196-14b3-4ed1-b9da-c1978be07ca2';
@@ -82,6 +79,10 @@ describe('Integration Tests', () => {
 		const clearUserSessionsSpy = vi
 			.spyOn(UsersService.prototype as any, 'clearUserSessions')
 			.mockResolvedValue(() => vi.fn());
+
+		beforeEach(() => {
+			_cache.secret = null;
+		});
 
 		afterEach(() => {
 			vi.clearAllMocks();
@@ -487,7 +488,7 @@ describe('Integration Tests', () => {
 		});
 
 		describe('registerUser', () => {
-			it('should sign email verification tokens with the resolved secret', async () => {
+			it('should sign email verification tokens with a secret when SECRET is not configured', async () => {
 				vi.spyOn(SettingsService.prototype, 'readSingleton').mockResolvedValueOnce({
 					public_registration: true,
 					public_registration_verify_email: true,
@@ -513,19 +514,20 @@ describe('Integration Tests', () => {
 
 				expect(signSpy).toHaveBeenCalledWith(
 					{ email: 'test@example.com', scope: 'pending-registration' },
-					'test-secret',
+					expect.any(String),
 					{
 						expiresIn: '1d',
 						issuer: 'directus',
 					},
 				);
 
+				expect(signSpy.mock.calls[0]![1]).not.toBe('');
 				expect(mailService.send).toHaveBeenCalledTimes(1);
 			});
 		});
 
 		describe('verifyRegistration', () => {
-			it('should verify registration tokens with the resolved secret', async () => {
+			it('should verify registration tokens with a secret when SECRET is not configured', async () => {
 				vi.mocked(verifyJWT).mockReturnValueOnce({ email: 'test@example.com', scope: 'pending-registration' });
 
 				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
@@ -541,7 +543,8 @@ describe('Integration Tests', () => {
 
 				await service.verifyRegistration('fake-token');
 
-				expect(verifyJWT).toHaveBeenCalledWith('fake-token', 'test-secret');
+				expect(verifyJWT).toHaveBeenCalledWith('fake-token', expect.any(String));
+				expect(vi.mocked(verifyJWT).mock.calls[0]![1]).not.toBe('');
 				expect(superUpdateOneSpy).toHaveBeenCalledWith('user-id-18', { status: 'active' });
 			});
 		});

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -28,6 +28,7 @@ vi.mock('@directus/env', () => ({
 		EMAIL_TEMPLATES_PATH: './templates',
 		EMAIL_VERIFICATION_TOKEN_TTL: '1d',
 		REGISTER_STALL_TIME: 0,
+		USER_REGISTER_URL_ALLOW_LIST: 'https://example.com/verify',
 		USERS_ADMIN_ACCESS_LIMIT: 3,
 		USERS_APP_ACCESS_LIMIT: 3,
 		USERS_API_ACCESS_LIMIT: 3,
@@ -79,6 +80,13 @@ describe('Integration Tests', () => {
 		const clearUserSessionsSpy = vi
 			.spyOn(UsersService.prototype as any, 'clearUserSessions')
 			.mockResolvedValue(() => vi.fn());
+
+		const mockGetUserByEmail = (user: unknown) => {
+			const getUserByEmailSpy = vi.spyOn(UsersService.prototype as any, 'getUserByEmail');
+
+			getUserByEmailSpy.mockReset();
+			getUserByEmailSpy.mockResolvedValueOnce(user);
+		};
 
 		beforeEach(() => {
 			_cache.secret = null;
@@ -367,7 +375,7 @@ describe('Integration Tests', () => {
 			vi.spyOn(UsersService.prototype as any, 'inviteUrl').mockImplementation(() => vi.fn());
 
 			it('should invite new users', async () => {
-				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce(undefined);
+				mockGetUserByEmail(undefined);
 
 				const service = new UsersService({
 					knex: db,
@@ -398,7 +406,7 @@ describe('Integration Tests', () => {
 				});
 
 				// mock an invited user
-				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+				mockGetUserByEmail({
 					status: 'invited',
 					role: 'invite-role',
 				});
@@ -418,7 +426,7 @@ describe('Integration Tests', () => {
 				});
 
 				// mock an active user
-				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+				mockGetUserByEmail({
 					status: 'active',
 					role: 'invite-role',
 				});
@@ -444,13 +452,12 @@ describe('Integration Tests', () => {
 				};
 
 				// mock an invited user with different role
-				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce(mockUser);
+				mockGetUserByEmail(mockUser);
 
 				const promise = service.inviteUser('user@example.com', 'invite-role', null);
 				await expect(promise).resolves.not.toThrow();
 
-				expect(superUpdateManySpy.mock.lastCall![0]).toEqual([mockUser.id]);
-				expect(superUpdateManySpy.mock.lastCall![1]).toEqual({ role: 'invite-role' });
+				expect(superUpdateOneSpy).toHaveBeenCalledWith(mockUser.id, { role: 'invite-role' }, {});
 			});
 		});
 
@@ -458,7 +465,7 @@ describe('Integration Tests', () => {
 			it('should throw InvalidInviteError when user is not in invited status', async () => {
 				vi.mocked(verifyJWT).mockReturnValueOnce({ email: 'test@example.com', scope: 'invite' });
 
-				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+				mockGetUserByEmail({
 					id: 'user-id',
 					status: 'active',
 					email: 'test@example.com',
@@ -497,7 +504,7 @@ describe('Integration Tests', () => {
 
 				const signSpy = vi.spyOn(jwt, 'sign');
 
-				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce(undefined);
+				mockGetUserByEmail(undefined);
 
 				const mailService = new MailService({ schema });
 
@@ -530,7 +537,7 @@ describe('Integration Tests', () => {
 			it('should verify registration tokens with a secret when SECRET is not configured', async () => {
 				vi.mocked(verifyJWT).mockReturnValueOnce({ email: 'test@example.com', scope: 'pending-registration' });
 
-				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+				mockGetUserByEmail({
 					id: 'user-id-18',
 					status: 'unverified',
 					email: 'test@example.com',

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -503,7 +503,7 @@ export class UsersService extends ItemsService {
 			const mailService = new MailService(serviceOptions);
 			const payload = { email: input.email, scope: 'pending-registration' };
 
-			const token = jwt.sign(payload, env['SECRET'] as string, {
+			const token = jwt.sign(payload, getSecret(), {
 				expiresIn: env['EMAIL_VERIFICATION_TOKEN_TTL'] as StringValue | number,
 				issuer: 'directus',
 			});
@@ -539,7 +539,7 @@ export class UsersService extends ItemsService {
 	}
 
 	async verifyRegistration(token: string): Promise<string> {
-		const { email, scope } = verifyJWT(token, env['SECRET'] as string) as {
+		const { email, scope } = verifyJWT(token, getSecret()) as {
 			email: string;
 			scope: string;
 		};

--- a/api/src/utils/get-secret.test.ts
+++ b/api/src/utils/get-secret.test.ts
@@ -1,0 +1,29 @@
+import { useEnv } from '@directus/env';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { _cache, getSecret } from './get-secret.js';
+
+vi.mock('@directus/env', () => ({
+	useEnv: vi.fn(),
+}));
+
+describe('getSecret', () => {
+	beforeEach(() => {
+		_cache.secret = null;
+
+		vi.mocked(useEnv).mockReturnValue({});
+	});
+
+	test('returns the configured secret', () => {
+		vi.mocked(useEnv).mockReturnValue({ SECRET: 'configured-secret' });
+
+		expect(getSecret()).toBe('configured-secret');
+	});
+
+	test('generates and caches a secret when SECRET is not configured', () => {
+		const secret = getSecret();
+
+		expect(secret).toEqual(expect.any(String));
+		expect(secret).not.toBe('');
+		expect(getSecret()).toBe(secret);
+	});
+});


### PR DESCRIPTION
## Scope

There was one stray place where we were reading `env['SECRET']` instead of using `getSecret`. This could cause the user invite endpoint to throw a 500 on user invite when the deployment didn't have the `SECRET` env var set — which is required in prod use. 

## Potential Risks / Drawbacks

None, just makes the behavior consistent between all uses of the secret value.

## Tested Scenarios

Added tests to make sure the secret value is always used. Added tests for getSecret util

## Review Notes / Questions

Tiny bug tiny fix.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required
