### PR TITLE
fix(api): avoid update by empty flow keys

### DIFF
--- a/.changeset/empty-update-keys.md
+++ b/.changeset/empty-update-keys.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Prevented the Update Items flow operation from updating records when neither item keys nor a query were provided.

--- a/api/src/operations/item-update/index.test.ts
+++ b/api/src/operations/item-update/index.test.ts
@@ -69,6 +69,18 @@ describe('Operations / Item Update', () => {
 		expect(vi.mocked(ItemsService).prototype.updateMany).not.toHaveBeenCalled();
 	});
 
+	test('should not update by query when key is an empty array and query is not defined', async () => {
+		const result = await config.handler(
+			{ collection: testCollection, payload: testPayload, key: [], query: null } as any,
+			{ accountability: testAccountability, getSchema } as any,
+		);
+
+		expect(result).toBe(null);
+		expect(vi.mocked(ItemsService).prototype.updateByQuery).not.toHaveBeenCalled();
+		expect(vi.mocked(ItemsService).prototype.updateOne).not.toHaveBeenCalled();
+		expect(vi.mocked(ItemsService).prototype.updateMany).not.toHaveBeenCalled();
+	});
+
 	test('should emit events for updateByQuery when true', async () => {
 		const query = { limit: -1 };
 

--- a/api/src/operations/item-update/index.ts
+++ b/api/src/operations/item-update/index.ts
@@ -50,11 +50,14 @@ export default defineOperationApi<Options>({
 		}
 
 		let result: PrimaryKey | PrimaryKey[] | null;
+		const hasQuery = !!query;
 
 		if (Array.isArray(payloadObject)) {
 			result = await itemsService.updateBatch(payloadObject, { emitEvents: !!emitEvents });
-		} else if (!key || (Array.isArray(key) && key.length === 0)) {
+		} else if ((!key || (Array.isArray(key) && key.length === 0)) && hasQuery) {
 			result = await itemsService.updateByQuery(sanitizedQueryObject, payloadObject, { emitEvents: !!emitEvents });
+		} else if (!key || (Array.isArray(key) && key.length === 0)) {
+			result = null;
 		} else {
 			const keys = toArray(key);
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -273,3 +273,4 @@
 - yogeshwaran-c
 - sanskar-soni-9
 - kropsi
+- puneetdixit200


### PR DESCRIPTION
## Scope

What's changed:

- Guarded the Update Items flow operation so it only calls `updateByQuery` when a query option is provided.
- Added a regression test for `key: []` with `query: null` to prevent accidental collection-wide updates.
- Added a patch changeset for `@directus/api`.

## Potential Risks / Drawbacks

- Flows that previously relied on an empty keys array with no query updating records will now return `null` instead.
- Explicit query-based updates still use `updateByQuery`.

## Tested Scenarios

- Red check before implementation: `pnpm --filter @directus/api exec vitest run src/operations/item-update/index.test.ts` failed on the new empty-keys regression.
- `pnpm --filter @directus/api exec vitest run src/operations/item-update/index.test.ts`
- `pnpm --filter @directus/api test`
- `pnpm --filter @directus/api build`
- `pnpm lint`
- `pnpm lint:style`
- `pnpm format`
- `git diff --check`

## Review Notes / Questions

- OpenAI GPT-5 assisted with the implementation and verification; I reviewed the resulting code and tests.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #27514
