### PR TITLE
dp ← Fix version read error for collections with non-id primary keys

### DIFF
--- a/api/src/utils/versioning/handle-version.ts
+++ b/api/src/utils/versioning/handle-version.ts
@@ -169,7 +169,7 @@ export async function handleVersion(self: ItemsServiceType, key: PrimaryKey | nu
 			_and: [
 				...(query.filter ? [query.filter] : []),
 				{
-					id: { _in: ids },
+					[primaryKeyField]: { _in: ids },
 				} as Filter,
 			],
 		};


### PR DESCRIPTION
This is a follow-up to https://github.com/directus/directus/pull/26675.

## Scope

What's changed:

- `handleVersion` previously filtered the rollback read by a hardcoded `id` field.
- The filter now uses the collection's actual primary key field, resolved from the schema.

## Potential Risks / Drawbacks

—

## Tested Scenarios

- Reading an item with `?version=…` on a collection whose primary key field is `id` (regression check).
- Reading an item with `?version=…` on a collection whose primary key field is something other than `id` (the case that used to fail).

## Review Notes / Questions

—

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Addresses CMS-2345