### PR TITLE
Update license wording

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -29,12 +29,6 @@ setup_info: Let's create your admin account and get your project up and running.
 setup_license_key_notice: >
   If have a license key enter it below to unlock your full plan. Qualifying businesses under $5M annual revenue may be
   eligible for our {oig}.
-setup_license_notice: >
-  You can continue to use Directus for free without a software key, provided the project stays within the Core tier's
-  limits.
-setup_license_follow_up: >
-  Alternatively, qualifying organizations with under $5M in annual revenue, funding, or operating budget can obtain a
-  free license without limits. Check eligibility for the {oig}.
 setup_save_accept_license: >
   By hitting save, you accept the terms of the {directusMscl} and {privacyPolicy}.
 setup_license_invalid: >

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -21,9 +21,8 @@
 # 'Proxy', 'Intl'
 
 about: About
-directus_bsl: Directus BSL 1.1
+directus_mscl: Directus MSCL-1.0-GPL
 privacy_policy: Privacy Policy
-contact_our_team: Contact our Team
 contact_support: contact support
 setup_welcome: Welcome to Directus
 setup_info: Let's create your admin account and get your project up and running.
@@ -31,15 +30,16 @@ setup_license_key_notice: >
   If have a license key enter it below to unlock your full plan. Qualifying businesses under $5M annual revenue may be
   eligible for our {oig}.
 setup_license_notice: >
-  Directus is free to use for entities under $5 million in annual revenue, funding, or operating budget.
+  You can continue to use Directus for free without a software key, provided the project stays within the Core tier's
+  limits.
 setup_license_follow_up: >
-  Entities above this threshold require a paid license. You can continue evaluating Directus now and {contactOurTeam}
-  when you're ready to discuss production use.
+  Alternatively, qualifying organizations with under $5M in annual revenue, funding, or operating budget can obtain a
+  free license without limits. Check eligibility for the {oig}.
 setup_save_accept_license: >
-  By hitting save, you accept the terms of the {directusBsl} and {privacyPolicy}.
+  By hitting save, you accept the terms of the {directusMscl} and {privacyPolicy}.
 setup_license_invalid: >
   License invalid. Please {contactSupport} to resolve this issue.
-setup_accept_license: I accept the terms of the {directusBsl} and {privacyPolicy}
+setup_accept_license: I accept the terms of the {directusMscl} and {privacyPolicy}
 setup_marketing_emails: Send me product updates and release notes
 setup_launch: Launch Directus
 setup_license_title: Set up your license
@@ -3182,11 +3182,11 @@ search_flow: Search Flow...
 percent: Percent
 show_password: Show password
 hide_password: Hide password
-bsl_banner:
+license_banner:
   title: You have not set a project owner.
   license:
-    We need this to ensure compliance with our BSL 1.1 license. This should be the primary contact responsible for your
-    project.
+    We need this to ensure compliance with our MSCL-1.0-GPL license. This should be the primary contact responsible for
+    your project.
   set_owner: Set Owner
   remind_later: Remind Later
   remind_next_login: We'll remind you again on your next login.

--- a/app/src/routes/setup/form.vue
+++ b/app/src/routes/setup/form.vue
@@ -107,12 +107,12 @@ const fields = useSetupFields(props.register);
 			<span v-md="$t('setup_license_notice')"></span>
 			<br />
 			<I18nT keypath="setup_license_follow_up" tag="span">
-				<template #contactOurTeam>
+				<template #oig>
 					<a
-						:href="`https://directus.io/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${info.version}&utm_content=${utmLocation}_contact_our_team_link`"
+						:href="`https://directus.io/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${info.version}&utm_content=${utmLocation}_open_innovation_grant_link`"
 						target="_blank"
 					>
-						{{ $t('contact_our_team') }}
+						{{ $t('open_innovation_grant') }}
 					</a>
 				</template>
 			</I18nT>
@@ -120,12 +120,12 @@ const fields = useSetupFields(props.register);
 			<span v-if="skipLicense">
 				<br />
 				<I18nT v-if="skipLicense" keypath="setup_save_accept_license" tag="span">
-					<template #directusBsl>
+					<template #directusMscl>
 						<a
-							:href="`https://directus.io/bsl?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${info.version}&utm_content=${utmLocation}_bsl_1.1_link`"
+							:href="`https://directus.io/mscl?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${info.version}&utm_content=${utmLocation}_mscl_1.0_gpl_link`"
 							target="_blank"
 						>
-							{{ $t('directus_bsl') }}
+							{{ $t('directus_mscl') }}
 						</a>
 					</template>
 					<template #privacyPolicy>
@@ -142,12 +142,12 @@ const fields = useSetupFields(props.register);
 
 		<VCheckbox v-if="!skipLicense" v-model="license">
 			<I18nT keypath="setup_accept_license" tag="span">
-				<template #directusBsl>
+				<template #directusMscl>
 					<a
-						:href="`https://directus.io/bsl?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${info.version}&utm_content=bsl_1.1_link`"
+						:href="`https://directus.io/mscl?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${info.version}&utm_content=mscl_1.0_gpl_link`"
 						target="_blank"
 					>
-						{{ $t('directus_bsl') }}
+						{{ $t('directus_mscl') }}
 					</a>
 				</template>
 				<template #privacyPolicy>

--- a/app/src/routes/setup/form.vue
+++ b/app/src/routes/setup/form.vue
@@ -103,41 +103,25 @@ const fields = useSetupFields(props.register);
 			:fields="fields"
 			disabled-menu
 		></VForm>
