### PR TITLE
use v-chip for styling entitlement-remaining

### DIFF
--- a/app/src/views/private/components/license/entitlement-remaining.vue
+++ b/app/src/views/private/components/license/entitlement-remaining.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
+import VChip from '@/components/v-chip.vue';
 import { useLicenseStore } from '@/stores/license';
 
 const REMAINING_THRESHOLD = 5;
@@ -29,35 +30,11 @@ const variant = computed(() => (remaining.value === 0 ? 'danger' : 'warning'));
 </script>
 
 <template>
-	<span v-if="show" class="entitlement-remaining" :class="variant">
-		{{ label }}
-	</span>
+	<VChip v-if="show" small :label="false" :kind="variant" class="entitlement-remaining">{{ label }}</VChip>
 </template>
 
 <style scoped lang="scss">
 .entitlement-remaining {
-	--entitlement-remaining-size: 1.25rem;
-	--entitlement-remaining-padding: 0.625rem;
-
-	display: inline-flex;
-	align-items: center;
-	align-self: center;
-	justify-content: center;
-	block-size: var(--entitlement-remaining-size);
-	padding: 0 var(--entitlement-remaining-padding);
-	border-radius: 9999px;
-	font-weight: 600;
-	font-size: 0.8125rem;
-	flex-shrink: 0;
-
-	&.warning {
-		background: var(--theme--warning-background);
-		color: var(--theme--warning-accent);
-	}
-
-	&.danger {
-		background: var(--theme--danger-background);
-		color: var(--theme--danger-accent);
-	}
+	--v-chip-font-weight: 600;
 }
 </style>


### PR DESCRIPTION
## Scope

What's changed:
Small refactor

Fixes [cms-2344](https://linear.app/directus/issue/CMS-2344/refactor-entitlement-remaining-component-to-use-the-v-chip-component)
