### PR TITLE
Fix vue console warnings related to the comparison modal

### DIFF
--- a/.changeset/late-dots-type.md
+++ b/.changeset/late-dots-type.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed vue console warnings related to the comparison modal

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -449,13 +449,11 @@ function revert(values: Record<string, any>) {
 
 		<ComparisonModal
 			:model-value="collabCollision !== undefined"
+			mode="collab"
 			collection="directus_files"
 			:primary-key="primaryKey"
 			:current-collab="collabCollision"
 			:collab-context="collabContext"
-			mode="collab"
-			:delete-versions-allowed="false"
-			:current-version="null"
 			@confirm="updateCollab"
 			@cancel="clearCollidingChanges"
 		/>

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -476,13 +476,11 @@ function revert(values: Record<string, any>) {
 
 		<ComparisonModal
 			:model-value="collabCollision !== undefined"
+			mode="collab"
 			collection="directus_users"
 			:primary-key="primaryKey"
 			:current-collab="collabCollision"
 			:collab-context="collabContext"
-			mode="collab"
-			:delete-versions-allowed="false"
-			:current-version="null"
 			@confirm="updateCollab"
 			@cancel="clearCollidingChanges"
 		/>

--- a/app/src/views/private/components/comparison/comparison-modal.vue
+++ b/app/src/views/private/components/comparison/comparison-modal.vue
@@ -18,15 +18,15 @@ import type { Revision } from '@/types/revisions';
 import type { ContentVersionWithType } from '@/types/versions';
 
 interface Props {
-	deleteVersionsAllowed: boolean;
 	collection: string;
 	primaryKey: PrimaryKey;
 	mode: 'version' | 'revision' | 'collab';
-	currentVersion: ContentVersionWithType | null | undefined;
-	currentCollab: { from: Item; to: Item } | undefined;
+	currentVersion?: ContentVersionWithType | null | undefined;
+	deleteVersionsAllowed?: boolean;
 	revisions?: Revision[] | null;
-	collabContext?: CollabContext;
 	publishVersionLoading?: boolean;
+	currentCollab?: { from: Item; to: Item } | undefined;
+	collabContext?: CollabContext;
 }
 
 const props = defineProps<Props>();

--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -763,23 +763,23 @@ function popoverClickOutsideMiddleware(e: Event) {
 	<ComparisonModal
 		v-if="collab"
 		:model-value="Boolean(collab.collabCollision.value) && overlayActive"
+		mode="collab"
 		:collection="collection"
 		:primary-key="primaryKey"
 		:current-collab="collab.collabCollision.value"
 		:collab-context="collab.collabContext"
-		mode="collab"
 		@confirm="collab.update"
 		@cancel="collab.clearCollidingChanges"
 	/>
 
 	<ComparisonModal
 		v-if="relatedCollab"
+		mode="collab"
 		:model-value="Boolean(relatedCollab.collabCollision.value) && overlayActive"
 		:collection="collection"
 		:primary-key="primaryKey"
 		:current-collab="relatedCollab.collabCollision.value"
 		:collab-context="relatedCollab.collabContext"
-		mode="collab"
 		@confirm="relatedCollab.update"
 		@cancel="relatedCollab.clearCollidingChanges"
 	/>

--- a/app/src/views/private/components/revisions-sidebar-detail.vue
+++ b/app/src/views/private/components/revisions-sidebar-detail.vue
@@ -129,10 +129,9 @@ defineExpose({
 		<ComparisonModal
 			v-model="comparisonModalActive"
 			v-model:current-revision="currentRevision"
-			:delete-versions-allowed="false"
+			mode="revision"
 			:collection
 			:primary-key
-			mode="revision"
 			:current-version="comparableVersion"
 			:revisions="revisions as Revision[]"
 			@confirm="$emit('revert', $event)"


### PR DESCRIPTION
## Scope

What's changed:

- Made mode-specific props on `ComparisonModal` optional: `currentVersion`, `currentCollab`, and `deleteVersionsAllowed` are no longer required by the type, since each is only meaningful in one of the three modes (`version` / `revision` / `collab`).
- Cleaned up callers to stop passing redundant defaults and to put `mode` first for readability.

## Potential Risks / Drawbacks

- Purely a prop-typing/cleanup change; runtime behavior is unchanged. Risk is limited to any external consumer of `ComparisonModal` that relied on those props being required at the type level.

## Tested Scenarios

- Open a record in Files and Users while another session edits it → collab collision modal appears, no Vue prop warnings in console.
- Open the revisions sidebar and trigger the comparison modal → revision diff still works, no warnings.
- Trigger the collab modal from `overlay-item` (related/nested item edits) → works as before.

## Review Notes / Questions

—

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required
