### PR TITLE
Prevent stacked onboarding and project owner modals

### DIFF
--- a/app/src/views/private/components/license-banner.vue
+++ b/app/src/views/private/components/license-banner.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { SetupForm as Form } from '@directus/types';
 import { useCookies } from '@vueuse/integrations/useCookies';
-import { computed, ref, watch } from 'vue';
+import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import VButton from '@/components/v-button.vue';
 import VCardActions from '@/components/v-card-actions.vue';
@@ -22,34 +22,11 @@ const cookies = useCookies(['license-banner-dismissed']);
 const { t } = useI18n();
 
 const errors = ref<Record<string, any>[]>([]);
-
-const form = ref<Form>(buildInitialForm());
-
+const form = ref<Form>(defaultValues);
 const fields = useSetupFields(false);
-
-function buildInitialForm(): Form {
-	return {
-		...defaultValues,
-		owner: {
-			...defaultValues.owner,
-			project_usage: settingsStore.settings?.project_usage ?? null,
-			org_name: settingsStore.settings?.org_name ?? null,
-		},
-	};
-}
-
-watch(model, (open) => {
-	if (open) form.value = buildInitialForm();
-});
-
-const isSaveDisabled = computed(
-	() =>
-		!form.value.owner.project_owner ||
-		!form.value.license ||
-		(form.value.owner.project_usage === 'commercial' && !form.value.owner.org_name),
-);
-
 const isSaving = ref(false);
