### PR TITLE
Show format-specific error for malformed license keys

### DIFF
--- a/app/src/interfaces/_system/system-license-key/system-license-key.vue
+++ b/app/src/interfaces/_system/system-license-key/system-license-key.vue
@@ -31,7 +31,7 @@ const props = withDefaults(
 const licenseInfo = ref<LicensePreview | null>(null);
 
 const validating = ref(false);
-const error = ref<Error | null>(null);
+const error = ref<'format' | 'server' | null>(null);
 
 const isLicenseKeyMasked = ref(false);
 
@@ -43,9 +43,7 @@ watch(
 	{ immediate: true },
 );
 
-const placeholder = computed(() =>
-	isLicenseKeyMasked.value ? t('value_securely_stored') : t('enter_license_key'),
-);
+const placeholder = computed(() => (isLicenseKeyMasked.value ? t('value_securely_stored') : t('enter_license_key')));
 
 const emit = defineEmits<{
 	input: [value: string | null];
@@ -74,7 +72,7 @@ const validate = throttle(async (value: string | null) => {
 	const parsed = LICENSE_KEY.safeParse(value);
 
 	if (parsed.error) {
-		error.value = parsed.error;
+		error.value = 'format';
 		licenseInfo.value = null;
 		emitValidity();
 		return;
@@ -88,8 +86,8 @@ const validate = throttle(async (value: string | null) => {
 	try {
 		const response = await api.post<{ data: LicensePreview }>('/license/preview', { license_key: value });
 		licenseInfo.value = response.data.data;
-	} catch (err) {
-		error.value = err instanceof Error ? err : new Error(String(err));
+	} catch {
+		error.value = 'server';
 	} finally {
 		validating.value = false;
 		emitValidity();
@@ -161,7 +159,11 @@ onMounted(() => {
 			</div>
 		</div>
 
-		<VNotice v-else-if="error && !validating" type="warning">
+		<VNotice v-else-if="error === 'format' && !validating" type="warning">
+			{{ $t('setup_license_invalid_format') }}
+		</VNotice>
+
+		<VNotice v-else-if="error === 'server' && !validating" type="warning">
 			<I18nT keypath="setup_license_invalid" tag="span">
 				<template #contactSupport>
 					<a :href="`https://directus.io/license-request`" target="_blank" rel="noopener noreferrer">

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -33,6 +33,7 @@ setup_save_accept_license: >
   By hitting save, you accept the terms of the {directusMscl} and {privacyPolicy}.
 setup_license_invalid: >
   License invalid. Please {contactSupport} to resolve this issue.
+setup_license_invalid_format: Invalid license key format.
 setup_accept_license: I accept the terms of the {directusMscl} and {privacyPolicy}
 setup_marketing_emails: Send me product updates and release notes
 setup_launch: Launch Directus


### PR DESCRIPTION
Distinguish format-validation errors from server-side errors in the license key input.

Previously, any failure — whether a malformed key (wrong prefix, wrong length, invalid checksum) or a server rejection from `/license/preview` — showed the same notice: *"License invalid. Please contact support to resolve this issue."* That's misleading when the user just made a typo: it tells them to email support instead of fixing their input.

Now we have two distinct notices:

- Schema rejection ([@directus/license PR](https://github.com/directus/license/pull/14)) → "Invalid license key format."
- API rejection → unchanged "License invalid. Please contact support"