### PR TITLE
Use non production label instead of staging

### DIFF
--- a/app/src/interfaces/_system/system-license-key/system-license-key.vue
+++ b/app/src/interfaces/_system/system-license-key/system-license-key.vue
@@ -157,7 +157,7 @@ onMounted(() => {
 
 			<div>
 				<VIcon name="check_circle" />
-				<span>{{ $t('environment') }}: {{ licenseInfo.production_enabled ? $t('production') : $t('staging') }}</span>
+				<span>{{ $t('environment') }}: {{ licenseInfo.production_enabled ? $t('production') : $t('non_production') }}</span>
 			</div>
 		</div>
 

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -61,6 +61,8 @@ no_license_key: Don't have a license key?
 get_license_key: Get License Key
 expires_on: Expires on
 environment: Environment
+production: Production
+non_production: Non-Production
 skip: Skip
 continue: Continue
 first_name: First Name


### PR DESCRIPTION
Replaces the missing `$t('staging')` key (which rendered as the literal string "staging") with a proper `non_production` translation.