### PR TITLE
feat(app): support translations for flow names

### DIFF
--- a/.changeset/translatable-flow-names.md
+++ b/.changeset/translatable-flow-names.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added support for translatable flow names via the existing `$t:` prefix and translation strings, matching the field/collection label pattern. The flow name input in the flow editor now exposes the translation picker.

--- a/app/src/composables/use-flows.ts
+++ b/app/src/composables/use-flows.ts
@@ -7,6 +7,7 @@ import api from '@/api';
 import { useFlowsStore } from '@/stores/flows';
 import { useNotificationsStore } from '@/stores/notifications';
 import { notify } from '@/utils/notify';
+import { translate as translateLiteral } from '@/utils/translate-literal';
 import { translate } from '@/utils/translate-object-values';
 import { unexpectedError } from '@/utils/unexpected-error';
 
@@ -133,6 +134,7 @@ export function useFlows(options: UseFlowsOptions) {
 			)
 			.map((flow) => ({
 				...flow,
+				name: translateLiteral(flow.name),
 				options: flow.options ? translate(flow.options) : null,
 				tooltip: getFlowTooltip(flow),
 				isFlowDisabled: checkFlowDisabled(flow),

--- a/app/src/interfaces/_system/system-manual-flow-select/system-manual-flow-select.vue
+++ b/app/src/interfaces/_system/system-manual-flow-select/system-manual-flow-select.vue
@@ -4,6 +4,7 @@ import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import VSelect from '@/components/v-select/v-select.vue';
 import { useFlowsStore } from '@/stores/flows';
+import { translate } from '@/utils/translate-literal';
 
 const props = defineProps<{ value: Record<string, unknown> | null; collectionName: string }>();
 defineEmits<{ input: [value: string | null] }>();
@@ -24,7 +25,7 @@ const flows = computed(() =>
 		)
 		.map((flow: FlowRaw) => ({
 			value: flow.id,
-			text: `${flow.name}${(flow.description && ': ' + flow.description) || ''}${flow.status === 'inactive' ? ` (${t('inactive')})` : ''}`,
+			text: `${translate(flow.name)}${(flow.description && ': ' + flow.description) || ''}${flow.status === 'inactive' ? ` (${t('inactive')})` : ''}`,
 			icon: flow.icon,
 			color: flow.color,
 		})),

--- a/app/src/modules/settings/routes/flows/flow-drawer.vue
+++ b/app/src/modules/settings/routes/flows/flow-drawer.vue
@@ -14,6 +14,7 @@ import VTabItem from '@/components/v-tab-item.vue';
 import VTab from '@/components/v-tab.vue';
 import VTabsItems from '@/components/v-tabs-items.vue';
 import VTabs from '@/components/v-tabs.vue';
+import InterfaceInputTranslatedString from '@/interfaces/_system/system-input-translated-string/input-translated-string.vue';
 import InterfaceSelectColor from '@/interfaces/select-color/select-color.vue';
 import InterfaceSelectIcon from '@/interfaces/select-icon/select-icon.vue';
 import { useFlowsStore } from '@/stores/flows';
@@ -207,7 +208,12 @@ function onApply() {
 							{{ $t('flow_name') }}
 							<VIcon v-tooltip="$t('required')" class="required" name="star" sup filled />
 						</div>
-						<VInput v-model="values.name" autofocus :placeholder="$t('flow_name')" />
+						<InterfaceInputTranslatedString
+							:value="values.name"
+							autofocus
+							:placeholder="$t('flow_name')"
+							@input="values.name = $event"
+						/>
 					</div>
 					<div class="field half">
 						<div class="type-label">{{ $t('status') }}</div>

--- a/app/src/modules/settings/routes/flows/flow.vue
+++ b/app/src/modules/settings/routes/flows/flow.vue
@@ -31,6 +31,7 @@ import { useExtensions } from '@/extensions';
 import { router } from '@/router';
 import { useFlowsStore } from '@/stores/flows';
 import { useLicenseStore } from '@/stores/license';
+import { translate } from '@/utils/translate-literal';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { Vector2 } from '@/utils/vector2';
 import { PrivateViewHeaderBarActionButton } from '@/views/private';
@@ -611,7 +612,7 @@ function discardAndLeave() {
 
 <template>
 	<SettingsNotFound v-if="!flow && !loading" />
-	<PrivateView v-else :title="flow?.name ?? $t('loading')" show-back back-to="/settings/flows">
+	<PrivateView v-else :title="flow?.name ? translate(flow.name) : $t('loading')" show-back back-to="/settings/flows">
 		<template #title:append>
 			<DisplayColor
 				v-tooltip="flow?.status === 'active' ? $t('active') : $t('inactive')"
@@ -735,7 +736,7 @@ function discardAndLeave() {
 
 		<VDialog :model-value="confirmDelete" @esc="confirmDelete = false" @apply="deleteFlow">
 			<VCard>
-				<VCardTitle>{{ $t('flow_delete_confirm', { flow: flow?.name }) }}</VCardTitle>
+				<VCardTitle>{{ $t('flow_delete_confirm', { flow: flow?.name ? translate(flow.name) : '' }) }}</VCardTitle>
 
 				<VCardActions>
 					<VButton secondary @click="confirmDelete = false">{{ $t('cancel') }}</VButton>

--- a/app/src/modules/settings/routes/flows/overview.vue
+++ b/app/src/modules/settings/routes/flows/overview.vue
@@ -26,6 +26,7 @@ import DisplayFormattedValue from '@/displays/formatted-value/formatted-value.vu
 import { router } from '@/router';
 import { useFlowsStore } from '@/stores/flows';
 import { useLicenseStore } from '@/stores/license';
+import { translate } from '@/utils/translate-literal';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { PrivateViewHeaderBarActionButton } from '@/views/private';
 import { PrivateView } from '@/views/private';
@@ -109,7 +110,8 @@ const internalSort = ref<Sort>({ by: 'name', desc: false });
 const flowsStore = useFlowsStore();
 
 const flows = computed(() => {
-	const sortedFlows = sortBy(flowsStore.flows, [internalSort.value.by]);
+	const translatedFlows = flowsStore.flows.map((flow) => ({ ...flow, name: translate(flow.name) }));
+	const sortedFlows = sortBy(translatedFlows, [internalSort.value.by]);
 	return internalSort.value.desc ? sortedFlows.reverse() : sortedFlows;
 });
 

--- a/app/src/operations/trigger/index.ts
+++ b/app/src/operations/trigger/index.ts
@@ -1,5 +1,6 @@
 import { defineOperationApp } from '@directus/extensions';
 import { useFlowsStore } from '@/stores/flows';
+import { translate } from '@/utils/translate-literal';
 
 export default defineOperationApp({
 	id: 'trigger',
@@ -18,7 +19,7 @@ export default defineOperationApp({
 		const flowChoices = flowStore.flows
 			.filter((flow) => flow.trigger === 'operation')
 			.map((flow) => {
-				return { text: flow.name, value: flow.id };
+				return { text: translate(flow.name), value: flow.id };
 			});
 
 		return [


### PR DESCRIPTION
Closes #27471

## Summary

Flow names render as plain strings everywhere in the UI, while every other label on collection/item pages respects the user's language. This PR wires `directus_flows.name` into the existing `$t:` translation pipeline used for field and collection labels.

After this change, an admin can rename a flow to `$t:flows.send_to_approval`, define translations in **Settings → Translation Strings**, and the flow button localizes per user — same UX as field labels.

## Changes

- Translate `flow.name` at every render site:
  - Sidebar manual-flow button
  - Flow picker (`system-manual-flow-select`)
  - Trigger-flow success notification
  - "Trigger flow" operation choices
  - Operation drawer subtitle
  - Settings → Flows list (with sort still working on translated name)
  - Flow editor page title and delete dialog
- Replace plain `VInput` in `flow-drawer.vue` with `system-input-translated-string` so admins can pick or create translation keys inline.

No DB migration, no schema change, no API change. Literal (non-`$t:`) flow names continue to render unchanged.

## Test plan

- [x] Create a flow named `$t:flows.test`, add a translation string `flows.test` with English/Spanish values
- [x] Switch user language to Spanish → flow button on item page shows Spanish value
- [x] Switch to English → shows English value
- [x] Flow with a literal name (no `$t:`) renders unchanged
- [x] Edit drawer name input shows the translate-icon picker
- [x] Settings → Flows list, flow editor title, delete dialog, and operation drawer subtitle all show translated name