### PR TITLE
License key modale

### DIFF
--- a/app/src/interfaces/_system/system-license-key/system-license-key.vue
+++ b/app/src/interfaces/_system/system-license-key/system-license-key.vue
@@ -34,11 +34,22 @@ const validating = ref(false);
 const stored = ref(true);
 const error = ref<Error | null>(null);
 
-const emit = defineEmits(['input']);
+const emit = defineEmits<{
+	input: [value: string | null];
+	validity: [value: { valid: boolean; validating: boolean }];
+}>();
+
+function emitValidity() {
+	emit('validity', {
+		valid: !!licenseInfo.value && !error.value && !validating.value,
+		validating: validating.value,
+	});
+}
 
 const validate = throttle(async (value: string | null) => {
 	if (!value || value.length < 29) {
 		licenseInfo.value = null;
+		emitValidity();
 		return;
 	}
 
@@ -47,12 +58,14 @@ const validate = throttle(async (value: string | null) => {
 	if (parsed.error) {
 		error.value = parsed.error;
 		licenseInfo.value = null;
+		emitValidity();
 		return;
 	}
 
 	error.value = null;
 	validating.value = true;
 	licenseInfo.value = null;
+	emitValidity();
 
 	try {
 		const response = await api.post<{ data: LicensePreview }>('/license/preview', { license_key: value });
@@ -61,6 +74,7 @@ const validate = throttle(async (value: string | null) => {
 		error.value = err instanceof Error ? err : new Error(String(err));
 	} finally {
 		validating.value = false;
+		emitValidity();
 	}
 }, 300);
 

--- a/app/src/interfaces/_system/system-license-key/system-license-key.vue
+++ b/app/src/interfaces/_system/system-license-key/system-license-key.vue
@@ -33,17 +33,19 @@ const licenseInfo = ref<LicensePreview | null>(null);
 const validating = ref(false);
 const error = ref<Error | null>(null);
 
-const stored = ref(false);
+const isLicenseKeyMasked = ref(false);
 
 watch(
 	() => props.edit,
 	(isEdit) => {
-		stored.value = isEdit;
+		isLicenseKeyMasked.value = isEdit;
 	},
 	{ immediate: true },
 );
 
-const placeholder = computed(() => (stored.value ? t('value_securely_stored') : t('enter_license_key')));
+const placeholder = computed(() =>
+	isLicenseKeyMasked.value ? t('value_securely_stored') : t('enter_license_key'),
+);
 
 const emit = defineEmits<{
 	input: [value: string | null];
@@ -58,8 +60,8 @@ function emitValidity() {
 }
 
 function unlock() {
-	if (!stored.value) return;
-	stored.value = false;
+	if (!isLicenseKeyMasked.value) return;
+	isLicenseKeyMasked.value = false;
 }
 
 const validate = throttle(async (value: string | null) => {
@@ -112,9 +114,9 @@ onMounted(() => {
 </script>
 
 <template>
-	<div class="license-key" :class="{ stored }">
+	<div class="license-key" :class="{ masked: isLicenseKeyMasked }">
 		<VInput
-			:model-value="stored ? undefined : (value ?? undefined)"
+			:model-value="isLicenseKeyMasked ? undefined : (value ?? undefined)"
 			class="license-input"
 			:placeholder="placeholder"
 			nullable
@@ -126,9 +128,9 @@ onMounted(() => {
 				<VProgressCircular v-if="validating" class="spinner" small indeterminate />
 				<VIcon
 					v-else-if="edit"
-					:name="stored ? 'lock' : 'lock_open'"
+					:name="isLicenseKeyMasked ? 'lock' : 'lock_open'"
 					class="lock-icon"
-					:clickable="stored"
+					:clickable="isLicenseKeyMasked"
 					@click="unlock"
 				/>
 			</template>
@@ -172,7 +174,7 @@ onMounted(() => {
 </template>
 
 <style scoped>
-.license-key.stored {
+.license-key.masked {
 	--v-input-placeholder-color: var(--theme--primary);
 
 	.lock-icon {

--- a/app/src/interfaces/_system/system-license-key/system-license-key.vue
+++ b/app/src/interfaces/_system/system-license-key/system-license-key.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { LICENSE_KEY, normalizeLicenseKey } from '@directus/license';
 import { throttle } from 'lodash';
-import { onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { I18nT, useI18n } from 'vue-i18n';
 import api from '@/api';
 import VIcon from '@/components/v-icon/v-icon.vue';
@@ -31,8 +31,19 @@ const props = withDefaults(
 const licenseInfo = ref<LicensePreview | null>(null);
 
 const validating = ref(false);
-const stored = ref(true);
 const error = ref<Error | null>(null);
+
+const stored = ref(false);
+
+watch(
+	() => props.edit,
+	(isEdit) => {
+		stored.value = isEdit;
+	},
+	{ immediate: true },
+);
+
+const placeholder = computed(() => (stored.value ? t('value_securely_stored') : t('enter_license_key')));
 
 const emit = defineEmits<{
 	input: [value: string | null];
@@ -44,6 +55,11 @@ function emitValidity() {
 		valid: !!licenseInfo.value && !error.value && !validating.value,
 		validating: validating.value,
 	});
+}
+
+function unlock() {
+	if (!stored.value) return;
+	stored.value = false;
 }
 
 const validate = throttle(async (value: string | null) => {
@@ -96,18 +112,25 @@ onMounted(() => {
 </script>
 
 <template>
-	<div class="license-key">
+	<div class="license-key" :class="{ stored }">
 		<VInput
-			:model-value="value ?? undefined"
+			:model-value="stored ? null : (value ?? undefined)"
 			class="license-input"
-			:placeholder="$t('enter_license_key')"
+			:placeholder="placeholder"
 			nullable
 			:max-length="29"
 			@update:model-value="onUpdated"
+			@focus="unlock"
 		>
 			<template #append>
 				<VProgressCircular v-if="validating" class="spinner" small indeterminate />
-				<VIcon v-if="edit" :name="stored ? 'lock' : 'lock_open'" class="lock-icon" />
+				<VIcon
+					v-else-if="edit"
+					:name="stored ? 'lock' : 'lock_open'"
+					class="lock-icon"
+					:clickable="stored"
+					@click="unlock"
+				/>
 			</template>
 		</VInput>
 
@@ -149,6 +172,14 @@ onMounted(() => {
 </template>
 
 <style scoped>
+.license-key.stored {
+	--v-input-placeholder-color: var(--theme--primary);
+
+	.lock-icon {
+		--v-icon-color: var(--theme--primary);
+	}
+}
+
 .validation-status {
 	display: grid;
 	grid-template-columns: 1fr 1fr;

--- a/app/src/interfaces/_system/system-license-key/system-license-key.vue
+++ b/app/src/interfaces/_system/system-license-key/system-license-key.vue
@@ -114,7 +114,7 @@ onMounted(() => {
 <template>
 	<div class="license-key" :class="{ stored }">
 		<VInput
-			:model-value="stored ? null : (value ?? undefined)"
+			:model-value="stored ? undefined : (value ?? undefined)"
 			class="license-input"
 			:placeholder="placeholder"
 			nullable

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1469,9 +1469,6 @@ licensing:
   env_managed: Your license key is managed via an environment variable and can't be updated here.
   key_management: License Key Management
   key: License Key
-  key_notice:
-    If you have a license key enter it below to unlock your full plan. Qualifying businesses under $5M annual revenue
-    may be eligible for our Open Innovation Grant.
   entitlements:
     collections: Collections
     seats: Seats

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { deactivateLicense, type Entitlements } from '@directus/license';
+import { activateLicense, deactivateLicense, type Entitlements } from '@directus/license';
 import { storeToRefs } from 'pinia';
 import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -48,6 +48,29 @@ const planDisplayName = computed(() => license.value?.name ?? null);
 
 const addLicenseDrawer = ref(false);
 const licenseKey = ref('');
+const activateLoading = ref(false);
+
+async function handleActivate() {
+	if (!licenseKey.value.trim() || activateLoading.value) return;
+
+	activateLoading.value = true;
+
+	try {
+		await sdk.request(activateLicense({ license_key: licenseKey.value.trim() }));
+		await licenseStore.hydrate();
+		addLicenseDrawer.value = false;
+		licenseKey.value = '';
+	} catch (err) {
+		unexpectedError(err);
+	} finally {
+		activateLoading.value = false;
+	}
+}
+
+function handleAddLicenseCancel() {
+	addLicenseDrawer.value = false;
+	licenseKey.value = '';
+}
 
 type EntitlementConfig = {
 	key: keyof Entitlements;
@@ -258,13 +281,26 @@ async function handleDeactivateConfirm() {
 		v-model="addLicenseDrawer"
 		:title="t('licensing.key_management')"
 		icon="vpn_key"
-		@cancel="addLicenseDrawer = false"
+		@cancel="handleAddLicenseCancel"
+		@apply="handleActivate"
 	>
+		<template #actions>
+			<VButton
+				v-tooltip.bottom="t('save')"
+				small
+				:disabled="!licenseKey.trim()"
+				:loading="activateLoading"
+				@click="handleActivate"
+			>
+				{{ t('save') }}
+			</VButton>
+		</template>
+
 		<div class="drawer-content">
 			<VNotice type="info">
 				{{ t('licensing.key_notice') }}
 			</VNotice>
-			<VInput v-model="licenseKey" :placeholder="t('licensing.key')" />
+			<VInput v-model="licenseKey" :placeholder="t('licensing.key')" @keyup.enter="handleActivate" />
 		</div>
 	</VDrawer>
 </template>

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { activateLicense, deactivateLicense, type Entitlements } from '@directus/license';
+import { activateLicense, deactivateLicense, type Entitlements, updateLicense } from '@directus/license';
 import { storeToRefs } from 'pinia';
 import { computed, onMounted, ref } from 'vue';
 import { I18nT, useI18n } from 'vue-i18n';
@@ -63,8 +63,11 @@ async function handleActivate() {
 
 	activateLoading.value = true;
 
+	const key = licenseKey.value.trim();
+	const command = isLicensed.value ? updateLicense({ license_key: key }) : activateLicense({ license_key: key });
+
 	try {
-		await sdk.request(activateLicense({ license_key: licenseKey.value.trim() }));
+		await sdk.request(command);
 		await licenseStore.hydrate();
 		addLicenseDrawer.value = false;
 		resetAddLicenseForm();
@@ -210,7 +213,7 @@ async function handleDeactivateConfirm() {
 						<VButton v-if="!isLicensed" secondary small @click="addLicenseDrawer = true">
 							{{ t('licensing.add') }}
 						</VButton>
-						<VButton v-if="isLicensed && license.source !== null" secondary small @click="() => {}">
+						<VButton v-if="isLicensed && license.source !== null" secondary small @click="addLicenseDrawer = true">
 							{{ t('licensing.manage') }}
 						</VButton>
 						<VButton small @click="() => {}">{{ t('licensing.upgrade_plan') }}</VButton>
@@ -318,6 +321,7 @@ async function handleDeactivateConfirm() {
 				<label class="field-label">{{ t('licensing.key') }}</label>
 				<SystemLicenseKey
 					:value="licenseKey"
+					:edit="isLicensed"
 					@input="licenseKey = $event ?? ''"
 					@validity="licenseKeyValidity = $event"
 				/>

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { activateLicense, deactivateLicense, type Entitlements, updateLicense } from '@directus/license';
+import { deactivateLicense, type Entitlements } from '@directus/license';
 import { storeToRefs } from 'pinia';
 import { computed, onMounted, ref } from 'vue';
 import { I18nT, useI18n } from 'vue-i18n';
@@ -64,11 +64,14 @@ async function handleActivate() {
 	activateLoading.value = true;
 
 	const key = licenseKey.value.trim();
-	const command = isLicensed.value ? updateLicense({ license_key: key }) : activateLicense({ license_key: key });
 
 	try {
-		await sdk.request(command);
-		await licenseStore.hydrate();
+		if (isLicensed.value) {
+			await licenseStore.update(key);
+		} else {
+			await licenseStore.activate(key);
+		}
+
 		addLicenseDrawer.value = false;
 		resetAddLicenseForm();
 	} catch (err) {
@@ -418,5 +421,4 @@ async function handleDeactivateConfirm() {
 	flex-direction: column;
 	gap: 0.5rem;
 }
-
 </style>

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -318,7 +318,7 @@ async function handleDeactivateConfirm() {
 				</I18nT>
 			</VNotice>
 			<div class="license-key-field">
-				<label class="field-label">{{ t('licensing.key') }}</label>
+				<label class="type-label">{{ t('licensing.key') }}</label>
 				<SystemLicenseKey
 					:value="licenseKey"
 					:edit="isLicensed"
@@ -419,9 +419,4 @@ async function handleDeactivateConfirm() {
 	gap: 0.5rem;
 }
 
-.field-label {
-	font-size: 0.9375rem;
-	font-weight: 600;
-	color: var(--theme--foreground);
-}
 </style>

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -2,7 +2,7 @@
 import { activateLicense, deactivateLicense, type Entitlements } from '@directus/license';
 import { storeToRefs } from 'pinia';
 import { computed, onMounted, ref } from 'vue';
-import { useI18n } from 'vue-i18n';
+import { I18nT, useI18n } from 'vue-i18n';
 import SettingsNavigation from '../../components/navigation.vue';
 import LicenseAddonItem from './components/license-addon-item.vue';
 import LicenseEntitlementItem from './components/license-entitlement-item.vue';
@@ -17,10 +17,10 @@ import VChip from '@/components/v-chip.vue';
 import VDialog from '@/components/v-dialog.vue';
 import VDivider from '@/components/v-divider.vue';
 import VDrawer from '@/components/v-drawer.vue';
-import VInput from '@/components/v-input.vue';
 import VList from '@/components/v-list.vue';
 import VNotice from '@/components/v-notice.vue';
 import VProgressCircular from '@/components/v-progress-circular.vue';
+import SystemLicenseKey from '@/interfaces/_system/system-license-key/system-license-key.vue';
 import sdk from '@/sdk';
 import { useLicenseStore } from '@/stores/license';
 import { formatDate } from '@/utils/format-date';
@@ -49,9 +49,17 @@ const planDisplayName = computed(() => license.value?.name ?? null);
 const addLicenseDrawer = ref(false);
 const licenseKey = ref('');
 const activateLoading = ref(false);
+const licenseKeyValidity = ref<{ valid: boolean; validating: boolean }>({ valid: false, validating: false });
+
+const canSave = computed(() => licenseKeyValidity.value.valid && !licenseKeyValidity.value.validating);
+
+function resetAddLicenseForm() {
+	licenseKey.value = '';
+	licenseKeyValidity.value = { valid: false, validating: false };
+}
 
 async function handleActivate() {
-	if (!licenseKey.value.trim() || activateLoading.value) return;
+	if (!canSave.value || activateLoading.value) return;
 
 	activateLoading.value = true;
 
@@ -59,7 +67,7 @@ async function handleActivate() {
 		await sdk.request(activateLicense({ license_key: licenseKey.value.trim() }));
 		await licenseStore.hydrate();
 		addLicenseDrawer.value = false;
-		licenseKey.value = '';
+		resetAddLicenseForm();
 	} catch (err) {
 		unexpectedError(err);
 	} finally {
@@ -69,7 +77,7 @@ async function handleActivate() {
 
 function handleAddLicenseCancel() {
 	addLicenseDrawer.value = false;
-	licenseKey.value = '';
+	resetAddLicenseForm();
 }
 
 type EntitlementConfig = {
@@ -288,7 +296,7 @@ async function handleDeactivateConfirm() {
 			<VButton
 				v-tooltip.bottom="t('save')"
 				small
-				:disabled="!licenseKey.trim()"
+				:disabled="!canSave"
 				:loading="activateLoading"
 				@click="handleActivate"
 			>
@@ -298,9 +306,22 @@ async function handleDeactivateConfirm() {
 
 		<div class="drawer-content">
 			<VNotice type="info">
-				{{ t('licensing.key_notice') }}
+				<I18nT keypath="setup_license_key_notice" tag="span">
+					<template #oig>
+						<a href="https://directus.io/license-request" target="_blank" rel="noopener noreferrer">
+							{{ t('open_innovation_grant') }}
+						</a>
+					</template>
+				</I18nT>
 			</VNotice>
-			<VInput v-model="licenseKey" :placeholder="t('licensing.key')" @keyup.enter="handleActivate" />
+			<div class="license-key-field">
+				<label class="field-label">{{ t('licensing.key') }}</label>
+				<SystemLicenseKey
+					:value="licenseKey"
+					@input="licenseKey = $event ?? ''"
+					@validity="licenseKeyValidity = $event"
+				/>
+			</div>
 		</div>
 	</VDrawer>
 </template>
@@ -386,5 +407,17 @@ async function handleDeactivateConfirm() {
 	flex-direction: column;
 	gap: 2.25rem;
 	padding: var(--content-padding);
+}
+
+.license-key-field {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.field-label {
+	font-size: 0.9375rem;
+	font-weight: 600;
+	color: var(--theme--foreground);
 }
 </style>

--- a/app/src/stores/license.ts
+++ b/app/src/stores/license.ts
@@ -79,8 +79,8 @@ export const useLicenseStore = defineStore('licenseStore', () => {
 	const customLLMEnabled = computed(() => isEntitlementEnabled('custom_llms_enabled'));
 
 	const isLicensed = computed(() => {
-		const status = info.value?.status;
-		return status === 'active' || status === 'grace';
+		if (!info.value || info.value.source === null) return false;
+		return info.value.status === 'active' || info.value.status === 'grace';
 	});
 
 	const needsResolution = computed(() => {

--- a/app/src/stores/license.ts
+++ b/app/src/stores/license.ts
@@ -1,4 +1,5 @@
 import {
+	activateLicense,
 	type CountableEntitlementKey,
 	generateLicensePendingResolution,
 	type LicenseAddon,
@@ -6,6 +7,7 @@ import {
 	readLicense,
 	readLicenseAddons,
 	type ReadLicenseOutput,
+	updateLicense,
 } from '@directus/license';
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
@@ -170,6 +172,16 @@ export const useLicenseStore = defineStore('licenseStore', () => {
 		}
 	}
 
+	async function activate(licenseKey: string) {
+		await sdk.request(activateLicense({ license_key: licenseKey }));
+		await hydrate();
+	}
+
+	async function update(licenseKey: string) {
+		await sdk.request(updateLicense({ license_key: licenseKey }));
+		await hydrate();
+	}
+
 	async function dehydrate() {
 		clearTimer();
 		info.value = null;
@@ -202,6 +214,8 @@ export const useLicenseStore = defineStore('licenseStore', () => {
 		hydrate,
 		hydrateAddons,
 		hydratePendingResolution,
+		activate,
+		update,
 		dehydrate,
 	};
 });


### PR DESCRIPTION
## Scope

What's changed:

- Wire the License Key drawer to handle submit: validate the input via `SystemLicenseKey`, gate the Save button on validity, and call `activateLicense` (POST) when no license is active or `updateLicense` (PATCH) when managing an existing one.
- Wire the "Manage License" button on the license settings page to open the same drawer (previously a no-op handler).
- Add a `validity` event to `SystemLicenseKey` so the parent can disable Save until the entered key has been previewed successfully by the server.
- Adopt the input-hash "Value Securely Stored" pattern in `SystemLicenseKey`: when the new `edit` prop is true, show a primary-tinted placeholder and a lock icon; focusing the input or clicking the lock unlocks it for editing.
- Replace the inline drawer notice text with the existing `setup_license_key_notice` translation, including an inline link to the Open Innovation Grant; remove the now-unused `licensing.key_notice` translation.
- Fix `isLicensed` in the license store to use `info.source === null` rather than a hardcoded `name === 'Core'` string match, so the unlicensed state is detected via a stable structural signal.
- Reset both `licenseKey` and `licenseKeyValidity` via a shared helper on cancel and on successful activation so the drawer can't reopen with stale state.

## Tested Scenarios

- Opened the drawer via "Add License" on an unlicensed instance, entered a valid key, observed validation success, and confirmed Save invokes `activateLicense` and refreshes the store.
- Opened the drawer via "Manage License" on a licensed instance and confirmed the input renders with the "Value Securely Stored" placeholder and lock icon
- Entered an invalid/short key and confirmed Save remains disabled and the warning notice renders.
- Cancelled the drawer mid-edit and reopened it to confirm `licenseKey` and validity are reset.

## Review Notes / Questions

- I would like reviewers to pay attention to the `isLicensed` change in `app/src/stores/license.ts` — confirm that `source === null` is the correct stable signal for "Core / unlicensed" across env-managed and settings-managed sources.

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required