### PR TITLE
fix license store reactivity issues

### DIFF
--- a/app/src/modules/settings/routes/data-model/collections/components/collection-dialog.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-dialog.vue
@@ -13,6 +13,7 @@ import InterfaceList from '@/interfaces/list/list.vue';
 import InterfaceSelectColor from '@/interfaces/select-color/select-color.vue';
 import InterfaceSelectIcon from '@/interfaces/select-icon/select-icon.vue';
 import { useCollectionsStore } from '@/stores/collections';
+import { useLicenseStore } from '@/stores/license';
 import { Collection } from '@/types/collections';
 import { extractErrorCode } from '@/utils/extract-error-code';
 import { unexpectedError } from '@/utils/unexpected-error';
@@ -26,6 +27,7 @@ const props = defineProps<{
 const emit = defineEmits(['update:modelValue']);
 
 const collectionsStore = useCollectionsStore();
+const licenseStore = useLicenseStore();
 
 const values = reactive({
 	collection: props.collection?.collection ?? null,
@@ -66,7 +68,7 @@ async function save() {
 			await collectionsStore.hydrate();
 		} else {
 			await api.post<any>('/collections', { collection: values.collection, meta: values });
-			await collectionsStore.hydrate();
+			await Promise.all([collectionsStore.hydrate(), licenseStore.hydrate()]);
 		}
 
 		emit('update:modelValue', false);

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
@@ -18,6 +18,7 @@ import VMenu from '@/components/v-menu.vue';
 import VNotice from '@/components/v-notice.vue';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
+import { useLicenseStore } from '@/stores/license';
 import { useRelationsStore } from '@/stores/relations';
 import { Collection } from '@/types/collections';
 import { getCollectionRoute } from '@/utils/get-route';
@@ -39,6 +40,7 @@ const isDeactivated = computed(() => props.collection.meta?.status !== 'active')
 const collectionsStore = useCollectionsStore();
 const fieldsStore = useFieldsStore();
 const relationsStore = useRelationsStore();
+const licenseStore = useLicenseStore();
 const { deleting, deleteActive, deleteCollection } = useDelete();
 
 const peerDependencies = computed(() => {
@@ -74,6 +76,7 @@ function useDelete() {
 			}
 
 			await collectionsStore.deleteCollection(props.collection.collection);
+			licenseStore.hydrate();
 			deleteActive.value = false;
 		} finally {
 			deleting.value = false;

--- a/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/collection-options.vue
@@ -18,7 +18,6 @@ import VMenu from '@/components/v-menu.vue';
 import VNotice from '@/components/v-notice.vue';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
-import { useLicenseStore } from '@/stores/license';
 import { useRelationsStore } from '@/stores/relations';
 import { Collection } from '@/types/collections';
 import { getCollectionRoute } from '@/utils/get-route';
@@ -40,7 +39,6 @@ const isDeactivated = computed(() => props.collection.meta?.status !== 'active')
 const collectionsStore = useCollectionsStore();
 const fieldsStore = useFieldsStore();
 const relationsStore = useRelationsStore();
-const licenseStore = useLicenseStore();
 const { deleting, deleteActive, deleteCollection } = useDelete();
 
 const peerDependencies = computed(() => {
@@ -76,7 +74,6 @@ function useDelete() {
 			}
 
 			await collectionsStore.deleteCollection(props.collection.collection);
-			licenseStore.hydrate();
 			deleteActive.value = false;
 		} finally {
 			deleting.value = false;

--- a/app/src/modules/settings/routes/data-model/new-collection.vue
+++ b/app/src/modules/settings/routes/data-model/new-collection.vue
@@ -19,6 +19,7 @@ import VTabs from '@/components/v-tabs.vue';
 import { useDialogRoute } from '@/composables/use-dialog-route';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
+import { useLicenseStore } from '@/stores/license';
 import { useRelationsStore } from '@/stores/relations';
 import { extractErrorCode } from '@/utils/extract-error-code';
 import { notify } from '@/utils/notify';
@@ -77,6 +78,7 @@ const router = useRouter();
 
 const collectionsStore = useCollectionsStore();
 const fieldsStore = useFieldsStore();
+const licenseStore = useLicenseStore();
 const relationsStore = useRelationsStore();
 
 const isOpen = useDialogRoute();
@@ -135,7 +137,7 @@ async function save() {
 			storeHydrations.push(relationsStore.hydrate());
 		}
 
-		storeHydrations.push(collectionsStore.hydrate(), fieldsStore.hydrate());
+		storeHydrations.push(collectionsStore.hydrate(), fieldsStore.hydrate(), licenseStore.hydrate());
 		await Promise.all(storeHydrations);
 
 		notify({

--- a/app/src/modules/settings/routes/flows/flow-drawer.vue
+++ b/app/src/modules/settings/routes/flows/flow-drawer.vue
@@ -145,7 +145,7 @@ async function save() {
 		}
 
 		await flowsStore.hydrate();
-		await licenseStore.hydrate();
+		licenseStore.hydrate();
 
 		emit('done', id);
 	} catch (error) {

--- a/app/src/modules/settings/routes/flows/flow-drawer.vue
+++ b/app/src/modules/settings/routes/flows/flow-drawer.vue
@@ -17,6 +17,7 @@ import VTabs from '@/components/v-tabs.vue';
 import InterfaceSelectColor from '@/interfaces/select-color/select-color.vue';
 import InterfaceSelectIcon from '@/interfaces/select-icon/select-icon.vue';
 import { useFlowsStore } from '@/stores/flows';
+import { useLicenseStore } from '@/stores/license';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { PrivateViewHeaderBarActionButton } from '@/views/private';
 
@@ -43,6 +44,7 @@ const props = withDefaults(
 const emit = defineEmits(['cancel', 'done']);
 
 const flowsStore = useFlowsStore();
+const licenseStore = useLicenseStore();
 
 const currentTab = ref(['flow_setup']);
 
@@ -143,6 +145,7 @@ async function save() {
 		}
 
 		await flowsStore.hydrate();
+		await licenseStore.hydrate();
 
 		emit('done', id);
 	} catch (error) {

--- a/app/src/modules/settings/routes/flows/flow.vue
+++ b/app/src/modules/settings/routes/flows/flow.vue
@@ -30,6 +30,7 @@ import DisplayColor from '@/displays/color/color.vue';
 import { useExtensions } from '@/extensions';
 import { router } from '@/router';
 import { useFlowsStore } from '@/stores/flows';
+import { useLicenseStore } from '@/stores/license';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { Vector2 } from '@/utils/vector2';
 import { PrivateViewHeaderBarActionButton } from '@/views/private';
@@ -61,6 +62,7 @@ useShortcut('meta+s', () => {
 // ------------- Manage Current Flow ------------- //
 
 const flowsStore = useFlowsStore();
+const licenseStore = useLicenseStore();
 const stagedFlow = ref<Partial<FlowRaw>>({});
 
 const flow = computed<FlowRaw | undefined>({
@@ -95,6 +97,7 @@ async function deleteFlow() {
 	try {
 		await api.delete(`/flows/${flow.value.id}`);
 		await flowsStore.hydrate();
+		await licenseStore.hydrate();
 	} catch (error) {
 		unexpectedError(error);
 	} finally {

--- a/app/src/modules/settings/routes/flows/flow.vue
+++ b/app/src/modules/settings/routes/flows/flow.vue
@@ -97,7 +97,7 @@ async function deleteFlow() {
 	try {
 		await api.delete(`/flows/${flow.value.id}`);
 		await flowsStore.hydrate();
-		await licenseStore.hydrate();
+		licenseStore.hydrate();
 	} catch (error) {
 		unexpectedError(error);
 	} finally {

--- a/app/src/modules/settings/routes/flows/overview.vue
+++ b/app/src/modules/settings/routes/flows/overview.vue
@@ -135,7 +135,7 @@ async function deleteFlow() {
 	try {
 		await api.delete(`/flows/${confirmDelete.value.id}`);
 		await flowsStore.hydrate();
-		await licenseStore.hydrate();
+		licenseStore.hydrate();
 		confirmDelete.value = null;
 	} catch (error) {
 		unexpectedError(error);
@@ -151,7 +151,7 @@ async function toggleFlowStatusById(id: string, value: string) {
 		});
 
 		await flowsStore.hydrate();
-		await licenseStore.hydrate();
+		licenseStore.hydrate();
 	} catch (error) {
 		unexpectedError(error);
 	}

--- a/app/src/modules/settings/routes/flows/overview.vue
+++ b/app/src/modules/settings/routes/flows/overview.vue
@@ -135,6 +135,7 @@ async function deleteFlow() {
 	try {
 		await api.delete(`/flows/${confirmDelete.value.id}`);
 		await flowsStore.hydrate();
+		await licenseStore.hydrate();
 		confirmDelete.value = null;
 	} catch (error) {
 		unexpectedError(error);
@@ -150,6 +151,7 @@ async function toggleFlowStatusById(id: string, value: string) {
 		});
 
 		await flowsStore.hydrate();
+		await licenseStore.hydrate();
 	} catch (error) {
 		unexpectedError(error);
 	}

--- a/app/src/modules/settings/routes/roles/item.vue
+++ b/app/src/modules/settings/routes/roles/item.vue
@@ -14,6 +14,7 @@ import VDialog from '@/components/v-dialog.vue';
 import VForm from '@/components/v-form/v-form.vue';
 import { useEditsGuard } from '@/composables/use-edits-guard';
 import { useItem } from '@/composables/use-item';
+import { useLicenseStore } from '@/stores/license';
 import { useServerStore } from '@/stores/server';
 import { useUserStore } from '@/stores/user';
 import { PrivateViewHeaderBarActionButton } from '@/views/private';
@@ -31,6 +32,7 @@ const router = useRouter();
 
 const userStore = useUserStore();
 const serverStore = useServerStore();
+const licenseStore = useLicenseStore();
 const userInviteModalActive = ref(false);
 const { primaryKey } = toRefs(props);
 
@@ -68,6 +70,7 @@ async function saveAndStay() {
 	try {
 		await save();
 		await userStore.hydrate();
+		licenseStore.hydrate();
 		revisionsSidebarDetailRef.value?.refresh?.();
 	} catch {
 		// `save` shows unexpected error dialog
@@ -78,6 +81,7 @@ async function saveAndAddNew() {
 	try {
 		await save();
 		await userStore.hydrate();
+		licenseStore.hydrate();
 		router.push({ name: 'settings-add-new-role' });
 	} catch {
 		// `save` shows unexpected error dialog
@@ -88,6 +92,7 @@ async function saveAndQuit() {
 	try {
 		await save();
 		await userStore.hydrate();
+		licenseStore.hydrate();
 		router.push({ name: 'settings-roles-collection' });
 	} catch {
 		// `save` shows unexpected error dialog
@@ -99,6 +104,7 @@ async function deleteAndQuit() {
 
 	try {
 		await remove();
+		licenseStore.hydrate();
 		edits.value = {};
 		router.replace({ name: 'settings-roles-collection' });
 	} catch {

--- a/app/src/modules/settings/routes/roles/use-save.ts
+++ b/app/src/modules/settings/routes/roles/use-save.ts
@@ -2,6 +2,7 @@ import type { Ref } from 'vue';
 import { ref } from 'vue';
 import { useRouter } from 'vue-router';
 import api from '@/api';
+import { useLicenseStore } from '@/stores/license';
 import { unexpectedError } from '@/utils/unexpected-error';
 
 export interface UseSaveOptions {
@@ -20,11 +21,14 @@ export function useSave({ name }: UseSaveOptions) {
 
 		saving.value = true;
 
+		const licenseStore = useLicenseStore();
+
 		try {
 			const roleResponse = await api.post('/roles', {
 				name: name.value,
 			});
 
+			licenseStore.hydrate();
 			router.push({ name: 'settings-roles-item', params: { primaryKey: roleResponse.data.data.id } });
 		} catch (error) {
 			unexpectedError(error);

--- a/app/src/modules/users/routes/collection.vue
+++ b/app/src/modules/users/routes/collection.vue
@@ -16,6 +16,7 @@ import VDialog from '@/components/v-dialog.vue';
 import VInfo from '@/components/v-info.vue';
 import { useCollectionPermissions } from '@/composables/use-permissions';
 import { usePreset } from '@/composables/use-preset';
+import { useLicenseStore } from '@/stores/license';
 import { useServerStore } from '@/stores/server';
 import { useUserStore } from '@/stores/user';
 import { unexpectedError } from '@/utils/unexpected-error';
@@ -36,6 +37,7 @@ const { roles } = useNavigation(role);
 const userInviteModalActive = ref(false);
 const serverStore = useServerStore();
 const userStore = useUserStore();
+const licenseStore = useLicenseStore();
 const router = useRouter();
 
 const layoutRef = ref();
@@ -148,7 +150,7 @@ function useBatch() {
 			}
 
 			await refresh();
-
+			licenseStore.hydrate();
 			selection.value = [];
 			confirmDelete.value = false;
 		} catch (e) {

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -25,6 +25,7 @@ import { useEditsGuard } from '@/composables/use-edits-guard';
 import { useItem } from '@/composables/use-item';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
+import { useLicenseStore } from '@/stores/license';
 import { useServerStore } from '@/stores/server';
 import { useUserStore } from '@/stores/user';
 import { getAssetUrl } from '@/utils/get-asset-url';
@@ -52,6 +53,7 @@ const fieldsStore = useFieldsStore();
 const collectionsStore = useCollectionsStore();
 const userStore = useUserStore();
 const serverStore = useServerStore();
+const licenseStore = useLicenseStore();
 const seatsLimitModalOpen = ref(false);
 
 async function saveAsInactive() {
@@ -63,6 +65,7 @@ async function saveAsInactive() {
 		if (savedItem) {
 			await setLang(savedItem);
 			await refreshCurrentUser();
+			licenseStore.hydrate();
 			router.push({ name: 'users-active' });
 		}
 	} catch {
@@ -201,6 +204,7 @@ async function saveAndQuit() {
 		const savedItem: Record<string, any> = await save();
 		await setLang(savedItem);
 		await refreshCurrentUser();
+		licenseStore.hydrate();
 		router.push({ name: 'users-active' });
 	} catch {
 		// `save` will show unexpected error dialog
@@ -212,6 +216,7 @@ async function saveAndStay() {
 		const savedItem: Record<string, any> = await save();
 		await setLang(savedItem);
 		await refreshCurrentUser();
+		licenseStore.hydrate();
 
 		if (props.primaryKey === '+') {
 			const newPrimaryKey = savedItem.id;
@@ -230,6 +235,7 @@ async function saveAndAddNew() {
 		const savedItem: Record<string, any> = await save();
 		await setLang(savedItem);
 		await refreshCurrentUser();
+		licenseStore.hydrate();
 		router.push({ name: 'users-item', params: { primaryKey: '+' } });
 	} catch {
 		// `save` will show unexpected error dialog
@@ -239,7 +245,11 @@ async function saveAndAddNew() {
 async function saveAsCopyAndNavigate() {
 	try {
 		const newPrimaryKey = await saveAsCopy();
-		if (newPrimaryKey) router.push({ name: 'users-item', params: { primaryKey: newPrimaryKey } });
+
+		if (newPrimaryKey) {
+			licenseStore.hydrate();
+			router.push({ name: 'users-item', params: { primaryKey: newPrimaryKey } });
+		}
 	} catch {
 		// `save` will show unexpected error dialog
 	}
@@ -259,6 +269,7 @@ async function deleteAndQuit() {
 		}
 
 		await remove();
+		licenseStore.hydrate();
 		edits.value = {};
 		router.replace({ name: 'users-active' });
 	} catch {

--- a/app/src/stores/collections.ts
+++ b/app/src/stores/collections.ts
@@ -5,6 +5,7 @@ import { getCollectionType } from '@directus/utils';
 import { isEqual, isNil, omit } from 'lodash';
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
+import { useLicenseStore } from './license';
 import { useRelationsStore } from './relations';
 import { useAiToolsStore } from '@/ai/stores/use-ai-tools';
 import api from '@/api';
@@ -209,10 +210,11 @@ export const useCollectionsStore = defineStore('collectionsStore', () => {
 
 	async function deleteCollection(collection: string) {
 		const relationsStore = useRelationsStore();
+		const licenseStore = useLicenseStore();
 
 		try {
 			await api.delete(`/collections/${collection}`);
-			await Promise.all([hydrate(), relationsStore.hydrate()]);
+			await Promise.all([hydrate(), relationsStore.hydrate(), licenseStore.hydrate()]);
 
 			notify({
 				title: i18n.global.t('delete_collection_success'),


### PR DESCRIPTION
## Scope

The frontend components display stale state for things like collections remaining, flows, remaining, and others.
This PR addresses that issue by adding the licenseStore.hydrate() call to any action that affects the countable entitlements. 


  Users

  - Save a user (create or edit) — via Save, Save & Stay, Save & Add New → app/src/modules/users/routes/item.vue
  - Save a user as a copy → app/src/modules/users/routes/item.vue
  - Set a user status to inactive-license ("Save as Inactive") → app/src/modules/users/routes/item.vue
  - Delete a user (single) → app/src/modules/users/routes/item.vue
  - Bulk delete users from the users list → app/src/modules/users/routes/collection.vue

  Roles

  - Save a role (create or edit) — via Save, Save & Stay, Save & Add New → app/src/modules/settings/routes/roles/item.vue
  - Delete a role → app/src/modules/settings/routes/roles/item.vue
  - Create a new role via the "Add Role" dialog → app/src/modules/settings/routes/roles/use-save.ts (shared by add-new.vue and the new-role flow)

  Collections

  - Create a new collection via the New Collection dialog → app/src/modules/settings/routes/data-model/new-collection.vue
  - Create a new collection via the collection dialog → app/src/modules/settings/routes/data-model/collections/components/collection-dialog.vue

  Flows

  - Create or edit a flow (via the flow drawer) → app/src/modules/settings/routes/flows/flow-drawer.vue
  - Delete a flow from the flows overview → app/src/modules/settings/routes/flows/overview.vue
  - Delete a flow from the flow detail page → app/src/modules/settings/routes/flows/flow.vue
  - Toggle a flow's active/inactive status → app/src/modules/settings/routes/flows/overview.vue

---

Fixes [CMS-2365](https://linear.app/directus/issue/CMS-2365/fix-license-store-reactivity-issues)
