### PR TITLE
show flow names in resolution dialog and submit proper IDs

### DIFF
--- a/api/src/license/entitlements/lib/flows.ts
+++ b/api/src/license/entitlements/lib/flows.ts
@@ -13,7 +13,7 @@ export async function getActiveFlows(opts?: { knex?: Knex | undefined }) {
     });
 
     const flows = await flowsService.readByQuery({
-        fields: ['id'],
+        fields: ['id', 'name'],
         filter: {
             status: {
                 _eq: 'active',

--- a/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
+++ b/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
@@ -76,6 +76,7 @@ const severity = computed<'warning' | 'danger'>(() => {
 });
 
 type SeatCandidate = LicensePendingResolutionLimitSeats['candidates'][number];
+type FlowCandidate = LicensePendingResolutionLimitFlows['candidates'][number];
 
 const collections = computed<LicensePendingResolutionLimitCollections | undefined>(
 	() => find('limit', 'collections') as LicensePendingResolutionLimitCollections | undefined,
@@ -266,8 +267,12 @@ function onEsc() {
 					:usage="flows.usage"
 					:limit="flows.limit"
 					:candidates="flows.candidates"
-					:id-for="(name: string) => name"
-				/>
+					:id-for="(flow: FlowCandidate) => flow.id"
+				>
+					<template #item="{ candidate }">
+						<span class="item-label">{{ candidate.name }}</span>
+					</template>
+				</ResolutionLimitSection>
 			</VCardText>
 
 			<footer class="action-row">


### PR DESCRIPTION
## Scope

What's changed:

- Update `getActiveFlows` to return `{ id, name }` candidates instead of bare `{ id }` rows

## Review Notes / Questions

- Needs https://github.com/directus/license/pull/16 first for typings.
