### PR TITLE
Fix seats computation in license store

### DIFF
--- a/app/src/stores/license.ts
+++ b/app/src/stores/license.ts
@@ -38,8 +38,10 @@ export const useLicenseStore = defineStore('licenseStore', () => {
 	const seatsRemaining = computed<number | null>(() => {
 		if (!info.value) return null;
 		const seats = info.value.entitlements.seats;
-		const effective = seats.limit + (seats.addon ?? 0) + (seats.overage ?? 0);
-		return effective - (info.value.usage?.seats ?? 0);
+		const addons = info.value.addons;
+		const usage = info.value.usage;
+		const effective = seats.limit + (addons?.seats ?? 0) + (seats.overage ?? 0);
+		return effective - (usage?.seats ?? 0);
 	});
 
 	const hasRemainingSeats = computed(() => seatsRemaining.value === null || seatsRemaining.value > 0);


### PR DESCRIPTION
We have some spec drift in how we're computing the remaining seats in the license store