### PR TITLE
[codex] Fix Studio tab refresh race 🤖🤖🤖

### DIFF
--- a/.changeset/quick-tabs-refresh.md
+++ b/.changeset/quick-tabs-refresh.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed users getting signed out when opening many Studio pages in quick succession by avoiding a session refresh race across tabs.

--- a/app/src/auth.test.ts
+++ b/app/src/auth.test.ts
@@ -1,0 +1,186 @@
+import { useAppStore } from '@directus/stores';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { cookieRemove, dehydrate, hydrate, readMe, resumeQueue, routerPush, sdk, serverHydrate } = vi.hoisted(() => ({
+	cookieRemove: vi.fn(),
+	dehydrate: vi.fn(),
+	hydrate: vi.fn(),
+	readMe: vi.fn((query: Record<string, unknown>) => ({ query, type: 'read-me' })),
+	resumeQueue: vi.fn(),
+	routerPush: vi.fn(),
+	sdk: {
+		login: vi.fn(),
+		logout: vi.fn(),
+		refresh: vi.fn(),
+		request: vi.fn(),
+		stopRefreshing: vi.fn(),
+	},
+	serverHydrate: vi.fn(),
+}));
+
+vi.mock('@directus/sdk', () => ({
+	authenticateShare: vi.fn(),
+	getAuthEndpoint: vi.fn(() => '/auth/login'),
+	readMe,
+}));
+
+vi.mock('@vueuse/integrations/useCookies', () => ({
+	useCookies: vi.fn(() => ({
+		remove: cookieRemove,
+	})),
+}));
+
+vi.mock('@/api', () => ({
+	resumeQueue,
+}));
+
+vi.mock('@/hydrate', () => ({
+	dehydrate,
+	hydrate,
+}));
+
+vi.mock('@/router', () => ({
+	router: {
+		push: routerPush,
+	},
+}));
+
+vi.mock('@/sdk', () => ({
+	sdk,
+}));
+
+vi.mock('@/stores/server', () => ({
+	useServerStore: vi.fn(() => ({
+		hydrate: serverHydrate,
+	})),
+}));
+
+vi.mock('./events', () => ({
+	emitter: {
+		on: vi.fn(),
+	},
+	Events: {
+		tabActive: 'tabActive',
+		tabIdle: 'tabIdle',
+	},
+}));
+
+const ACCESS_TOKEN_EXPIRY_STORAGE_KEY = 'directus-access-token-expiry';
+const NOW = new Date('2026-05-10T10:00:00.000Z');
+
+async function loadAuth() {
+	vi.resetModules();
+	return import('./auth');
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.setSystemTime(NOW);
+	vi.clearAllMocks();
+	localStorage.clear();
+
+	setActivePinia(
+		createTestingPinia({
+			createSpy: vi.fn,
+		}),
+	);
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe('refresh', () => {
+	test('validates a fresh stored session without refreshing the token', async () => {
+		const expiresAt = Date.now() + 60_000;
+		localStorage.setItem(ACCESS_TOKEN_EXPIRY_STORAGE_KEY, String(expiresAt));
+		sdk.request.mockResolvedValueOnce({});
+
+		const { refresh } = await loadAuth();
+
+		await refresh();
+
+		const appStore = useAppStore();
+
+		expect(sdk.refresh).not.toHaveBeenCalled();
+		expect(readMe).toHaveBeenCalledWith({ fields: ['id'] });
+		expect(sdk.request).toHaveBeenCalledWith({ query: { fields: ['id'] }, type: 'read-me' });
+		expect(appStore.authenticated).toBe(true);
+		expect(appStore.accessTokenExpiry).toBe(expiresAt);
+		expect(resumeQueue).toHaveBeenCalledOnce();
+	});
+
+	test('refreshes before a validated stored session expires', async () => {
+		const expiresAt = Date.now() + 60_000;
+		localStorage.setItem(ACCESS_TOKEN_EXPIRY_STORAGE_KEY, String(expiresAt));
+		sdk.request.mockResolvedValueOnce({});
+
+		const { refresh } = await loadAuth();
+
+		await refresh();
+
+		sdk.refresh.mockResolvedValueOnce({ expires: 60_000 });
+
+		await vi.advanceTimersByTimeAsync(50_000);
+
+		const refreshedExpiresAt = Date.now() + 60_000;
+
+		expect(sdk.refresh).toHaveBeenCalledOnce();
+		expect(localStorage.getItem(ACCESS_TOKEN_EXPIRY_STORAGE_KEY)).toBe(String(refreshedExpiresAt));
+	});
+
+	test('persists the access token expiry after refreshing', async () => {
+		sdk.refresh.mockResolvedValueOnce({ expires: 60_000 });
+
+		const { refresh } = await loadAuth();
+
+		await refresh();
+
+		const expiresAt = Date.now() + 60_000;
+		const appStore = useAppStore();
+
+		expect(localStorage.getItem(ACCESS_TOKEN_EXPIRY_STORAGE_KEY)).toBe(String(expiresAt));
+		expect(appStore.authenticated).toBe(true);
+		expect(appStore.accessTokenExpiry).toBe(expiresAt);
+	});
+
+	test('recovers when another tab refreshed the session after this tab sent a stale refresh request', async () => {
+		const expiresAt = Date.now() + 60_000;
+
+		sdk.refresh.mockImplementationOnce(async () => {
+			localStorage.setItem(ACCESS_TOKEN_EXPIRY_STORAGE_KEY, String(expiresAt));
+			throw new Error('Invalid credentials');
+		});
+
+		sdk.request.mockResolvedValueOnce({});
+
+		const { refresh } = await loadAuth();
+
+		await refresh();
+
+		const appStore = useAppStore();
+
+		expect(sdk.refresh).toHaveBeenCalledOnce();
+		expect(sdk.request).toHaveBeenCalledWith({ query: { fields: ['id'] }, type: 'read-me' });
+		expect(appStore.authenticated).toBe(true);
+		expect(routerPush).not.toHaveBeenCalled();
+		expect(dehydrate).not.toHaveBeenCalled();
+	});
+});
+
+describe('logout', () => {
+	test('clears the persisted access token expiry', async () => {
+		const appStore = useAppStore();
+		appStore.accessTokenExpiry = Date.now() + 60_000;
+		localStorage.setItem(ACCESS_TOKEN_EXPIRY_STORAGE_KEY, String(appStore.accessTokenExpiry));
+
+		const { LogoutReason, logout } = await loadAuth();
+
+		await logout({ navigate: false, reason: LogoutReason.SESSION_EXPIRED });
+
+		expect(appStore.accessTokenExpiry).toBe(0);
+		expect(localStorage.getItem(ACCESS_TOKEN_EXPIRY_STORAGE_KEY)).toBeNull();
+	});
+});

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -7,6 +7,7 @@ import {
 	RestCommand,
 } from '@directus/sdk';
 import { useAppStore } from '@directus/stores';
+import { useLocalStorage } from '@vueuse/core';
 import { useCookies } from '@vueuse/integrations/useCookies';
 import { RouteLocationRaw } from 'vue-router';
 import { emitter, Events } from './events';
@@ -32,6 +33,9 @@ type LoginParams = {
 };
 
 const cookies = useCookies(['license-banner-dismissed']);
+const ACCESS_TOKEN_EXPIRY_STORAGE_KEY = 'directus-access-token-expiry';
+const MAX_SAFE_TIMEOUT = 2 ** 31 - 1;
+const accessTokenExpiryStorage = useLocalStorage<number | null>(ACCESS_TOKEN_EXPIRY_STORAGE_KEY, null);
 
 export async function login({ credentials, provider, share }: LoginParams): Promise<void> {
 	const appStore = useAppStore();
@@ -72,7 +76,7 @@ export async function login({ credentials, provider, share }: LoginParams): Prom
 		}
 	}
 
