### PR TITLE
Resolution modale: LLM, custom rules, and user email

### DIFF
--- a/api/src/license/entitlements/lib/seats.ts
+++ b/api/src/license/entitlements/lib/seats.ts
@@ -121,7 +121,7 @@ export async function getActiveSeats(opts?: {
 	}
 
 	const adminCandidates = await usersService.readByQuery({
-		fields: ['id', 'first_name', 'last_name', 'avatar'],
+		fields: ['id', 'first_name', 'last_name', 'avatar', 'email'],
 		filter: {
 			_and: adminFilters,
 		},
@@ -129,7 +129,7 @@ export async function getActiveSeats(opts?: {
 	});
 
 	const appCandidates = await usersService.readByQuery({
-		fields: ['id', 'first_name', 'last_name', 'avatar'],
+		fields: ['id', 'first_name', 'last_name', 'avatar', 'email'],
 		filter: {
 			_and: appFilters,
 		},

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1500,11 +1500,14 @@ licensing:
   resolve_sso_caption:
     SSO-only users will be deactivated when this change is made. To restore their access, you'll need to reactivate them
     and configure an email and password via the user directory.
-  resolve_sso_blocker_notice:
-    The current admin account does not have a local email and/or password configured. Set them below to avoid being
-    locked out once SSO is deactivated.
-  resolve_sso_admin_email: Admin Email
-  resolve_sso_admin_password: Admin Password
+  resolve_sso_admin_title: Confirm SSO Admin Information
+  resolve_sso_admin_description:
+    Please confirm your email and password is correct. Once SSO has been deactivated, you will need both your email and
+    password to log back in.
+  resolve_sso_admin_email: Email Address
+  resolve_sso_admin_password: Password
+  resolve_sso_admin_password_placeholder: Set a password...
+  resolve_sso_admin_confirm: Confirm
   resolve_section_custom_llms: Custom LLM
   resolve_custom_llms_confirm: Confirm Custom LLM Deactivation
   resolve_custom_llms_caption: Custom LLM configurations will be disabled when this change is made.

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1502,8 +1502,10 @@ licensing:
     and configure an email and password via the user directory.
   resolve_sso_admin_title: Confirm SSO Admin Information
   resolve_sso_admin_description:
-    Please confirm your email and password is correct. Once SSO has been deactivated, you will need both your email and
-    password to log back in.
+    Please confirm your email and password are correct. Once SSO has been deactivated, you will need both to log back
+    in.
+  resolve_sso_admin_description_email_only:
+    Please confirm your email is correct. Once SSO has been deactivated, you will need it to log back in.
   resolve_sso_admin_email: Email Address
   resolve_sso_admin_password: Password
   resolve_sso_admin_password_placeholder: Set a password...

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1445,10 +1445,10 @@ licensing:
     '{active} current → {effective} effective at next renewal ({date}). Increase to cancel the pending deactivation.'
   addon_summary_upgrade: '{active} current + {difference} unit(s) = {new} unit(s) total'
   addon_summary_downgrade: '{active} current - {difference} unit(s) = {new} unit(s) total'
-  addon_price_summary:  '{ new } x ${ unitPrice }/unit/{ interval } = ${ total }/{ interval }'
+  addon_price_summary: '{ new } x ${ unitPrice }/unit/{ interval } = ${ total }/{ interval }'
   addon_prorated_notice:
-    'By confirming, you agree to be charged ${total}/{interval} when your next renewal occurs ({renewalDate}). A charge of ${adjustedTotal} prorated for the remainder of your current
-    billing period will be charged immediately.'
+    'By confirming, you agree to be charged ${total}/{interval} when your next renewal occurs ({renewalDate}). A charge
+    of ${adjustedTotal} prorated for the remainder of your current billing period will be charged immediately.'
   addon_renewal_notice_date: 'Changes will take effect next renewal ({date}).'
   addon_update: Update
   addon_confirm_purchase: Confirm Purchase
@@ -1508,11 +1508,11 @@ licensing:
     locked out once SSO is deactivated.
   resolve_sso_admin_email: Admin Email
   resolve_sso_admin_password: Admin Password
-  resolve_section_custom_llms: Custom LLM Deactivation
+  resolve_section_custom_llms: Custom LLM
   resolve_custom_llms_confirm: Confirm Custom LLM Deactivation
   resolve_custom_llms_caption: Custom LLM configurations will be disabled when this change is made.
-  resolve_section_custom_permissions: Custom Permission Rules Deactivation
-  resolve_custom_permissions_confirm: Confirm Custom Permission Rules Deactivation
+  resolve_section_custom_permissions: Custom Access Policies
+  resolve_custom_permissions_confirm: Confirm Custom Access Rules Deactivation
   resolve_custom_permissions_caption:
     Any access policies/permissions governed by custom rules will fall back to “No Access”.
   env_managed: Your license key is managed via an environment variable and can't be updated here.

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1458,9 +1458,9 @@ licensing:
     Voluntary removal — your project will be downgraded to the Starter plan limits of 50 collections and 3 user seats.
     Deactivated items will remained stored but locked in Directus, and custom access rules will also be locked.
   resolve_notice_locked:
-    Your project exceeds the Core plan limits of 50 collections and 3 user seats. To unlock your project, reduce
-    usage below those limits. Deactivated items will remain stored but locked in Directus, and custom access rules will
-    also be locked.
+    Your project exceeds the Core plan limits of 50 collections and 3 user seats. To unlock your project, reduce usage
+    below those limits. Deactivated items will remain stored but locked in Directus, and custom access rules will also
+    be locked.
   resolve_notice_env_removed:
     Your project no longer has an active license key. To unlock your project, reduce it to the Starter plan limits of 50
     collections and 3 user seats, or add a new license key to continue. Deactivated items will remained stored but
@@ -1492,6 +1492,13 @@ licensing:
     locked out once SSO is deactivated.
   resolve_sso_admin_email: Admin Email
   resolve_sso_admin_password: Admin Password
+  resolve_section_custom_llms: Custom LLM Deactivation
+  resolve_custom_llms_confirm: Confirm Custom LLM Deactivation
+  resolve_custom_llms_caption: Custom LLM configurations will be disabled when this change is made.
+  resolve_section_custom_permissions: Custom Permission Rules Deactivation
+  resolve_custom_permissions_confirm: Confirm Custom Permission Rules Deactivation
+  resolve_custom_permissions_caption:
+    Any access policies/permissions governed by custom rules will fall back to “No Access”.
   env_managed: Your license key is managed via an environment variable and can't be updated here.
   key_management: License Key Management
   key: License Key

--- a/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
+++ b/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
@@ -79,7 +79,7 @@ const severity = computed<'warning' | 'danger'>(() => {
 	return scope.value === 'grace' || scope.value === 'no_resolution' ? 'warning' : 'danger';
 });
 
-type SeatCandidate = LicensePendingResolutionLimitSeats['candidates'][number];
+type SeatCandidate = LicensePendingResolutionLimitSeats['candidates'][number] & { email?: string | null };
 type FlowCandidate = LicensePendingResolutionLimitFlows['candidates'][number];
 
 const collections = computed<LicensePendingResolutionLimitCollections | undefined>(
@@ -136,6 +136,7 @@ function toUser(candidate: SeatCandidate) {
 	return {
 		first_name: candidate.first_name ?? undefined,
 		last_name: candidate.last_name ?? undefined,
+		email: candidate.email ?? undefined,
 	};
 }
 
@@ -339,6 +340,18 @@ function onEsc() {
 				v-model:active="userDrawerActive"
 				collection="directus_users"
 				:primary-key="editingUserId"
+				:selected-fields="[
+					'first_name',
+					'last_name',
+					'email',
+					'avatar',
+					'title',
+					'status',
+					'role',
+					'provider',
+					'external_identifier',
+					'policies',
+				]"
 				non-editable
 			/>
 		</VCard>

--- a/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
+++ b/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
@@ -2,6 +2,8 @@
 import {
 	type InvalidLicenseStatus,
 	type LicensePendingResolution,
+	type LicensePendingResolutionFeatureGateCustomLLMs,
+	type LicensePendingResolutionFeatureGateCustomPermissionRules,
 	type LicensePendingResolutionFeatureGateSSO,
 	type LicensePendingResolutionLimitCollections,
 	type LicensePendingResolutionLimitFlows,
@@ -18,6 +20,7 @@ import VAvatar from '@/components/v-avatar.vue';
 import VButton from '@/components/v-button.vue';
 import VCardText from '@/components/v-card-text.vue';
 import VCard from '@/components/v-card.vue';
+import VCheckbox from '@/components/v-checkbox.vue';
 import VDialog from '@/components/v-dialog.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
 import VNotice from '@/components/v-notice.vue';
@@ -128,6 +131,17 @@ const sso = computed<LicensePendingResolutionFeatureGateSSO | undefined>(
 	() => find('feature_gate', 'sso_enabled') as LicensePendingResolutionFeatureGateSSO | undefined,
 );
 
+const customLLMs = computed<LicensePendingResolutionFeatureGateCustomLLMs | undefined>(
+	() => find('feature_gate', 'custom_llms_enabled') as LicensePendingResolutionFeatureGateCustomLLMs | undefined,
+);
+
+const customPermissionRules = computed<LicensePendingResolutionFeatureGateCustomPermissionRules | undefined>(
+	() =>
+		find('feature_gate', 'custom_permission_rules_enabled') as
+			| LicensePendingResolutionFeatureGateCustomPermissionRules
+			| undefined,
+);
+
 function find(kind: LicensePendingResolution['kind'], key: string): LicensePendingResolution | undefined {
 	return pendingResolution.value?.find((entry: LicensePendingResolution) => entry.kind === kind && entry.key === key);
 }
@@ -145,6 +159,8 @@ const selected = reactive({
 	seats: new Set<string>(),
 	flows: new Set<string>(),
 	sso: false,
+	customLLMs: false,
+	customPermissionRules: false,
 });
 
 const adminCreds = ref<{ email?: string; password?: string }>({});
@@ -168,6 +184,8 @@ const isValid = computed(() => {
 	if (seats.value && selected.seats.size < seats.value.usage - seats.value.limit) return false;
 	if (flows.value && selected.flows.size < flows.value.usage - flows.value.limit) return false;
 	if (sso.value && !ssoSectionRef.value?.isValid) return false;
+	if (customLLMs.value && !selected.customLLMs) return false;
+	if (customPermissionRules.value && !selected.customPermissionRules) return false;
 	return true;
 });
 
@@ -179,8 +197,6 @@ async function submit() {
 	submitting.value = true;
 
 	try {
-		// Feature gates custom_llms_enabled and custom_permission_rules_enabled are
-		// locked server-side without user action and are intentionally not submitted.
 		await licenseStore.resolve({
 			...(collections.value ? { collections: [...selected.collections] } : {}),
 			...(seats.value ? { seats: [...selected.seats] } : {}),
@@ -274,6 +290,44 @@ function onEsc() {
 					:blockers="sso.blockers"
 					@update:admin="adminCreds = $event"
 				/>
+
+				<section v-if="customLLMs" class="resolution-feature-section">
+					<header class="section-header">
+						<span class="section-title">
+							<VIcon name="smart_toy" small />
+							{{ t('licensing.resolve_section_custom_llms') }}
+						</span>
+					</header>
+					<button
+						type="button"
+						class="confirm"
+						:class="{ selected: selected.customLLMs }"
+						@click="selected.customLLMs = !selected.customLLMs"
+					>
+						<VCheckbox :checked="selected.customLLMs" />
+						<span>{{ t('licensing.resolve_custom_llms_confirm') }}</span>
+					</button>
+					<p class="feature-caption">{{ t('licensing.resolve_custom_llms_caption') }}</p>
+				</section>
+
+				<section v-if="customPermissionRules" class="resolution-feature-section">
+					<header class="section-header">
+						<span class="section-title">
+							<VIcon name="policy" small />
+							{{ t('licensing.resolve_section_custom_permissions') }}
+						</span>
+					</header>
+					<button
+						type="button"
+						class="confirm"
+						:class="{ selected: selected.customPermissionRules }"
+						@click="selected.customPermissionRules = !selected.customPermissionRules"
+					>
+						<VCheckbox :checked="selected.customPermissionRules" />
+						<span>{{ t('licensing.resolve_custom_permissions_confirm') }}</span>
+					</button>
+					<p class="feature-caption">{{ t('licensing.resolve_custom_permissions_caption') }}</p>
+				</section>
 
 				<ResolutionLimitSection
 					v-if="collections && collectionGroups.length > 0"
@@ -432,5 +486,58 @@ function onEsc() {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.resolution-feature-section {
+	margin-block-start: 2rem;
+}
+
+.section-header {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	margin-block-end: 0.75rem;
+	padding-block-end: 0.75rem;
+	border-block-end: 1px solid var(--theme--border-color-subdued);
+}
+
+.section-title {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	font-size: 1.125rem;
+	font-weight: 600;
+	color: var(--theme--foreground-accent);
+}
+
+.confirm {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	inline-size: 100%;
+	padding: 0.5rem 0.75rem;
+	border: 1px solid var(--theme--form--field--input--border-color);
+	border-radius: var(--theme--border-radius);
+	background: var(--theme--form--field--input--background);
+	color: var(--theme--foreground);
+	font: inherit;
+	text-align: start;
+	cursor: pointer;
+	transition: border-color var(--fast) var(--transition);
+}
+
+.confirm:hover {
+	border-color: var(--theme--form--field--input--border-color-hover);
+}
+
+.confirm.selected {
+	border-color: var(--theme--primary);
+}
+
+.feature-caption {
+	color: var(--theme--foreground-subdued);
+	margin-block-start: 0.5rem;
+	font-size: 0.8125rem;
+	line-height: 1.4;
 }
 </style>

--- a/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
+++ b/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
@@ -15,6 +15,7 @@ import { computed, reactive, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import ResolutionLimitSection from './resolution-limit-section.vue';
+import ResolutionSsoAdminDialog from './resolution-sso-admin-dialog.vue';
 import ResolutionSsoSection from './resolution-sso-section.vue';
 import VAvatar from '@/components/v-avatar.vue';
 import VButton from '@/components/v-button.vue';
@@ -85,7 +86,10 @@ const severity = computed<'warning' | 'danger'>(() => {
 	return scope.value === 'grace' || scope.value === 'no_resolution' ? 'warning' : 'danger';
 });
 
-type SeatCandidate = LicensePendingResolutionLimitSeats['candidates'][number] & { disabled?: boolean };
+type SeatCandidate = LicensePendingResolutionLimitSeats['candidates'][number] & {
+	email?: string | null;
+	disabled?: boolean;
+};
 type FlowCandidate = LicensePendingResolutionLimitFlows['candidates'][number];
 
 const collections = computed<LicensePendingResolutionLimitCollections | undefined>(
@@ -183,7 +187,12 @@ const selected = reactive({
 });
 
 const adminCreds = ref<{ email?: string; password?: string }>({});
-const ssoSectionRef = ref<InstanceType<typeof ResolutionSsoSection> | null>(null);
+const ssoAdminDialogOpen = ref(false);
+
+function onSsoConfirm(creds: { email: string; password?: string }) {
+	adminCreds.value = creds;
+	selected.sso = true;
+}
 
 const editingUserId = ref<string | null>(null);
 
@@ -202,7 +211,7 @@ const isValid = computed(() => {
 	if (collections.value && selected.collections.size < collections.value.usage - collections.value.limit) return false;
 	if (seats.value && selected.seats.size < seats.value.usage - seats.value.limit) return false;
 	if (flows.value && selected.flows.size < flows.value.usage - flows.value.limit) return false;
-	if (sso.value && !ssoSectionRef.value?.isValid) return false;
+	if (sso.value && !selected.sso) return false;
 	if (customLLMs.value && !selected.customLLMs) return false;
 	if (customPermissionRules.value && !selected.customPermissionRules) return false;
 	return true;
@@ -220,11 +229,7 @@ async function submit() {
 			...(collections.value ? { collections: [...selected.collections] } : {}),
 			...(seats.value ? { seats: [...selected.seats] } : {}),
 			...(flows.value ? { flows: [...selected.flows] } : {}),
-			...(sso.value
-				? {
-						sso_enabled: sso.value.blockers?.length ? { admin: { ...adminCreds.value } } : true,
-					}
-				: {}),
+			...(sso.value ? { sso_enabled: { admin: { ...adminCreds.value } } } : {}),
 		});
 
 		if (scope.value === 'manual') {
@@ -303,13 +308,7 @@ function onEsc() {
 				</p>
 
 				<div v-if="sso || customLLMs || customPermissionRules" class="feature-gate-grid">
-					<ResolutionSsoSection
-						v-if="sso"
-						ref="ssoSectionRef"
-						v-model="selected.sso"
-						:blockers="sso.blockers"
-						@update:admin="adminCreds = $event"
-					/>
+					<ResolutionSsoSection v-if="sso" v-model="selected.sso" @open-admin-dialog="ssoAdminDialogOpen = true" />
 
 					<section v-if="customLLMs" class="resolution-feature-section">
 						<header class="section-header">
@@ -411,6 +410,13 @@ function onEsc() {
 					{{ t('licensing.resolve_submit') }}
 				</VButton>
 			</footer>
+
+			<ResolutionSsoAdminDialog
+				v-if="sso"
+				v-model="ssoAdminDialogOpen"
+				:blockers="sso.blockers"
+				@confirm="onSsoConfirm"
+			/>
 
 			<DrawerItem
 				v-if="editingUserId"

--- a/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
+++ b/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
@@ -524,10 +524,6 @@ function onEsc() {
 	}
 }
 
-.resolution-feature-section {
-	margin-block-start: 0;
-}
-
 .section-header {
 	display: flex;
 	align-items: center;

--- a/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
+++ b/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
@@ -283,51 +283,47 @@ function onEsc() {
 					{{ t('licensing.resolve_countdown', graceCountdown, graceCountdown.days) }}
 				</p>
 
-				<ResolutionSsoSection
-					v-if="sso"
-					ref="ssoSectionRef"
-					v-model="selected.sso"
-					:blockers="sso.blockers"
-					@update:admin="adminCreds = $event"
-				/>
+				<div v-if="sso || customLLMs || customPermissionRules" class="feature-gate-grid">
+					<ResolutionSsoSection
+						v-if="sso"
+						ref="ssoSectionRef"
+						v-model="selected.sso"
+						:blockers="sso.blockers"
+						@update:admin="adminCreds = $event"
+					/>
 
-				<section v-if="customLLMs" class="resolution-feature-section">
-					<header class="section-header">
-						<span class="section-title">
-							<VIcon name="smart_toy" small />
-							{{ t('licensing.resolve_section_custom_llms') }}
-						</span>
-					</header>
-					<button
-						type="button"
-						class="confirm"
-						:class="{ selected: selected.customLLMs }"
-						@click="selected.customLLMs = !selected.customLLMs"
-					>
-						<VCheckbox :checked="selected.customLLMs" />
-						<span>{{ t('licensing.resolve_custom_llms_confirm') }}</span>
-					</button>
-					<p class="feature-caption">{{ t('licensing.resolve_custom_llms_caption') }}</p>
-				</section>
+					<section v-if="customLLMs" class="resolution-feature-section">
+						<header class="section-header">
+							<span class="section-title">{{ t('licensing.resolve_section_custom_llms') }}</span>
+						</header>
+						<button
+							type="button"
+							class="confirm"
+							:class="{ selected: selected.customLLMs }"
+							@click="selected.customLLMs = !selected.customLLMs"
+						>
+							<VCheckbox :checked="selected.customLLMs" style="pointer-events: none" />
+							<span>{{ t('licensing.resolve_custom_llms_confirm') }}</span>
+						</button>
+						<p class="feature-caption">{{ t('licensing.resolve_custom_llms_caption') }}</p>
+					</section>
 
-				<section v-if="customPermissionRules" class="resolution-feature-section">
-					<header class="section-header">
-						<span class="section-title">
-							<VIcon name="policy" small />
-							{{ t('licensing.resolve_section_custom_permissions') }}
-						</span>
-					</header>
-					<button
-						type="button"
-						class="confirm"
-						:class="{ selected: selected.customPermissionRules }"
-						@click="selected.customPermissionRules = !selected.customPermissionRules"
-					>
-						<VCheckbox :checked="selected.customPermissionRules" />
-						<span>{{ t('licensing.resolve_custom_permissions_confirm') }}</span>
-					</button>
-					<p class="feature-caption">{{ t('licensing.resolve_custom_permissions_caption') }}</p>
-				</section>
+					<section v-if="customPermissionRules" class="resolution-feature-section">
+						<header class="section-header">
+							<span class="section-title">{{ t('licensing.resolve_section_custom_permissions') }}</span>
+						</header>
+						<button
+							type="button"
+							class="confirm"
+							:class="{ selected: selected.customPermissionRules }"
+							@click="selected.customPermissionRules = !selected.customPermissionRules"
+						>
+							<VCheckbox :checked="selected.customPermissionRules" style="pointer-events: none" />
+							<span>{{ t('licensing.resolve_custom_permissions_confirm') }}</span>
+						</button>
+						<p class="feature-caption">{{ t('licensing.resolve_custom_permissions_caption') }}</p>
+					</section>
+				</div>
 
 				<ResolutionLimitSection
 					v-if="collections && collectionGroups.length > 0"
@@ -494,8 +490,21 @@ function onEsc() {
 	white-space: nowrap;
 }
 
-.resolution-feature-section {
+.feature-gate-grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 1.5rem;
 	margin-block-start: 2rem;
+}
+
+@media (max-width: 37.5rem) {
+	.feature-gate-grid {
+		grid-template-columns: 1fr;
+	}
+}
+
+.resolution-feature-section {
+	margin-block-start: 0;
 }
 
 .section-header {
@@ -503,15 +512,13 @@ function onEsc() {
 	align-items: center;
 	gap: 0.75rem;
 	margin-block-end: 0.75rem;
-	padding-block-end: 0.75rem;
-	border-block-end: 1px solid var(--theme--border-color-subdued);
 }
 
 .section-title {
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;
-	font-size: 1.125rem;
+	font-size: 0.875rem;
 	font-weight: 600;
 	color: var(--theme--foreground-accent);
 }

--- a/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
+++ b/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
@@ -82,7 +82,7 @@ const severity = computed<'warning' | 'danger'>(() => {
 	return scope.value === 'grace' || scope.value === 'no_resolution' ? 'warning' : 'danger';
 });
 
-type SeatCandidate = LicensePendingResolutionLimitSeats['candidates'][number] & { email?: string | null };
+type SeatCandidate = LicensePendingResolutionLimitSeats['candidates'][number];
 type FlowCandidate = LicensePendingResolutionLimitFlows['candidates'][number];
 
 const collections = computed<LicensePendingResolutionLimitCollections | undefined>(

--- a/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
+++ b/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
@@ -225,6 +225,8 @@ async function submit() {
 	submitting.value = true;
 
 	try {
+		// Feature gates custom_llms_enabled and custom_permission_rules_enabled are
+		// locked server-side without user action and are intentionally not submitted.
 		await licenseStore.resolve({
 			...(collections.value ? { collections: [...selected.collections] } : {}),
 			...(seats.value ? { seats: [...selected.seats] } : {}),

--- a/app/src/modules/settings/routes/license/components/resolution-sso-admin-dialog.vue
+++ b/app/src/modules/settings/routes/license/components/resolution-sso-admin-dialog.vue
@@ -1,0 +1,147 @@
+<script setup lang="ts">
+import { computed, reactive, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import VButton from '@/components/v-button.vue';
+import VCardText from '@/components/v-card-text.vue';
+import VCard from '@/components/v-card.vue';
+import VDialog from '@/components/v-dialog.vue';
+import VIcon from '@/components/v-icon/v-icon.vue';
+import VInput from '@/components/v-input.vue';
+import { useUserStore } from '@/stores/user';
+
+const props = defineProps<{
+	/** Whether the dialog is open (v-model) */
+	modelValue: boolean;
+	/** Blockers reported by the backend for the SSO feature gate */
+	blockers?: ('ADMIN_MISSING_EMAIL' | 'ADMIN_MISSING_PASSWORD')[];
+}>();
+
+const emit = defineEmits<{
+	'update:modelValue': [value: boolean];
+	confirm: [value: { email: string; password?: string }];
+}>();
+
+const { t } = useI18n();
+const userStore = useUserStore();
+
+const needsPassword = computed(() => props.blockers?.includes('ADMIN_MISSING_PASSWORD') ?? false);
+
+const admin = reactive<{ email: string; password: string }>({ email: '', password: '' });
+
+// Prefill the email from the current admin each time the dialog opens.
+watch(
+	() => props.modelValue,
+	(open) => {
+		if (!open) return;
+		const user = userStore.currentUser;
+		admin.email = user && !('share' in user) ? (user.email ?? '') : '';
+		admin.password = '';
+	},
+);
+
+const isValid = computed(() => {
+	if (!admin.email) return false;
+	if (needsPassword.value && !admin.password) return false;
+	return true;
+});
+
+function confirm() {
+	if (!isValid.value) return;
+
+	emit('confirm', {
+		email: admin.email,
+		...(needsPassword.value ? { password: admin.password } : {}),
+	});
+
+	emit('update:modelValue', false);
+}
+
+function cancel() {
+	emit('update:modelValue', false);
+}
+</script>
+
+<template>
+	<VDialog :model-value="modelValue" @update:model-value="emit('update:modelValue', $event)" @esc="cancel">
+		<VCard class="sso-admin-card">
+			<header class="title-row">
+				<span class="title-text">{{ t('licensing.resolve_sso_admin_title') }}</span>
+			</header>
+
+			<VCardText>
+				<p class="description">{{ t('licensing.resolve_sso_admin_description') }}</p>
+
+				<div class="field">
+					<label class="field-label">{{ t('licensing.resolve_sso_admin_email') }}</label>
+					<VInput v-model="admin.email" type="email" autocomplete="off">
+						<template #append>
+							<VIcon name="mail" />
+						</template>
+					</VInput>
+				</div>
+
+				<div v-if="needsPassword" class="field">
+					<label class="field-label">{{ t('licensing.resolve_sso_admin_password') }}</label>
+					<VInput
+						v-model="admin.password"
+						type="password"
+						autocomplete="new-password"
+						:placeholder="t('licensing.resolve_sso_admin_password_placeholder')"
+					>
+						<template #append>
+							<VIcon name="lock_open" />
+						</template>
+					</VInput>
+				</div>
+			</VCardText>
+
+			<footer class="action-row">
+				<VButton secondary @click="cancel">{{ t('cancel') }}</VButton>
+				<VButton :disabled="!isValid" @click="confirm">{{ t('licensing.resolve_sso_admin_confirm') }}</VButton>
+			</footer>
+		</VCard>
+	</VDialog>
+</template>
+
+<style scoped>
+.sso-admin-card {
+	--v-card-min-width: 28rem;
+}
+
+.sso-admin-card :deep(.v-card-text) {
+	padding: 1.25rem 1.75rem;
+}
+
+.title-row {
+	padding: 1rem 1.75rem;
+	border-block-end: 1px solid var(--theme--border-color-subdued);
+}
+
+.title-text {
+	font-size: 1rem;
+	font-weight: 600;
+}
+
+.description {
+	color: var(--theme--foreground-normal);
+	margin-block-end: 1.25rem;
+}
+
+.field + .field {
+	margin-block-start: 1rem;
+}
+
+.field-label {
+	display: block;
+	margin-block-end: 0.25rem;
+	font-weight: 600;
+}
+
+.action-row {
+	display: flex;
+	justify-content: flex-end;
+	gap: 0.6875rem;
+	padding: 1rem 1.75rem;
+	border-block-start: 1px solid var(--theme--border-color-subdued);
+}
+</style>

--- a/app/src/modules/settings/routes/license/components/resolution-sso-admin-dialog.vue
+++ b/app/src/modules/settings/routes/license/components/resolution-sso-admin-dialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { z } from 'zod';
 import VButton from '@/components/v-button.vue';
 import VCardText from '@/components/v-card-text.vue';
 import VCard from '@/components/v-card.vue';
@@ -26,6 +27,12 @@ const userStore = useUserStore();
 
 const needsPassword = computed(() => props.blockers?.includes('ADMIN_MISSING_PASSWORD') ?? false);
 
+const description = computed(() =>
+	needsPassword.value
+		? t('licensing.resolve_sso_admin_description')
+		: t('licensing.resolve_sso_admin_description_email_only'),
+);
+
 const admin = reactive<{ email: string; password: string }>({ email: '', password: '' });
 
 // Prefill the email from the current admin each time the dialog opens.
@@ -39,8 +46,10 @@ watch(
 	},
 );
 
+const emailValid = computed(() => z.email().safeParse(admin.email).success);
+
 const isValid = computed(() => {
-	if (!admin.email) return false;
+	if (!emailValid.value) return false;
 	if (needsPassword.value && !admin.password) return false;
 	return true;
 });
@@ -69,7 +78,7 @@ function cancel() {
 			</header>
 
 			<VCardText>
-				<p class="description">{{ t('licensing.resolve_sso_admin_description') }}</p>
+				<p class="description">{{ description }}</p>
 
 				<div class="field">
 					<label class="field-label">{{ t('licensing.resolve_sso_admin_email') }}</label>

--- a/app/src/modules/settings/routes/license/components/resolution-sso-section.vue
+++ b/app/src/modules/settings/routes/license/components/resolution-sso-section.vue
@@ -80,10 +80,6 @@ defineExpose({ isValid });
 </template>
 
 <style scoped>
-.resolution-sso-section {
-	margin-block-start: 2rem;
-}
-
 .section-header {
 	display: flex;
 	align-items: center;

--- a/app/src/modules/settings/routes/license/components/resolution-sso-section.vue
+++ b/app/src/modules/settings/routes/license/components/resolution-sso-section.vue
@@ -1,45 +1,25 @@
 <script setup lang="ts">
-import { computed, reactive, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import VCheckbox from '@/components/v-checkbox.vue';
-import VInput from '@/components/v-input.vue';
-import VNotice from '@/components/v-notice.vue';
 
 const props = defineProps<{
-	/** Blockers reported by the backend that prevent SSO deactivation */
-	blockers?: ('ADMIN_MISSING_EMAIL' | 'ADMIN_MISSING_PASSWORD')[];
 	/** Whether the user has confirmed SSO deactivation (v-model) */
 	modelValue: boolean;
 }>();
 
 const emit = defineEmits<{
 	'update:modelValue': [value: boolean];
-	'update:admin': [value: { email?: string; password?: string }];
+	/** Emitted when the user checks the box — the parent opens the admin confirmation dialog */
+	'open-admin-dialog': [];
 }>();
 
 const { t } = useI18n();
 
-const hasEmailBlocker = computed(() => props.blockers?.includes('ADMIN_MISSING_EMAIL') ?? false);
-const hasPasswordBlocker = computed(() => props.blockers?.includes('ADMIN_MISSING_PASSWORD') ?? false);
-const hasBlockers = computed(() => hasEmailBlocker.value || hasPasswordBlocker.value);
-
-const admin = reactive<{ email: string; password: string }>({ email: '', password: '' });
-
-watch(admin, () => {
-	emit('update:admin', {
-		...(hasEmailBlocker.value ? { email: admin.email } : {}),
-		...(hasPasswordBlocker.value ? { password: admin.password } : {}),
-	});
-});
-
-const isValid = computed(() => {
-	if (!props.modelValue) return false;
-	if (hasEmailBlocker.value && !admin.email) return false;
-	if (hasPasswordBlocker.value && !admin.password) return false;
-	return true;
-});
-
-defineExpose({ isValid });
+function toggle() {
+	// Turning on requires confirming admin credentials first
+	if (!props.modelValue) emit('open-admin-dialog');
+	else emit('update:modelValue', false);
+}
 </script>
 
 <template>
@@ -48,34 +28,12 @@ defineExpose({ isValid });
 			<span class="section-title">{{ t('licensing.resolve_section_sso') }}</span>
 		</header>
 
-		<button
-			type="button"
-			class="confirm"
-			:class="{ selected: modelValue }"
-			@click="emit('update:modelValue', !modelValue)"
-		>
-			<VCheckbox :model-value="modelValue" @update:model-value="emit('update:modelValue', $event)" />
+		<button type="button" class="confirm" :class="{ selected: modelValue }" @click="toggle">
+			<VCheckbox :model-value="modelValue" />
 			<span>{{ t('licensing.resolve_sso_confirm') }}</span>
 		</button>
 
 		<p class="caption">{{ t('licensing.resolve_sso_caption') }}</p>
-
-		<template v-if="modelValue && hasBlockers">
-			<VNotice type="warning" class="blocker-notice">
-				{{ t('licensing.resolve_sso_blocker_notice') }}
-			</VNotice>
-
-			<div class="admin-fields">
-				<div v-if="hasEmailBlocker" class="field">
-					<label class="field-label">{{ t('licensing.resolve_sso_admin_email') }}</label>
-					<VInput v-model="admin.email" type="email" autocomplete="off" />
-				</div>
-				<div v-if="hasPasswordBlocker" class="field">
-					<label class="field-label">{{ t('licensing.resolve_sso_admin_password') }}</label>
-					<VInput v-model="admin.password" type="password" autocomplete="new-password" />
-				</div>
-			</div>
-		</template>
 	</section>
 </template>
 
@@ -125,29 +83,5 @@ defineExpose({ isValid });
 	margin-block-start: 0.5rem;
 	font-size: 0.8125rem;
 	line-height: 1.4;
-}
-
-.blocker-notice {
-	margin-block-start: 0.75rem;
-}
-
-.admin-fields {
-	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
-	gap: 0.75rem;
-	margin-block-start: 0.75rem;
-}
-
-@media (max-width: 600px) {
-	.admin-fields {
-		grid-template-columns: 1fr;
-	}
-}
-
-.field-label {
-	display: block;
-	margin-block-end: 0.25rem;
-	color: var(--theme--foreground-subdued);
-	font-size: 0.8125rem;
 }
 </style>

--- a/app/src/modules/settings/routes/license/components/resolution-sso-section.vue
+++ b/app/src/modules/settings/routes/license/components/resolution-sso-section.vue
@@ -2,7 +2,6 @@
 import { computed, reactive, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import VCheckbox from '@/components/v-checkbox.vue';
-import VIcon from '@/components/v-icon/v-icon.vue';
 import VInput from '@/components/v-input.vue';
 import VNotice from '@/components/v-notice.vue';
 
@@ -46,10 +45,7 @@ defineExpose({ isValid });
 <template>
 	<section class="resolution-sso-section">
 		<header class="section-header">
-			<span class="section-title">
-				<VIcon name="key" small />
-				{{ t('licensing.resolve_section_sso') }}
-			</span>
+			<span class="section-title">{{ t('licensing.resolve_section_sso') }}</span>
 		</header>
 
 		<button
@@ -93,15 +89,13 @@ defineExpose({ isValid });
 	align-items: center;
 	gap: 0.75rem;
 	margin-block-end: 0.75rem;
-	padding-block-end: 0.75rem;
-	border-block-end: 1px solid var(--theme--border-color-subdued);
 }
 
 .section-title {
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;
-	font-size: 1.125rem;
+	font-size: 0.875rem;
 	font-weight: 600;
 	color: var(--theme--foreground-accent);
 }


### PR DESCRIPTION
## Scope

What's changed:

- Add `custom_llms_enabled` and `custom_permission_rules_enabled` feature gate sections to the license resolution dialog, displayed in a 2-column grid alongside the existing SSO section
- Refactor the SSO feature gate into a dedicated confirmation modal 