-		<VNotice>
-			<span v-md="$t('setup_license_notice')"></span>
-			<br />
-			<I18nT keypath="setup_license_follow_up" tag="span">
-				<template #oig>
+		<VNotice v-if="skipLicense">
+			<I18nT keypath="setup_save_accept_license" tag="span">
+				<template #directusMscl>
 					<a
-						:href="`https://directus.io/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${info.version}&utm_content=${utmLocation}_open_innovation_grant_link`"
+						:href="`https://directus.io/mscl?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${info.version}&utm_content=${utmLocation}_mscl_1.0_gpl_link`"
 						target="_blank"
 					>
-						{{ $t('open_innovation_grant') }}
+						{{ $t('directus_mscl') }}
+					</a>
+				</template>
+				<template #privacyPolicy>
+					<a
+						:href="`https://directus.io/privacy?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${info.version}&utm_content=${utmLocation}_privacy_link`"
+						target="_blank"
+					>
+						{{ $t('privacy_policy') }}
 					</a>
 				</template>
 			</I18nT>
-			<br />
-			<span v-if="skipLicense">
-				<br />
-				<I18nT v-if="skipLicense" keypath="setup_save_accept_license" tag="span">
-					<template #directusMscl>
-						<a
-							:href="`https://directus.io/mscl?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${info.version}&utm_content=${utmLocation}_mscl_1.0_gpl_link`"
-							target="_blank"
-						>
-							{{ $t('directus_mscl') }}
-						</a>
-					</template>
-					<template #privacyPolicy>
-						<a
-							:href="`https://directus.io/privacy?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${info.version}&utm_content=${utmLocation}_privacy_link`"
-							target="_blank"
-						>
-							{{ $t('privacy_policy') }}
-						</a>
-					</template>
-				</I18nT>
-			</span>
 		</VNotice>
 
 		<VCheckbox v-if="!skipLicense" v-model="license">
@@ -190,6 +174,10 @@ const fields = useSetupFields(props.register);
 
 .v-notice {
 	margin-block: 1.8125rem;
+}
+
+.v-form + .v-checkbox {
+	margin-block-start: 1.8125rem;
 }
 
 .v-checkbox {

--- a/app/src/views/private/components/license-banner.vue
+++ b/app/src/views/private/components/license-banner.vue
@@ -46,7 +46,7 @@ async function setOwner() {
 async function remindLater() {
 	// 30 days, will be deleted on logout / session end
 	cookies.set('license-banner-dismissed', 'true', { expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30) });
-	notify({ title: t('bsl_banner.remind_next_login'), type: 'info' });
+	notify({ title: t('license_banner.remind_next_login'), type: 'info' });
 }
 
 const form = ref<Form>(defaultValues);
@@ -60,22 +60,22 @@ const fields = useSetupFields(false);
 			<div class="inner">
 				<VCardTitle>
 					<span class="warning">
-						{{ $t('bsl_banner.title') }}
+						{{ $t('license_banner.title') }}
 						<VIcon name="warning" filled />
 					</span>
 				</VCardTitle>
 
 				<VCardText>
-					<div class="sub">{{ $t('bsl_banner.license') }}</div>
+					<div class="sub">{{ $t('license_banner.license') }}</div>
 					<SetupForm v-model="form" :errors="errors" :register="false" utm-location="banner"></SetupForm>
 				</VCardText>
 
 				<VCardActions>
 					<VButton secondary @click="remindLater">
-						{{ $t('bsl_banner.remind_later') }}
+						{{ $t('license_banner.remind_later') }}
 					</VButton>
 					<VButton :disabled="isSaveDisabled" :loading="isSaving" @click="setOwner">
-						{{ $t('bsl_banner.set_owner') }}
+						{{ $t('license_banner.set_owner') }}
 					</VButton>
 				</VCardActions>
 			</div>


### PR DESCRIPTION
## Scope

What's changed:

- Replace BSL 1.1 references with MSCL-1.0-GPL across the setup form and project owner modal, including i18n keys (`directus_bsl` → `directus_mscl`), slot names, link URLs (`directus.io/bsl` → `directus.io/mscl`), and UTM content tags
- Rename the `bsl_banner` i18n to `license_banner` and update its consumer (`app/src/views/private/components/license-banner.vue`); update the modal body copy to reference MSCL-1.0-GPL
- Rewrite `setup_license_notice` to describe the free Core tier and `setup_license_follow_up` to point to the Open Innovation Grant; swap the `contactOurTeam` link slot for the existing `oig` slot pattern
- Drop the now-unused `contact_our_team` entry from `en-US.yaml`

## Potential Risks / Drawbacks

- UTM term names were renamed (`bsl_1.1_link` → `mscl_1.0_gpl_link`, `contact_our_team_link` → `open_innovation_grant_link`) — visible in analytics, may need to align with marketing

## Tested Scenarios

- Verified the project owner modal renders the new MSCL-1.0-GPL
- Verified `setup_license_follow_up` renders the Open Innovation Grant link through the existing `#oig` slot pattern already used in `setup.vue` and `license-onboarding.vue`
- Searched `app/src` for any remaining `bsl_banner` / `directus_bsl` / `directusBsl` / `/bsl` references — none in consumer code outside non-EN translation files

## Review Notes / Questions

- I would like reviewers to confirm the UTM term renames (`mscl_1.0_gpl_link`, `open_innovation_grant_link`) match whatever marketing/analytics expects

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---