### PR TITLE
Update license link utm params

### DIFF
--- a/app/src/interfaces/_system/system-license-key/system-license-key.vue
+++ b/app/src/interfaces/_system/system-license-key/system-license-key.vue
@@ -8,8 +8,10 @@ import VIcon from '@/components/v-icon/v-icon.vue';
 import VInput from '@/components/v-input.vue';
 import VNotice from '@/components/v-notice.vue';
 import VProgressCircular from '@/components/v-progress-circular.vue';
+import { useServerStore } from '@/stores/server';
 
 const { t } = useI18n();
+const serverStore = useServerStore();
 
 type LicensePreview = {
 	plan_name: string;
@@ -164,7 +166,11 @@ onMounted(() => {
 		<VNotice v-else-if="error && !validating" type="warning">
 			<I18nT keypath="setup_license_invalid" tag="span">
 				<template #contactSupport>
-					<a :href="`https://directus.io/license-request`" target="_blank" rel="noopener noreferrer">
+					<a
+						:href="`https://directus.io/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=license_key_invalid_contact_support_link`"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
 						{{ $t('contact_support') }}
 					</a>
 				</template>

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -23,6 +23,7 @@ import VProgressCircular from '@/components/v-progress-circular.vue';
 import SystemLicenseKey from '@/interfaces/_system/system-license-key/system-license-key.vue';
 import sdk from '@/sdk';
 import { useLicenseStore } from '@/stores/license';
+import { useServerStore } from '@/stores/server';
 import { formatDate } from '@/utils/format-date';
 import { formatTimeframe } from '@/utils/format-timeframe';
 import { getRootPath } from '@/utils/get-root-path';
@@ -32,6 +33,7 @@ import { PrivateView } from '@/views/private';
 const { t } = useI18n();
 
 const licenseStore = useLicenseStore();
+const serverStore = useServerStore();
 
 const { info: license, addons, loading, boundary, isLicensed } = storeToRefs(licenseStore);
 
@@ -224,7 +226,12 @@ async function handleDeactivateConfirm() {
 							<VButton secondary small @click="addLicenseDrawer = true">
 								{{ t('licensing.add') }}
 							</VButton>
-							<VButton small href="https://directus.io/pricing" target="_blank" rel="noopener noreferrer">
+							<VButton
+								small
+								:href="`https://directus.io/pricing?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=settings_license_upgrade_plan_link`"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
 								{{ t('licensing.upgrade_plan') }}
 							</VButton>
 						</template>
@@ -331,7 +338,11 @@ async function handleDeactivateConfirm() {
 			<VNotice type="info">
 				<I18nT keypath="setup_license_key_notice" tag="span">
 					<template #oig>
-						<a href="https://directus.io/license-request" target="_blank" rel="noopener noreferrer">
+						<a
+							:href="`https://directus.io/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=settings_license_drawer_open_innovation_grant_link`"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
 							{{ t('open_innovation_grant') }}
 						</a>
 					</template>

--- a/app/src/routes/setup/form.vue
+++ b/app/src/routes/setup/form.vue
@@ -107,7 +107,7 @@ const fields = useSetupFields(props.register);
 			<I18nT keypath="setup_save_accept_license" tag="span">
 				<template #directusMscl>
 					<a
-						:href="`https://directus.io/mscl?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${info.version}&utm_content=${utmLocation}_mscl_1.0_gpl_link`"
+						:href="`https://directus.io/mscl?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=${utmLocation}_mscl_1.0_gpl_link`"
 						target="_blank"
 					>
 						{{ $t('directus_mscl') }}
@@ -115,7 +115,7 @@ const fields = useSetupFields(props.register);
 				</template>
 				<template #privacyPolicy>
 					<a
-						:href="`https://directus.io/privacy?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${info.version}&utm_content=${utmLocation}_privacy_link`"
+						:href="`https://directus.io/privacy?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=${utmLocation}_privacy_link`"
 						target="_blank"
 					>
 						{{ $t('privacy_policy') }}
@@ -128,7 +128,7 @@ const fields = useSetupFields(props.register);
 			<I18nT keypath="setup_accept_license" tag="span">
 				<template #directusMscl>
 					<a
-						:href="`https://directus.io/mscl?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${info.version}&utm_content=mscl_1.0_gpl_link`"
+						:href="`https://directus.io/mscl?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=mscl_1.0_gpl_link`"
 						target="_blank"
 					>
 						{{ $t('directus_mscl') }}
@@ -136,7 +136,7 @@ const fields = useSetupFields(props.register);
 				</template>
 				<template #privacyPolicy>
 					<a
-						:href="`https://directus.io/privacy?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${info.version}&utm_content=privacy_link`"
+						:href="`https://directus.io/privacy?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=privacy_link`"
 						target="_blank"
 					>
 						{{ $t('privacy_policy') }}

--- a/app/src/routes/setup/license.vue
+++ b/app/src/routes/setup/license.vue
@@ -118,7 +118,7 @@ defineExpose({ canProceed });
 			{{ $t('no_license_key') }}
 			<VButton
 				secondary
-				:href="`https://directus.io/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${serverStore.info.version}&utm_content=onboarding_get_license_link`"
+				:href="`https://directus.io/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=onboarding_get_license_link`"
 				target="_blank"
 			>
 				<VIcon name="key" />

--- a/app/src/routes/setup/setup.vue
+++ b/app/src/routes/setup/setup.vue
@@ -112,7 +112,7 @@ const setupComplete = computed(() => SetupValidator.safeParse(form.value).succes
 			<I18nT keypath="setup_license_key_notice" tag="p">
 				<template #oig>
 					<a
-						:href="`https://directus.io/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2025_10_kyc&utm_term=${info.version}&utm_content=onboarding_contact_our_team_link`"
+						:href="`https://directus.io/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=onboarding_contact_our_team_link`"
 						target="_blank"
 					>
 						{{ $t('open_innovation_grant') }}

--- a/app/src/views/private/components/license-onboarding.vue
+++ b/app/src/views/private/components/license-onboarding.vue
@@ -106,7 +106,10 @@ function dismiss() {
 				<VCardText>
 					<I18nT keypath="license_onboarding_desc" tag="p">
 						<template #oig>
-							<a href="https://directus.io/license-request" target="_blank">{{ $t('open_innovation_grant') }}</a>
+							<a
+								:href="`https://directus.io/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=license_onboarding_open_innovation_grant_link`"
+								target="_blank"
+							>{{ $t('open_innovation_grant') }}</a>
 						</template>
 					</I18nT>
 


### PR DESCRIPTION
Swaps the campaign tag from `2025_10_kyc` to `2026_05_licensing` across all license-related marketing links, and backfills UTM params on the **Upgrade Plan** button, settings drawer OIG link, license-onboarding dialog OIG link, and contact-support link in `system-license-key`.