### PR TITLE
Resolve SSO section interactivity and deactivation flow

### DIFF
--- a/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
+++ b/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
@@ -327,7 +327,13 @@ function onEsc() {
 				<VButton v-else-if="scope === 'no_resolution'" @click="close">
 					{{ t('continue_label') }}
 				</VButton>
-				<VButton v-else kind="danger" :disabled="!isValid" :loading="submitting" @click="submit">
+				<VButton
+					v-if="!['grace', 'no_resolution'].includes(scope)"
+					kind="danger"
+					:disabled="!isValid"
+					:loading="submitting"
+					@click="submit"
+				>
 					{{ t('licensing.resolve_submit') }}
 				</VButton>
 			</footer>

--- a/app/src/modules/settings/routes/license/components/resolution-sso-section.vue
+++ b/app/src/modules/settings/routes/license/components/resolution-sso-section.vue
@@ -58,7 +58,7 @@ defineExpose({ isValid });
 			:class="{ selected: modelValue }"
 			@click="emit('update:modelValue', !modelValue)"
 		>
-			<VCheckbox :checked="modelValue" />
+			<VCheckbox :model-value="modelValue" @update:model-value="emit('update:modelValue', $event)" />
 			<span>{{ t('licensing.resolve_sso_confirm') }}</span>
 		</button>
 

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -190,7 +190,7 @@ async function handleDeactivateClick() {
 	deactivateLoading.value = true;
 
 	try {
-		await licenseStore.hydratePendingResolution();
+		await licenseStore.hydratePendingResolution({ license_key: null });
 
 		if ((licenseStore.pendingResolution?.length ?? 0) === 0) {
 			deactivateConfirmOpen.value = true;


### PR DESCRIPTION
## Scope

What's changed:

- Fix SSO confirmation checkbox being unclickable by replacing the read-only `:checked` prop with `:model-value` and a proper `@update:model-value` handler — VCheckbox stops click propagation internally, so the parent button's handler was never reached
- Show the submit button in the resolution dialog for the `manual` scope (active license deactivation), not only for `expired`/`suspended`/`env_removed` states
- Pass `license_key: null` when fetching pending resolutions on license deactivation so conflicts are evaluated against Core entitlements rather than the current active license