+
+const isSaveDisabled = computed(() => !form.value.owner.project_owner || !form.value.license);
 
 async function setOwner() {
 	errors.value = validate({ project_owner: form.value.owner.project_owner }, fields);
@@ -58,7 +35,12 @@ async function setOwner() {
 
 	isSaving.value = true;
 
-	await settingsStore.setOwner(form.value.owner);
+	await settingsStore.setOwner({
+		project_owner: form.value.owner.project_owner,
+		product_updates: form.value.owner.product_updates,
+		project_usage: settingsStore.settings?.project_usage ?? null,
+		org_name: settingsStore.settings?.org_name ?? null,
+	});
 
 	await settingsStore.hydrate();
 	isSaving.value = false;

--- a/app/src/views/private/components/license-banner.vue
+++ b/app/src/views/private/components/license-banner.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { SetupForm as Form } from '@directus/types';
 import { useCookies } from '@vueuse/integrations/useCookies';
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import VButton from '@/components/v-button.vue';
 import VCardActions from '@/components/v-card-actions.vue';
@@ -15,11 +15,32 @@ import SetupForm from '@/routes/setup/form.vue';
 import { useSettingsStore } from '@/stores/settings';
 import { notify } from '@/utils/notify';
 
+const model = defineModel<boolean>();
+
 const settingsStore = useSettingsStore();
 const cookies = useCookies(['license-banner-dismissed']);
 const { t } = useI18n();
 
 const errors = ref<Record<string, any>[]>([]);
+
+const form = ref<Form>(buildInitialForm());
+
+const fields = useSetupFields(false);
+
+function buildInitialForm(): Form {
+	return {
+		...defaultValues,
+		owner: {
+			...defaultValues.owner,
+			project_usage: settingsStore.settings?.project_usage ?? null,
+			org_name: settingsStore.settings?.org_name ?? null,
+		},
+	};
+}
+
+watch(model, (open) => {
+	if (open) form.value = buildInitialForm();
+});
 
 const isSaveDisabled = computed(
 	() =>
@@ -41,21 +62,19 @@ async function setOwner() {
 
 	await settingsStore.hydrate();
 	isSaving.value = false;
+	model.value = false;
 }
 
-async function remindLater() {
+function remindLater() {
 	// 30 days, will be deleted on logout / session end
 	cookies.set('license-banner-dismissed', 'true', { expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30) });
 	notify({ title: t('license_banner.remind_next_login'), type: 'info' });
+	model.value = false;
 }
-
-const form = ref<Form>(defaultValues);
-
-const fields = useSetupFields(false);
 </script>
 
 <template>
-	<VDialog>
+	<VDialog v-model="model">
 		<VCard>
 			<div class="inner">
 				<VCardTitle>

--- a/app/src/views/private/components/license-onboarding.vue
+++ b/app/src/views/private/components/license-onboarding.vue
@@ -15,7 +15,9 @@ import VRadioCards from '@/components/v-radio-cards.vue';
 import VSelect from '@/components/v-select/v-select.vue';
 import { useLicenseForm } from '@/composables/use-license-form';
 import SystemLicenseKey from '@/interfaces/_system/system-license-key/system-license-key.vue';
+import { useLicenseStore } from '@/stores/license';
 import { useServerStore } from '@/stores/server';
+import { useSettingsStore } from '@/stores/settings';
 import { unexpectedError } from '@/utils/unexpected-error';
 
 const model = defineModel<boolean>();
@@ -23,6 +25,8 @@ const model = defineModel<boolean>();
 const cookies = useCookies(['license-onboarding-dismissed']);
 const { t } = useI18n();
 const serverStore = useServerStore();
+const settingsStore = useSettingsStore();
+const licenseStore = useLicenseStore();
 
 const licenseKey = ref<string | null>(null);
 const projectUsage = ref<string | null>(null);
@@ -66,17 +70,17 @@ async function save() {
 	isSaving.value = true;
 
 	try {
-		const payload: Record<string, any> = {};
-
 		if (licenseChoice.value === 'key') {
-			payload.license_key = licenseKey.value;
+			await licenseStore.activate(licenseKey.value!);
+			await serverStore.hydrate();
 		} else {
-			payload.project_usage = projectUsage.value;
+			const payload: Record<string, any> = { project_usage: projectUsage.value };
 			if (showOrgName.value) payload.org_name = orgName.value;
+
+			await api.patch('/settings', payload);
+			await Promise.all([serverStore.hydrate(), settingsStore.hydrate()]);
 		}
 
-		await api.patch('/settings', payload);
-		await serverStore.hydrate();
 		model.value = false;
 	} catch (err) {
 		unexpectedError(err);

--- a/app/src/views/private/private-view/components/private-view.vue
+++ b/app/src/views/private/private-view/components/private-view.vue
@@ -62,13 +62,17 @@ const cookies = useCookies(['license-banner-dismissed', 'license-onboarding-dism
 const serverStore = useServerStore();
 const settingsStore = useSettingsStore();
 
-const showLicenseBanner = computed(
-	() =>
+const showLicenseBanner = computed({
+	get: () =>
 		userStore.isAdmin &&
 		!serverStore.info.license?.source &&
 		!settingsStore.settings?.project_owner &&
+		!!settingsStore.settings?.project_usage &&
 		!cookies.get('license-banner-dismissed'),
-);
+	set: () => {
+		// close is handled by cookie and hydrate inside the modal
+	},
+});
 
 const showLicenseOnboarding = computed({
 	get: () =>


### PR DESCRIPTION
## Scope

What's changed:

- Gate `showLicenseBanner` on `settings.project_usage` being set so the project-owner banner and the license onboarding modal are mutually exclusive — onboarding shows first, banner only follows when the user picks the Core path.
- Fix `LicenseBanner` v-model wiring (the inner `VDialog` had no binding, so the banner was silently never opening regardless of the parent flag).
- Read `project_usage` / `org_name` fresh from `settingsStore` at banner save time instead of relying on form state, so saving the owner no longer overwrites values captured during onboarding.
- Hydrate `settingsStore` after the onboarding save so the Core path correctly transitions to the banner, and route the Key path through `licenseStore.activate()` instead of a raw `PATCH /settings` (the manager wasn't picking up the new key, leaving the modal stuck open).
