### PR TITLE
Adjust activity license notice margin and hide for unlimited

### DIFF
--- a/app/src/modules/activity/routes/collection.vue
+++ b/app/src/modules/activity/routes/collection.vue
@@ -53,7 +53,12 @@ const { activityHistoryTimeframe } = storeToRefs(useLicenseStore());
 				<ActivityNavigation v-model:filter="roleFilter" />
 			</template>
 
-			<VNotice v-if="activityHistoryTimeframe !== null" type="info" icon="diamond" class="history-notice">
+			<VNotice
+				v-if="activityHistoryTimeframe !== null && parseInt(activityHistoryTimeframe) >= 0"
+				type="info"
+				icon="diamond"
+				class="history-notice"
+			>
 				{{ $t('license.activity_history_notice', { timeframe: activityHistoryTimeframe }) }}
 			</VNotice>
 
@@ -88,5 +93,6 @@ const { activityHistoryTimeframe } = storeToRefs(useLicenseStore());
 	--v-notice-background-color: var(--theme--background-subdued);
 
 	margin: var(--content-padding);
+	margin-block-end: 0;
 }
 </style>


### PR DESCRIPTION
Before
<img width="1116" height="516" alt="CleanShot 2026-05-19 at 12 09 00" src="https://github.com/user-attachments/assets/c8b789bf-3c30-4110-96ff-c6eb79d1e461" />


After
<img width="1108" height="601" alt="CleanShot 2026-05-19 at 12 08 34" src="https://github.com/user-attachments/assets/dd0f2dc7-1ff6-44ef-8d66-4d41d0a842a7" />


Also it is now hidden in the case it receives -1 as a value for `activityHistoryTimeframe`
<img width="1121" height="298" alt="CleanShot 2026-05-19 at 12 10 43" src="https://github.com/user-attachments/assets/263cc0d1-967e-4dc3-b259-9f1ec235afae" />

