### PR TITLE
Fix license settings

### DIFF
--- a/app/src/modules/settings/routes/data-model/collections/collections.vue
+++ b/app/src/modules/settings/routes/data-model/collections/collections.vue
@@ -220,7 +220,7 @@ async function downloadSnapshot() {
 		</template>
 
 		<div class="padding-box" :class="{ 'has-action': hasExpandableCollections }">
-			<MaxCapacityAlert />
+			<MaxCapacityAlert v-if="licenseStore.collectionsRemaining !== null && licenseStore.collectionsRemaining <= 0" />
 
 			<VInfo v-if="collections.length === 0" icon="box" :title="$t('no_collections')">
 				{{ $t('no_collections_copy_admin') }}

--- a/app/src/modules/settings/routes/flows/overview.vue
+++ b/app/src/modules/settings/routes/flows/overview.vue
@@ -184,7 +184,7 @@ function onFlowDrawerCompletion(id: string) {
 			/>
 		</template>
 
-		<div class="padding-box">
+		<div v-if="licenseStore.flowsRemaining !== null && licenseStore.flowsRemaining <= 0" class="padding-box">
 			<MaxCapacityAlert entitlement-key="flows" />
 		</div>
 

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -36,7 +36,7 @@ const licenseStore = useLicenseStore();
 const { info: license, addons, loading, boundary, isLicensed } = storeToRefs(licenseStore);
 
 const boundaryDate = computed(() => {
-	if (!boundary.value || !Number.isFinite(boundary.value.timestamp)) return null;
+	if (!boundary.value || !Number.isFinite(boundary.value.timestamp) || boundary.value.timestamp === -1) return null;
 	const dateStr = new Date(boundary.value.timestamp * 1000).toISOString().slice(0, 10);
 	return formatDate(dateStr, { type: 'date', format: 'long' });
 });

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -219,7 +219,7 @@ async function handleDeactivateConfirm() {
 					</VList>
 				</LicenseSection>
 
-				<LicenseSection icon="emergency_home" :title="t('danger_zone')" variant="danger">
+				<LicenseSection v-if="license.source !== null" icon="emergency_home" :title="t('danger_zone')" variant="danger">
 					<div class="danger-zone-content">
 						<VNotice v-if="license.source === 'env'" type="info">
 							{{ t('licensing.env_managed') }}

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -180,7 +180,9 @@ async function handleDeactivateConfirm() {
 						<VButton v-if="!isLicensed" secondary small @click="addLicenseDrawer = true">
 							{{ t('licensing.add') }}
 						</VButton>
-						<VButton v-if="isLicensed" secondary small @click="() => {}">{{ t('licensing.manage') }}</VButton>
+						<VButton v-if="isLicensed && license.source !== null" secondary small @click="() => {}">
+							{{ t('licensing.manage') }}
+						</VButton>
 						<VButton small @click="() => {}">{{ t('licensing.upgrade_plan') }}</VButton>
 					</div>
 				</div>

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -154,10 +154,6 @@ async function handleDeactivateConfirm() {
 
 <template>
 	<PrivateView :title="t('settings_license')" icon="diamond">
-		<template #headline>
-			<VBreadcrumb :items="[{ name: t('settings'), to: '/settings' }]" />
-		</template>
-
 		<template #navigation>
 			<SettingsNavigation />
 		</template>

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -8,7 +8,6 @@ import LicenseAddonItem from './components/license-addon-item.vue';
 import LicenseEntitlementItem from './components/license-entitlement-item.vue';
 import LicenseResolutionDialog from './components/license-resolution-dialog.vue';
 import LicenseSection from './components/license-section.vue';
-import VBreadcrumb from '@/components/deprecated/v-breadcrumb.vue';
 import VButton from '@/components/v-button.vue';
 import VCardActions from '@/components/v-card-actions.vue';
 import VCardText from '@/components/v-card-text.vue';

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -211,7 +211,7 @@ async function handleDeactivateConfirm() {
 					</template>
 				</div>
 
-				<LicenseSection icon="diamond" :title="t('licensing.addons')">
+				<LicenseSection v-if="addons && addons.length > 0" icon="diamond" :title="t('licensing.addons')">
 					<VList>
 						<LicenseAddonItem v-for="addon in addons" :key="addon.id" :addon="addon" />
 					</VList>


### PR DESCRIPTION
## Scope

What's changed:

- Add license settings page with plan info, entitlements, add-ons, and deactivation flow
- Hide add-ons section for non-Team plans (shown only when the server returns available add-ons)
- Hide "Manage" button and Danger Zone for Core tier (identified by `source === null`)
- Fix expiry/renewal date rendering for unlimited licenses (`expires_at = -1`)
- Guard `MaxCapacityAlert` in Collections and Flows views so the wrapper only renders when capacity is actually exceeded
- Wire collections and flows views to the license guard (entitlement limit modal, entitlement remaining counter)
- Remove deprecated `VBreadcrumb` headline slots from Collections and Flows

## Potential Risks / Drawbacks

- Core-tier detection relies on `source === null`; any future non-Core unlicensed state would also suppress the Manage button and Danger Zone
- Add-ons visibility is fully backend-driven — if the server ever returns add-ons for a non-Team plan, the section will appear

## Tested Scenarios

- License page renders correctly for Core tier (no Manage button, no Danger Zone, no add-ons section)
- License page renders correctly for Team tier (Manage button present, Danger Zone present, add-ons section visible when add-ons available)
- Unlimited license (`expires_at = -1`) shows no expiry/renewal date
- Collections and Flows pages show the capacity alert only when at or over the limit

## Review Notes / Questions

- I would like reviewers to verify the `source === null` heuristic covers all intended Core-tier cases and doesn't accidentally hide controls for other unlicensed states

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes [CMS-2329](https://linear.app/directus/issue/CMS-2329/amend-license-settings-page)