-	appStore.accessTokenExpiry = Date.now() + (response.expires ?? 0);
+	setAccessTokenExpiry(appStore, Date.now() + (response.expires ?? 0));
 	cookies.remove('license-banner-dismissed');
 	appStore.authenticated = true;
 
@@ -84,9 +88,11 @@ export async function login({ credentials, provider, share }: LoginParams): Prom
 
 let idle = false;
 let firstRefresh = true;
+let scheduledRefresh: number | null = null;
 
 // Prevent the auto-refresh when the app isn't in use
 emitter.on(Events.tabIdle, () => {
+	clearScheduledRefresh();
 	sdk.stopRefreshing();
 	idle = true;
 });
@@ -106,18 +112,22 @@ export async function refresh({ navigate }: LogoutOptions = { navigate: true }):
 	if (!firstRefresh && !appStore.authenticated) return;
 
 	try {
-		// Skip access token refreshing if it is still fresh but validate the session
-		if (appStore.accessTokenExpiry && Date.now() < appStore.accessTokenExpiry - SDK_AUTH_REFRESH_BEFORE_EXPIRES) {
-			await sdk.request(readMe({ fields: ['id'] }));
-			return;
-		}
+		if (await validateStoredSession(appStore)) return;
 
+		clearScheduledRefresh();
 		const response = await sdk.refresh();
 
-		appStore.accessTokenExpiry = Date.now() + (response.expires ?? 0);
+		setAccessTokenExpiry(appStore, Date.now() + (response.expires ?? 0));
 		appStore.authenticated = true;
 		firstRefresh = false;
 	} catch {
+		// The failed request may have been sent with a stale session cookie while another tab was refreshing.
+		try {
+			if (await validateStoredSession(appStore)) return;
+		} catch {
+			// Fall through to the regular session-expired logout flow.
+		}
+
 		await logout({ navigate, reason: LogoutReason.SESSION_EXPIRED });
 	} finally {
 		resumeQueue();
@@ -159,6 +169,8 @@ export async function logout(options: LogoutOptions = {}): Promise<void> {
 	}
 
 	appStore.authenticated = false;
+	clearScheduledRefresh();
+	clearAccessTokenExpiry(appStore);
 
 	await dehydrate();
 
@@ -169,5 +181,64 @@ export async function logout(options: LogoutOptions = {}): Promise<void> {
 		};
 
 		router.push(location);
+	}
+}
+
+async function validateStoredSession(appStore: ReturnType<typeof useAppStore>): Promise<boolean> {
+	const accessTokenExpiry = Math.max(appStore.accessTokenExpiry, getStoredAccessTokenExpiry());
+
+	if (!accessTokenExpiry || Date.now() >= accessTokenExpiry - SDK_AUTH_REFRESH_BEFORE_EXPIRES) return false;
+
+	await sdk.request(readMe({ fields: ['id'] }));
+
+	setAccessTokenExpiry(appStore, accessTokenExpiry);
+	scheduleRefresh(accessTokenExpiry);
+	appStore.authenticated = true;
+	firstRefresh = false;
+
+	return true;
+}
+
+function setAccessTokenExpiry(appStore: ReturnType<typeof useAppStore>, accessTokenExpiry: number): void {
+	appStore.accessTokenExpiry = accessTokenExpiry;
+	accessTokenExpiryStorage.value = accessTokenExpiry;
+}
+
+function clearAccessTokenExpiry(appStore: ReturnType<typeof useAppStore>): void {
+	appStore.accessTokenExpiry = 0;
+	accessTokenExpiryStorage.value = null;
+}
+
+function scheduleRefresh(accessTokenExpiry: number): void {
+	clearScheduledRefresh();
+
+	const delay = accessTokenExpiry - Date.now() - SDK_AUTH_REFRESH_BEFORE_EXPIRES;
+
+	if (delay <= 0 || delay > MAX_SAFE_TIMEOUT) return;
+
+	scheduledRefresh = window.setTimeout(() => {
+		scheduledRefresh = null;
+
+		refresh().catch(() => {
+			// refresh handles session-expired state internally.
+		});
+	}, delay);
+}
+
+function clearScheduledRefresh(): void {
+	if (!scheduledRefresh) return;
+
+	window.clearTimeout(scheduledRefresh);
+	scheduledRefresh = null;
+}
+
+function getStoredAccessTokenExpiry(): number {
+	try {
+		// Read storage directly so recovery sees cross-tab refreshes before the VueUse ref receives a storage event.
+		const accessTokenExpiry = Number(localStorage.getItem(ACCESS_TOKEN_EXPIRY_STORAGE_KEY));
+
+		return Number.isFinite(accessTokenExpiry) ? accessTokenExpiry : 0;
+	} catch {
+		return accessTokenExpiryStorage.value ?? 0;
 	}
 }


### PR DESCRIPTION
## Scope

What's changed:

- Persisted the Studio access-token expiry in local storage so newly opened tabs could validate an already-fresh session without rotating the session cookie.
- Rechecked the session after a failed refresh so a tab could recover when another tab had already refreshed the session cookie.
- Scheduled a one-shot refresh for tabs that skipped SDK refresh, and cleared it on idle/logout.
- Added focused auth tests for stored-session validation, scheduled refresh, race recovery, and logout cleanup.

## Potential Risks / Drawbacks

- Stores a non-secret expiry timestamp in local storage.
- Auth refresh timing is sensitive to idle/visibility behavior; the new tests cover the changed paths.

## Tested Scenarios

- `pnpm --filter @directus/app test app/src/auth.test.ts`
- `pnpm lint`
- `pnpm lint:style`
- `pnpm format`

## Review Notes / Questions

- This fixes the current multi-tab logout symptom by avoiding unnecessary refreshes that could race session-cookie rotation.
- Related historical context: #22360 reported the original multi-tab refresh race, and #22503 added the server-side refresh grace period.
- I did not create docs or OpenAPI PRs because this changes Studio auth behavior only.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #26176