### PR TITLE
Fix SDK DOM-dependent public types

### DIFF
--- a/.changeset/sdk-dom-public-types.md
+++ b/.changeset/sdk-dom-public-types.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Fixed SDK type declarations that referenced DOM-only `RequestCredentials` and `CloseEvent` globals.

--- a/contributors.yml
+++ b/contributors.yml
@@ -273,3 +273,4 @@
 - yogeshwaran-c
 - sanskar-soni-9
 - kropsi
+- mturac

--- a/sdk/src/auth/types.ts
+++ b/sdk/src/auth/types.ts
@@ -1,3 +1,5 @@
+import type { RequestCredentials } from '../types/globals.js';
+
 export type AuthenticationMode = 'json' | 'cookie' | 'session';
 
 export type LocalLoginPayload = { email: string; password: string };

--- a/sdk/src/graphql/types.ts
+++ b/sdk/src/graphql/types.ts
@@ -1,3 +1,5 @@
+import type { RequestCredentials } from '../types/globals.js';
+
 export interface GraphqlClient<_Schema> {
 	query<Output extends object = Record<string, any>>(
 		query: string,

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -1,5 +1,5 @@
 import type { AuthenticationClient } from '../auth/types.js';
-import type { ConsoleInterface, ExtendedQuery, WebSocketInterface } from '../index.js';
+import type { ConsoleInterface, ExtendedQuery, WebSocketCloseEvent, WebSocketInterface } from '../index.js';
 import type { DirectusClient } from '../types/client.js';
 import { queryToParams } from '../utils/query-to-params.js';
 import { auth } from './commands/auth.js';
@@ -341,7 +341,7 @@ export function realtime(config: WebSocketConfig = {}) {
 					if (!resolved) reject(evt);
 				});
 
-				ws.addEventListener('close', (evt: CloseEvent) => {
+				ws.addEventListener('close', (evt: WebSocketCloseEvent) => {
 					debug('info', `Connection closed.`);
 					eventHandlers['close'].forEach((handler) => handler.call(ws, evt));
 					uid = generateUid();
@@ -359,7 +359,10 @@ export function realtime(config: WebSocketConfig = {}) {
 					state.connection.close();
 				}
 			},
-			onWebSocket(event: WebSocketEvents, callback: (this: WebSocketInterface, ev: Event | CloseEvent | any) => any) {
+			onWebSocket(
+				event: WebSocketEvents,
+				callback: (this: WebSocketInterface, ev: Event | WebSocketCloseEvent | any) => any,
+			) {
 				if (event === 'message') {
 					// add some message parsing
 					const updatedCallback = function (this: WebSocketInterface, event: MessageEvent<any>) {

--- a/sdk/src/realtime/types.ts
+++ b/sdk/src/realtime/types.ts
@@ -1,4 +1,4 @@
-import type { ApplyQueryFields, CollectionType, WebSocketInterface } from '../index.js';
+import type { ApplyQueryFields, CollectionType, WebSocketCloseEvent, WebSocketInterface } from '../index.js';
 import type { Query } from '../types/query.js';
 
 export type WebSocketAuthModes = 'public' | 'handshake' | 'strict';
@@ -29,7 +29,7 @@ export interface SubscribeOptions<Schema, Collection extends keyof Schema> {
 
 export type WebSocketEvents = 'open' | 'close' | 'error' | 'message';
 export type RemoveEventHandler = () => void;
-export type WebSocketEventHandler = (this: WebSocketInterface, ev: Event | CloseEvent | any) => any;
+export type WebSocketEventHandler = (this: WebSocketInterface, ev: Event | WebSocketCloseEvent | any) => any;
 
 export interface WebSocketClient<Schema> {
 	isConnected(): Promise<boolean>;
@@ -37,7 +37,7 @@ export interface WebSocketClient<Schema> {
 	disconnect(): void;
 	onWebSocket(event: 'open', callback: (this: WebSocketInterface, ev: Event) => any): RemoveEventHandler;
 	onWebSocket(event: 'error', callback: (this: WebSocketInterface, ev: Event) => any): RemoveEventHandler;
-	onWebSocket(event: 'close', callback: (this: WebSocketInterface, ev: CloseEvent) => any): RemoveEventHandler;
+	onWebSocket(event: 'close', callback: (this: WebSocketInterface, ev: WebSocketCloseEvent) => any): RemoveEventHandler;
 	onWebSocket(event: 'message', callback: (this: WebSocketInterface, ev: any) => any): RemoveEventHandler;
 	onWebSocket(event: WebSocketEvents, callback: WebSocketEventHandler): RemoveEventHandler;
 	sendMessage(message: string | Record<string, any>): void;

--- a/sdk/src/rest/types.ts
+++ b/sdk/src/rest/types.ts
@@ -1,3 +1,4 @@
+import type { RequestCredentials } from '../types/globals.js';
 import type { RequestOptions, RequestTransformer, ResponseTransformer } from '../types/request.js';
 
 export interface RestCommand<_Output extends object | unknown, _Schema> {

--- a/sdk/src/types/globals.ts
+++ b/sdk/src/types/globals.ts
@@ -3,6 +3,16 @@ export type FetchInterface = (input: string | any, init?: RequestInit | any) => 
 
 export type UrlInterface = typeof URL;
 
+/* v8 ignore start -- fallback type aliases for non-DOM TypeScript environments */
+export type RequestCredentials = 'include' | 'omit' | 'same-origin';
+
+export type WebSocketCloseEvent = Event & {
+	readonly code: number;
+	readonly reason: string;
+	readonly wasClean: boolean;
+};
+/* v8 ignore stop */
+
 /** While the standard says 'string | URL' for the 'url' parameter, some implementations (e.g. React Native) only accept 'string' */
 export type WebSocketConstructor = {
 	new (url: string, protocols?: string | string[]): WebSocketInterface;

--- a/sdk/tests/realtime.test.ts
+++ b/sdk/tests/realtime.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createDirectus, realtime } from '../src/index.js';
+import type { WebSocketCloseEvent, WebSocketInterface } from '../src/types/globals.js';
+
+class MockWebSocket implements WebSocketInterface {
+	static instances: MockWebSocket[] = [];
+
+	listeners = new Map<string, Set<(event: any) => void>>();
+	readyState = 0;
+	send = vi.fn();
+	close = vi.fn();
+
+	constructor(_url: string, _protocols?: string | string[]) {
+		MockWebSocket.instances.push(this);
+	}
+
+	addEventListener(type: string, listener: (this: WebSocketInterface, ev: any) => any) {
+		if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+		this.listeners.get(type)?.add(listener);
+	}
+
+	removeEventListener(type: string, listener: (this: WebSocketInterface, ev: any) => any) {
+		this.listeners.get(type)?.delete(listener);
+	}
+
+	dispatch(type: string, event: any) {
+		for (const listener of this.listeners.get(type) ?? []) {
+			listener.call(this, event);
+		}
+	}
+}
+
+afterEach(() => {
+	MockWebSocket.instances = [];
+	vi.clearAllMocks();
+});
+
+describe('realtime', () => {
+	it('passes close events to registered websocket handlers', async () => {
+		const client = createDirectus('http://example.com', {
+			globals: {
+				WebSocket: MockWebSocket,
+			},
+		}).with(
+			realtime({
+				authMode: 'public',
+				heartbeat: false,
+				reconnect: false,
+			}),
+		);
+
+		const onClose = vi.fn();
+		client.onWebSocket('close', onClose);
+
+		const connection = client.connect();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		const socket = MockWebSocket.instances[0]!;
+		socket.dispatch('open', new Event('open'));
+
+		await expect(connection).resolves.toBe(socket);
+
+		const closeEvent = Object.assign(new Event('close'), {
+			code: 1000,
+			reason: 'done',
+			wasClean: true,
+		}) as WebSocketCloseEvent;
+
+		socket.dispatch('close', closeEvent);
+
+		expect(onClose).toHaveBeenCalledWith(closeEvent);
+	});
+});


### PR DESCRIPTION
## Scope

Fixes #26850 by removing DOM-only type names from the SDK public type surface.

This keeps request credential options and realtime close event callbacks usable in TypeScript projects that do not include the DOM lib, while preserving the runtime event shape used by browser WebSocket implementations.

I also signed the Directus CLA by adding my GitHub username to `contributors.yml`.

## Testing

- `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && pnpm install --frozen-lockfile`
- `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && pnpm --filter @directus/sdk test`
- `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && pnpm exec prettier --check .changeset/sdk-dom-public-types.md contributors.yml sdk/src/auth/types.ts sdk/src/graphql/types.ts sdk/src/realtime/composable.ts sdk/src/realtime/types.ts sdk/src/rest/types.ts sdk/src/types/globals.ts sdk/tests/realtime.test.ts`
- `git diff --check`