### PR TITLE
Show project locked warning for non-admin logins

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -901,9 +901,11 @@ errors:
   LIMIT_EXCEEDED: 'Limit exceeded'
   METHOD_NOT_ALLOWED: Method not allowed
   NOT_NULL_VIOLATION: Value can't be null
+  PROJECT_LOCKED: Project has been locked. Contact your admin to resolve the issue.
   RANGE_NOT_SATISFIABLE: Invalid range
   RECORD_NOT_UNIQUE: Duplicate value detected
   REQUESTS_EXCEEDED: Requests limit reached
+  RESOURCE_RESTRICTED: Resource restricted
   ROUTE_NOT_FOUND: Not found
   SERVICE_UNAVAILABLE: Service Unavailable
   TOKEN_EXPIRED: Token expired
@@ -911,7 +913,6 @@ errors:
   UNKNOWN: Unexpected Error
   UNPROCESSABLE_CONTENT: Unprocessable Content
   UNSUPPORTED_MEDIA_TYPE: Unsupported media type
-  PROJECT_LOCKED: The project has reached its user seat limit. Please contact your project admin to resolve this issue.
   USER_SUSPENDED: User Suspended
   VALUE_OUT_OF_RANGE: Value is out of range
   VALUE_TOO_LONG: Value is too long

--- a/app/src/routes/login/components/login-form/login-form.vue
+++ b/app/src/routes/login/components/login-form/login-form.vue
@@ -52,6 +52,10 @@ const errorFormatted = computed(() => {
 		return translateAPIError('INVALID_CREDENTIALS');
 	}
 
+	if (error.value === 'RESOURCE_RESTRICTED') {
+		return translateAPIError('PROJECT_LOCKED');
+	}
+
 	if (error.value) {
 		return translateAPIError(error.value);
 	}


### PR DESCRIPTION
This pops a warning for non-admins attempting to login to a locked instance.

- To test:

- Put instance over the limit
- Attempt to log in with non-admin

<img width="421" height="567" alt="CleanShot 2026-05-15 at 15 28 46" src="https://github.com/user-attachments/assets/74c45fa7-8059-408c-9086-308abe0573cb" />

Fixes CMS-2311
