### PR TITLE
fix(search-input): trim whitespace from search value

### DIFF
--- a/.changeset/search-input-trim-whitespace.md
+++ b/.changeset/search-input-trim-whitespace.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed search input not trimming leading and trailing whitespace from search values

--- a/app/src/views/private/components/search-input.vue
+++ b/app/src/views/private/components/search-input.vue
@@ -133,8 +133,8 @@ function onFocusOut(event: FocusEvent) {
 
 function emitValue() {
 	if (!input.value) return;
-	const value = input.value?.value;
-	emit('update:modelValue', value);
+	const value = input.value?.value.trim();
+	emit('update:modelValue', value || null);
 }
 </script>
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -272,4 +272,4 @@
 - om-singh-D
 - yogeshwaran-c
 - sanskar-soni-9
-- kropsi
+- kropsi- algojogacor


### PR DESCRIPTION
## Scope

What's changed:

- Trim leading and trailing whitespace from the search input value in `emitValue()` of `search-input.vue`
- Treat whitespace-only input as `null`, matching the existing behavior of the `clear()` function

## Potential Risks / Drawbacks

- None. The change is localized to the single shared search-input component used by every list view in the app. Consumer components already handle `null` values correctly (the clear function emits null, which is already supported).
- The `.trim()` call is safe even on strings without whitespace — it returns the original string unchanged.

## Tested Scenarios

- Typing a known collection name with a trailing space (e.g., `"post "`) now matches the collection `"post"` correctly ✅
- Typing only whitespace characters treats the input as empty (null) — no search is performed ✅
- Typing a query with leading whitespace (e.g., `" post"`) correctly matches items named `"post"` ✅
- Regular search without surrounding whitespace continues to work as before ✅
- The clear button still emits `null` and clears the input properly ✅

## Review Notes / Questions

- This is a one-line behavioral change in the shared search input component. The fix follows the pattern suggested in issue #27358.
- A related issue (#13255) was reported in 2022 for the leading-space variant but the trailing-space variant and the underlying lack of trim remained.

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #27358