### PR TITLE
dp ← Render non-clickable version menu without directus_versions read access

### DIFF
--- a/.changeset/free-rocks-take.md
+++ b/.changeset/free-rocks-take.md
@@ -2,4 +2,4 @@
 '@directus/app': minor
 ---
 
-Rendered non-clickable version menu without directus_versions read access
+Rendered non-clickable version menu without directus_versions read access @alvarosabu

--- a/.changeset/free-rocks-take.md
+++ b/.changeset/free-rocks-take.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Rendered non-clickable version menu without directus_versions read access

--- a/app/src/modules/content/components/version-chip.test.ts
+++ b/app/src/modules/content/components/version-chip.test.ts
@@ -6,8 +6,11 @@ import VersionChip from './version-chip.vue';
 const mountOptions = {
 	global: {
 		stubs: {
-			VChip: { props: ['kind'], template: '<button class="v-chip" :class="kind"><slot /></button>' },
-			VIcon: { template: '<span class="v-icon" />' },
+			VChip: {
+				props: ['kind', 'clickable'],
+				template: '<button class="v-chip" :class="[kind, { clickable }]"><slot /></button>',
+			},
+			VIcon: { props: ['name'], template: '<span class="v-icon" :data-name="name" />' },
 			VTextOverflow: { template: '<span class="v-text-overflow" />' },
 		},
 	},
@@ -46,5 +49,25 @@ describe('VersionChip', () => {
 		await wrapper.setProps({ version: { key: 'my-version', name: 'My Version' } });
 		expect(wrapper.classes()).toContain('neutral');
 		expect(wrapper.classes()).not.toContain('primary');
+	});
+
+	describe('clickable prop', () => {
+		it('is clickable and shows the dropdown arrow by default', () => {
+			const wrapper = mount(VersionChip, { ...mountOptions, props: { version: null } });
+			expect(wrapper.classes()).toContain('clickable');
+			expect(wrapper.classes()).not.toContain('not-clickable');
+			expect(wrapper.find('[data-name="arrow_drop_down"]').exists()).toBe(true);
+		});
+
+		it('hides the dropdown arrow and applies non-clickable styling when clickable is false', () => {
+			const wrapper = mount(VersionChip, {
+				...mountOptions,
+				props: { version: null, clickable: false },
+			});
+
+			expect(wrapper.classes()).not.toContain('clickable');
+			expect(wrapper.classes()).toContain('not-clickable');
+			expect(wrapper.find('[data-name="arrow_drop_down"]').exists()).toBe(false);
+		});
 	});
 });

