### PR TITLE
Disable license management when key is set via env

### DIFF
--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -35,6 +35,8 @@ const licenseStore = useLicenseStore();
 
 const { info: license, addons, loading, boundary, isLicensed } = storeToRefs(licenseStore);
 
+const isEnvManaged = computed(() => license.value?.source === 'env');
+
 const boundaryDate = computed(() => {
 	if (!boundary.value || !Number.isFinite(boundary.value.timestamp) || boundary.value.timestamp === -1) return null;
 	const dateStr = new Date(boundary.value.timestamp * 1000).toISOString().slice(0, 10);
@@ -229,7 +231,13 @@ async function handleDeactivateConfirm() {
 							</VButton>
 						</template>
 						<template v-else>
-							<VButton secondary small @click="addLicenseDrawer = true">
+							<VButton
+								v-tooltip.bottom="isEnvManaged ? t('licensing.env_managed') : null"
+								secondary
+								small
+								:disabled="isEnvManaged"
+								@click="addLicenseDrawer = true"
+							>
 								{{ t('licensing.manage') }}
 							</VButton>
 							<VButton small :href="`${getRootPath()}license/portal`" target="_blank" rel="noopener noreferrer">
@@ -274,11 +282,11 @@ async function handleDeactivateConfirm() {
 
 				<LicenseSection v-if="license.source !== null" icon="emergency_home" :title="t('danger_zone')" variant="danger">
 					<div class="danger-zone-content">
-						<VNotice v-if="license.source === 'env'" type="info">
+						<VNotice v-if="isEnvManaged" type="info">
 							{{ t('licensing.env_managed') }}
 						</VNotice>
 						<VButton
-							:disabled="license.source === 'env'"
+							:disabled="isEnvManaged"
 							:loading="deactivateLoading"
 							danger
 							@click="handleDeactivateClick"


### PR DESCRIPTION
## Scope

What's changed:

- Add an `isEnvManaged` computed on the license settings page that flags when `license.source === 'env'`
- Disable the "Manage" button (with a tooltip reusing `licensing.env_managed`) when the key is set via the `LICENSE_KEY` env var, so users don't open a drawer the API will reject
- Switch the existing Deactivate button and danger-zone notice from inline `license.source === 'env'` checks to the same computed (no behavior change, single source of truth)

## Tested Scenarios

- Manage button renders disabled with the `licensing.env_managed` tooltip when `license.source === 'env'`
- Manage button remains enabled and opens the drawer when `license.source === 'settings'`
- Deactivate button behavior unchanged in both env-managed and settings-managed states
