### PR TITLE
xiiui ← Fix VersionChip / VersionMenu edit-dot color mismatch on custom themes

### DIFF
--- a/app/src/modules/content/components/version-menu.vue
+++ b/app/src/modules/content/components/version-menu.vue
@@ -541,11 +541,11 @@ function hasVersionEdits(version: ContentVersionMaybeNew | null) {
 		background-color: var(--theme--foreground);
 
 		&.edit-dot-primary {
-			background-color: var(--theme--primary);
+			background-color: var(--primary);
 		}
 
 		&.edit-dot-secondary {
-			background-color: var(--theme--secondary);
+			background-color: var(--secondary);
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to https://github.com/directus/directus/pull/27339.

## Scope

What's changed:

- Switch the version menu edit-dot indicators from theme-aware (`--theme--primary` / `--theme--secondary`) to the base palette tokens (`--primary` / `--secondary`), so they match the VChip pills

## Potential Risks / Drawbacks

- Edit dots no longer adapt to per-collection theme overrides — intentional, since the version chip they mirror also uses the base palette

## Tested Scenarios

- Edit-dot color in the version menu now matches the version chip color in the header even with theme overrides
- Verified on both primary (current/main version) and secondary (other versions) states

## Review Notes / Questions

- Single-line change in `version-menu.vue`; reviewer just needs to confirm the chip ↔ dot color parity is the desired behavior across themes

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Addresses CMS-2372
