### PR TITLE
Fix Studio tab refresh race

### DIFF
--- a/.changeset/quick-tabs-refresh.md
+++ b/.changeset/quick-tabs-refresh.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed users getting signed out when opening many Studio pages in quick succession by avoiding a session refresh race across tabs.

--- a/app/src/auth.test.ts
+++ b/app/src/auth.test.ts
@@ -1,0 +1,187 @@
+import { useAppStore } from '@directus/stores';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { SDK_AUTH_REFRESH_BEFORE_EXPIRES } from '@/constants';
+
+const { dehydrate, readMe, resumeQueue, routerPush, sdk } = vi.hoisted(() => ({
+	dehydrate: vi.fn(),
+	readMe: vi.fn((query: Record<string, unknown>) => ({ query, type: 'read-me' })),
+	resumeQueue: vi.fn(),
+	routerPush: vi.fn(),
+	sdk: {
+		logout: vi.fn(),
+		refresh: vi.fn(),
+		request: vi.fn(),
+		stopRefreshing: vi.fn(),
+	},
+}));
+
+vi.mock('@directus/sdk', () => ({
+	authenticateShare: vi.fn(),
+	getAuthEndpoint: vi.fn(() => '/auth/login'),
+	readMe,
+}));
+
+vi.mock('@vueuse/integrations/useCookies', () => ({
+	useCookies: vi.fn(() => ({
+		remove: vi.fn(),
+	})),
+}));
+
+vi.mock('@/api', () => ({
+	resumeQueue,
+}));
+
+vi.mock('@/hydrate', () => ({
+	dehydrate,
+	hydrate: vi.fn(),
+}));
+
+vi.mock('@/router', () => ({
+	router: {
+		push: routerPush,
+	},
+}));
+
+vi.mock('@/sdk', () => ({
+	sdk,
+}));
+
+vi.mock('@/stores/server', () => ({
+	useServerStore: vi.fn(() => ({
+		hydrate: vi.fn(),
+	})),
+}));
+
+vi.mock('./events', () => ({
+	emitter: {
+		on: vi.fn(),
+	},
+	Events: {
+		tabActive: 'tabActive',
+		tabIdle: 'tabIdle',
+	},
+}));
+
+const ACCESS_TOKEN_EXPIRY_STORAGE_KEY = 'directus-access-token-expiry';
+const ACCESS_TOKEN_TTL = 60_000;
+const NOW = new Date('2026-05-10T10:00:00.000Z');
+
+async function loadAuth() {
+	vi.resetModules();
+	return import('./auth');
+}
+
+function setStoredAccessTokenExpiry(expiresAt = Date.now() + ACCESS_TOKEN_TTL) {
+	localStorage.setItem(ACCESS_TOKEN_EXPIRY_STORAGE_KEY, String(expiresAt));
+
+	return expiresAt;
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.setSystemTime(NOW);
+	vi.clearAllMocks();
+	localStorage.clear();
+
+	setActivePinia(
+		createTestingPinia({
+			createSpy: vi.fn,
+		}),
+	);
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe('refresh', () => {
+	test('should validate a fresh stored session without refreshing the token', async () => {
+		const expiresAt = setStoredAccessTokenExpiry();
+		sdk.request.mockResolvedValueOnce({});
+
+		const { refresh } = await loadAuth();
+
+		await refresh();
+
+		const appStore = useAppStore();
+
+		expect(sdk.refresh).not.toHaveBeenCalled();
+		expect(readMe).toHaveBeenCalledWith({ fields: ['id'] });
+		expect(sdk.request).toHaveBeenCalledWith({ query: { fields: ['id'] }, type: 'read-me' });
+		expect(appStore.authenticated).toBe(true);
+		expect(appStore.accessTokenExpiry).toBe(expiresAt);
+		expect(resumeQueue).toHaveBeenCalledOnce();
+	});
+
+	test('should refresh before a validated stored session expires', async () => {
+		setStoredAccessTokenExpiry();
+		sdk.request.mockResolvedValueOnce({});
+
+		const { refresh } = await loadAuth();
+
+		await refresh();
+
+		sdk.refresh.mockResolvedValueOnce({ expires: ACCESS_TOKEN_TTL });
+
+		await vi.advanceTimersByTimeAsync(ACCESS_TOKEN_TTL - SDK_AUTH_REFRESH_BEFORE_EXPIRES);
+
+		const refreshedExpiresAt = Date.now() + ACCESS_TOKEN_TTL;
+
+		expect(sdk.refresh).toHaveBeenCalledOnce();
+		expect(localStorage.getItem(ACCESS_TOKEN_EXPIRY_STORAGE_KEY)).toBe(String(refreshedExpiresAt));
+	});
+
+	test('should persist the access token expiry after refreshing', async () => {
+		sdk.refresh.mockResolvedValueOnce({ expires: ACCESS_TOKEN_TTL });
+
+		const { refresh } = await loadAuth();
+
+		await refresh();
+
+		const expiresAt = Date.now() + ACCESS_TOKEN_TTL;
+		const appStore = useAppStore();
+
+		expect(localStorage.getItem(ACCESS_TOKEN_EXPIRY_STORAGE_KEY)).toBe(String(expiresAt));
+		expect(appStore.authenticated).toBe(true);
+		expect(appStore.accessTokenExpiry).toBe(expiresAt);
+	});
+
+	test('should recover if another tab refreshed the session after this tab sent a stale refresh request', async () => {
+		const expiresAt = Date.now() + ACCESS_TOKEN_TTL;
+
+		sdk.refresh.mockImplementationOnce(async () => {
+			setStoredAccessTokenExpiry(expiresAt);
+			throw new Error('Invalid credentials');
+		});
+
+		sdk.request.mockResolvedValueOnce({});
+
+		const { refresh } = await loadAuth();
+
+		await refresh();
+
+		const appStore = useAppStore();
+
+		expect(sdk.refresh).toHaveBeenCalledOnce();
+		expect(sdk.request).toHaveBeenCalledWith({ query: { fields: ['id'] }, type: 'read-me' });
+		expect(appStore.authenticated).toBe(true);
+		expect(routerPush).not.toHaveBeenCalled();
+		expect(dehydrate).not.toHaveBeenCalled();
+	});
+});
+
+describe('logout', () => {
+	test('should clear the persisted access token expiry', async () => {
+		const appStore = useAppStore();
+		appStore.accessTokenExpiry = setStoredAccessTokenExpiry();
+
+		const { LogoutReason, logout } = await loadAuth();
+
+		await logout({ navigate: false, reason: LogoutReason.SESSION_EXPIRED });
+
+		expect(appStore.accessTokenExpiry).toBe(0);
+		expect(localStorage.getItem(ACCESS_TOKEN_EXPIRY_STORAGE_KEY)).toBeNull();
+	});
+});

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -1,3 +1,4 @@
+import { MAX_SAFE_INT32 } from '@directus/constants';
 import {
 	authenticateShare,
 	AuthenticationData,
@@ -7,6 +8,7 @@ import {
 	RestCommand,
 } from '@directus/sdk';
 import { useAppStore } from '@directus/stores';
+import { StorageSerializers, useLocalStorage } from '@vueuse/core';
 import { useCookies } from '@vueuse/integrations/useCookies';
 import { RouteLocationRaw } from 'vue-router';
 import { emitter, Events } from './events';
@@ -32,6 +34,12 @@ type LoginParams = {
 };
 
 const cookies = useCookies(['license-banner-dismissed']);
+const ACCESS_TOKEN_EXPIRY_STORAGE_KEY = 'directus-access-token-expiry';
+
+// Share the session expiry across tabs so new tabs can reuse a fresh session without rotating the cookie.
+const accessTokenExpiryStorage = useLocalStorage<number | null>(ACCESS_TOKEN_EXPIRY_STORAGE_KEY, null, {
+	serializer: StorageSerializers.number,
+});
 
 export async function login({ credentials, provider, share }: LoginParams): Promise<void> {
 	const appStore = useAppStore();
@@ -72,7 +80,7 @@ export async function login({ credentials, provider, share }: LoginParams): Prom
 		}
 	}
 
-	appStore.accessTokenExpiry = Date.now() + (response.expires ?? 0);
+	setAccessTokenExpiry(appStore, Date.now() + (response.expires ?? 0));
 	cookies.remove('license-banner-dismissed');
 	appStore.authenticated = true;
 
@@ -84,9 +92,11 @@ export async function login({ credentials, provider, share }: LoginParams): Prom
 
 let idle = false;
 let firstRefresh = true;
+let scheduledRefresh: number | null = null;
 
 // Prevent the auto-refresh when the app isn't in use
 emitter.on(Events.tabIdle, () => {
+	clearScheduledRefresh();
 	sdk.stopRefreshing();
 	idle = true;
 });
@@ -107,17 +117,23 @@ export async function refresh({ navigate }: LogoutOptions = { navigate: true }):
 
 	try {
 		// Skip access token refreshing if it is still fresh but validate the session
-		if (appStore.accessTokenExpiry && Date.now() < appStore.accessTokenExpiry - SDK_AUTH_REFRESH_BEFORE_EXPIRES) {
-			await sdk.request(readMe({ fields: ['id'] }));
-			return;
-		}
+		if (await validateFreshSession(appStore)) return;
 
+		// Validation did not reuse the current session, so hand refresh scheduling back to the SDK.
+		clearScheduledRefresh();
 		const response = await sdk.refresh();
 
-		appStore.accessTokenExpiry = Date.now() + (response.expires ?? 0);
+		setAccessTokenExpiry(appStore, Date.now() + (response.expires ?? 0));
 		appStore.authenticated = true;
 		firstRefresh = false;
 	} catch {
+		// The failed request may have been sent with a stale session cookie while another tab was refreshing.
+		try {
+			if (await validateFreshSession(appStore)) return;
+		} catch {
+			// Fall through to the regular session-expired logout flow.
+		}
+
 		await logout({ navigate, reason: LogoutReason.SESSION_EXPIRED });
 	} finally {
 		resumeQueue();
@@ -159,6 +175,8 @@ export async function logout(options: LogoutOptions = {}): Promise<void> {
 	}
 
 	appStore.authenticated = false;
+	clearScheduledRefresh();
+	clearAccessTokenExpiry(appStore);
 
 	await dehydrate();
 
@@ -170,4 +188,75 @@ export async function logout(options: LogoutOptions = {}): Promise<void> {
 
 		router.push(location);
 	}
+}
+
+/**
+ * Validates a still-fresh session without rotating the shared session cookie.
+ *
+ * The app store covers this tab's expiry, while local storage lets newly opened
+ * tabs reuse the fresh session already established by another tab.
+ */
+async function validateFreshSession(appStore: ReturnType<typeof useAppStore>): Promise<boolean> {
+	const accessTokenExpiry = Math.max(appStore.accessTokenExpiry, getStoredAccessTokenExpiry());
+
+	if (!accessTokenExpiry || Date.now() >= accessTokenExpiry - SDK_AUTH_REFRESH_BEFORE_EXPIRES) return false;
+
+	await sdk.request(readMe({ fields: ['id'] }));
+
+	setAccessTokenExpiry(appStore, accessTokenExpiry);
+
+	// sdk.refresh() would have scheduled the next SDK auto-refresh. Since we
+	// skipped the refresh to avoid rotating the cookie, schedule that window here.
+	scheduleRefresh(accessTokenExpiry);
+	appStore.authenticated = true;
+	firstRefresh = false;
+
+	return true;
+}
+
+function setAccessTokenExpiry(appStore: ReturnType<typeof useAppStore>, accessTokenExpiry: number): void {
+	appStore.accessTokenExpiry = accessTokenExpiry;
+	accessTokenExpiryStorage.value = accessTokenExpiry;
+}
+
+function clearAccessTokenExpiry(appStore: ReturnType<typeof useAppStore>): void {
+	appStore.accessTokenExpiry = 0;
+	accessTokenExpiryStorage.value = null;
+}
+
+function scheduleRefresh(accessTokenExpiry: number): void {
+	clearScheduledRefresh();
+
+	const delay = accessTokenExpiry - Date.now() - SDK_AUTH_REFRESH_BEFORE_EXPIRES;
+
+	// Avoid scheduling refreshes for timers longer than setTimeout can safely handle.
+	if (delay <= 0 || delay > MAX_SAFE_INT32) return;
+
+	scheduledRefresh = window.setTimeout(() => {
+		scheduledRefresh = null;
+
+		refresh().catch(() => {
+			// refresh handles session-expired state internally.
+		});
+	}, delay);
+}
+
+function clearScheduledRefresh(): void {
+	if (scheduledRefresh === null) return;
+	window.clearTimeout(scheduledRefresh);
+	scheduledRefresh = null;
+}
+
+function getStoredAccessTokenExpiry(): number {
+	let storedAccessTokenExpiry: string | number | null = accessTokenExpiryStorage.value;
+
+	try {
+		// Read storage directly so recovery sees cross-tab refreshes before the VueUse ref receives a storage event.
+		storedAccessTokenExpiry = localStorage.getItem(ACCESS_TOKEN_EXPIRY_STORAGE_KEY);
+	} catch {
+		// Fall back to the VueUse ref if direct storage access is unavailable.
+	}
+
+	const accessTokenExpiry = Number(storedAccessTokenExpiry);
+	return Number.isFinite(accessTokenExpiry) ? accessTokenExpiry : 0;
 }

--- a/contributors.yml
+++ b/contributors.yml
@@ -273,3 +273,4 @@
 - yogeshwaran-c
 - sanskar-soni-9
 - kropsi
+- luciemdx


### PR DESCRIPTION
## Scope

Avoids session refresh races across tabs causing logout when opening Studio tabs in quick succession (e.g. cmd + click on multiple items in a collection list view).

Studio now keeps the known access-token expiry in local storage. When a newly opened tab still has a fresh session, it validates with `/users/me` instead of rotating the session cookie through `/auth/refresh`. If a refresh fails because another tab just rotated the cookie, the tab rechecks the stored expiry and session before logging out.

## Potential Risks / Drawbacks

- This stores a (non-secret) access-token expiry timestamp in local storage.
- Tabs that use that stored expiry to skip `sdk.refresh()` schedule a refresh timeout so they do not miss the next refresh window.

## Tested Scenarios

pnpm --filter @directus/app test app/src/auth.test.ts

## Review Notes / Questions

This targets the multi-tab logout in #26176. #22360 and #22503 are relevant history: the server has a grace period, but Studio could still create many unnecessary refresh calls from new tabs.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

## Notes

AI-assisted, gave Codex a description of my own symptoms + my own Directus logs and let it dig, then cleaned up as well as I could with my limited knowledge of the repo.

### Code archeology

This issue has been chased for quite a few years now, here's the puzzle I could put together with Codex's help:
- #8452 first added “skip refresh while the access token is still fresh” in 2021, after [#8449](https://github.com/directus/directus/issues/8449) showed refresh-on-focus could race with normal App requests. #8880 followed up because the skip path also needed to restore the next refresh timeout after idle.
- #21239 introduced session-based auth with an httpOnly session cookie. One stated benefit was credential sharing between multiple tabs. Later, #21938 migrated App auth/refreshing to the SDK and removed the older App-level skip-refresh logic as part of that rewrite.
- #22353 tightened session JWT validation by checking that the JWT’s session still exists in directus_sessions. That was correct, but it made stale session-cookie races surface as real invalid-token/logout failures instead of being silently tolerated.
- #22360] identified the concrete race: two tabs can call /auth/refresh with the same session identifier; one rotates it, the other then fails.
- #22433 tried fixing this server-side by not rotating the session identifier in session mode. That was closed after concerns that the session identifier could still be extracted and used through other auth modes, which would need a stronger distinction between stateful session tokens and regular refresh tokens.
- #22457 tried a client-side mutex using Web Locks/localStorage. That reduced concurrent refreshes, but still reproduced with many tabs or slow/throttled conditions. The important insight from that PR was that locking serialized the problem but did not remove it: tabs could still refresh in a waterfall, rotating the shared cookie while earlier tabs were hydrating or sending authenticated requests. In that discussion, storing the current auth expiry in local/session storage was suggested as a way to let later tabs skip their first refresh entirely.
- #22464 reimplemented the old skip-refresh behavior removed by #21938: if the current tab’s appStore.accessTokenExpiry is still fresh, validate with /users/me instead of refreshing. This helped existing active tabs, but it remained per-tab/in-memory state. A newly opened tab still starts without appStore.accessTokenExpiry, so it goes straight to sdk.refresh().
- #22503 added the backend safety window: after refresh, the old session row briefly points at next_token, controlled by SESSION_REFRESH_GRACE_PERIOD (10s by default). This handles in-flight duplicate refreshes much better, but it is still reactive. It does not stop the App from creating a burst or waterfall of unnecessary refreshes in the first place.

This PR keeps the behavior from #22464 but makes the freshness signal available across tabs, as suggested in the discussion for (closed) #22457. After login/refresh, Studio stores the session expiry timestamp in local storage. A new tab can then see that another tab already established a fresh session, validate it with a cheap readMe({ fields: ['id'] }) request, and avoid calling /auth/refresh.

---

Fixes #26176