### PR TITLE
add password mismatch warning

### DIFF
--- a/app/src/routes/setup/form.ts
+++ b/app/src/routes/setup/form.ts
@@ -6,16 +6,20 @@ import { useI18n } from 'vue-i18n';
 import z from 'zod';
 import { validateItem } from '@/utils/validate-item';
 
-export const SetupValidator = z.object({
-	admin: z.object({
-		email: z.email(),
-		password: z.string().min(1),
-		first_name: z.string().min(1),
-		last_name: z.string().min(1),
-	}),
-	password_confirm: z.string().min(1),
-	license: z.literal(true),
-});
+export const SetupValidator = z
+	.object({
+		admin: z.object({
+			email: z.email(),
+			password: z.string().min(1),
+			first_name: z.string().min(1),
+			last_name: z.string().min(1),
+		}),
+		password_confirm: z.string().min(1),
+		license: z.literal(true),
+	})
+	.refine((data) => data.admin.password === data.password_confirm, {
+		path: ['password_confirm'],
+	});
 
 export const FormValidator = z.object({
 	admin: z.object({

--- a/app/src/routes/setup/form.vue
+++ b/app/src/routes/setup/form.vue
@@ -91,6 +91,13 @@ const product_updates = computed({
 });
 
 const fields = useSetupFields(props.register);
+
+const showPasswordMismatch = computed(() => {
+	if (!props.register) return false;
+	const password = value.value?.admin.password;
+	const passwordConfirm = value.value?.password_confirm;
+	return !!password && !!passwordConfirm && password !== passwordConfirm;
+});
 </script>
 
 <template>
@@ -103,6 +110,9 @@ const fields = useSetupFields(props.register);
 			:fields="fields"
 			disabled-menu
 		></VForm>
+		<VNotice v-if="showPasswordMismatch" type="warning">
+			{{ $t('validationError.confirm_password') }}
+		</VNotice>
 		<VNotice v-if="skipLicense">
 			<I18nT keypath="setup_save_accept_license" tag="span">
 				<template #directusMscl>


### PR DESCRIPTION
- Add a live `VNotice` under the admin setup form that surfaces "Passwords do not match" whenever the password and confirm-password fields hold different non-empty values
- Refine `SetupValidator` with a password-equality check so the Continue button (driven by `setupComplete`) stays disabled until the two values match
