### PR TITLE
dp ← Ensure versioned singleton navigates to Published after publishing

### DIFF
--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -51,7 +51,7 @@ import { BREAKPOINTS } from '@/constants';
 import { useUserStore } from '@/stores/user';
 import type { ContentVersionWithType } from '@/types/versions';
 import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fields';
-import { getItemRoute } from '@/utils/get-route';
+import { getCollectionRoute, getItemRoute } from '@/utils/get-route';
 import { mergeItemData } from '@/utils/merge-item-data';
 import { pushGroupOptionsDown } from '@/utils/push-group-options-down';
 import { renderStringTemplate } from '@/utils/render-string-template';
@@ -893,7 +893,8 @@ function usePublishActions() {
 		const newItemKey = await publishVersion(versionId, {});
 		if (!newItemKey) return;
 
-		if (quit || isSingleton.value) router.push(collectionRoute.value);
+		if (isSingleton.value) router.push(getCollectionRoute(props.collection));
+		else if (quit) router.push(collectionRoute.value);
 		else router.replace(getItemRoute(props.collection, newItemKey));
 
 		deleteVersion(versionId);


### PR DESCRIPTION
## Scope

What's changed:

- Fix navigation after publishing a versioned singleton from a draft. The user now lands on the Published view of the singleton instead of being kept in the draft context.
- In `publishItemlessAndNavigate`, split the singleton branch out of the shared `quit || isSingleton` path: singletons push to `getCollectionRoute(props.collection)` (clean URL), so the `version=draft` query no longer survives the post-publish navigation.
- The non-singleton "quit after publish" path is preserved (still uses `collectionRoute.value`, which intentionally keeps `version=draft` for collection list).

## Potential Risks / Drawbacks

- The fix only addresses the pristine-singleton (itemless version) path explicitly. The existing-singleton path still relies on `finalizePublishedItem` clearing `currentVersion` to drop the query param via the `useRouteQuery` watcher chain — verified working but worth a smoke check in review.
- No change to the non-singleton publish flow.

## Tested Scenarios

- Pristine singleton: edit a fresh `?version=draft` → Publish → lands on `/content/<collection>` with Published values.
- Existing singleton: open Published, create a new draft, edit, Publish → URL drops `?version=draft`, Published view shows new values.
- Non-singleton (regression check): publishing a draft on a regular item still navigates to the item route without `?version=draft` leakage.
- Existing `use-versions` and `content/index` unit tests pass.

## Review Notes / Questions

- Worth confirming in the browser that the existing-singleton path (Scenario B) is reliably clean. If the `currentVersion = null` watcher chain shows any flicker, happy to add an explicit `router.replace(getCollectionRoute(...))` inside `finalizePublishedItem` for singletons.

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Closes CMS-2298