### PR TITLE
xiiui ← Increase module bar button hit area

### DIFF
--- a/app/src/views/private/components/module-bar-button.vue
+++ b/app/src/views/private/components/module-bar-button.vue
@@ -33,4 +33,12 @@ defineEmits<VButtonEmits>();
 	--v-button-background-color-hover: var(--theme--navigation--modules--button--background-hover);
 	--v-button-background-color-active: var(--theme--navigation--modules--button--background-active);
 }
+
+.v-button :deep(.button)::before {
+	--hit-area: calc(-1 * var(--module-bar-gap) / 2);
+
+	content: '';
+	position: absolute;
+	inset: var(--hit-area);
+}
 </style>


### PR DESCRIPTION
Follow-up to https://github.com/directus/directus/pull/27009

## Scope

What's changed:

- Extend each module bar button's hit area into the surrounding gap via an invisible `::before` pseudo-element
- Adjacent buttons now meet at the midpoint of the gap, eliminating dead space
- No visual change — purely a click-target improvement

## Potential Risks / Drawbacks

—

## Tested Scenarios

- Clicks in the previously-dead gap between buttons now activate the nearer module
- Hover/active visual states remain confined to the original button shape

## Review Notes / Questions

- Pattern mirrors the existing approach in `module-bar-avatar.vue` — kept intentionally consistent

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Addresses CMS-2331