### PR TITLE
fix(licensing): hide SSO providers on signin when sso disabled

### DIFF
--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -1,6 +1,7 @@
 import { useEnv } from '@directus/env';
 import { ErrorCode, InvalidPayloadError, isDirectusError } from '@directus/errors';
 import type { Accountability } from '@directus/types';
+import { toBoolean } from '@directus/utils';
 import type { Request } from 'express';
 import { Router } from 'express';
 import {
@@ -11,6 +12,9 @@ import {
 	createSAMLAuthRouter,
 } from '../auth/drivers/index.js';
 import { DEFAULT_AUTH_PROVIDER, REFRESH_COOKIE_OPTIONS, SESSION_COOKIE_OPTIONS } from '../constants.js';
+import { getActiveSeats } from '../license/entitlements/lib/seats.js';
+import { getEntitlementManager } from '../license/index.js';
+import { getLicenseManager } from '../license/manager.js';
 import { useLogger } from '../logger/index.js';
 import { respond } from '../middleware/respond.js';
 import { createDefaultAccountability } from '../permissions/utils/create-default-accountability.js';
@@ -254,9 +258,38 @@ router.get(
 		const sessionOnly =
 			'sessionOnly' in req.query && (req.query['sessionOnly'] === '' || Boolean(req.query['sessionOnly']));
 
+		let providers = getAuthProviders({ sessionOnly });
+
+		// Hide SSO providers when license doesn't entitle them
+		const isSSOEnabled = getEntitlementManager().isEntitled('sso_enabled');
+
+		if (isSSOEnabled === false && providers.length > 0) {
+			if (await getLicenseManager().isLocked()) {
+				// Lockout escape hatch — keep SSO visible if at least one admin has SSO to allow recovery
+				// LICENSE-TODO: cache
+				const activeSeats = await getActiveSeats();
+				const adminSeats = activeSeats.filter((seat) => seat.admin).map((seat) => seat.id);
+
+				const usersService = new UsersService({ schema: req.schema });
+
+				const admins = await usersService.readByQuery({
+					filter: {
+						id: { _in: adminSeats },
+						provider: { _neq: DEFAULT_AUTH_PROVIDER },
+					},
+				});
+
+				if (admins.length === 0) {
+					providers = [];
+				}
+			} else {
+				providers = [];
+			}
+		}
+
 		res.locals['payload'] = {
-			data: getAuthProviders({ sessionOnly }),
-			disableDefault: env['AUTH_DISABLE_DEFAULT'],
+			data: providers,
+			disableDefault: isSSOEnabled ? toBoolean(env['AUTH_DISABLE_DEFAULT']) : false,
 		};
 
 		return next();


### PR DESCRIPTION
## Scope

What's changed:

- Hides (configured) SSO providers on login page if license is not entitled to sso
  - During lockdown SSO providers are displayed if at least one admin has sso configured

## Potential Risks / Drawbacks

- Fairly low, the expensive admin query is only done if the instance is within lockdown

## Tested Scenarios

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #\<num\>
