### PR TITLE
fix(licensing): prevent license fields from being set manually in settings

### DIFF
--- a/api/src/services/settings.ts
+++ b/api/src/services/settings.ts
@@ -1,4 +1,4 @@
-import { ResourceRestrictedError } from '@directus/errors';
+import { InvalidPayloadError, ResourceRestrictedError } from '@directus/errors';
 import type {
 	AbstractServiceOptions,
 	MutationOptions,
@@ -20,6 +20,16 @@ export class SettingsService extends ItemsService<Settings> {
 	}
 
 	override async createOne(data: Partial<Settings>, opts?: MutationOptions): Promise<PrimaryKey> {
+		if (this.accountability !== null) {
+			if ('license_key' in data) {
+				throw new InvalidPayloadError({ reason: `You can't change the "license_key" value manually` });
+			}
+
+			if ('license_token' in data) {
+				throw new InvalidPayloadError({ reason: `You can't change the "license_token" value manually` });
+			}
+		}
+
 		const entitlementManager = getEntitlementManager();
 		const changesLLM = CUSTOM_LLM_FIELDS.some((field) => field in data && data[field] !== null);
 
@@ -41,8 +51,18 @@ export class SettingsService extends ItemsService<Settings> {
 		data: Partial<Settings>,
 		opts?: MutationOptions,
 	): Promise<PrimaryKey[]> {
+		if (this.accountability !== null) {
+			if ('license_key' in data) {
+				throw new InvalidPayloadError({ reason: `You can't change the "license_key" value manually` });
+			}
+
+			if ('license_token' in data) {
+				throw new InvalidPayloadError({ reason: `You can't change the "license_token" value manually` });
+			}
+		}
+
 		const entitlementManager = getEntitlementManager();
-		const changesLLM = CUSTOM_LLM_FIELDS.some((field) => field in data && data[field] !== null)
+		const changesLLM = CUSTOM_LLM_FIELDS.some((field) => field in data && data[field] !== null);
 
 		if (!entitlementManager.isEntitled('custom_llms_enabled') && changesLLM) {
 			throw new ResourceRestrictedError({ category: 'custom_llms_enabled' });


### PR DESCRIPTION
## Scope

What's changed:

- license key/token cannot be set via `/settings` endpoint

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Tested Scenarios

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #\<num\>
