### PR TITLE
fix: typo 'overriden' -> 'overridden' in private-view.vue

### DIFF
--- a/app/src/views/private/private-view/components/private-view.vue
+++ b/app/src/views/private/private-view/components/private-view.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 export interface PrivateViewProps {
-	/** Title to show in the header bar. Can be overriden through the #title slot */
+	/** Title to show in the header bar. Can be overridden through the #title slot */
 	title?: string;
 
 	/** Render an icon before the title */


### PR DESCRIPTION
This is an independent contribution made by an individual developer. This work is not associated with any hackathon, competition, or coordinated PR campaign.

## Summary

A typo in the JSDoc comment of `PrivateView` component uses `overriden` instead of `overridden`.

## Root Cause

The comment on line 3 of `app/src/views/private/private-view/components/private-view.vue` reads:

```
/** Title to show in the header bar. Can be overriden through the #title slot */
```

`overriden` is a misspelling of `overridden`.

## Fix

Changed `overriden` to `overridden` in the JSDoc comment.

## Changes

- `app/src/views/private/private-view/components/private-view.vue`: 1 line changed (`+1 -1`)

## Testing

- Component renders unchanged — comment-only change ✅
- JSDoc still compiles correctly ✅
- No runtime impact ✅