### PR TITLE
xiiui ← Update VChip usages to appear as pills

### DIFF
--- a/.changeset/eighty-frogs-add.md
+++ b/.changeset/eighty-frogs-add.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Updated VChip component to appear as a pill in form field label, group accordion, group tabs, kanban, deployment status, extension item, marketplace extension list item, marketplace extension banner, and user popover @formfcw

--- a/app/src/components/v-form/components/form-field-label.vue
+++ b/app/src/components/v-form/components/form-field-label.vue
@@ -93,7 +93,7 @@ const isPromotableField = computed(() => {
 					filled
 				/>
 
-				<VChip v-if="badge" class="badge" x-small>{{ badge }}</VChip>
+				<VChip v-if="badge" class="badge" :label="false" x-small>{{ badge }}</VChip>
 
 				<VIcon
 					v-if="!disabled && rawEditorEnabled"

--- a/app/src/interfaces/group-accordion/accordion-section.vue
+++ b/app/src/interfaces/group-accordion/accordion-section.vue
@@ -212,8 +212,9 @@ function useComparisonIndicator() {
 
 	.edit-dot {
 		position: absolute;
-		inset-block-start: 0.8125rem;
 		inset-inline-start: -0.375rem;
+		inset-block-start: 50%;
+		transform: translateY(-50%);
 		display: block;
 		inline-size: 0.25rem;
 		block-size: 0.25rem;

--- a/app/src/interfaces/group-accordion/accordion-section.vue
+++ b/app/src/interfaces/group-accordion/accordion-section.vue
@@ -120,7 +120,7 @@ function useComparisonIndicator() {
 					<VIcon class="icon" :class="{ active }" name="expand_more" />
 					<span class="field-name">{{ field.name }}</span>
 					<VIcon v-if="field.meta?.required === true" class="required" sup name="star" filled />
-					<VChip v-if="badge" x-small>{{ badge }}</VChip>
+					<VChip v-if="badge" :label="false" x-small>{{ badge }}</VChip>
 					<VIcon v-if="!active && validationMessage" v-tooltip="validationMessage" class="warning" name="error" small />
 				</button>
 

--- a/app/src/interfaces/group-tabs/tab-trigger.vue
+++ b/app/src/interfaces/group-tabs/tab-trigger.vue
@@ -88,7 +88,7 @@ function useComparisonIndicator() {
 	>
 		<span v-if="edited" v-tooltip="t('edited')" class="edit-dot"></span>
 		<span class="field-name">{{ field.name }}</span>
-		<VChip v-if="badge" x-small>{{ badge }}</VChip>
+		<VChip v-if="badge" :label="false" x-small>{{ badge }}</VChip>
 		<VIcon
 			v-if="validationMessages.length > 0"
 			v-tooltip="validationMessages.join('\n')"

--- a/app/src/layouts/kanban/kanban.vue
+++ b/app/src/layouts/kanban/kanban.vue
@@ -10,6 +10,7 @@ import VCardActions from '@/components/v-card-actions.vue';
 import VCardText from '@/components/v-card-text.vue';
 import VCardTitle from '@/components/v-card-title.vue';
 import VCard from '@/components/v-card.vue';
+import VChip from '@/components/v-chip.vue';
 import VDialog from '@/components/v-dialog.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
 import VImage from '@/components/v-image.vue';
@@ -175,7 +176,7 @@ const reorderGroupsDisabled = computed(() => !props.canReorderGroups || props.se
 									<div class="title-content">
 										{{ group.id === null ? $t('layouts.kanban.no_group') : group.title }}
 									</div>
-									<span class="badge">{{ group.items.length }}</span>
+									<VChip :label="false" x-small>{{ group.items.length }}</VChip>
 								</div>
 								<div v-if="isRelational && group.id !== null && !selectMode" class="actions">
 									<VMenu show-arrow placement="bottom-end">
@@ -351,20 +352,6 @@ const reorderGroupsDisabled = computed(() => !props.canReorderGroups || props.se
 						color: var(--theme--foreground-accent);
 						margin-inline-end: 0.3125rem;
 					}
-				}
-
-				.badge {
-					display: inline-flex;
-					justify-content: center;
-					padding: 0 0.3125rem;
-					block-size: 1.125rem;
-					min-inline-size: 1.125rem;
-					margin-block-start: 0.125rem;
-					text-align: center;
-					font-size: 0.6875rem;
-					line-height: 1.6364;
-					background-color: var(--theme--background-accent);
-					border-radius: 0.6875rem;
 				}
 
 				.actions {

--- a/app/src/modules/deployment/components/deployment-status.vue
+++ b/app/src/modules/deployment/components/deployment-status.vue
@@ -57,6 +57,7 @@ const statusLabel = computed(() => {
 
 <template>
 	<VChip
+		:label="false"
 		small
 		disabled
 		:style="{

--- a/app/src/modules/settings/routes/extensions/components/ExtensionItem.vue
+++ b/app/src/modules/settings/routes/extensions/components/ExtensionItem.vue
@@ -117,7 +117,7 @@ function isAppExtension(type?: ExtensionType) {
 				</RouterLink>
 				<span v-else>{{ name }}</span>
 				{{ ' ' }}
-				<VChip v-if="version" class="version" small>
+				<VChip v-if="version" class="version" :label="false" small>
 					{{ version }}
 				</VChip>
 			</span>
@@ -127,7 +127,7 @@ function isAppExtension(type?: ExtensionType) {
 			<VProgressCircular indeterminate small />
 		</span>
 
-		<VChip v-if="type !== 'missing'" class="state" :class="state.value" small>
+		<VChip v-if="type !== 'missing'" class="state" :class="state.value" :label="false" small>
 			{{ state.text }}
 		</VChip>
 

--- a/app/src/modules/settings/routes/marketplace/components/extension-list-item.vue
+++ b/app/src/modules/settings/routes/marketplace/components/extension-list-item.vue
@@ -37,8 +37,14 @@ const chip = computed(() => t(`extension_${props.extension.type}`));
 		<VListItemContent>
 			<div class="name">
 				{{ formatName(extension) }}
-				<VChip v-if="showType" outlined x-small class="chip">{{ chip }}</VChip>
-				<VChip v-if="extensionsStore.extensionIds.includes(extension.id)" outlined x-small class="chip">
+				<VChip v-if="showType" kind="primary" :label="false" x-small class="chip">{{ chip }}</VChip>
+				<VChip
+					v-if="extensionsStore.extensionIds.includes(extension.id)"
+					kind="primary"
+					:label="false"
+					x-small
+					class="chip"
+				>
 					{{ $t('installed') }}
 				</VChip>
 			</div>
@@ -114,9 +120,6 @@ const chip = computed(() => t(`extension_${props.extension.type}`));
 .chip {
 	margin-inline-start: 0.25rem;
 	vertical-align: 0.125rem;
-
-	--v-chip-color: var(--theme--primary);
-	--v-chip-background-color: var(--theme--primary-subdued);
 }
 
 .license.known {

--- a/app/src/modules/settings/routes/marketplace/routes/extension/components/extension-banner.vue
+++ b/app/src/modules/settings/routes/marketplace/routes/extension/components/extension-banner.vue
@@ -18,7 +18,7 @@ const newestVersion = computed(() => props.extension.versions.at(0)!);
 <template>
 	<VBanner :icon="icon">
 		<template #headline>
-			<VChip outlined x-small>{{ $t(`extension_${extension.type}`) }}</VChip>
+			<VChip kind="primary" :label="false" x-small>{{ $t(`extension_${extension.type}`) }}</VChip>
 		</template>
 
 		<h2 class="name">{{ formatName(extension) }}</h2>

--- a/app/src/views/private/components/user-popover.vue
+++ b/app/src/views/private/components/user-popover.vue
@@ -97,10 +97,10 @@ function navigateToUser() {
 			</VAvatar>
 			<div class="data">
 				<div class="name type-label">{{ userName(data) }}</div>
-				<VChip class="status" :class="data.status" small>
+				<VChip class="status" :class="data.status" :label="false" small>
 					{{ $t(`fields.directus_users.status_${data.status}`) }}
 				</VChip>
-				<VChip v-if="data.role?.name" small>{{ data.role.name }}</VChip>
+				<VChip v-if="data.role?.name" :label="false" small>{{ data.role.name }}</VChip>
 				<div class="email">{{ data.email }}</div>
 			</div>
 		</div>


### PR DESCRIPTION
## Scope

What's changed:

- Switch `VChip` usages across the app to render as pills instead of the new default rectangle shape
- Align the marketplace chips with the standard `kind="primary"` styling
- Fix vertical alignment of the edit dot in the group accordion interface

## Potential Risks / Drawbacks

—

## Tested Scenarios

- All updated call sites reviewed visually in the app (forms, group interfaces, kanban, deployment status, extensions, marketplace, user popover)

## Review Notes / Questions

- Please pay special attention to `app/src/layouts/kanban/kanban.vue` — it's the only call site that swaps a custom element for `VChip` rather than just toggling a prop
- Marketplace chips now rely on `kind="primary"` rather than manual color overrides

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Addresses CMS-2184
