### PR TITLE
Amend non prod badge to use license store

### DIFF
--- a/app/src/components/v-non-production-badge.vue
+++ b/app/src/components/v-non-production-badge.vue
@@ -2,11 +2,11 @@
 import { computed } from 'vue';
 import VChip from '@/components/v-chip.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
-import { useServerStore } from '@/stores/server';
+import { useLicenseStore } from '@/stores/license';
 
-const serverStore = useServerStore();
+const licenseStore = useLicenseStore();
 
-const displayPoweredBy = computed(() => serverStore.info?.license?.entitlements?.display_powered_by);
+const displayPoweredBy = computed(() => licenseStore.info?.entitlements?.display_powered_by);
 </script>
 
 <template>

--- a/app/src/views/private/private-view/components/private-view-nav-footer.vue
+++ b/app/src/views/private/private-view/components/private-view-nav-footer.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { useServerStore } from '@/stores/server';
+import { useLicenseStore } from '@/stores/license';
 
-const serverStore = useServerStore();
+const licenseStore = useLicenseStore();
 
 const visible = computed(() => {
-	if (!serverStore.info?.license?.entitlements?.display_powered_by) return false;
+	if (!licenseStore.info?.entitlements?.display_powered_by) return false;
 
-	return serverStore.info?.license?.entitlements?.display_powered_by !== 'NONE';
+	return licenseStore.info?.entitlements?.display_powered_by !== 'HIDDEN';
 });
 </script>
 


### PR DESCRIPTION
The non production badge now uses the private license store for consistency with the other powered by badge