### PR TITLE
Split admins from users in seats resolution

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1473,8 +1473,10 @@ licensing:
   resolve_section_seats: User Seats
   resolve_section_flows: Flows
   resolve_section_collections_caption: Select collection(s) to deactivate
-  resolve_section_seats_caption: Select user seat(s) to deactivate
+  resolve_section_seats_users_caption: Select user seat(s) to deactivate
+  resolve_section_seats_admins_caption: Select admin(s) to deactivate
   resolve_section_flows_caption: Select flow(s) to deactivate
+  resolve_all_set: All Set
   resolve_section_sso: SSO Deactivation
   resolve_sso_confirm: Confirm SSO Deactivation
   resolve_sso_caption:

--- a/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
+++ b/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
@@ -23,6 +23,7 @@ import VNotice from '@/components/v-notice.vue';
 import { useLicenseStore } from '@/stores/license';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { userName } from '@/utils/user-name';
+import DrawerItem from '@/views/private/components/drawer-item.vue';
 
 defineProps<{
 	/** Whether the dialog is open (v-model) */
@@ -85,6 +86,26 @@ const seats = computed<LicensePendingResolutionLimitSeats | undefined>(
 	() => find('limit', 'seats') as LicensePendingResolutionLimitSeats | undefined,
 );
 
+const seatGroups = computed(() => {
+	if (!seats.value) return [];
+	const users: SeatCandidate[] = [];
+	const admins: SeatCandidate[] = [];
+
+	for (const candidate of seats.value.candidates) {
+		if (candidate.admin) admins.push(candidate);
+		else users.push(candidate);
+	}
+
+	const groups: Array<{ caption: string; candidates: SeatCandidate[] }> = [];
+	if (users.length > 0) groups.push({ caption: t('licensing.resolve_section_seats_users_caption'), candidates: users });
+
+	if (admins.length > 0) {
+		groups.push({ caption: t('licensing.resolve_section_seats_admins_caption'), candidates: admins });
+	}
+
+	return groups;
+});
+
 const flows = computed<LicensePendingResolutionLimitFlows | undefined>(
 	() => find('limit', 'flows') as LicensePendingResolutionLimitFlows | undefined,
 );
@@ -113,6 +134,19 @@ const selected = reactive({
 
 const adminCreds = ref<{ email?: string; password?: string }>({});
 const ssoSectionRef = ref<InstanceType<typeof ResolutionSsoSection> | null>(null);
+
+const editingUserId = ref<string | null>(null);
+
+const userDrawerActive = computed({
+	get: () => editingUserId.value !== null,
+	set: (value: boolean) => {
+		if (!value) editingUserId.value = null;
+	},
+});
+
+function openUserDrawer(candidate: SeatCandidate) {
+	editingUserId.value = candidate.id;
+}
 
 const isValid = computed(() => {
 	if (collections.value && selected.collections.size < collections.value.usage - collections.value.limit) return false;
@@ -194,6 +228,7 @@ function onEsc() {
 	<VDialog
 		:model-value="modelValue"
 		:persistent="scope !== 'manual'"
+		:keep-behind="userDrawerActive"
 		@update:model-value="emit('update:modelValue', $event)"
 		@esc="onEsc"
 	>
@@ -230,23 +265,25 @@ function onEsc() {
 					v-model="selected.collections"
 					icon="database"
 					:title="t('licensing.resolve_section_collections')"
-					:description="t('licensing.resolve_section_collections_caption')"
 					:usage="collections.usage"
 					:limit="collections.limit"
-					:candidates="collections.candidates"
+					:groups="[
+						{ caption: t('licensing.resolve_section_collections_caption'), candidates: collections.candidates },
+					]"
 					:id-for="(name: string) => name"
 				/>
 
 				<ResolutionLimitSection
-					v-if="seats && seats.candidates.length > 0"
+					v-if="seatGroups.length > 0 && seats"
 					v-model="selected.seats"
 					icon="group"
 					:title="t('licensing.resolve_section_seats')"
-					:description="t('licensing.resolve_section_seats_caption')"
 					:usage="seats.usage"
 					:limit="seats.limit"
-					:candidates="seats.candidates"
+					:groups="seatGroups"
 					:id-for="(user: SeatCandidate) => user.id"
+					linkable
+					@open-item="openUserDrawer"
 				>
 					<template #item="{ candidate }">
 						<VAvatar x-small round>
@@ -262,10 +299,9 @@ function onEsc() {
 					v-model="selected.flows"
 					icon="bolt"
 					:title="t('licensing.resolve_section_flows')"
-					:description="t('licensing.resolve_section_flows_caption')"
 					:usage="flows.usage"
 					:limit="flows.limit"
-					:candidates="flows.candidates"
+					:groups="[{ caption: t('licensing.resolve_section_flows_caption'), candidates: flows.candidates }]"
 					:id-for="(name: string) => name"
 				/>
 			</VCardText>
@@ -282,6 +318,13 @@ function onEsc() {
 					{{ t('licensing.resolve_submit') }}
 				</VButton>
 			</footer>
+
+			<DrawerItem
+				v-model:active="userDrawerActive"
+				collection="directus_users"
+				:primary-key="editingUserId ?? '+'"
+				non-editable
+			/>
 		</VCard>
 	</VDialog>
 </template>

--- a/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
+++ b/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
@@ -82,6 +82,11 @@ const collections = computed<LicensePendingResolutionLimitCollections | undefine
 	() => find('limit', 'collections') as LicensePendingResolutionLimitCollections | undefined,
 );
 
+const collectionGroups = computed(() => {
+	if (!collections.value || collections.value.candidates.length === 0) return [];
+	return [{ caption: t('licensing.resolve_section_collections_caption'), candidates: collections.value.candidates }];
+});
+
 const seats = computed<LicensePendingResolutionLimitSeats | undefined>(
 	() => find('limit', 'seats') as LicensePendingResolutionLimitSeats | undefined,
 );
@@ -109,6 +114,11 @@ const seatGroups = computed(() => {
 const flows = computed<LicensePendingResolutionLimitFlows | undefined>(
 	() => find('limit', 'flows') as LicensePendingResolutionLimitFlows | undefined,
 );
+
+const flowGroups = computed(() => {
+	if (!flows.value || flows.value.candidates.length === 0) return [];
+	return [{ caption: t('licensing.resolve_section_flows_caption'), candidates: flows.value.candidates }];
+});
 
 const sso = computed<LicensePendingResolutionFeatureGateSSO | undefined>(
 	() => find('feature_gate', 'sso_enabled') as LicensePendingResolutionFeatureGateSSO | undefined,
@@ -261,15 +271,13 @@ function onEsc() {
 				/>
 
 				<ResolutionLimitSection
-					v-if="collections && collections.candidates.length > 0"
+					v-if="collections && collectionGroups.length > 0"
 					v-model="selected.collections"
 					icon="database"
 					:title="t('licensing.resolve_section_collections')"
 					:usage="collections.usage"
 					:limit="collections.limit"
-					:groups="[
-						{ caption: t('licensing.resolve_section_collections_caption'), candidates: collections.candidates },
-					]"
+					:groups="collectionGroups"
 					:id-for="(name: string) => name"
 				/>
 
@@ -295,13 +303,13 @@ function onEsc() {
 				</ResolutionLimitSection>
 
 				<ResolutionLimitSection
-					v-if="flows && flows.candidates.length > 0"
+					v-if="flows && flowGroups.length > 0"
 					v-model="selected.flows"
 					icon="bolt"
 					:title="t('licensing.resolve_section_flows')"
 					:usage="flows.usage"
 					:limit="flows.limit"
-					:groups="[{ caption: t('licensing.resolve_section_flows_caption'), candidates: flows.candidates }]"
+					:groups="flowGroups"
 					:id-for="(name: string) => name"
 				/>
 			</VCardText>
@@ -322,7 +330,7 @@ function onEsc() {
 			<DrawerItem
 				v-model:active="userDrawerActive"
 				collection="directus_users"
-				:primary-key="editingUserId ?? '+'"
+				:primary-key="editingUserId"
 				non-editable
 			/>
 		</VCard>

--- a/app/src/modules/settings/routes/license/components/resolution-limit-section.vue
+++ b/app/src/modules/settings/routes/license/components/resolution-limit-section.vue
@@ -45,10 +45,10 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 
-const expanded = reactive(new Set<number>());
+const expanded = reactive(new Set<string>());
 
-function visibleCandidatesFor(index: number, candidates: TCandidate[]): TCandidate[] {
-	if (expanded.has(index)) return candidates;
+function visibleCandidatesFor(caption: string, candidates: TCandidate[]): TCandidate[] {
+	if (expanded.has(caption)) return candidates;
 	return candidates.slice(0, props.initialVisible);
 }
 
@@ -88,12 +88,12 @@ function toggle(candidate: TCandidate): void {
 			</span>
 		</header>
 
-		<div v-for="(group, index) in groups" :key="index" class="group">
+		<div v-for="group in groups" :key="group.caption" class="group">
 			<p class="caption">{{ group.caption }}</p>
 
 			<div class="grid">
 				<div
-					v-for="candidate in visibleCandidatesFor(index, group.candidates)"
+					v-for="candidate in visibleCandidatesFor(group.caption, group.candidates)"
 					:key="idFor(candidate)"
 					class="item"
 					:class="{ selected: isChecked(candidate) }"
@@ -107,16 +107,16 @@ function toggle(candidate: TCandidate): void {
 						</span>
 					</button>
 					<button v-if="linkable" type="button" class="item-link" @click.stop="emit('open-item', candidate)">
-						<VIcon name="launch" small />
+						<VIcon name="open_in_new" small />
 					</button>
 				</div>
 			</div>
 
 			<button
-				v-if="!expanded.has(index) && hiddenCountFor(group.candidates) > 0"
+				v-if="!expanded.has(group.caption) && hiddenCountFor(group.candidates) > 0"
 				type="button"
 				class="show-more"
-				@click="expanded.add(index)"
+				@click="expanded.add(group.caption)"
 			>
 				{{ t('licensing.resolve_show_n_more', { count: hiddenCountFor(group.candidates) }) }}
 			</button>

--- a/app/src/modules/settings/routes/license/components/resolution-limit-section.vue
+++ b/app/src/modules/settings/routes/license/components/resolution-limit-section.vue
@@ -1,51 +1,64 @@
 <script setup lang="ts" generic="TCandidate">
-import { computed, ref } from 'vue';
+import { computed, reactive } from 'vue';
 import { useI18n } from 'vue-i18n';
 import VCheckbox from '@/components/v-checkbox.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
+
+type Group = {
+	/** Caption rendered above this group's grid (e.g. "Select user seat(s) to deactivate") */
+	caption: string;
+	/** Candidates rendered in this group */
+	candidates: TCandidate[];
+};
 
 const props = withDefaults(
 	defineProps<{
 		/** Material icon name shown next to the section title */
 		icon: string;
-		/** Section title shown in the header (e.g. "Data Collections") */
+		/** Section title shown in the header (e.g. "User Seats") */
 		title: string;
-		/** Caption rendered above the grid (e.g. "Select collection(s) to deactivate") */
-		description: string;
 		/** Current usage as reported by the license backend */
 		usage: number;
 		/** Plan limit as reported by the license backend */
 		limit: number;
-		/** Candidates returned by the backend — generic over candidate shape */
-		candidates: TCandidate[];
-		/** Set of selected candidate identifiers (v-model) */
+		/** One or more captioned groups of candidates rendered under the section */
+		groups: Group[];
+		/** Set of selected candidate identifiers (v-model) — selections are shared across groups */
 		modelValue: Set<string>;
 		/** Returns the unique identifier for a candidate (used for selection state) */
 		idFor: (candidate: TCandidate) => string;
-		/** Number of candidates rendered before the "Show more" toggle expands the rest */
+		/** When true, each card shows a launch icon that emits `open-item` on click */
+		linkable?: boolean;
+		/** Number of candidates rendered per group before the "Show more" toggle expands the rest */
 		initialVisible?: number;
 	}>(),
 	{
 		initialVisible: 8,
+		linkable: false,
 	},
 );
 
 const emit = defineEmits<{
 	'update:modelValue': [value: Set<string>];
+	'open-item': [candidate: TCandidate];
 }>();
 
 const { t } = useI18n();
 
-const expanded = ref(false);
+const expanded = reactive(new Set<number>());
 
-const visibleCandidates = computed(() => {
-	if (expanded.value) return props.candidates;
-	return props.candidates.slice(0, props.initialVisible);
-});
+function visibleCandidatesFor(index: number, candidates: TCandidate[]): TCandidate[] {
+	if (expanded.has(index)) return candidates;
+	return candidates.slice(0, props.initialVisible);
+}
 
-const hiddenCount = computed(() => Math.max(0, props.candidates.length - props.initialVisible));
+function hiddenCountFor(candidates: TCandidate[]): number {
+	return Math.max(0, candidates.length - props.initialVisible);
+}
 
 const requiredCount = computed(() => Math.max(0, props.usage - props.limit - props.modelValue.size));
+
+const isSatisfied = computed(() => requiredCount.value === 0);
 
 function isChecked(candidate: TCandidate): boolean {
 	return props.modelValue.has(props.idFor(candidate));
@@ -67,34 +80,47 @@ function toggle(candidate: TCandidate): void {
 				<VIcon :name="icon" small />
 				{{ title }}
 			</span>
-			<span v-if="requiredCount > 0" class="badge">
+			<span v-if="isSatisfied" class="badge satisfied">
+				{{ t('licensing.resolve_all_set') }}
+			</span>
+			<span v-else class="badge required">
 				{{ t('licensing.resolve_select_n_items', { count: requiredCount }, requiredCount) }}
 			</span>
 		</header>
 
-		<p class="caption">{{ description }}</p>
+		<div v-for="(group, index) in groups" :key="index" class="group">
+			<p class="caption">{{ group.caption }}</p>
 
-		<div class="grid">
+			<div class="grid">
+				<div
+					v-for="candidate in visibleCandidatesFor(index, group.candidates)"
+					:key="idFor(candidate)"
+					class="item"
+					:class="{ selected: isChecked(candidate) }"
+				>
+					<button type="button" class="item-toggle" @click="toggle(candidate)">
+						<VCheckbox :checked="isChecked(candidate)" />
+						<span class="item-content">
+							<slot name="item" :candidate="candidate">
+								<span class="item-label">{{ idFor(candidate) }}</span>
+							</slot>
+						</span>
+					</button>
+					<button v-if="linkable" type="button" class="item-link" @click.stop="emit('open-item', candidate)">
+						<VIcon name="launch" small />
+					</button>
+				</div>
+			</div>
+
 			<button
-				v-for="candidate in visibleCandidates"
-				:key="idFor(candidate)"
+				v-if="!expanded.has(index) && hiddenCountFor(group.candidates) > 0"
 				type="button"
-				class="item"
-				:class="{ selected: isChecked(candidate) }"
-				@click="toggle(candidate)"
+				class="show-more"
+				@click="expanded.add(index)"
 			>
-				<VCheckbox :checked="isChecked(candidate)" />
-				<span class="item-content">
-					<slot name="item" :candidate="candidate">
-						<span class="item-label">{{ idFor(candidate) }}</span>
-					</slot>
-				</span>
+				{{ t('licensing.resolve_show_n_more', { count: hiddenCountFor(group.candidates) }) }}
 			</button>
 		</div>
-
-		<button v-if="!expanded && hiddenCount > 0" type="button" class="show-more" @click="expanded = true">
-			{{ t('licensing.resolve_show_n_more', { count: hiddenCount }) }}
-		</button>
 	</section>
 </template>
 
@@ -126,11 +152,23 @@ function toggle(candidate: TCandidate): void {
 	align-items: center;
 	padding: 0.125rem 0.5rem;
 	border-radius: 999px;
-	background-color: var(--theme--danger-background, var(--theme--danger));
-	color: var(--theme--danger);
 	font-size: 0.75rem;
 	font-weight: 600;
 	line-height: 1.4;
+}
+
+.badge.required {
+	background-color: var(--theme--danger-background, var(--theme--danger));
+	color: var(--theme--danger);
+}
+
+.badge.satisfied {
+	background-color: var(--theme--success-background, var(--theme--success));
+	color: var(--theme--success);
+}
+
+.group + .group {
+	margin-block-start: 1.5rem;
 }
 
 .caption {
@@ -153,15 +191,12 @@ function toggle(candidate: TCandidate): void {
 .item {
 	display: flex;
 	align-items: center;
-	gap: 0.5rem;
-	padding: 0.5rem 0.75rem;
+	gap: 0.25rem;
+	padding-inline-end: 0.5rem;
 	border: 1px solid var(--theme--form--field--input--border-color);
 	border-radius: var(--theme--border-radius);
 	background: var(--theme--form--field--input--background);
 	color: var(--theme--foreground);
-	font: inherit;
-	text-align: start;
-	cursor: pointer;
 	transition: border-color var(--fast) var(--transition);
 }
 
@@ -171,6 +206,25 @@ function toggle(candidate: TCandidate): void {
 
 .item.selected {
 	border-color: var(--theme--primary);
+}
+
+.item.selected :deep(.item-label) {
+	color: var(--theme--primary);
+}
+
+.item-toggle {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	flex: 1;
+	min-width: 0;
+	padding: 0.5rem 0.75rem;
+	border: none;
+	background: none;
+	color: inherit;
+	font: inherit;
+	text-align: start;
+	cursor: pointer;
 }
 
 .item-content {
@@ -185,6 +239,21 @@ function toggle(candidate: TCandidate): void {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.item-link {
+	display: inline-flex;
+	align-items: center;
+	padding: 0;
+	border: none;
+	background: none;
+	color: var(--theme--foreground-subdued);
+	cursor: pointer;
+	transition: color var(--fast) var(--transition);
+}
+
+.item-link:hover {
+	color: var(--theme--foreground);
 }
 
 .show-more {

--- a/app/src/modules/settings/routes/license/components/resolution-limit-section.vue
+++ b/app/src/modules/settings/routes/license/components/resolution-limit-section.vue
@@ -98,14 +98,21 @@ function toggle(candidate: TCandidate): void {
 					class="item"
 					:class="{ selected: isChecked(candidate) }"
 				>
-					<button type="button" class="item-toggle" @click="toggle(candidate)">
-						<VCheckbox :checked="isChecked(candidate)" />
+					<div
+						class="item-toggle"
+						role="button"
+						tabindex="0"
+						@click="toggle(candidate)"
+						@keydown.space.prevent="toggle(candidate)"
+						@keydown.enter.prevent="toggle(candidate)"
+					>
+						<VCheckbox :model-value="isChecked(candidate)" @update:model-value="toggle(candidate)" />
 						<span class="item-content">
 							<slot name="item" :candidate="candidate">
 								<span class="item-label">{{ idFor(candidate) }}</span>
 							</slot>
 						</span>
-					</button>
+					</div>
 					<button v-if="linkable" type="button" class="item-link" @click.stop="emit('open-item', candidate)">
 						<VIcon name="open_in_new" small />
 					</button>
@@ -219,12 +226,16 @@ function toggle(candidate: TCandidate): void {
 	flex: 1;
 	min-width: 0;
 	padding: 0.5rem 0.75rem;
-	border: none;
-	background: none;
 	color: inherit;
 	font: inherit;
 	text-align: start;
 	cursor: pointer;
+}
+
+.item-toggle:focus-visible {
+	outline: 2px solid var(--theme--primary);
+	outline-offset: -2px;
+	border-radius: var(--theme--border-radius);
 }
 
 .item-content {


### PR DESCRIPTION
## Scope

What's changed:

- Split seat candidates into two captioned subgroups (users, admins) under a single "User Seats" section header, partitioned by `admin` flag on `LicensePendingResolutionLimitSeats` candidates
- Refactor `ResolutionLimitSection` to accept a `groups` array instead of a single `candidates`/`description` pair, keeping selection state as one shared `Set<string>` and the overage badge unified across groups
- Add an "All Set" green badge state shown when the section's required overage is fully covered by the current selection; the existing "Select N" red badge remains for partial selections
- Add button on each seat card that emits `open-item`; the resolution dialog handles it by opening a read-only `DrawerItem` on `directus_users`

## Tested Scenarios

- Open the resolution dialog with a license that has only non-admin seat overage and verify only the "Select user seat(s)" subgroup renders
- Open the resolution dialog with a license that has both admin and non-admin overage and verify both subgroups render under one header with a single combined badge
- Select enough candidates (any mix of admins/users) to cover the overage and verify the badge flips from red "Select N" to green "All Set"
- Click the launch button on a seat card and verify the user drawer opens on top of the resolution dialog with read-only fields (no greyed-out state)
- Close the user drawer and verify the resolution dialog regains focus and z-index without the underlying selection state being lost
