### PR TITLE
feat(app): support setting field value via conditions

### DIFF
--- a/app/src/components/v-form/v-form.vue
+++ b/app/src/components/v-form/v-form.vue
@@ -17,7 +17,7 @@ import { updateSystemDivider } from './utils/update-system-divider';
 import { CollabContext } from '@/composables/use-collab';
 import { useFieldsStore } from '@/stores/fields';
 import type { ContentVersionMaybeNew } from '@/types/versions';
-import { applyConditions } from '@/utils/apply-conditions';
+import { applyConditions, findMatchingCondition } from '@/utils/apply-conditions';
 import { extractFieldFromFunction } from '@/utils/extract-field-from-function';
 import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fields';
 import { pushGroupOptionsDown } from '@/utils/push-group-options-down';
@@ -301,6 +301,37 @@ function setValue(fieldKey: string, value: any, opts?: { force?: boolean }) {
 	edits[fieldKey] = value;
 	emit('update:modelValue', edits);
 }
+
+const lastAppliedConditionByField = new Map<string, string | null>();
+
+watch([() => props.primaryKey, () => props.version?.name ?? null], () => lastAppliedConditionByField.clear());
+
+watch(
+	[() => values.value, () => fieldDefinitions.value, () => props.version],
+	() => {
+		for (const field of fieldDefinitions.value) {
+			if (!field.meta?.conditions?.length) continue;
+
+			const matched = findMatchingCondition(values.value, field, props.version);
+			const currentName = matched?.name ?? null;
+
+			if (!lastAppliedConditionByField.has(field.field)) {
+				lastAppliedConditionByField.set(field.field, currentName);
+				continue;
+			}
+
+			const prevName = lastAppliedConditionByField.get(field.field) ?? null;
+			if (currentName === prevName) continue;
+
+			lastAppliedConditionByField.set(field.field, currentName);
+
+			if (matched?.set_value === true && matched.value !== undefined) {
+				setValue(field.field, matched.value, { force: true });
+			}
+		}
+	},
+	{ flush: 'post', immediate: true },
+);
 
 function apply(updates: { [field: string]: any }) {
 	const updatableKeys = props.batchMode

--- a/app/src/composables/use-item/index.ts
+++ b/app/src/composables/use-item/index.ts
@@ -21,6 +21,7 @@ import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fiel
 import { mergeItemData } from '@/utils/merge-item-data';
 import { notify } from '@/utils/notify';
 import { pushGroupOptionsDown } from '@/utils/push-group-options-down';
+import { setConditionalValues } from '@/utils/set-conditional-values';
 import { translate } from '@/utils/translate-object-values';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { validateItem } from '@/utils/validate-item';
@@ -151,7 +152,14 @@ export function useItem<T extends Item>(
 
 		const editsWithClearedValues = clearHiddenFieldsByCondition(edits.value, fields, defaultValues.value, item.value);
 
-		const payloadToValidate = mergeItemData(defaultValues.value, item.value ?? {}, editsWithClearedValues);
+		const editsWithConditionalValues = setConditionalValues(
+			editsWithClearedValues,
+			fields,
+			defaultValues.value,
+			item.value,
+		);
+
+		const payloadToValidate = mergeItemData(defaultValues.value, item.value ?? {}, editsWithConditionalValues);
 
 		const errors = validateItem(payloadToValidate, fields, isNew.value);
 		if (nestedValidationErrors.value?.length) errors.push(...nestedValidationErrors.value);
@@ -169,7 +177,7 @@ export function useItem<T extends Item>(
 				response = await sdk.request<T>(
 					requestEndpoint(getEndpoint(collection.value), {
 						method: 'POST',
-						body: editsWithClearedValues,
+						body: editsWithConditionalValues,
 					}),
 				);
 
@@ -180,7 +188,7 @@ export function useItem<T extends Item>(
 				response = await sdk.request<T>(
 					requestEndpoint(itemEndpoint.value, {
 						method: 'PATCH',
-						body: editsWithClearedValues,
+						body: editsWithConditionalValues,
 					}),
 				);
 

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -397,6 +397,8 @@ hidden_field: Hidden Field
 hidden_on_detail: Hidden on Detail
 clear_hidden_field: Clear Value(s)
 clear_value_on_save_when_hidden: Clear value(s) on save when hidden
+set_value: Set Value
+set_field_value_when_condition_matches: Set field value when condition matches
 readonly_field_label: Disable the field in the app
 required_readonly_field_warning:
   Enabling both readonly and required on a field prevents saving an item if the value is empty.

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue
@@ -15,6 +15,55 @@ const { loading, field, collection } = storeToRefs(fieldDetailStore);
 const interfaceId = computed(() => field.value.meta?.interface ?? null);
 const conditions = syncFieldDetailStoreProperty('field.meta.conditions');
 
+const valueFieldDef = computed<DeepPartial<Field>>(() => {
+	const targetType = field.value.type;
+
+	const base: DeepPartial<Field> = {
+		field: 'value',
+		name: t('value'),
+		type: 'json',
+		meta: {
+			readonly: true,
+			width: 'half',
+			conditions: [
+				{
+					rule: { set_value: { _eq: true } },
+					readonly: false,
+				},
+			],
+		},
+	};
+
+	if (targetType === 'boolean') {
+		base.meta!.interface = 'select-dropdown';
+
+		base.meta!.options = {
+			choices: [
+				{ text: 'true', value: true },
+				{ text: 'false', value: false },
+				{ text: 'NULL', value: null },
+			],
+		};
+	} else if (['integer', 'bigInteger', 'float', 'decimal'].includes(targetType as string)) {
+		base.meta!.interface = 'input';
+		base.meta!.options = { type: 'number', placeholder: t('enter_a_value') };
+	} else if (targetType === 'text') {
+		base.meta!.interface = 'input-multiline';
+		base.meta!.options = { placeholder: t('enter_a_value') };
+	} else if (targetType === 'json') {
+		base.meta!.interface = 'input-code';
+		base.meta!.options = { language: 'JSON', placeholder: t('enter_a_value') };
+	} else if (['timestamp', 'dateTime', 'date', 'time'].includes(targetType as string)) {
+		base.meta!.interface = 'datetime';
+		base.meta!.options = { type: targetType };
+	} else {
+		base.meta!.interface = 'input';
+		base.meta!.options = { placeholder: t('enter_a_value') };
+	}
+
+	return base;
+});
+
 const conditionsSync = computed({
 	get() {
 		return { conditions: conditions.value };
@@ -109,6 +158,19 @@ const repeaterFields = computed<DeepPartial<Field>[]>(() => [
 			],
 		},
 	},
+	{
+		field: 'set_value',
+		name: t('set_value'),
+		type: 'boolean',
+		meta: {
+			interface: 'boolean',
+			options: {
+				label: t('set_field_value_when_condition_matches'),
+			},
+			width: 'half',
+		},
+	},
+	valueFieldDef.value,
 	{
 		field: 'options',
 		name: t('interface_options'),

--- a/app/src/utils/apply-conditions.ts
+++ b/app/src/utils/apply-conditions.ts
@@ -1,8 +1,31 @@
-import { Field } from '@directus/types';
+import { Condition, Field } from '@directus/types';
 import { validatePayload } from '@directus/utils';
 import { isArray, mergeWith } from 'lodash';
 import type { ContentVersionMaybeNew } from '@/types/versions';
 import { parseFilter } from '@/utils/parse-filter';
+
+export function findMatchingCondition(
+	item: Record<string, any>,
+	field: Field,
+	version: ContentVersionMaybeNew | null = null,
+): Condition | undefined {
+	if (!field.meta || !Array.isArray(field.meta?.conditions)) return undefined;
+
+	const conditions = [...field.meta.conditions].reverse();
+
+	return conditions.find((condition) => {
+		if (!condition.rule || Object.keys(condition.rule).length !== 1) return;
+
+		const validationContext = {
+			...item,
+			$version: version?.name ?? null,
+		};
+
+		const rule = parseFilter(condition.rule);
+		const errors = validatePayload(rule, validationContext, { requireAll: true });
+		return errors.length === 0;
+	});
+}
 
 export function applyConditions(
 	item: Record<string, any>,
@@ -10,21 +33,7 @@ export function applyConditions(
 	version: ContentVersionMaybeNew | null = null,
 ) {
 	if (field.meta && Array.isArray(field.meta?.conditions)) {
-		const conditions = [...field.meta.conditions].reverse();
-
-		const matchingCondition = conditions.find((condition) => {
-			if (!condition.rule || Object.keys(condition.rule).length !== 1) return;
-
-			// because $version is not an item field, we need to add it to the validation context
-			const validationContext = {
-				...item,
-				$version: version?.name ?? null,
-			};
-
-			const rule = parseFilter(condition.rule);
-			const errors = validatePayload(rule, validationContext, { requireAll: true });
-			return errors.length === 0;
-		});
+		const matchingCondition = findMatchingCondition(item, field, version);
 
 		if (matchingCondition) {
 			const updatedField = {
@@ -38,6 +47,8 @@ export function applyConditions(
 						hidden: matchingCondition.hidden,
 						required: matchingCondition.required,
 						clear_hidden_value_on_save: matchingCondition.clear_hidden_value_on_save,
+						set_value: matchingCondition.set_value,
+						value: matchingCondition.set_value ? matchingCondition.value : undefined,
 					},
 					(objValue, srcValue) => {
 						if (isArray(objValue) && isArray(srcValue)) {

--- a/app/src/utils/set-conditional-values.test.ts
+++ b/app/src/utils/set-conditional-values.test.ts
@@ -1,0 +1,245 @@
+import { Field } from '@directus/types';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { setConditionalValues } from './set-conditional-values.js';
+
+function makeField(fieldName: string, overrides: Partial<Field> = {}): Field {
+	return {
+		collection: 'test',
+		field: fieldName,
+		name: fieldName,
+		type: 'string',
+		schema: null,
+		meta: {
+			id: 1,
+			collection: 'test',
+			field: fieldName,
+			special: null,
+			interface: 'input',
+			options: null,
+			display: null,
+			display_options: null,
+			readonly: false,
+			hidden: false,
+			sort: 1,
+			width: 'full',
+			translations: null,
+			note: null,
+			conditions: null,
+			required: false,
+			group: null,
+			validation: null,
+			validation_message: null,
+		},
+		...overrides,
+	} as Field;
+}
+
+beforeEach(() => {
+	setActivePinia(createTestingPinia({ createSpy: vi.fn }));
+});
+
+describe('setConditionalValues', () => {
+	it('returns edits unchanged when no fields have conditions', () => {
+		const edits = { title: 'hello' };
+		const result = setConditionalValues(edits, [makeField('title')], {}, {});
+		expect(result).toEqual(edits);
+	});
+
+	it('returns edits unchanged when condition does not match', () => {
+		const edits = { is_okay: false, status: 'draft' };
+
+		const field = makeField('status', {
+			meta: {
+				...makeField('status').meta!,
+				conditions: [
+					{
+						name: 'approve when okay',
+						rule: { is_okay: { _eq: true } },
+						set_value: true,
+						value: 'approved',
+					},
+				],
+			},
+		});
+
+		const result = setConditionalValues(edits, [field, makeField('is_okay')], {}, {});
+		expect(result.status).toBe('draft');
+	});
+
+	it('sets the value when condition matches and set_value is true', () => {
+		const edits = { is_okay: true, status: 'draft' };
+
+		const field = makeField('status', {
+			meta: {
+				...makeField('status').meta!,
+				conditions: [
+					{
+						name: 'approve when okay',
+						rule: { is_okay: { _eq: true } },
+						set_value: true,
+						value: 'approved',
+					},
+				],
+			},
+		});
+
+		const result = setConditionalValues(edits, [field, makeField('is_okay')], {}, {});
+		expect(result.status).toBe('approved');
+	});
+
+	it('does not set value when set_value is false', () => {
+		const edits = { is_okay: true, status: 'draft' };
+
+		const field = makeField('status', {
+			meta: {
+				...makeField('status').meta!,
+				conditions: [
+					{
+						name: 'no-op rule',
+						rule: { is_okay: { _eq: true } },
+						set_value: false,
+						value: 'approved',
+					},
+				],
+			},
+		});
+
+		const result = setConditionalValues(edits, [field, makeField('is_okay')], {}, {});
+		expect(result.status).toBe('draft');
+	});
+
+	it('forces set value at save even when user manually changed the field', () => {
+		const edits = { is_okay: true, status: 'user_typed_value' };
+
+		const field = makeField('status', {
+			meta: {
+				...makeField('status').meta!,
+				conditions: [
+					{
+						name: 'approve when okay',
+						rule: { is_okay: { _eq: true } },
+						set_value: true,
+						value: 'approved',
+					},
+				],
+			},
+		});
+
+		const result = setConditionalValues(edits, [field, makeField('is_okay')], {}, {});
+		expect(result.status).toBe('approved');
+	});
+
+	it('supports null as a set value', () => {
+		const edits = { is_okay: true, reviewer: 'someone' };
+
+		const field = makeField('reviewer', {
+			meta: {
+				...makeField('reviewer').meta!,
+				conditions: [
+					{
+						name: 'clear reviewer when okay',
+						rule: { is_okay: { _eq: true } },
+						set_value: true,
+						value: null,
+					},
+				],
+			},
+		});
+
+		const result = setConditionalValues(edits, [field, makeField('is_okay')], {}, {});
+		expect(result.reviewer).toBeNull();
+	});
+
+	it('reads rule context from defaults+item+edits merge', () => {
+		const edits = {};
+		const item = { is_okay: true };
+
+		const field = makeField('status', {
+			meta: {
+				...makeField('status').meta!,
+				conditions: [
+					{
+						name: 'approve when okay',
+						rule: { is_okay: { _eq: true } },
+						set_value: true,
+						value: 'approved',
+					},
+				],
+			},
+		});
+
+		const result = setConditionalValues(edits, [field, makeField('is_okay')], {}, item);
+		expect(result.status).toBe('approved');
+	});
+
+	it('returns a new object only when changes occur', () => {
+		const edits = { title: 'hello' };
+		const result = setConditionalValues(edits, [makeField('title')], {}, {});
+		expect(result).toBe(edits);
+	});
+
+	it('handles multiple fields with conditions independently', () => {
+		const edits = { is_okay: true };
+
+		const status = makeField('status', {
+			meta: {
+				...makeField('status').meta!,
+				conditions: [
+					{
+						name: 'approve',
+						rule: { is_okay: { _eq: true } },
+						set_value: true,
+						value: 'approved',
+					},
+				],
+			},
+		});
+
+		const priority = makeField('priority', {
+			meta: {
+				...makeField('priority').meta!,
+				conditions: [
+					{
+						name: 'urgent',
+						rule: { is_okay: { _eq: true } },
+						set_value: true,
+						value: 'high',
+					},
+				],
+			},
+		});
+
+		const result = setConditionalValues(edits, [status, priority, makeField('is_okay')], {}, {});
+		expect(result.status).toBe('approved');
+		expect(result.priority).toBe('high');
+	});
+
+	it('matches the last condition in array when multiple match (reversed precedence)', () => {
+		const edits = { is_okay: true };
+
+		const field = makeField('status', {
+			meta: {
+				...makeField('status').meta!,
+				conditions: [
+					{
+						name: 'first',
+						rule: { is_okay: { _eq: true } },
+						set_value: true,
+						value: 'first_value',
+					},
+					{
+						name: 'second',
+						rule: { is_okay: { _eq: true } },
+						set_value: true,
+						value: 'second_value',
+					},
+				],
+			},
+		});
+
+		const result = setConditionalValues(edits, [field, makeField('is_okay')], {}, {});
+		expect(result.status).toBe('second_value');
+	});
+});

--- a/app/src/utils/set-conditional-values.ts
+++ b/app/src/utils/set-conditional-values.ts
@@ -1,0 +1,29 @@
+import { Field, Item } from '@directus/types';
+import { cloneDeep } from 'lodash';
+import { findMatchingCondition } from './apply-conditions';
+import { mergeItemData } from './merge-item-data';
+
+export function setConditionalValues(edits: Item, fields: Field[], defaultValues: any, item: any): Item {
+	const currentValues = mergeItemData(defaultValues, item, edits);
+
+	const fieldsToSet: Map<string, any> = new Map();
+
+	for (const field of fields) {
+		if (!field.meta?.conditions?.length) continue;
+
+		const matched = findMatchingCondition(currentValues, field);
+		if (!matched?.set_value) continue;
+
+		fieldsToSet.set(field.field, matched.value);
+	}
+
+	if (fieldsToSet.size === 0) return edits;
+
+	const result = cloneDeep(edits);
+
+	for (const [field, value] of fieldsToSet) {
+		result[field] = value;
+	}
+
+	return result;
+}

--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -35,6 +35,7 @@ import { useRelationsStore } from '@/stores/relations';
 import { clearHiddenFieldsByCondition } from '@/utils/clear-hidden-fields-by-condition';
 import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fields';
 import { mergeItemData } from '@/utils/merge-item-data';
+import { setConditionalValues } from '@/utils/set-conditional-values';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { validateItem } from '@/utils/validate-item';
 import CollabIndicatorHeader from '@/views/private/components/collab/CollabIndicatorHeader.vue';
@@ -568,10 +569,24 @@ function useActions() {
 			initialValues.value,
 		);
 
+		internalEdits.value = setConditionalValues(
+			internalEdits.value,
+			fieldsWithoutCircular.value,
+			mainDefaults,
+			initialValues.value,
+		);
+
 		if (props.junctionField && internalEdits.value[props.junctionField]) {
 			const junctionDefaults = unref(getDefaultValuesFromFields(relatedCollectionFields.value));
 
 			internalEdits.value[props.junctionField] = clearHiddenFieldsByCondition(
+				internalEdits.value[props.junctionField],
+				relatedCollectionFields.value,
+				junctionDefaults,
+				initialValues.value?.[props.junctionField],
+			);
+
+			internalEdits.value[props.junctionField] = setConditionalValues(
 				internalEdits.value[props.junctionField],
 				relatedCollectionFields.value,
 				junctionDefaults,

--- a/packages/types/src/fields.ts
+++ b/packages/types/src/fields.ts
@@ -93,6 +93,8 @@ export type Condition = {
 	options?: Record<string, any>;
 	required?: boolean;
 	clear_hidden_value_on_save?: boolean;
+	set_value?: boolean;
+	value?: any;
 };
 
 export type AppField = Field & { schema: { default_value: any } };


### PR DESCRIPTION
Closes #27473

## Summary

Field conditions can override every aspect of a field except the value itself. This PR adds a `set_value` toggle and a `value` payload to the `Condition` type so a matching rule can declaratively set the field's value — both live in the form (on rising-edge transition) and at save time.

The original "Conditional Fields" discussion in #3151 considered this as a "later iteration" and marked it out of scope for the initial MVP ([Rijk's comment](https://github.com/directus/directus/issues/3151#issuecomment-839933472)). Four years on, no follow-up exists; #27473 revisits that decision with concrete use cases.

## Behavior

- **Live form (UI):** when a condition transitions from not-matching to matching (rising edge), the field's value is set. Falling edges do not clear. Users can manually override afterward.
- **Save pipeline:** at save time, any matching condition with `set_value: true` forces the value. Same enforcement model as `clear_hidden_value_on_save`.
- **No cascade loops:** rising-edge tracking ensures each transition fires once. A → B → A oscillations stabilize in two steps.
- **Reset on navigation:** the rising-edge map resets when `primaryKey` or `version` changes, so navigating between items in the same form instance does not misfire.

## Changes

- `packages/types/src/fields.ts` — `Condition` type gains `set_value?: boolean` and `value?: any`
- `app/src/utils/apply-conditions.ts` — extracts `findMatchingCondition`; merges new overrides into resolved meta
- `app/src/components/v-form/v-form.vue` — rising-edge watcher emits `setValue` on transition; resets on `primaryKey`/`version` change
- `app/src/utils/set-conditional-values.ts` (new) — save-pipeline counterpart to `clear-hidden-fields-by-condition.ts`
- `app/src/composables/use-item/index.ts`, `app/src/views/private/components/overlay-item.vue` — call `setConditionalValues` after `clearHiddenFieldsByCondition`; submit body uses the result
- `app/src/modules/settings/.../field-detail-advanced-conditions.vue` — repeater gains a `set_value` boolean and a type-aware `value` input (boolean dropdown, integer numeric, json code editor, etc.)
- `app/src/lang/translations/en-US.yaml` — `set_value`, `set_field_value_when_condition_matches`

## Test plan

- [x] On a collection with `decision` (dropdown) and `status` (string), add a condition on `status` with rule `{ decision: { _eq: "approve" } }`, Set Value on, value `"approved"`
- [x] Open an existing item where `decision = pending`, `status = "draft"` → `status` stays `"draft"` (no initial fire)
- [x] Change `decision` to `approve` → `status` flips to `"approved"` instantly in the UI
- [ ] Manually change `status` back to `"draft"` → UI keeps `"draft"` (no re-fire while rule keeps matching)
- [ ] Save → server persists `status = "approved"` (save-pipeline force)
- [ ] Change `decision` back to `pending` → `status` stays `"approved"` (falling edge ignored)
- [ ] Change `decision` to `approve` again → rising edge fires `"approved"` again
- [ ] Navigate to a different item in the same form view → no phantom `set_value` fire
- [ ] Create a new item with `decision = approve`, save → DB row has `status = "approved"`
- [ ] Conditions UI: target field is `boolean` → value input renders as `true / false / NULL` dropdown
- [ ] Conditions UI: target field is `integer` → value input renders as numeric input
- [ ] Conditions UI: target field is `json` → value input renders as JSON code editor
- [ ] Existing condition behaviors (readonly, hidden, required, clear-hidden-on-save) unchanged
- [ ] `pnpm vitest run src/utils/set-conditional-values.test.ts src/utils/clear-hidden-fields-by-condition.test.ts` → 22/22 pass