### PR TITLE
xiiui ← Update UI for the Draft & Publish workflow

### DIFF
--- a/.changeset/grumpy-doodles-knock.md
+++ b/.changeset/grumpy-doodles-knock.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Updated UI for the Draft & Publish workflow

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -8,6 +8,7 @@ import { isNil } from 'lodash';
 import { computed, ref, toRefs, watch } from 'vue';
 import { onBeforeRouteUpdate, useRouter } from 'vue-router';
 import ContentNavigation from '../components/navigation.vue';
+import VersionChip from '../components/version-chip.vue';
 import ContentNotFound from './not-found.vue';
 import api from '@/api';
 import VButton from '@/components/v-button.vue';
@@ -15,7 +16,6 @@ import VCardActions from '@/components/v-card-actions.vue';
 import VCardText from '@/components/v-card-text.vue';
 import VCardTitle from '@/components/v-card-title.vue';
 import VCard from '@/components/v-card.vue';
-import VChip from '@/components/v-chip.vue';
 import VDialog from '@/components/v-dialog.vue';
 import VError from '@/components/v-error.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
@@ -370,11 +370,8 @@ function clearFilters() {
 		<PrivateView v-else :title="headerTitle" :icon="headerIcon" :icon-color="headerIconColor">
 			<template #title-outer:append>
 				<VMenu v-if="isVersioned" show-arrow placement="bottom">
-					<template #activator="{ toggle, active }">
-						<VChip small clickable :label="false" class="version-select-activator" :class="{ active }" @click="toggle">
-							{{ versionName }}
-							<VIcon small name="arrow_drop_down" />
-						</VChip>
+					<template #activator="{ toggle }">
+						<VersionChip :version="version ? { key: version, name: null } : null" @click="toggle" />
 					</template>
 
 					<VList>
@@ -647,24 +644,5 @@ function clearFilters() {
 	justify-content: center;
 	inline-size: 2rem;
 	block-size: 2rem;
-}
-
-.version-select-activator {
-	--v-chip-padding: 0 0.3125rem 0 0.6875rem;
-	--v-chip-color: var(--theme--foreground-accent);
-	--v-chip-color-hover: var(--v-chip-color);
-	--v-chip-background-color-hover: color-mix(in srgb, var(--theme--background), var(--theme--foreground) 10%);
-
-	margin-inline-start: 0.5rem;
-
-	&.active {
-		--v-chip-color: var(--foreground-inverted);
-		--v-chip-background-color: var(--theme--primary);
-		--v-chip-background-color-hover: var(--v-chip-background-color);
-	}
-
-	&.v-chip {
-		border-width: 0;
-	}
 }
 </style>

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -510,7 +510,7 @@ function clearFilters() {
 			<template #actions:primary>
 				<PrivateViewHeaderBarActionButton
 					:tooltip="createAllowed ? undefined : $t('not_allowed')"
-					:label="$t('create_item')"
+					:label="$t('create')"
 					icon="add"
 					:to="addNewLink"
 					:disabled="createAllowed === false"

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -371,7 +371,7 @@ function clearFilters() {
 			<template #title-outer:append>
 				<VMenu v-if="isVersioned" show-arrow placement="bottom">
 					<template #activator="{ toggle }">
-						<VersionChip :version="version ? { key: version, name: null } : null" @click="toggle" />
+						<VersionChip :version="version ? { key: version, name: null } : null" @click="toggle()" />
 					</template>
 
 					<VList>

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -392,55 +392,48 @@ function clearFilters() {
 			<template #actions>
 				<SearchInput v-model="search" v-model:filter="filter" :collection="collection" />
 
-				<div class="bookmark-controls">
-					<BookmarkAdd
-						v-if="!bookmark"
-						v-model="bookmarkDialogActive"
-						:saving="creatingBookmark"
-						@save="createBookmark"
-					>
-						<template #activator="{ on }">
-							<PrivateViewHeaderBarActionButton
-								v-tooltip.bottom="$t('create_bookmark')"
-								icon="bookmark"
-								variant="ghost"
-								@click="on"
-							/>
-						</template>
-					</BookmarkAdd>
+				<BookmarkAdd v-if="!bookmark" v-model="bookmarkDialogActive" :saving="creatingBookmark" @save="createBookmark">
+					<template #activator="{ on }">
+						<PrivateViewHeaderBarActionButton
+							v-tooltip.bottom="$t('create_bookmark')"
+							icon="bookmark"
+							variant="ghost"
+							@click="on"
+						/>
+					</template>
+				</BookmarkAdd>
 
-					<div v-else-if="bookmarkSaved" class="saved-bookmark">
-						<VIcon name="bookmark" filled />
-					</div>
-
-					<PrivateViewHeaderBarActionButton
-						v-else-if="bookmarkIsMine"
-						v-tooltip.bottom="$t('update_bookmark')"
-						icon="bookmark_save"
-						variant="ghost"
-						@click="savePreset()"
-					/>
-
-					<BookmarkAdd v-else v-model="bookmarkDialogActive" :saving="creatingBookmark" @save="createBookmark">
-						<template #activator="{ on }">
-							<PrivateViewHeaderBarActionButton
-								v-tooltip.bottom="$t('create_bookmark')"
-								icon="bookmark"
-								variant="ghost"
-								@click="on"
-							/>
-						</template>
-					</BookmarkAdd>
-
-					<PrivateViewHeaderBarActionButton
-						v-if="bookmark && !bookmarkSaving && bookmarkSaved === false"
-						v-tooltip.bottom="$t('reset_bookmark')"
-						icon="settings_backup_restore"
-						variant="ghost"
-						kind="danger"
-						@click="clearLocalSave"
-					/>
+				<div v-else-if="bookmarkSaved" class="saved-bookmark">
+					<VIcon name="bookmark" filled />
 				</div>
+
+				<PrivateViewHeaderBarActionButton
+					v-else-if="bookmarkIsMine"
+					v-tooltip.bottom="$t('update_bookmark')"
+					icon="bookmark_save"
+					variant="ghost"
+					@click="savePreset()"
+				/>
+
+				<BookmarkAdd v-else v-model="bookmarkDialogActive" :saving="creatingBookmark" @save="createBookmark">
+					<template #activator="{ on }">
+						<PrivateViewHeaderBarActionButton
+							v-tooltip.bottom="$t('create_bookmark')"
+							icon="bookmark"
+							variant="ghost"
+							@click="on"
+						/>
+					</template>
+				</BookmarkAdd>
+
+				<PrivateViewHeaderBarActionButton
+					v-if="bookmark && !bookmarkSaving && bookmarkSaved === false"
+					v-tooltip.bottom="$t('reset_bookmark')"
+					icon="settings_backup_restore"
+					variant="ghost"
+					kind="danger"
+					@click="clearLocalSave"
+				/>
 
 				<VDialog v-if="selection.length > 0" v-model="confirmDelete" @esc="confirmDelete = false" @apply="batchDelete">
 					<template #activator="{ on }">
@@ -642,7 +635,8 @@ function clearFilters() {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	inline-size: 2rem;
 	block-size: 2rem;
+	inline-size: 2rem;
+	min-inline-size: 2rem;
 }
 </style>

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -977,6 +977,7 @@ function editDraftVersion() {
 						:tooltip="translateShortcut(['meta', 's'])"
 						icon="beenhere"
 						secondary
+						:loading="saveVersionLoading"
 						:disabled="!isSavable"
 						@click="saveVersionAction()"
 					/>

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -888,7 +888,7 @@ function editDraftVersion() {
 		<template #actions>
 			<PrivateViewHeaderBarActionButton
 				v-if="previewUrl"
-				v-tooltip.bottom="$t(livePreviewMode === null ? 'live_preview.enable' : 'live_preview.disable')"
+				:tooltip="$t(livePreviewMode === null ? 'live_preview.enable' : 'live_preview.disable')"
 				icon="visibility"
 				variant="ghost"
 				:active="!!livePreviewMode"
@@ -905,7 +905,7 @@ function editDraftVersion() {
 				<template #activator="{ on }">
 					<PrivateViewHeaderBarActionButton
 						v-if="collectionInfo.meta && collectionInfo.meta.singleton === false"
-						v-tooltip.bottom="deleteAllowed ? $t('delete_label') : $t('not_allowed')"
+						:tooltip="deleteAllowed ? $t('delete_label') : $t('not_allowed')"
 						icon="delete"
 						kind="danger"
 						variant="ghost"
@@ -938,7 +938,7 @@ function editDraftVersion() {
 				<template #activator="{ on }">
 					<PrivateViewHeaderBarActionButton
 						v-if="collectionInfo.meta && collectionInfo.meta.singleton === false"
-						v-tooltip.bottom="archiveTooltip"
+						:tooltip="archiveTooltip"
 						:icon="isArchived ? 'unarchive' : 'archive'"
 						kind="warning"
 						variant="ghost"

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -960,72 +960,58 @@ function editDraftVersion() {
 					</VCardActions>
 				</VCard>
 			</VDialog>
+		</template>
+
+		<template #actions:primary>
 			<template v-if="shouldShowVersioning">
-				<VButton v-if="currentVersion === null" rounded icon :tooltip="$t('edit_item')" small @click="editDraftVersion">
-					<VIcon name="edit" small />
-				</VButton>
+				<PrivateViewHeaderBarActionButton
+					v-if="currentVersion === null"
+					:label="$t('edit')"
+					icon="edit"
+					@click="editDraftVersion()"
+				/>
 
 				<template v-else>
-					<VButton
-						rounded
-						icon
+					<PrivateViewHeaderBarActionButton
+						:label="$t('save')"
+						:tooltip="translateShortcut(['meta', 's'])"
+						icon="beenhere"
 						secondary
-						:tooltip="$t('save_version')"
-						:loading="saveVersionLoading"
 						:disabled="!isSavable"
-						small
 						@click="saveVersionAction()"
-					>
-						<VIcon name="beenhere" small />
-					</VButton>
+					/>
 
-					<VButton
-						rounded
-						icon
-						small
+					<PrivateViewHeaderBarActionButton
+						:label="$t('publish')"
+						:tooltip="translateShortcut(['meta', 'alt', 'p'])"
+						icon="public"
 						:disabled="!isPublishAllowed"
-						:tooltip="`${$t('publish')} (${translateShortcut(['meta', 'alt', 'p'])})`"
 						@click="onVersionPublishCompare()"
 					>
-						<VIcon name="public" small />
-
-						<template #append-outer>
-							<VMenu
-								v-if="collectionInfo.meta && collectionInfo.meta.singleton !== true && isPublishAllowed"
-								show-arrow
-							>
-								<template #activator="{ toggle }">
-									<VIcon class="version-more-options" name="more_vert" clickable @click="toggle" />
-								</template>
-
-								<VList>
-									<VListItem clickable @click="onVersionPublishCompare(true)">
-										<VListItemIcon><VIcon name="public" /></VListItemIcon>
-										<VListItemContent>{{ $t('publish_and_quit') }}</VListItemContent>
-										<VListItemHint>{{ translateShortcut(['meta', 'alt', 'shift', 'p']) }}</VListItemHint>
-									</VListItem>
-								</VList>
-							</VMenu>
+						<template v-if="collectionInfo.meta && collectionInfo.meta.singleton !== true" #split-menu>
+							<VList>
+								<VListItem clickable @click="onVersionPublishCompare(true)">
+									<VListItemIcon><VIcon name="public" /></VListItemIcon>
+									<VListItemContent>{{ $t('publish_and_quit') }}</VListItemContent>
+									<VListItemHint>{{ translateShortcut(['meta', 'alt', 'shift', 'p']) }}</VListItemHint>
+								</VListItem>
+							</VList>
 						</template>
-					</VButton>
+					</PrivateViewHeaderBarActionButton>
 				</template>
 			</template>
+
 			<template v-else>
-				<VButton
-					v-if="currentVersion === null"
-					rounded
-					icon
-					:tooltip="saveAllowed ? $t('save') : $t('not_allowed')"
+				<PrivateViewHeaderBarActionButton
+					:label="$t('save')"
+					:tooltip="!saveAllowed ? $t('not_allowed') : undefined"
+					icon="check"
 					:loading="saving"
 					:disabled="!isSavable"
-					small
-					@click="saveAndQuit"
+					@click="saveAndQuit()"
 				>
-					<VIcon name="check" small />
-
-					<template #append-outer>
+					<template v-if="collectionInfo.meta && collectionInfo.meta.singleton !== true" #split-menu>
 						<SaveOptions
-							v-if="collectionInfo.meta && collectionInfo.meta.singleton !== true && isSavable === true"
 							:disabled-options="disabledOptions"
 							@save-and-stay="saveAndStay"
 							@save-and-add-new="saveAndAddNew"
@@ -1033,7 +1019,7 @@ function editDraftVersion() {
 							@discard-and-stay="discardAndStay"
 						/>
 					</template>
-				</VButton>
+				</PrivateViewHeaderBarActionButton>
 			</template>
 		</template>
 

--- a/app/src/modules/visual/routes/visual-editor.test.ts
+++ b/app/src/modules/visual/routes/visual-editor.test.ts
@@ -112,7 +112,7 @@ describe('Version selector', () => {
 			props: { dynamicUrl: 'https://example.com/preview' },
 		});
 
-		expect(wrapper.find('.version-select-activator').exists()).toBe(false);
+		expect(wrapper.find('.version-chip').exists()).toBe(false);
 	});
 
 	it('is not rendered when user lacks read permission on directus_versions', () => {
@@ -123,7 +123,7 @@ describe('Version selector', () => {
 			props: { dynamicUrl: 'https://example.com/?version=v1' },
 		});
 
-		expect(wrapper.find('.version-select-activator').exists()).toBe(false);
+		expect(wrapper.find('.version-chip').exists()).toBe(false);
 	});
 
 	it('is rendered when the URL matches a version template and user can read versions', () => {
@@ -135,7 +135,7 @@ describe('Version selector', () => {
 			props: { dynamicUrl: 'https://example.com/?version=v1' },
 		});
 
-		expect(wrapper.find('.version-select-activator').exists()).toBe(true);
+		expect(wrapper.find('.version-chip').exists()).toBe(true);
 	});
 
 	it('adds a new version to the list when the URL contains a custom version key', async () => {

--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -663,7 +663,13 @@ function popoverClickOutsideMiddleware(e: Event) {
 		</template>
 
 		<template #actions:primary>
-			<PrivateViewHeaderBarActionButton :label="$t('save')" :disabled="!isSavable" icon="check" @click="save" />
+			<PrivateViewHeaderBarActionButton
+				:label="$t('save')"
+				:tooltip="getSaveShortcut()"
+				:disabled="!isSavable"
+				icon="check"
+				@click="save"
+			/>
 		</template>
 
 		<OverlayItemContent

--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -96,7 +96,7 @@ const { junctionFieldInfo, relatedCollection, relatedCollectionInfo, relatedPrim
 
 const { internalEdits, loading, initialValues, refresh } = useItem();
 
-const { save, cancel, overlayActive, getSaveShortcut } = useActions();
+const { save, cancel, overlayActive, applyShortcutFormatted } = useActions();
 
 const { resolvedPopoverProps } = usePopoverProps();
 
@@ -458,6 +458,7 @@ function useRelation() {
 
 function useActions() {
 	const { nestedValidationErrors, resetNestedValidationErrors } = useNestedValidation();
+	const applyShortcutFormatted = computed(() => translateShortcut(props.applyShortcut.split('+')));
 
 	watch(internalActive, (active) => {
 		if (!active) resetNestedValidationErrors();
@@ -489,11 +490,7 @@ function useActions() {
 		cancelNext();
 	});
 
-	return { save, cancel, overlayActive, getSaveShortcut };
-
-	function getSaveShortcut() {
-		return translateShortcut(props.applyShortcut.split('+'));
-	}
+	return { save, cancel, overlayActive, applyShortcutFormatted };
 
 	function validateForm({ defaultValues, existingValues, editsToValidate, fieldsToValidate }: Record<string, any>) {
 		return validateItem(
@@ -665,7 +662,7 @@ function popoverClickOutsideMiddleware(e: Event) {
 		<template #actions:primary>
 			<PrivateViewHeaderBarActionButton
 				:label="$t('save')"
-				:tooltip="getSaveShortcut()"
+				:tooltip="applyShortcutFormatted"
 				:disabled="!isSavable"
 				icon="check"
 				@click="save"
@@ -707,7 +704,7 @@ function popoverClickOutsideMiddleware(e: Event) {
 
 				<slot name="actions" />
 
-				<VButton v-tooltip="getSaveShortcut()" :disabled="!isSavable" @click="save">{{ $t('save') }}</VButton>
+				<VButton v-tooltip="applyShortcutFormatted" :disabled="!isSavable" @click="save">{{ $t('save') }}</VButton>
 			</VCardActions>
 		</VCard>
 	</VDialog>
@@ -754,7 +751,7 @@ function popoverClickOutsideMiddleware(e: Event) {
 
 				<slot name="actions" />
 
-				<VButton v-tooltip="getSaveShortcut()" x-small :disabled="!isSavable" @click="save">
+				<VButton v-tooltip="applyShortcutFormatted" x-small :disabled="!isSavable" @click="save">
 					{{ $t('save') }}
 				</VButton>
 			</div>

--- a/app/src/views/private/private-view/components/private-view-header-bar-action-button.vue
+++ b/app/src/views/private/private-view/components/private-view-header-bar-action-button.vue
@@ -45,6 +45,7 @@ function useIcon() {
 	});
 
 	const activeTooltip = computed(() => {
+		if (showIcon.value && tooltip) return `${label} (${tooltip})`;
 		if (tooltip) return tooltip;
 		if (showIcon.value) return label;
 		return undefined;

--- a/app/src/views/private/private-view/components/private-view-header-bar-action-button.vue
+++ b/app/src/views/private/private-view/components/private-view-header-bar-action-button.vue
@@ -45,7 +45,7 @@ function useIcon() {
 	});
 
 	const activeTooltip = computed(() => {
-		if (showIcon.value && tooltip) return `${label} (${tooltip})`;
+		if (showIcon.value && label && tooltip) return `${label} (${tooltip})`;
 		if (tooltip) return tooltip;
 		if (showIcon.value) return label;
 		return undefined;


### PR DESCRIPTION
## Scope

What's changed:

- Migrate item-view primary CTAs (Edit / Save / Publish / Save-and-quit) to the `#actions:primary` slot and `PrivateViewHeaderBarActionButton`, using the standardized `#split-menu` slot for Publish and Save options.
- Replace the inline `VChip` version selector in the collection view with the existing `VersionChip` component.
- Rename the collection "Create Item" CTA to "Create" — a version is not an item, so the old label was misleading in the draft/publish flow.
- Small fixes along the way: vertical bookmark-icon bug, overlay-item shortcut tooltip, and a `v-tooltip` → `:tooltip` prop cleanup on header action buttons.

## Potential Risks / Drawbacks

—

## Tested Scenarios

- Item detail with and without versioning: Edit, Save, Publish, Publish-and-quit, Save-and-quit / -and-add-new / -and-stay, Discard-and-stay.
- Versioned collection: switch between main and versions via `VersionChip`.
- Bookmark create / update / reset on the collection header.
- Overlay item save via keyboard shortcut and button; tooltip shows the shortcut.

## Review Notes / Questions

- Please pay special attention to permissions

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Addresses CMS-2288
