### PR TITLE
xiiui ← Ensure to render split-menu even if disabled

### DIFF
--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -365,7 +365,7 @@ function revert(values: Record<string, any>) {
 				icon="check"
 				@click="saveAndQuit"
 			>
-				<template v-if="isSavable" #split-menu>
+				<template #split-menu>
 					<SaveOptions
 						:disabled-options="createAllowed ? ['save-and-add-new'] : ['save-and-add-new', 'save-as-copy']"
 						@save-and-stay="saveAndStay"

--- a/app/src/modules/settings/routes/policies/item.vue
+++ b/app/src/modules/settings/routes/policies/item.vue
@@ -153,7 +153,7 @@ function discardAndStay() {
 				:disabled="!hasEdits"
 				@click="saveAndQuit"
 			>
-				<template v-if="hasEdits" #split-menu>
+				<template #split-menu>
 					<SaveOptions
 						:disabled-options="['save-as-copy']"
 						@save-and-stay="saveAndStay"

--- a/app/src/modules/settings/routes/roles/item.vue
+++ b/app/src/modules/settings/routes/roles/item.vue
@@ -169,7 +169,7 @@ function discardAndStay() {
 				icon="check"
 				@click="saveAndQuit"
 			>
-				<template v-if="hasEdits" #split-menu>
+				<template #split-menu>
 					<SaveOptions
 						:disabled-options="['save-as-copy']"
 						@save-and-stay="saveAndStay"

--- a/app/src/modules/settings/routes/roles/public-item.vue
+++ b/app/src/modules/settings/routes/roles/public-item.vue
@@ -215,7 +215,7 @@ function isAlterations<T extends Item>(value: any): value is Alterations<T> {
 				icon="check"
 				@click="saveAndQuit"
 			>
-				<template v-if="hasEdits" #split-menu>
+				<template #split-menu>
 					<SaveOptions
 						:disabled-options="['save-as-copy']"
 						@save-and-stay="saveAndStay"

--- a/app/src/modules/settings/routes/translations/item.vue
+++ b/app/src/modules/settings/routes/translations/item.vue
@@ -241,7 +241,7 @@ async function revert(values: Record<string, any>) {
 				icon="check"
 				@click="saveAndQuit"
 			>
-				<template v-if="hasEdits" #split-menu>
+				<template #split-menu>
 					<SaveOptions
 						:disabled-options="disabledOptions"
 						@save-and-stay="saveAndStay"

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -373,7 +373,7 @@ function revert(values: Record<string, any>) {
 				icon="check"
 				@click="saveAndQuit"
 			>
-				<template v-if="isSavable" #split-menu>
+				<template #split-menu>
 					<SaveOptions
 						:disabled-options="createAllowed ? [] : ['save-and-add-new', 'save-as-copy']"
 						@save-and-stay="saveAndStay"


### PR DESCRIPTION
Follow-up to https://github.com/directus/directus/pull/27130.

## Scope

What's changed:

- Drop the `v-if` guards on the `#split-menu` slot of primary save buttons across users, files, roles, public role, policies, and translations item pages
- The split-menu chevron now stays rendered and inherits the disabled state from the main save button, instead of disappearing until the first edit

## Potential Risks / Drawbacks

—

## Tested Scenarios

- Opened each affected item page and confirmed the split-menu button is visible and disabled before edits, then becomes enabled after the first edit

## Review Notes / Questions

- No changeset since this fixes an unreleased change from #27130

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Addresses CMS-2328