### PR TITLE
xiiui ← Adjust spacing for header without leading icon/button

### DIFF
--- a/app/src/views/private/private-view/components/private-view-header-bar.vue
+++ b/app/src/views/private/private-view/components/private-view-header-bar.vue
@@ -178,6 +178,10 @@ const showNavToggle = computed(() => {
 	margin-inline-end: 0.25rem;
 }
 
+.header-bar:has(.nav-toggle) .title-outer-prepend:empty + .title-container {
+	margin-inline-start: 0.5rem;
+}
+
 .title-outer-append {
 	margin-inline-start: 0.5rem;
 }


### PR DESCRIPTION
Follow-up to https://github.com/directus/directus/pull/27058

## Scope

What's changed:

- Add a margin between the nav toggle and the title when the header has no leading icon/button

## Potential Risks / Drawbacks

—

## Tested Scenarios

- Header with leading icon/button — spacing unchanged
- Header without leading icon/button — title is now properly spaced from the nav toggle
- Header without nav toggle (e.g. larger viewports) — spacing unchanged

## Review Notes / Questions

—

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Addresses CMS-2479