--- a/app/src/modules/content/components/version-chip.vue
+++ b/app/src/modules/content/components/version-chip.vue
@@ -34,7 +34,6 @@ const kind = computed(() => {
 
 	&.not-clickable {
 		padding-inline: 0.6875rem;
-		cursor: default;
 	}
 }
 

--- a/app/src/modules/content/components/version-chip.vue
+++ b/app/src/modules/content/components/version-chip.vue
@@ -7,8 +7,9 @@ import VIcon from '@/components/v-icon/v-icon.vue';
 import VTextOverflow from '@/components/v-text-overflow.vue';
 import { getVersionDisplayName } from '@/utils/get-version-display-name';
 
-const { version } = defineProps<{
+const { version, clickable = true } = defineProps<{
 	version: Pick<ContentVersion, 'key' | 'name'> | null;
+	clickable?: boolean;
 }>();
 
 const kind = computed(() => {
@@ -19,9 +20,9 @@ const kind = computed(() => {
 </script>
 
 <template>
-	<VChip small clickable :label="false" class="version-chip" :kind>
+	<VChip small :clickable :label="false" class="version-chip" :class="{ 'not-clickable': !clickable }" :kind>
 		<VTextOverflow class="version-name" :text="getVersionDisplayName(version)" placement="bottom" />
-		<VIcon small name="arrow_drop_down" />
+		<VIcon v-if="clickable" small name="arrow_drop_down" />
 	</VChip>
 </template>
 
@@ -30,6 +31,11 @@ const kind = computed(() => {
 	--v-chip-font-weight: var(--theme--fonts--title--font-weight);
 
 	padding-inline: 0.6875rem 0.3125rem;
+
+	&.not-clickable {
+		padding-inline: 0.6875rem;
+		cursor: default;
+	}
 }
 
 .version-name {

--- a/app/src/modules/content/components/version-menu.test.ts
+++ b/app/src/modules/content/components/version-menu.test.ts
@@ -1,6 +1,7 @@
 import { createTestingPinia } from '@pinia/testing';
 import { mount } from '@vue/test-utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
 import VersionMenu from './version-menu.vue';
 import { Tooltip } from '@/__utils__/tooltip';
 import { i18n } from '@/lang';
@@ -17,10 +18,10 @@ vi.mock('@/api', () => ({
 
 vi.mock('@/composables/use-permissions', () => ({
 	useCollectionPermissions: vi.fn(() => ({
-		createAllowed: { value: true },
-		readAllowed: { value: true },
-		updateAllowed: { value: true },
-		deleteAllowed: { value: true },
+		createAllowed: ref(true),
+		readAllowed: ref(true),
+		updateAllowed: ref(true),
+		deleteAllowed: ref(true),
 	})),
 }));
 

--- a/app/src/modules/content/components/version-menu.vue
+++ b/app/src/modules/content/components/version-menu.vue
@@ -282,9 +282,9 @@ function hasVersionEdits(version: ContentVersionMaybeNew | null) {
 </script>
 
 <template>
-	<VMenu class="version-menu" placement="bottom" show-arrow>
+	<VMenu class="version-menu" placement="bottom" show-arrow :disabled="!readVersionsAllowed">
 		<template #activator="{ toggle }">
-			<VersionChip :version="currentVersion" @click="toggle()" />
+			<VersionChip :version="currentVersion" :clickable="readVersionsAllowed" @click="toggle()" />
 		</template>
 
 		<VList class="version-list">

--- a/app/src/modules/content/index.test.ts
+++ b/app/src/modules/content/index.test.ts
@@ -2,9 +2,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import api from '@/api';
 
 const mockGetCollection = vi.fn();
+const mockHasPermission = vi.fn();
 
 vi.mock('@/stores/collections', () => ({
 	useCollectionsStore: () => ({ getCollection: mockGetCollection }),
+}));
+
+vi.mock('@/stores/permissions', () => ({
+	usePermissionsStore: () => ({ hasPermission: mockHasPermission }),
 }));
 
 vi.mock('@/api', () => ({ default: { get: vi.fn() } }));
@@ -14,6 +19,7 @@ const {
 	redirectSingleton,
 	stripOrphanedVersionId,
 	stripVersionOnNonVersioned,
+	stripVersionWithoutReadAccess,
 	stripVersionIdOnRealItem,
 	validateItemlessDraft,
 } = await import('./index');
@@ -245,6 +251,50 @@ describe('stripVersionOnNonVersioned', () => {
 		});
 
 		expect(stripVersionOnNonVersioned(to, {} as any, vi.fn())).toBe('/content/posts/3?bookmark=my-bookmark');
+	});
+});
+
+describe('stripVersionWithoutReadAccess', () => {
+	beforeEach(() => mockHasPermission.mockReset());
+
+	it('strips version and versionId when user lacks directus_versions read access', () => {
+		mockHasPermission.mockReturnValue(false);
+
+		const to = makeRoute({
+			query: { version: 'draft', versionId: 'abc' },
+			fullPath: '/content/posts/3?version=draft&versionId=abc',
+		});
+
+		expect(stripVersionWithoutReadAccess(to, {} as any, vi.fn())).toBe('/content/posts/3');
+		expect(mockHasPermission).toHaveBeenCalledWith('directus_versions', 'read');
+	});
+
+	it('passes through when user has read access', () => {
+		mockHasPermission.mockReturnValue(true);
+
+		const to = makeRoute({
+			query: { version: 'draft' },
+			fullPath: '/content/posts/3?version=draft',
+		});
+
+		expect(stripVersionWithoutReadAccess(to, {} as any, vi.fn())).toBeUndefined();
+	});
+
+	it('passes through when no version params present', () => {
+		mockHasPermission.mockReturnValue(false);
+		const to = makeRoute({ query: {}, fullPath: '/content/posts/3' });
+		expect(stripVersionWithoutReadAccess(to, {} as any, vi.fn())).toBeUndefined();
+	});
+
+	it('preserves other query params when stripping', () => {
+		mockHasPermission.mockReturnValue(false);
+
+		const to = makeRoute({
+			query: { version: 'draft', bookmark: 'my-bookmark' },
+			fullPath: '/content/posts/3?version=draft&bookmark=my-bookmark',
+		});
+
+		expect(stripVersionWithoutReadAccess(to, {} as any, vi.fn())).toBe('/content/posts/3?bookmark=my-bookmark');
 	});
 });
 

--- a/app/src/modules/content/index.test.ts
+++ b/app/src/modules/content/index.test.ts
@@ -265,7 +265,7 @@ describe('stripVersionWithoutReadAccess', () => {
 			fullPath: '/content/posts/3?version=draft&versionId=abc',
 		});
 
-		expect(stripVersionWithoutReadAccess(to, {} as any, vi.fn())).toBe('/content/posts/3');
+		expect(stripVersionWithoutReadAccess(to)).toBe('/content/posts/3');
 		expect(mockHasPermission).toHaveBeenCalledWith('directus_versions', 'read');
 	});
 
@@ -277,13 +277,13 @@ describe('stripVersionWithoutReadAccess', () => {
 			fullPath: '/content/posts/3?version=draft',
 		});
 
-		expect(stripVersionWithoutReadAccess(to, {} as any, vi.fn())).toBeUndefined();
+		expect(stripVersionWithoutReadAccess(to)).toBeUndefined();
 	});
 
 	it('passes through when no version params present', () => {
 		mockHasPermission.mockReturnValue(false);
 		const to = makeRoute({ query: {}, fullPath: '/content/posts/3' });
-		expect(stripVersionWithoutReadAccess(to, {} as any, vi.fn())).toBeUndefined();
+		expect(stripVersionWithoutReadAccess(to)).toBeUndefined();
 	});
 
 	it('preserves other query params when stripping', () => {
@@ -294,7 +294,7 @@ describe('stripVersionWithoutReadAccess', () => {
 			fullPath: '/content/posts/3?version=draft&bookmark=my-bookmark',
 		});
 
-		expect(stripVersionWithoutReadAccess(to, {} as any, vi.fn())).toBe('/content/posts/3?bookmark=my-bookmark');
+		expect(stripVersionWithoutReadAccess(to)).toBe('/content/posts/3?bookmark=my-bookmark');
 	});
 });
 

--- a/app/src/modules/content/index.ts
+++ b/app/src/modules/content/index.ts
@@ -106,7 +106,7 @@ export const stripVersionOnNonVersioned: NavigationGuard = (to) => {
 	return target;
 };
 
-export const stripVersionWithoutReadAccess: NavigationGuard = (to) => {
+export const stripVersionWithoutReadAccess = (to: RouteLocationNormalized) => {
 	if (!to.query.version && !to.query.versionId) return;
 
 	const permissionsStore = usePermissionsStore();

--- a/app/src/modules/content/index.ts
+++ b/app/src/modules/content/index.ts
@@ -12,6 +12,7 @@ import ItemNotFound from './routes/not-found.vue';
 import Preview from './routes/preview.vue';
 import api from '@/api';
 import { useCollectionsStore } from '@/stores/collections';
+import { usePermissionsStore } from '@/stores/permissions';
 import { addQueryToPath } from '@/utils/add-query-to-path';
 import { getCollectionRoute, getItemRoute, getSystemCollectionRoute } from '@/utils/get-route';
 import { removeQueryFromPath } from '@/utils/remove-query-from-path';
@@ -99,6 +100,17 @@ export const stripVersionOnNonVersioned: NavigationGuard = (to) => {
 
 	const collection = useCollectionsStore().getCollection(to.params.collection);
 	if (!collection || collection.meta?.versioning) return;
+
+	const target = removeQueryFromPath(to.fullPath, 'version', 'versionId');
+	if (target === to.fullPath) return;
+	return target;
+};
+
+export const stripVersionWithoutReadAccess: NavigationGuard = (to) => {
+	if (!to.query.version && !to.query.versionId) return;
+
+	const permissionsStore = usePermissionsStore();
+	if (permissionsStore.hasPermission('directus_versions', 'read')) return;
 
 	const target = removeQueryFromPath(to.fullPath, 'version', 'versionId');
 	if (target === to.fullPath) return;
@@ -234,7 +246,13 @@ export default defineModule({
 							archive,
 						};
 					},
-					beforeEnter: [checkForSystem, trackLastAccessedCollection, redirectSingleton, stripVersionOnNonVersioned],
+					beforeEnter: [
+						checkForSystem,
+						trackLastAccessedCollection,
+						redirectSingleton,
+						stripVersionOnNonVersioned,
+						stripVersionWithoutReadAccess,
+					],
 				},
 				{
 					name: 'content-singleton',
@@ -244,7 +262,13 @@ export default defineModule({
 						collection: route.params.collection,
 						singleton: true,
 					}),
-					beforeEnter: [checkForSystem, trackLastAccessedCollection, enterDraftContext, stripVersionOnNonVersioned],
+					beforeEnter: [
+						checkForSystem,
+						trackLastAccessedCollection,
+						enterDraftContext,
+						stripVersionOnNonVersioned,
+						stripVersionWithoutReadAccess,
+					],
 				},
 				{
 					name: 'content-item',
@@ -256,6 +280,7 @@ export default defineModule({
 						enterDraftContext,
 						stripOrphanedVersionId,
 						stripVersionOnNonVersioned,
+						stripVersionWithoutReadAccess,
 						stripVersionIdOnRealItem,
 						validateItemlessDraft,
 					],
@@ -271,6 +296,7 @@ export default defineModule({
 				enterDraftContext,
 				stripOrphanedVersionId,
 				stripVersionOnNonVersioned,
+				stripVersionWithoutReadAccess,
 				stripVersionIdOnRealItem,
 				validateItemlessDraft,
 			],

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -9,6 +9,7 @@ import { computed, ref, toRefs, watch } from 'vue';
 import { onBeforeRouteUpdate, useRouter } from 'vue-router';
 import ContentNavigation from '../components/navigation.vue';
 import VersionChip from '../components/version-chip.vue';
+import { stripVersionWithoutReadAccess } from '../index';
 import ContentNotFound from './not-found.vue';
 import api from '@/api';
 import VButton from '@/components/v-button.vue';
@@ -64,8 +65,7 @@ const { collection } = toRefs(props);
 const bookmarkID = computed(() => (props.bookmark ? +props.bookmark : null));
 
 const { info: currentCollection } = useCollection(collection);
-const { readAllowed: readVersionsAllowed } = useCollectionPermissions('directus_versions');
-const { isVersioned, isVersion, version, versionName, versionKeyQuery } = useVersion();
+const { isVersioned, isVersion, version, versionName, versionKeyQuery, readVersionsAllowed } = useVersion();
 const { selection } = useSelection();
 
 onBeforeRouteUpdate((to) => {
@@ -75,6 +75,9 @@ onBeforeRouteUpdate((to) => {
 	if (collectionsStore.getCollection(collectionParam)?.meta?.singleton) {
 		return { name: 'content-singleton', params: to.params, query: to.query };
 	}
+
+	const stripped = stripVersionWithoutReadAccess(to);
+	if (stripped) return stripped;
 
 	return true;
 });
@@ -133,6 +136,11 @@ const {
 	deleteAllowed: batchDeleteAllowed,
 	createAllowed,
 } = useCollectionPermissions(collection);
+
+const createNewAllowed = computed(() => {
+	if (isVersioned.value) return createAllowed.value && readVersionsAllowed.value;
+	return createAllowed.value;
+});
 
 const permissionsStore = usePermissionsStore();
 
@@ -225,17 +233,12 @@ function useSelection() {
 function useVersion() {
 	const versionKeyQuery = useVersionQuery();
 	const isVersioned = computed(() => !!currentCollection.value?.meta?.versioning);
+	const { readAllowed: readVersionsAllowed } = useCollectionPermissions('directus_versions');
 	const version = computed(() => getValidVersion());
 	const versionName = computed(() => getVersionDisplayName(version.value ? { key: version.value, name: null } : null));
 	const isVersion = computed(() => !isNil(version.value));
 
-	watch([isVersioned, readVersionsAllowed, versionKeyQuery], ([newIsVersioned, newReadAllowed, newVersionKey]) => {
-		if (newIsVersioned && !newReadAllowed && newVersionKey === VERSION_KEY_DRAFT) {
-			versionKeyQuery.value = null;
-		}
-	});
-
-	return { isVersioned, isVersion, version, versionName, versionKeyQuery };
+	return { isVersioned, isVersion, version, versionName, versionKeyQuery, readVersionsAllowed };
 
 	function getValidVersion() {
 		if (!isVersioned.value) return undefined;
@@ -377,9 +380,13 @@ function clearFilters() {
 
 		<PrivateView v-else :title="headerTitle" :icon="headerIcon" :icon-color="headerIconColor">
 			<template #title-outer:append>
-				<VMenu v-if="isVersioned && readVersionsAllowed" show-arrow placement="bottom">
+				<VMenu v-if="isVersioned" show-arrow placement="bottom" :disabled="!readVersionsAllowed">
 					<template #activator="{ toggle }">
-						<VersionChip :version="version ? { key: version, name: null } : null" @click="toggle()" />
+						<VersionChip
+							:version="version ? { key: version, name: null } : null"
+							:clickable="readVersionsAllowed"
+							@click="toggle()"
+						/>
 					</template>
 
 					<VList>
@@ -391,8 +398,6 @@ function clearFilters() {
 						</VListItem>
 					</VList>
 				</VMenu>
-
-				<VersionChip v-else-if="isVersioned" :version="null" :clickable="false" />
 			</template>
 
 			<template #actions:prepend>
@@ -519,11 +524,11 @@ function clearFilters() {
 
 			<template #actions:primary>
 				<PrivateViewHeaderBarActionButton
-					:tooltip="createAllowed ? undefined : $t('not_allowed')"
+					:tooltip="createNewAllowed ? undefined : $t('not_allowed')"
 					:label="$t('create')"
 					icon="add"
 					:to="addNewLink"
-					:disabled="createAllowed === false"
+					:disabled="createNewAllowed === false"
 				/>
 			</template>
 

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -64,7 +64,7 @@ const { collection } = toRefs(props);
 const bookmarkID = computed(() => (props.bookmark ? +props.bookmark : null));
 
 const { info: currentCollection } = useCollection(collection);
-const { isVersioned, isVersion, version, versionName, versionKeyQuery } = useVersion();
+const { isVersioned, isVersion, version, versionName, versionKeyQuery, readVersionsAllowed } = useVersion();
 const { selection } = useSelection();
 
 onBeforeRouteUpdate((to) => {
@@ -224,14 +224,26 @@ function useSelection() {
 function useVersion() {
 	const versionKeyQuery = useVersionQuery();
 	const isVersioned = computed(() => !!currentCollection.value?.meta?.versioning);
+	const { readAllowed: readVersionsAllowed } = useCollectionPermissions('directus_versions');
 	const version = computed(() => getValidVersion());
 	const versionName = computed(() => getVersionDisplayName(version.value ? { key: version.value, name: null } : null));
 	const isVersion = computed(() => !isNil(version.value));
 
-	return { isVersioned, isVersion, version, versionName, versionKeyQuery };
+	watch(
+		[isVersioned, readVersionsAllowed, versionKeyQuery],
+		([newIsVersioned, newReadAllowed, newVersionKey]) => {
+			if (newIsVersioned && !newReadAllowed && newVersionKey === VERSION_KEY_DRAFT) {
+				versionKeyQuery.value = null;
+			}
+		},
+		{ immediate: true },
+	);
+
+	return { isVersioned, isVersion, version, versionName, versionKeyQuery, readVersionsAllowed };
 
 	function getValidVersion() {
 		if (!isVersioned.value) return undefined;
+		if (!readVersionsAllowed.value) return null;
 		if (versionKeyQuery.value === VERSION_KEY_DRAFT) return VERSION_KEY_DRAFT;
 		if (!versionKeyQuery.value || isPublishedVersionKey(versionKeyQuery.value)) return null;
 		return undefined;
@@ -369,7 +381,7 @@ function clearFilters() {
 
 		<PrivateView v-else :title="headerTitle" :icon="headerIcon" :icon-color="headerIconColor">
 			<template #title-outer:append>
-				<VMenu v-if="isVersioned" show-arrow placement="bottom">
+				<VMenu v-if="isVersioned && readVersionsAllowed" show-arrow placement="bottom">
 					<template #activator="{ toggle }">
 						<VersionChip :version="version ? { key: version, name: null } : null" @click="toggle()" />
 					</template>
@@ -383,6 +395,8 @@ function clearFilters() {
 						</VListItem>
 					</VList>
 				</VMenu>
+
+				<VersionChip v-else-if="isVersioned" :version="null" :clickable="false" />
 			</template>
 
 			<template #actions:prepend>

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -64,7 +64,8 @@ const { collection } = toRefs(props);
 const bookmarkID = computed(() => (props.bookmark ? +props.bookmark : null));
 
 const { info: currentCollection } = useCollection(collection);
-const { isVersioned, isVersion, version, versionName, versionKeyQuery, readVersionsAllowed } = useVersion();
+const { readAllowed: readVersionsAllowed } = useCollectionPermissions('directus_versions');
+const { isVersioned, isVersion, version, versionName, versionKeyQuery } = useVersion();
 const { selection } = useSelection();
 
 onBeforeRouteUpdate((to) => {
@@ -224,22 +225,17 @@ function useSelection() {
 function useVersion() {
 	const versionKeyQuery = useVersionQuery();
 	const isVersioned = computed(() => !!currentCollection.value?.meta?.versioning);
-	const { readAllowed: readVersionsAllowed } = useCollectionPermissions('directus_versions');
 	const version = computed(() => getValidVersion());
 	const versionName = computed(() => getVersionDisplayName(version.value ? { key: version.value, name: null } : null));
 	const isVersion = computed(() => !isNil(version.value));
 
-	watch(
-		[isVersioned, readVersionsAllowed, versionKeyQuery],
-		([newIsVersioned, newReadAllowed, newVersionKey]) => {
-			if (newIsVersioned && !newReadAllowed && newVersionKey === VERSION_KEY_DRAFT) {
-				versionKeyQuery.value = null;
-			}
-		},
-		{ immediate: true },
-	);
+	watch([isVersioned, readVersionsAllowed, versionKeyQuery], ([newIsVersioned, newReadAllowed, newVersionKey]) => {
+		if (newIsVersioned && !newReadAllowed && newVersionKey === VERSION_KEY_DRAFT) {
+			versionKeyQuery.value = null;
+		}
+	});
 
-	return { isVersioned, isVersion, version, versionName, versionKeyQuery, readVersionsAllowed };
+	return { isVersioned, isVersion, version, versionName, versionKeyQuery };
 
 	function getValidVersion() {
 		if (!isVersioned.value) return undefined;

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -20,7 +20,6 @@ import {
 import { useI18n } from 'vue-i18n';
 import { onBeforeRouteUpdate, useRoute, useRouter } from 'vue-router';
 import ContentNavigation from '../components/navigation.vue';
-import VersionChip from '../components/version-chip.vue';
 import VersionMenu from '../components/version-menu.vue';
 import { trackLastAccessedCollection } from '../index';
 import ContentNotFound from './not-found.vue';
@@ -113,12 +112,12 @@ const revisionsSidebarDetailRef = ref<InstanceType<typeof RevisionsSidebarDetail
 
 const { info: collectionInfo, defaults, primaryKeyField, isSingleton, accountabilityScope } = useCollection(collection);
 
-const { readAllowed: readVersionsAllowed, deleteAllowed: deleteVersionsAllowed } =
-	useCollectionPermissions('directus_versions');
+const { deleteAllowed: deleteVersionsAllowed } = useCollectionPermissions('directus_versions');
 
 const { primaryKeyParam, resolvedPrimaryKey, existingPrimaryKey, resolvePrimaryKey } = useResolvePrimaryKey();
 
 const {
+	readVersionsAllowed,
 	currentVersion,
 	versions,
 	loading: versionsLoading,
@@ -346,7 +345,9 @@ const isFormDisabled = computed(() => {
 	return true;
 });
 
-const isFormNonEditable = computed(() => shouldShowVersioning.value && currentVersion.value === null);
+const isFormNonEditable = computed(
+	() => shouldShowVersioning.value && readVersionsAllowed.value && currentVersion.value === null,
+);
 
 const disabledOptions = computed(() => {
 	if (!createAllowed.value) return ['save-and-add-new', 'save-as-copy'];
@@ -658,14 +659,8 @@ function revert(values: Record<string, any>) {
 
 const shouldShowVersioning = computed(() => {
 	if (!collectionInfo.value?.meta?.versioning) return false;
-	if (!readVersionsAllowed.value) return false;
 	if (versionsLoading.value) return false;
 	return true;
-});
-
-const shouldShowReadOnlyVersionChip = computed(() => {
-	if (!collectionInfo.value?.meta?.versioning) return false;
-	return !readVersionsAllowed.value;
 });
 
 function enterSingletonDraftContext(
@@ -882,10 +877,6 @@ function editDraftVersion() {
 			/>
 		</template>
 
-		<template v-else-if="shouldShowReadOnlyVersionChip" #title-outer:append>
-			<VersionChip :version="null" :clickable="false" />
-		</template>
-
 		<template #actions:prepend>
 			<CollabIndicatorHeader
 				:model-value="collabUsers"
@@ -973,7 +964,7 @@ function editDraftVersion() {
 		</template>
 
 		<template #actions:primary>
-			<template v-if="shouldShowVersioning">
+			<template v-if="shouldShowVersioning && readVersionsAllowed">
 				<PrivateViewHeaderBarActionButton
 					v-if="currentVersion === null"
 					:label="$t('edit')"

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -20,6 +20,7 @@ import {
 import { useI18n } from 'vue-i18n';
 import { onBeforeRouteUpdate, useRoute, useRouter } from 'vue-router';
 import ContentNavigation from '../components/navigation.vue';
+import VersionChip from '../components/version-chip.vue';
 import VersionMenu from '../components/version-menu.vue';
 import { trackLastAccessedCollection } from '../index';
 import ContentNotFound from './not-found.vue';
@@ -662,6 +663,11 @@ const shouldShowVersioning = computed(() => {
 	return true;
 });
 
+const shouldShowReadOnlyVersionChip = computed(() => {
+	if (!collectionInfo.value?.meta?.versioning) return false;
+	return !readVersionsAllowed.value;
+});
+
 function enterSingletonDraftContext(
 	newIsSingleton: boolean,
 	newResolvedPK: PrimaryKey | null,
@@ -874,6 +880,10 @@ function editDraftVersion() {
 				@delete="onVersionDelete"
 				@switch="currentVersion = $event"
 			/>
+		</template>
+
+		<template v-else-if="shouldShowReadOnlyVersionChip" #title-outer:append>
+			<VersionChip :version="null" :clickable="false" />
 		</template>
 
 		<template #actions:prepend>

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -113,10 +113,12 @@ const revisionsSidebarDetailRef = ref<InstanceType<typeof RevisionsSidebarDetail
 
 const { info: collectionInfo, defaults, primaryKeyField, isSingleton, accountabilityScope } = useCollection(collection);
 
+const { readAllowed: readVersionsAllowed, deleteAllowed: deleteVersionsAllowed } =
+	useCollectionPermissions('directus_versions');
+
 const { primaryKeyParam, resolvedPrimaryKey, existingPrimaryKey, resolvePrimaryKey } = useResolvePrimaryKey();
 
 const {
-	readVersionsAllowed,
 	currentVersion,
 	versions,
 	loading: versionsLoading,
@@ -227,8 +229,6 @@ const {
 	collectionPermissions: { createAllowed, revisionsAllowed },
 	itemPermissions: { updateAllowed, deleteAllowed, saveAllowed, archiveAllowed, shareAllowed, fields },
 } = permissions;
-
-const { deleteAllowed: deleteVersionsAllowed } = useCollectionPermissions('directus_versions');
 
 const { templateData } = useTemplateData(collectionInfo, primaryKeyParam);
 


### PR DESCRIPTION
## Scope

What's changed:

- Add `clickable` prop to `VersionChip` (default `true`); when `false`, hides the dropdown arrow and applies non-interactive styling
- Render a non-clickable `VersionChip` (showing Published) in both content collection and item routes when the user lacks `directus_versions` read access, instead of hiding the version menu entirely
- Add `stripVersionWithoutReadAccess` navigation guard on all content routes (collection, singleton, item, preview) that strips `?version` / `?versionId` from the URL when the user lacks read access — runs before the route component mounts, preventing the brief flash of error from the layout firing a versioned `items` request
- Override `getValidVersion` in collection.vue to coerce the version to Published when read access is missing
- Merge the two `useCollectionPermissions('directus_versions')` calls in `item.vue` into one (extracting `readAllowed` and `deleteAllowed` together)

## Potential Risks / Drawbacks

- Behavior change: previously the version menu was hidden entirely for users without read access; now they see a static Published pill. The intent is to make the current state visible while preventing erroneous interactions
- The new guard runs synchronously against the permissions store; relies on the store being populated before navigation (it is — populated on login)

## Tested Scenarios

- User without `directus_versions` read access visits `/admin/content/<collection>?version=draft` → URL is stripped, Published view is shown, no flash of error
- Same user visits an item page with `?version=draft` → redirected to Published, no error
- User without read access sees a non-clickable Published pill in the header (no dropdown arrow)
- User with full access still sees the full version menu and can switch between Published/Draft/local versions
- Existing 87 unit tests pass, including 4 new tests for `stripVersionWithoutReadAccess` and 2 new tests for the `clickable` prop on `VersionChip`

## Review Notes / Questions

- The `useVersion()` composable in `collection.vue` still has a runtime `watch` to strip `version=draft` if perms change reactively after navigation — kept as defense-in-depth alongside the route guard, but happy to remove if considered noise
- Visual editor (`modules/visual/routes/visual-editor.vue`) was intentionally left untouched: its existing logic already hides the version selector when read access is missing. Happy to apply the non-clickable chip pattern there too for consistency if desired

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Closes CMS-2324