### PR TITLE
[WIP] Add AI assistant support for content versions

### DIFF
--- a/.changeset/clean-ai-version-edits.md
+++ b/.changeset/clean-ai-version-edits.md
@@ -1,0 +1,8 @@
+---
+'@directus/api': patch
+'@directus/app': patch
+'@directus/ai': patch
+'@directus/utils': patch
+---
+
+Fixed AI assistant and visual editor updates so edits to versioned items, and edits to child rows reached through versioned parents, were saved to the correct version delta instead of published content.

--- a/.changeset/quiet-fields-save.md
+++ b/.changeset/quiet-fields-save.md
@@ -6,3 +6,5 @@
 ---
 
 Fixed AI assistant and visual editor updates so edits to versioned items, and edits to child rows reached through versioned parents, were saved to the correct version delta instead of published content.
+
+Added shared write-target resolution for versioned saves and merged nested version deltas by relation identity so repeated saves updated existing relation entries instead of replacing sibling updates.

--- a/api/src/ai/chat/controllers/chat.post.ts
+++ b/api/src/ai/chat/controllers/chat.post.ts
@@ -51,6 +51,7 @@ export const aiChatPostHandler: RequestHandler = async (req, res, _next) => {
 			accountability: req.accountability!,
 			schema: req.schema,
 			...(toolApprovals && { toolApprovals }),
+			...(context && { context }),
 		}) as Tool<unknown, unknown>;
 
 		acc[name] = aiTool;

--- a/api/src/ai/chat/models/chat-request.ts
+++ b/api/src/ai/chat/models/chat-request.ts
@@ -27,6 +27,14 @@ const VisualElementContextData = z.object({
 	collection: z.string(),
 	item: z.union([z.string(), z.number()]),
 	fields: z.array(z.string()).optional(),
+	version: z.string().optional(),
+	parent: z
+		.object({
+			collection: z.string(),
+			item: z.union([z.string(), z.number()]),
+			version: z.string(),
+		})
+		.optional(),
 	rect: z
 		.object({
 			top: z.number(),
@@ -70,6 +78,7 @@ export const PageContext = z.object({
 	path: z.string(),
 	collection: z.string().optional(),
 	item: z.union([z.string(), z.number()]).optional(),
+	version: z.string().optional(),
 	module: z.string().optional(),
 });
 

--- a/api/src/ai/chat/utils/chat-request-tool-to-ai-sdk-tool.ts
+++ b/api/src/ai/chat/utils/chat-request-tool-to-ai-sdk-tool.ts
@@ -5,18 +5,20 @@ import { jsonSchema, tool, zodSchema } from 'ai';
 import { fromZodError } from 'zod-validation-error';
 import { ALL_TOOLS } from '../../tools/index.js';
 import { coerceJsonFields } from '../../tools/utils.js';
-import type { ChatRequestTool, ToolApprovalMode } from '../models/chat-request.js';
+import type { ChatContext, ChatRequestTool, ToolApprovalMode } from '../models/chat-request.js';
 
 export const chatRequestToolToAiSdkTool = ({
 	chatRequestTool,
 	accountability,
 	schema,
 	toolApprovals,
+	context,
 }: {
 	chatRequestTool: ChatRequestTool;
 	accountability: Accountability;
 	schema: SchemaOverview;
 	toolApprovals?: Record<string, ToolApprovalMode>;
+	context?: ChatContext;
 }): Tool => {
 	if (typeof chatRequestTool === 'string') {
 		const directusTool = ALL_TOOLS.find(({ name }) => name === chatRequestTool);
@@ -47,7 +49,7 @@ export const chatRequestToolToAiSdkTool = ({
 					throw new InvalidPayloadError({ reason: fromZodError(error).message });
 				}
 
-				return directusTool.handler({ args, accountability, schema });
+				return directusTool.handler({ args, accountability, schema, context });
 			},
 		});
 	}

--- a/api/src/ai/chat/utils/format-context.ts
+++ b/api/src/ai/chat/utils/format-context.ts
@@ -40,10 +40,12 @@ function formatVisualElement(att: ContextAttachment & { type: 'visual-element' }
 	const collection = escapeAngleBrackets(String(att.data.collection));
 	const item = escapeAngleBrackets(String(att.data.item));
 	const display = escapeAngleBrackets(att.display);
+	const version = att.data.version ?? att.data.parent?.version;
+	const query = version ? `, query: { "version": "${escapeAngleBrackets(version)}" }` : '';
 
 	return `### ${collection}/${item} — "${display}"
 Editable fields: ${fields}
-To update: items tool with collection="${collection}", keys=["${item}"], action="update"
+To update: items tool with collection="${collection}", keys=["${item}"], action="update"${query}
 \`\`\`json
 ${escapeAngleBrackets(JSON.stringify(att.snapshot, null, 2))}
 \`\`\``;
@@ -115,6 +117,7 @@ ${promptBlocks}
 
 		if (page.collection) pageLines.push(`Collection: ${escapeAngleBrackets(String(page.collection))}`);
 		if (page.item !== undefined) pageLines.push(`Item: ${escapeAngleBrackets(String(page.item))}`);
+		if (page.version !== undefined) pageLines.push(`Version: ${escapeAngleBrackets(String(page.version))}`);
 		if (page.module) pageLines.push(`Module: ${escapeAngleBrackets(String(page.module))}`);
 
 		sections.push(`## Current Page\n${pageLines.join('\n')}`);

--- a/api/src/ai/tools/items/index.test.ts
+++ b/api/src/ai/tools/items/index.test.ts
@@ -1,5 +1,5 @@
 import { ForbiddenError, InvalidPayloadError } from '@directus/errors';
-import type { Accountability, SchemaOverview } from '@directus/types';
+import type { Accountability, Relation, SchemaOverview } from '@directus/types';
 import { afterEach, beforeEach, describe, expect, type MockedFunction, test, vi } from 'vitest';
 import { CollectionsService } from '../../../services/collections.js';
 import { ItemsService } from '../../../services/items.js';
@@ -8,6 +8,7 @@ import { items } from './index.js';
 
 vi.mock('../../../services/collections.js');
 vi.mock('../../../services/items.js');
+
 vi.mock('../../../services/versions.js', () => ({
 	VersionsService: vi.fn(),
 }));
@@ -353,6 +354,7 @@ describe('items tool', () => {
 			test('should save versioned item updates to the requested version', async () => {
 				const updateData = { title: 'Updated Title' };
 				const updatedItem = { id: 1, title: 'Updated Title' };
+
 				const mockVersionsService = {
 					readByQuery: vi.fn().mockResolvedValue([]),
 					createOne: vi.fn().mockResolvedValue('version-1'),
@@ -383,17 +385,87 @@ describe('items tool', () => {
 				});
 
 				expect(mockItemsService.updateMany).not.toHaveBeenCalled();
+
 				expect(mockVersionsService.createOne).toHaveBeenCalledWith({
 					key: 'draft',
 					collection: 'test_collection',
 					item: '1',
 				});
+
 				expect(mockVersionsService.save).toHaveBeenCalledWith('version-1', updateData);
 				expect(mockItemsService.readMany).toHaveBeenCalledWith([1], expect.objectContaining({ version: 'draft' }));
 
 				expect(result).toEqual({
 					type: 'text',
 					data: [updatedItem],
+				});
+			});
+
+			test('should merge multiple child updates into one parent version save', async () => {
+				const mockVersionsService = {
+					readByQuery: vi.fn().mockResolvedValue([]),
+					createOne: vi.fn().mockResolvedValue('version-1'),
+					save: vi.fn().mockResolvedValue({}),
+				};
+
+				const schema = {
+					collections: {
+						pages: { singleton: false, primary: 'id' },
+						pages_blocks: { singleton: false, primary: 'id' },
+						block_hero: { singleton: false, primary: 'id' },
+					},
+					fields: {},
+					relations: [
+						relation('pages_blocks', 'pages_id', 'pages', {
+							oneField: 'blocks',
+							junctionField: 'item',
+						}),
+						relation('pages_blocks', 'item', null, {
+							oneCollectionField: 'collection',
+							oneAllowedCollections: ['block_hero'],
+						}),
+					],
+				} as unknown as SchemaOverview;
+
+				vi.mocked(CollectionsService).mockImplementation(
+					() =>
+						({
+							readOne: vi.fn(async (collection) => ({ meta: { versioning: collection === 'pages' } })),
+						}) as unknown as CollectionsService,
+				);
+
+				vi.mocked(VersionsService).mockImplementation(() => mockVersionsService as unknown as VersionsService);
+
+				mockItemsService.readOne.mockResolvedValue({
+					blocks: [
+						{ id: 7, collection: 'block_hero', item: { id: 9 } },
+						{ id: 8, collection: 'block_hero', item: { id: 10 } },
+					],
+				});
+
+				await items.handler({
+					args: {
+						action: 'update',
+						collection: 'block_hero',
+						keys: [9, 10],
+						data: { title: 'Updated Title' },
+					},
+					schema,
+					accountability: mockAccountability,
+					context: { page: { path: '/visual/pages/page-id', collection: 'pages', item: 'page-id', version: 'draft' } },
+				});
+
+				expect(mockVersionsService.save).toHaveBeenCalledTimes(1);
+
+				expect(mockVersionsService.save).toHaveBeenCalledWith('version-1', {
+					blocks: {
+						create: [],
+						update: [
+							{ id: 7, collection: 'block_hero', item: { id: 9, title: 'Updated Title' } },
+							{ id: 8, collection: 'block_hero', item: { id: 10, title: 'Updated Title' } },
+						],
+						delete: [],
+					},
 				});
 			});
 		});
@@ -664,3 +736,34 @@ describe('items tool', () => {
 		});
 	});
 });
+
+function relation(
+	collection: string,
+	field: string,
+	relatedCollection: string | null,
+	options: {
+		oneField?: string | null;
+		junctionField?: string | null;
+		oneCollectionField?: string | null;
+		oneAllowedCollections?: string[] | null;
+	} = {},
+): Relation {
+	return {
+		collection,
+		field,
+		related_collection: relatedCollection,
+		schema: null,
+		meta: {
+			id: 1,
+			many_collection: collection,
+			many_field: field,
+			one_collection: relatedCollection,
+			one_field: options.oneField ?? null,
+			one_collection_field: options.oneCollectionField ?? null,
+			one_allowed_collections: options.oneAllowedCollections ?? null,
+			one_deselect_action: 'nullify',
+			junction_field: options.junctionField ?? null,
+			sort_field: null,
+		},
+	};
+}

--- a/api/src/ai/tools/items/index.test.ts
+++ b/api/src/ai/tools/items/index.test.ts
@@ -1,10 +1,16 @@
 import { ForbiddenError, InvalidPayloadError } from '@directus/errors';
 import type { Accountability, SchemaOverview } from '@directus/types';
 import { afterEach, beforeEach, describe, expect, type MockedFunction, test, vi } from 'vitest';
+import { CollectionsService } from '../../../services/collections.js';
 import { ItemsService } from '../../../services/items.js';
+import { VersionsService } from '../../../services/versions.js';
 import { items } from './index.js';
 
+vi.mock('../../../services/collections.js');
 vi.mock('../../../services/items.js');
+vi.mock('../../../services/versions.js', () => ({
+	VersionsService: vi.fn(),
+}));
 
 describe('items tool', () => {
 	const mockSchema = {
@@ -18,6 +24,24 @@ describe('items tool', () => {
 
 	const mockAccountability = { user: 'test-user' } as Accountability;
 
+	beforeEach(() => {
+		vi.mocked(CollectionsService).mockImplementation(
+			() =>
+				({
+					readOne: vi.fn().mockResolvedValue({ meta: { versioning: false } }),
+				}) as unknown as CollectionsService,
+		);
+
+		vi.mocked(VersionsService).mockImplementation(
+			() =>
+				({
+					readByQuery: vi.fn().mockResolvedValue([]),
+					createOne: vi.fn().mockResolvedValue('version-1'),
+					save: vi.fn().mockResolvedValue({}),
+				}) as unknown as VersionsService,
+		);
+	});
+
 	afterEach(() => {
 		vi.clearAllMocks();
 	});
@@ -26,8 +50,10 @@ describe('items tool', () => {
 		let mockItemsService: {
 			createMany: MockedFunction<any>;
 			readMany: MockedFunction<any>;
+			readOne: MockedFunction<any>;
 			readByQuery: MockedFunction<any>;
 			readSingleton: MockedFunction<any>;
+			updateOne: MockedFunction<any>;
 			updateMany: MockedFunction<any>;
 			updateBatch: MockedFunction<any>;
 			updateByQuery: MockedFunction<any>;
@@ -39,8 +65,10 @@ describe('items tool', () => {
 			mockItemsService = {
 				createMany: vi.fn(),
 				readMany: vi.fn(),
+				readOne: vi.fn(),
 				readByQuery: vi.fn(),
 				readSingleton: vi.fn(),
+				updateOne: vi.fn(),
 				updateMany: vi.fn(),
 				updateBatch: vi.fn(),
 				updateByQuery: vi.fn(),
@@ -321,6 +349,53 @@ describe('items tool', () => {
 					data: updatedSingleton,
 				});
 			});
+
+			test('should save versioned item updates to the requested version', async () => {
+				const updateData = { title: 'Updated Title' };
+				const updatedItem = { id: 1, title: 'Updated Title' };
+				const mockVersionsService = {
+					readByQuery: vi.fn().mockResolvedValue([]),
+					createOne: vi.fn().mockResolvedValue('version-1'),
+					save: vi.fn().mockResolvedValue({}),
+				};
+
+				vi.mocked(CollectionsService).mockImplementation(
+					() =>
+						({
+							readOne: vi.fn().mockResolvedValue({ meta: { versioning: true } }),
+						}) as unknown as CollectionsService,
+				);
+
+				vi.mocked(VersionsService).mockImplementation(() => mockVersionsService as unknown as VersionsService);
+				vi.mocked(ItemsService).mockImplementation(() => mockItemsService as unknown as ItemsService);
+				mockItemsService.readMany.mockResolvedValue([updatedItem]);
+
+				const result = await items.handler({
+					args: {
+						action: 'update',
+						collection: 'test_collection',
+						keys: [1],
+						data: updateData,
+						query: { version: 'draft' },
+					},
+					schema: mockSchema,
+					accountability: mockAccountability,
+				});
+
+				expect(mockItemsService.updateMany).not.toHaveBeenCalled();
+				expect(mockVersionsService.createOne).toHaveBeenCalledWith({
+					key: 'draft',
+					collection: 'test_collection',
+					item: '1',
+				});
+				expect(mockVersionsService.save).toHaveBeenCalledWith('version-1', updateData);
+				expect(mockItemsService.readMany).toHaveBeenCalledWith([1], expect.objectContaining({ version: 'draft' }));
+
+				expect(result).toEqual({
+					type: 'text',
+					data: [updatedItem],
+				});
+			});
 		});
 
 		describe('DELETE action', () => {
@@ -368,8 +443,10 @@ describe('items tool', () => {
 		let mockItemsService: {
 			createMany: MockedFunction<any>;
 			readMany: MockedFunction<any>;
+			readOne: MockedFunction<any>;
 			readByQuery: MockedFunction<any>;
 			readSingleton: MockedFunction<any>;
+			updateOne: MockedFunction<any>;
 			updateMany: MockedFunction<any>;
 			updateBatch: MockedFunction<any>;
 			updateByQuery: MockedFunction<any>;
@@ -381,8 +458,10 @@ describe('items tool', () => {
 			mockItemsService = {
 				createMany: vi.fn(),
 				readMany: vi.fn(),
+				readOne: vi.fn(),
 				readByQuery: vi.fn(),
 				readSingleton: vi.fn(),
+				updateOne: vi.fn(),
 				updateMany: vi.fn(),
 				updateBatch: vi.fn(),
 				updateByQuery: vi.fn(),
@@ -441,8 +520,10 @@ describe('items tool', () => {
 		let mockItemsService: {
 			createMany: MockedFunction<any>;
 			readMany: MockedFunction<any>;
+			readOne: MockedFunction<any>;
 			readByQuery: MockedFunction<any>;
 			readSingleton: MockedFunction<any>;
+			updateOne: MockedFunction<any>;
 			updateMany: MockedFunction<any>;
 			updateBatch: MockedFunction<any>;
 			updateByQuery: MockedFunction<any>;
@@ -454,8 +535,10 @@ describe('items tool', () => {
 			mockItemsService = {
 				createMany: vi.fn(),
 				readMany: vi.fn(),
+				readOne: vi.fn(),
 				readByQuery: vi.fn(),
 				readSingleton: vi.fn(),
+				updateOne: vi.fn(),
 				updateMany: vi.fn(),
 				updateBatch: vi.fn(),
 				updateByQuery: vi.fn(),

--- a/api/src/ai/tools/items/index.test.ts
+++ b/api/src/ai/tools/items/index.test.ts
@@ -20,7 +20,7 @@ describe('items tool', () => {
 			singleton_collection: { singleton: true },
 		},
 		fields: {},
-		relations: {},
+		relations: [],
 	} as unknown as SchemaOverview;
 
 	const mockAccountability = { user: 'test-user' } as Accountability;
@@ -275,6 +275,29 @@ describe('items tool', () => {
 				expect(result).toEqual({
 					type: 'text',
 					data: updatedItems,
+				});
+			});
+
+			test('should not route unrelated updates through draft page context', async () => {
+				const updateData = { status: 'published' };
+				const updatedItem = { id: 1, status: 'published' };
+
+				mockItemsService.updateMany.mockResolvedValue([1]);
+				mockItemsService.readMany.mockResolvedValue([updatedItem]);
+
+				const result = await items.handler({
+					args: { action: 'update', collection: 'test_collection', keys: [1], data: updateData },
+					schema: mockSchema,
+					accountability: mockAccountability,
+					context: { page: { path: '/visual/pages/1', collection: 'pages', item: 1, version: 'draft' } },
+				});
+
+				expect(mockItemsService.updateMany).toHaveBeenCalledWith([1], updateData);
+				expect(mockItemsService.updateOne).not.toHaveBeenCalled();
+
+				expect(result).toEqual({
+					type: 'text',
+					data: [updatedItem],
 				});
 			});
 

--- a/api/src/ai/tools/items/index.test.ts
+++ b/api/src/ai/tools/items/index.test.ts
@@ -491,6 +491,72 @@ describe('items tool', () => {
 					},
 				});
 			});
+
+			test('should include the child primary key when reading back parent-version updates with selected fields', async () => {
+				const mockVersionsService = {
+					readByQuery: vi.fn().mockResolvedValue([]),
+					createOne: vi.fn().mockResolvedValue('version-1'),
+					save: vi.fn().mockResolvedValue({}),
+				};
+
+				const schema = {
+					collections: {
+						pages: { singleton: false, primary: 'id' },
+						pages_blocks: { singleton: false, primary: 'id' },
+						block_hero: { singleton: false, primary: 'id' },
+					},
+					fields: {},
+					relations: [
+						relation('pages_blocks', 'pages_id', 'pages', {
+							oneField: 'blocks',
+							junctionField: 'item',
+						}),
+						relation('pages_blocks', 'item', null, {
+							oneCollectionField: 'collection',
+							oneAllowedCollections: ['block_hero'],
+						}),
+					],
+				} as unknown as SchemaOverview;
+
+				vi.mocked(CollectionsService).mockImplementation(
+					() =>
+						({
+							readOne: vi.fn(async (collection) => ({ meta: { versioning: collection === 'pages' } })),
+						}) as unknown as CollectionsService,
+				);
+
+				vi.mocked(VersionsService).mockImplementation(() => mockVersionsService as unknown as VersionsService);
+
+				mockItemsService.readOne.mockResolvedValue({
+					blocks: [{ id: 7, collection: 'block_hero', item: { id: 9, title: 'Updated Title' } }],
+				});
+
+				const result = await items.handler({
+					args: {
+						action: 'update',
+						collection: 'block_hero',
+						keys: [9],
+						data: { title: 'Updated Title' },
+						query: { fields: ['title'] },
+					},
+					schema,
+					accountability: mockAccountability,
+					context: { page: { path: '/visual/pages/page-id', collection: 'pages', item: 'page-id', version: 'draft' } },
+				});
+
+				expect(mockItemsService.readOne).toHaveBeenLastCalledWith(
+					'page-id',
+					expect.objectContaining({
+						fields: ['blocks.collection', 'blocks.item.id', 'blocks.item.title'],
+						version: 'draft',
+					}),
+				);
+
+				expect(result).toEqual({
+					type: 'text',
+					data: [{ id: 9, title: 'Updated Title' }],
+				});
+			});
 		});
 
 		describe('DELETE action', () => {

--- a/api/src/ai/tools/items/index.ts
+++ b/api/src/ai/tools/items/index.ts
@@ -563,12 +563,3 @@ function getPrimaryKeyField(schema: SchemaOverview, collection: string) {
 function mergePayloadForSingleSave(target: Item, source: Item, identityFields: string[]) {
 	mergeNestedRelationDeltaInto(target, source, { identityFields });
 }
-
-function isDetailedUpdatePayload(value: unknown) {
-	return (
-		isObject(value) &&
-		Array.isArray(value['create']) &&
-		Array.isArray(value['update']) &&
-		Array.isArray(value['delete'])
-	);
-}

--- a/api/src/ai/tools/items/index.ts
+++ b/api/src/ai/tools/items/index.ts
@@ -1,12 +1,23 @@
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isPublishedVersionKey } from '@directus/constants';
 import { ForbiddenError, InvalidPayloadError } from '@directus/errors';
 import { isSystemCollection } from '@directus/system-data';
-import type { PrimaryKey } from '@directus/types';
-import { toArray } from '@directus/utils';
-import { isObject } from 'graphql-compose';
+import type { Accountability, Item, PrimaryKey, SchemaOverview } from '@directus/types';
+import {
+	buildPayload,
+	isObject,
+	mergeNestedRelationDeltaInto,
+	REFUSAL,
+	resolveWriteTarget,
+	toArray,
+} from '@directus/utils';
 import { z } from 'zod';
+import type { ChatContext } from '../../chat/models/chat-request.js';
+import { CollectionsService } from '../../../services/collections.js';
 import { ItemsService } from '../../../services/items.js';
+import { VersionsService } from '../../../services/versions.js';
+import { ensureVersionId } from '../../../utils/ensure-version-id.js';
 import { requireText } from '../../../utils/require-text.js';
 import { defineTool } from '../define-tool.js';
 import {
@@ -59,6 +70,8 @@ const ItemsInputSchema = z.object({
 		.describe('Object when using keys, array with PKs for batch updates'),
 });
 
+type ItemsArgs = z.infer<typeof ItemsValidateSchema>;
+
 export const items = defineTool<z.infer<typeof ItemsValidateSchema>>({
 	name: 'items',
 	description: requireText(resolve(__dirname, './prompt.md')),
@@ -74,7 +87,7 @@ export const items = defineTool<z.infer<typeof ItemsValidateSchema>>({
 
 		return ['content', input.collection, data['id']];
 	},
-	async handler({ args, schema, accountability }) {
+	async handler({ args, schema, accountability, context }) {
 		if (isSystemCollection(args.collection)) {
 			throw new InvalidPayloadError({ reason: 'Cannot provide a core collection' });
 		}
@@ -90,7 +103,15 @@ export const items = defineTool<z.infer<typeof ItemsValidateSchema>>({
 			accountability,
 		});
 
+		const collectionHasVersioning = createCollectionVersioningResolver(schema, accountability);
+
 		if (args.action === 'create') {
+			if (hasDraftVersionHint(args.query?.version, context)) {
+				throw new InvalidPayloadError({
+					reason: `${REFUSAL.VERSIONING_REQUIRED} Creating items through a content version is not supported.`,
+				});
+			}
+
 			const sanitizedQuery = await buildSanitizedQueryFromArgs(args, schema, accountability);
 			const data = toArray(args.data);
 
@@ -139,10 +160,52 @@ export const items = defineTool<z.infer<typeof ItemsValidateSchema>>({
 
 		if (args.action === 'update') {
 			const sanitizedQuery = await buildSanitizedQueryFromArgs(args, schema, accountability);
+			const collectionIsVersioned = await collectionHasVersioning(args.collection);
+			const needsVersionRouting = collectionIsVersioned || hasDraftVersionHint(args.query?.version, context);
 
 			if (isSingleton) {
 				if (Array.isArray(args.data)) {
-					throw new InvalidPayloadError({ reason: 'Invalid data payload, object exptected' });
+					throw new InvalidPayloadError({ reason: 'Invalid data payload, object expected' });
+				}
+
+				if (needsVersionRouting) {
+					const primaryKeyField = getPrimaryKeyField(schema, args.collection);
+					const singleton = await itemsService.readSingleton({ fields: [primaryKeyField] });
+					const singletonKey = singleton?.[primaryKeyField];
+
+					if (singletonKey === undefined || singletonKey === null) {
+						if (collectionIsVersioned) {
+							throw new InvalidPayloadError({
+								reason: `${REFUSAL.NO_PUBLISHED_SINGLETON} Versioned singleton has no published row to version.`,
+							});
+						}
+
+						await itemsService.upsertSingleton(args.data);
+
+						const item = await itemsService.readSingleton(sanitizedQuery);
+
+						return {
+							type: 'text',
+							data: item || null,
+						};
+					}
+
+					const result = await updateWithVersionRouting({
+						args,
+						schema,
+						accountability,
+						context,
+						sanitizedQuery,
+						itemsService,
+						collectionHasVersioning,
+						updates: [{ key: singletonKey as PrimaryKey, data: args.data }],
+						isSingleton,
+					});
+
+					return {
+						type: 'text',
+						data: result[0] ?? null,
+					};
 				}
 
 				await itemsService.upsertSingleton(args.data);
@@ -152,6 +215,33 @@ export const items = defineTool<z.infer<typeof ItemsValidateSchema>>({
 				return {
 					type: 'text',
 					data: item || null,
+				};
+			}
+
+			if (needsVersionRouting) {
+				const updates = getKeyedUpdates(args, getPrimaryKeyField(schema, args.collection));
+
+				if (updates.length === 0) {
+					throw new InvalidPayloadError({
+						reason: `${REFUSAL.NO_KEYS} Versioned updates require explicit item keys.`,
+					});
+				}
+
+				const result = await updateWithVersionRouting({
+					args,
+					schema,
+					accountability,
+					context,
+					sanitizedQuery,
+					itemsService,
+					collectionHasVersioning,
+					updates,
+					isSingleton,
+				});
+
+				return {
+					type: 'text',
+					data: result,
 				};
 			}
 
@@ -174,6 +264,12 @@ export const items = defineTool<z.infer<typeof ItemsValidateSchema>>({
 		}
 
 		if (args.action === 'delete') {
+			if (hasDraftVersionHint(args.query?.version, context)) {
+				throw new InvalidPayloadError({
+					reason: `${REFUSAL.VERSIONING_REQUIRED} Deleting items through a content version is not supported.`,
+				});
+			}
+
 			const deletedKeys = await itemsService.deleteMany(args.keys);
 
 			return {
@@ -185,3 +281,234 @@ export const items = defineTool<z.infer<typeof ItemsValidateSchema>>({
 		throw new Error('Invalid action.');
 	},
 });
+
+async function updateWithVersionRouting({
+	args,
+	schema,
+	accountability,
+	context,
+	sanitizedQuery,
+	itemsService,
+	collectionHasVersioning,
+	updates,
+	isSingleton,
+}: {
+	args: ItemsArgs;
+	schema: SchemaOverview;
+	accountability: Accountability | undefined;
+	context: ChatContext | undefined;
+	sanitizedQuery: Record<string, any>;
+	itemsService: ItemsService;
+	collectionHasVersioning: (collection: string) => Promise<boolean>;
+	updates: { key: PrimaryKey; data: Item }[];
+	isSingleton: boolean;
+}) {
+	const versionsService = new VersionsService({ schema, accountability });
+	const results: unknown[] = [];
+	const parentBatches = new Map<string, { collection: string; item: PrimaryKey; versionKey: string; payload: Item }>();
+
+	for (const update of updates) {
+		const target = await resolveWriteTarget({
+			schema,
+			target: { collection: args.collection, key: update.key },
+			hint: getVersionHint(args, update.key, context),
+			collectionHasVersioning,
+			readParent: async (parent, fields) => {
+				const parentService = new ItemsService(parent.collection, { schema, accountability });
+
+				return parentService.readOne(parent.key, {
+					fields,
+					version: parent.versionKey,
+					versionRaw: false,
+				});
+			},
+		});
+
+		if (target.kind === 'refuse') {
+			throw new InvalidPayloadError({ reason: target.message });
+		}
+
+		if (target.kind === 'published') {
+			if (isSingleton) {
+				await itemsService.upsertSingleton(update.data);
+				results.push(await itemsService.readSingleton(sanitizedQuery));
+			} else {
+				await itemsService.updateOne(target.key, update.data);
+				results.push(await itemsService.readOne(target.key, sanitizedQuery));
+			}
+
+			continue;
+		}
+
+		const payload = buildPayload(target, update.data, update.key);
+
+		if (target.kind === 'item-version') {
+			const versionId = await ensureVersionId(versionsService, {
+				collection: target.collection,
+				item: target.key,
+				versionKey: target.versionKey,
+			});
+
+			await versionsService.save(versionId, payload);
+
+			const readQuery = {
+				...sanitizedQuery,
+				version: target.versionKey,
+				versionRaw: false,
+			};
+
+			if (isSingleton) {
+				results.push(await itemsService.readSingleton(readQuery));
+			} else {
+				const readService = new ItemsService(args.collection, { schema, accountability });
+				const items = await readService.readMany([target.key], readQuery);
+				results.push(items[0] ?? null);
+			}
+
+			continue;
+		}
+
+		const batchKey = `${target.parent.collection}:${target.parent.key}:${target.parent.versionKey}`;
+		const batch = parentBatches.get(batchKey);
+
+		if (batch) {
+			mergePayloadForSingleSave(batch.payload, payload);
+		} else {
+			parentBatches.set(batchKey, {
+				collection: target.parent.collection,
+				item: target.parent.key,
+				versionKey: target.parent.versionKey,
+				payload,
+			});
+		}
+
+		results.push(null);
+	}
+
+	for (const batch of parentBatches.values()) {
+		const versionId = await ensureVersionId(versionsService, batch);
+		await versionsService.save(versionId, batch.payload);
+	}
+
+	return results;
+}
+
+function getKeyedUpdates(args: ItemsArgs, primaryKeyField: string): { key: PrimaryKey; data: Item }[] {
+	if (Array.isArray(args.data)) {
+		return args.data.map((item) => {
+			const key = item[primaryKeyField];
+
+			if (key === undefined || key === null) {
+				throw new InvalidPayloadError({
+					reason: `${REFUSAL.NO_KEYS} Batch updates against versions require "${primaryKeyField}".`,
+				});
+			}
+
+			return { key: key as PrimaryKey, data: item };
+		});
+	}
+
+	if (args.keys) {
+		return args.keys.map((key) => ({ key, data: args.data }));
+	}
+
+	return [];
+}
+
+function createCollectionVersioningResolver(schema: SchemaOverview, accountability: Accountability | undefined) {
+	const cache = new Map<string, boolean>();
+	let collectionsService: CollectionsService | null = null;
+
+	return async function collectionHasVersioning(collection: string) {
+		const cached = cache.get(collection);
+		if (cached !== undefined) return cached;
+
+		collectionsService ??= new CollectionsService({ schema, accountability });
+
+		const collectionInfo = await collectionsService.readOne(collection);
+		const hasVersioning = Boolean(collectionInfo.meta?.versioning);
+
+		cache.set(collection, hasVersioning);
+
+		return hasVersioning;
+	};
+}
+
+function getVersionHint(args: ItemsArgs, key: PrimaryKey, context: ChatContext | undefined) {
+	const visualElement = context?.attachments?.find((attachment) => {
+		if (attachment.type !== 'visual-element') return false;
+		if (attachment.data.collection !== args.collection) return false;
+
+		return String(attachment.data.item) === String(key);
+	});
+
+	const visualElementParent = visualElement?.data.parent;
+
+	return {
+		explicitVersion: args.query?.version,
+		page: context?.page,
+		attachment: visualElement
+			? {
+					collection: visualElement.data.collection,
+					item: visualElement.data.item,
+					version: visualElement.data.version,
+					parent: visualElementParent
+						? {
+								collection: visualElementParent.collection,
+								key: visualElementParent.item,
+								versionKey: visualElementParent.version,
+							}
+						: null,
+				}
+			: null,
+	};
+}
+
+function hasDraftVersionHint(queryVersion: string | null | undefined, context: ChatContext | undefined) {
+	if (isDraftVersionKey(queryVersion)) return true;
+	if (isDraftVersionKey(context?.page?.version)) return true;
+
+	return (
+		context?.attachments?.some((attachment) => {
+			if (attachment.type !== 'visual-element') return false;
+			if (isDraftVersionKey(attachment.data.version)) return true;
+
+			return isDraftVersionKey(attachment.data.parent?.version);
+		}) ?? false
+	);
+}
+
+function isDraftVersionKey(versionKey: string | null | undefined) {
+	return Boolean(versionKey && !isPublishedVersionKey(versionKey));
+}
+
+function getPrimaryKeyField(schema: SchemaOverview, collection: string) {
+	return schema.collections[collection]?.primary ?? 'id';
+}
+
+function mergePayloadForSingleSave(target: Item, source: Item) {
+	for (const [field, incoming] of Object.entries(source)) {
+		const existing = target[field];
+
+		if (
+			isObject(existing) &&
+			isObject(incoming) &&
+			!isDetailedUpdatePayload(existing) &&
+			!isDetailedUpdatePayload(incoming)
+		) {
+			target[field] = { ...existing, ...incoming };
+			continue;
+		}
+
+		mergeNestedRelationDeltaInto(target, { [field]: incoming });
+	}
+}
+
+function isDetailedUpdatePayload(value: unknown) {
+	return (
+		isObject(value) &&
+		Array.isArray(value['create']) &&
+		Array.isArray(value['update']) &&
+		Array.isArray(value['delete'])
+	);
+}

--- a/api/src/ai/tools/items/index.ts
+++ b/api/src/ai/tools/items/index.ts
@@ -6,19 +6,20 @@ import { isSystemCollection } from '@directus/system-data';
 import type { Accountability, Item, PrimaryKey, SchemaOverview } from '@directus/types';
 import {
 	buildPayload,
+	getSchemaPrimaryKeyFields,
 	isObject,
 	mergeNestedRelationDeltaInto,
-	REFUSAL,
 	resolveWriteTarget,
 	toArray,
+	WRITE_TARGET_REFUSAL,
 } from '@directus/utils';
 import { z } from 'zod';
-import type { ChatContext } from '../../chat/models/chat-request.js';
 import { CollectionsService } from '../../../services/collections.js';
 import { ItemsService } from '../../../services/items.js';
 import { VersionsService } from '../../../services/versions.js';
 import { ensureVersionId } from '../../../utils/ensure-version-id.js';
 import { requireText } from '../../../utils/require-text.js';
+import type { ChatContext } from '../../chat/models/chat-request.js';
 import { defineTool } from '../define-tool.js';
 import {
 	ItemInputSchema,
@@ -31,6 +32,11 @@ import {
 import { buildSanitizedQueryFromArgs } from '../utils.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const ITEM_TOOL_REFUSAL = {
+	NO_KEYS: 'NO_KEYS',
+	NO_PUBLISHED_SINGLETON: 'NO_PUBLISHED_SINGLETON',
+} as const;
 
 const PartialItemInputSchema = z.strictObject({
 	collection: z.string(),
@@ -108,7 +114,10 @@ export const items = defineTool<z.infer<typeof ItemsValidateSchema>>({
 		if (args.action === 'create') {
 			if (hasDraftVersionHint(args.query?.version, context)) {
 				throw new InvalidPayloadError({
-					reason: `${REFUSAL.VERSIONING_REQUIRED} Creating items through a content version is not supported.`,
+					reason: formatVersioningRefusal(
+						WRITE_TARGET_REFUSAL.VERSIONING_REQUIRED,
+						'Creating items through a content version is not supported.',
+					),
 				});
 			}
 
@@ -176,7 +185,10 @@ export const items = defineTool<z.infer<typeof ItemsValidateSchema>>({
 					if (singletonKey === undefined || singletonKey === null) {
 						if (collectionIsVersioned) {
 							throw new InvalidPayloadError({
-								reason: `${REFUSAL.NO_PUBLISHED_SINGLETON} Versioned singleton has no published row to version.`,
+								reason: formatVersioningRefusal(
+									ITEM_TOOL_REFUSAL.NO_PUBLISHED_SINGLETON,
+									'Versioned singleton has no published row to version.',
+								),
 							});
 						}
 
@@ -223,7 +235,7 @@ export const items = defineTool<z.infer<typeof ItemsValidateSchema>>({
 
 				if (updates.length === 0) {
 					throw new InvalidPayloadError({
-						reason: `${REFUSAL.NO_KEYS} Versioned updates require explicit item keys.`,
+						reason: formatVersioningRefusal(ITEM_TOOL_REFUSAL.NO_KEYS, 'Versioned updates require explicit item keys.'),
 					});
 				}
 
@@ -266,7 +278,10 @@ export const items = defineTool<z.infer<typeof ItemsValidateSchema>>({
 		if (args.action === 'delete') {
 			if (hasDraftVersionHint(args.query?.version, context)) {
 				throw new InvalidPayloadError({
-					reason: `${REFUSAL.VERSIONING_REQUIRED} Deleting items through a content version is not supported.`,
+					reason: formatVersioningRefusal(
+						WRITE_TARGET_REFUSAL.VERSIONING_REQUIRED,
+						'Deleting items through a content version is not supported.',
+					),
 				});
 			}
 
@@ -306,6 +321,7 @@ async function updateWithVersionRouting({
 	const versionsService = new VersionsService({ schema, accountability });
 	const results: unknown[] = [];
 	const parentBatches = new Map<string, { collection: string; item: PrimaryKey; versionKey: string; payload: Item }>();
+	const identityFields = getSchemaPrimaryKeyFields(schema);
 
 	for (const update of updates) {
 		const target = await resolveWriteTarget({
@@ -314,6 +330,15 @@ async function updateWithVersionRouting({
 			hint: getVersionHint(args, update.key, context),
 			collectionHasVersioning,
 			readParent: async (parent, fields) => {
+				// Materialize the version row before reading. ItemsService.readOne with `version`
+				// throws 403 when no directus_versions row exists for that (collection, item, key).
+				// Phase 2 will teach handleVersion to fall back to published.
+				await ensureVersionId(versionsService, {
+					collection: parent.collection,
+					item: parent.key,
+					versionKey: parent.versionKey,
+				});
+
 				const parentService = new ItemsService(parent.collection, { schema, accountability });
 
 				return parentService.readOne(parent.key, {
@@ -325,7 +350,7 @@ async function updateWithVersionRouting({
 		});
 
 		if (target.kind === 'refuse') {
-			throw new InvalidPayloadError({ reason: target.message });
+			throw new InvalidPayloadError({ reason: formatVersioningRefusal(target.token, target.message) });
 		}
 
 		if (target.kind === 'published') {
@@ -372,7 +397,7 @@ async function updateWithVersionRouting({
 		const batch = parentBatches.get(batchKey);
 
 		if (batch) {
-			mergePayloadForSingleSave(batch.payload, payload);
+			mergePayloadForSingleSave(batch.payload, payload, identityFields);
 		} else {
 			parentBatches.set(batchKey, {
 				collection: target.parent.collection,
@@ -400,7 +425,10 @@ function getKeyedUpdates(args: ItemsArgs, primaryKeyField: string): { key: Prima
 
 			if (key === undefined || key === null) {
 				throw new InvalidPayloadError({
-					reason: `${REFUSAL.NO_KEYS} Batch updates against versions require "${primaryKeyField}".`,
+					reason: formatVersioningRefusal(
+						ITEM_TOOL_REFUSAL.NO_KEYS,
+						`Batch updates against versions require "${primaryKeyField}".`,
+					),
 				});
 			}
 
@@ -409,7 +437,7 @@ function getKeyedUpdates(args: ItemsArgs, primaryKeyField: string): { key: Prima
 	}
 
 	if (args.keys) {
-		return args.keys.map((key) => ({ key, data: args.data }));
+		return args.keys.map((key) => ({ key, data: { ...args.data } }));
 	}
 
 	return [];
@@ -482,11 +510,16 @@ function isDraftVersionKey(versionKey: string | null | undefined) {
 	return Boolean(versionKey && !isPublishedVersionKey(versionKey));
 }
 
+function formatVersioningRefusal(token: string, message: string) {
+	if (token === WRITE_TARGET_REFUSAL.VERSIONING_REQUIRED) return `[VERSIONING_REQUIRED] ${message}`;
+	return `[VERSIONING_REQUIRED:${token}] ${message}`;
+}
+
 function getPrimaryKeyField(schema: SchemaOverview, collection: string) {
 	return schema.collections[collection]?.primary ?? 'id';
 }
 
-function mergePayloadForSingleSave(target: Item, source: Item) {
+function mergePayloadForSingleSave(target: Item, source: Item, identityFields: string[]) {
 	for (const [field, incoming] of Object.entries(source)) {
 		const existing = target[field];
 
@@ -500,7 +533,7 @@ function mergePayloadForSingleSave(target: Item, source: Item) {
 			continue;
 		}
 
-		mergeNestedRelationDeltaInto(target, { [field]: incoming });
+		mergeNestedRelationDeltaInto(target, { [field]: incoming }, { identityFields });
 	}
 }
 

--- a/api/src/ai/tools/items/index.ts
+++ b/api/src/ai/tools/items/index.ts
@@ -6,12 +6,14 @@ import { isSystemCollection } from '@directus/system-data';
 import type { Accountability, Item, PrimaryKey, SchemaOverview } from '@directus/types';
 import {
 	buildPayload,
+	findParentInitialValue,
 	findParentRelationCandidates,
 	getSchemaPrimaryKeyFields,
 	isObject,
 	mergeNestedRelationDeltaInto,
 	type ParentRef,
 	type ParentRelation,
+	prefixChildFields,
 	resolveWriteTarget,
 	toArray,
 	WRITE_TARGET_REFUSAL,
@@ -401,7 +403,7 @@ async function updateWithVersionRouting({
 		const batch = parentBatches.get(batchKey);
 
 		if (batch) {
-			mergePayloadForSingleSave(batch.payload, payload, identityFields);
+			mergeNestedRelationDeltaInto(batch.payload, payload, { identityFields });
 		} else {
 			parentBatches.set(batchKey, {
 				collection: target.parent.collection,
@@ -434,7 +436,11 @@ async function updateWithVersionRouting({
 	for (const deferred of deferredReads) {
 		const parentService = new ItemsService(deferred.parent.collection, { schema, accountability });
 
-		const childFields = sanitizedQuery['fields']?.length ? sanitizedQuery['fields'] : ['*'];
+		const requestedFields =
+			Array.isArray(sanitizedQuery['fields']) && sanitizedQuery['fields'].length ? sanitizedQuery['fields'] : ['*'];
+		const childFields = requestedFields.includes('*')
+			? requestedFields
+			: Array.from(new Set([deferred.relation.childPkField, ...requestedFields]));
 
 		const parentItem = await parentService.readOne(deferred.parent.key, {
 			fields: prefixChildFields(deferred.relation, childFields),
@@ -442,7 +448,9 @@ async function updateWithVersionRouting({
 			versionRaw: false,
 		});
 
-		results[deferred.index] = parentItem ? extractChildFromParent(deferred.relation, parentItem, deferred.key) : null;
+		results[deferred.index] = parentItem
+			? findParentInitialValue(deferred.relation, parentItem, args.collection, deferred.key)
+			: null;
 	}
 
 	return results;
@@ -573,48 +581,4 @@ function formatVersioningRefusal(token: string, message: string) {
 
 function getPrimaryKeyField(schema: SchemaOverview, collection: string) {
 	return schema.collections[collection]?.primary ?? 'id';
-}
-
-function prefixChildFields(relation: ParentRelation, childFields: string[]): string[] {
-	const path =
-		relation.kind === 'm2o' || relation.kind === 'o2m'
-			? relation.parentField
-			: `${relation.parentField}.${relation.junctionField}`;
-
-	return childFields.map((field) => `${path}.${field}`);
-}
-
-function extractChildFromParent(relation: ParentRelation, parentItem: Item, childKey: PrimaryKey): Item | null {
-	const root = (parentItem as Record<string, unknown>)[relation.parentField];
-
-	if (relation.kind === 'm2o') {
-		return isObject(root) ? (root as Item) : null;
-	}
-
-	if (!Array.isArray(root)) return null;
-
-	for (const entry of root) {
-		if (!isObject(entry)) continue;
-
-		if (relation.kind === 'o2m') {
-			if (String((entry as Record<string, unknown>)[relation.childPkField]) === String(childKey)) {
-				return entry as Item;
-			}
-
-			continue;
-		}
-
-		const child = (entry as Record<string, unknown>)[relation.junctionField];
-		if (!isObject(child)) continue;
-
-		if (String((child as Record<string, unknown>)[relation.childPkField]) === String(childKey)) {
-			return child as Item;
-		}
-	}
-
-	return null;
-}
-
-function mergePayloadForSingleSave(target: Item, source: Item, identityFields: string[]) {
-	mergeNestedRelationDeltaInto(target, source, { identityFields });
 }

--- a/api/src/ai/tools/items/index.ts
+++ b/api/src/ai/tools/items/index.ts
@@ -321,6 +321,7 @@ async function updateWithVersionRouting({
 }) {
 	const versionsService = new VersionsService({ schema, accountability });
 	const results: unknown[] = [];
+	const deferredReads: Array<{ index: number; key: PrimaryKey; versionKey: string }> = [];
 	const parentBatches = new Map<string, { collection: string; item: PrimaryKey; versionKey: string; payload: Item }>();
 	const identityFields = getSchemaPrimaryKeyFields(schema);
 
@@ -408,12 +409,25 @@ async function updateWithVersionRouting({
 			});
 		}
 
+		deferredReads.push({ index: results.length, key: update.key, versionKey: target.parent.versionKey });
 		results.push(null);
 	}
 
 	for (const batch of parentBatches.values()) {
 		const versionId = await ensureVersionId(versionsService, batch);
 		await versionsService.save(versionId, batch.payload);
+	}
+
+	for (const deferred of deferredReads) {
+		const readService = new ItemsService(args.collection, { schema, accountability });
+
+		const items = await readService.readMany([deferred.key], {
+			...sanitizedQuery,
+			version: deferred.versionKey,
+			versionRaw: false,
+		});
+
+		results[deferred.index] = items[0] ?? null;
 	}
 
 	return results;
@@ -475,7 +489,10 @@ function getVersionHint(args: ItemsArgs, key: PrimaryKey, context: ChatContext |
 
 	return {
 		explicitVersion: args.query?.version,
-		page: context?.page,
+		page:
+			context?.page?.collection === args.collection && String(context.page.item) !== String(key)
+				? undefined
+				: context?.page,
 		attachment: visualElement
 			? {
 					collection: visualElement.data.collection,
@@ -497,7 +514,14 @@ function hasDraftVersionHint(args: ItemsArgs, context: ChatContext | undefined, 
 	if (isDraftVersionKey(args.query?.version)) return true;
 
 	if (context?.page?.collection === args.collection && isDraftVersionKey(context.page.version)) {
-		return true;
+		const pkField = getPrimaryKeyField(schema, args.collection);
+		const pageItemStr = String(context.page.item);
+
+		const hasMatchingKey =
+			args.keys?.some((k) => String(k) === pageItemStr) ||
+			(Array.isArray(args.data) && args.data.some((d) => String(d[pkField]) === pageItemStr));
+
+		if (hasMatchingKey) return true;
 	}
 
 	if (
@@ -537,21 +561,7 @@ function getPrimaryKeyField(schema: SchemaOverview, collection: string) {
 }
 
 function mergePayloadForSingleSave(target: Item, source: Item, identityFields: string[]) {
-	for (const [field, incoming] of Object.entries(source)) {
-		const existing = target[field];
-
-		if (
-			isObject(existing) &&
-			isObject(incoming) &&
-			!isDetailedUpdatePayload(existing) &&
-			!isDetailedUpdatePayload(incoming)
-		) {
-			target[field] = { ...existing, ...incoming };
-			continue;
-		}
-
-		mergeNestedRelationDeltaInto(target, { [field]: incoming }, { identityFields });
-	}
+	mergeNestedRelationDeltaInto(target, source, { identityFields });
 }
 
 function isDetailedUpdatePayload(value: unknown) {

--- a/api/src/ai/tools/items/index.ts
+++ b/api/src/ai/tools/items/index.ts
@@ -10,6 +10,8 @@ import {
 	getSchemaPrimaryKeyFields,
 	isObject,
 	mergeNestedRelationDeltaInto,
+	type ParentRef,
+	type ParentRelation,
 	resolveWriteTarget,
 	toArray,
 	WRITE_TARGET_REFUSAL,
@@ -321,7 +323,7 @@ async function updateWithVersionRouting({
 }) {
 	const versionsService = new VersionsService({ schema, accountability });
 	const results: unknown[] = [];
-	const deferredReads: Array<{ index: number; key: PrimaryKey; versionKey: string }> = [];
+	const deferredReads: Array<{ index: number; key: PrimaryKey; parent: ParentRef; relation: ParentRelation }> = [];
 	const parentBatches = new Map<string, { collection: string; item: PrimaryKey; versionKey: string; payload: Item }>();
 	const identityFields = getSchemaPrimaryKeyFields(schema);
 
@@ -409,7 +411,13 @@ async function updateWithVersionRouting({
 			});
 		}
 
-		deferredReads.push({ index: results.length, key: update.key, versionKey: target.parent.versionKey });
+		deferredReads.push({
+			index: results.length,
+			key: update.key,
+			parent: target.parent,
+			relation: target.relation,
+		});
+
 		results.push(null);
 	}
 
@@ -418,16 +426,23 @@ async function updateWithVersionRouting({
 		await versionsService.save(versionId, batch.payload);
 	}
 
+	// Child rows don't get their own directus_versions entries when edits route through
+	// a parent — the row exists against the parent collection. Reading the child at the
+	// parent's version key would 403 in handleVersion. Read the parent at its version
+	// instead and pluck the child out of the draft-merged relation array; this also
+	// reflects draft edits accumulated across earlier turns, not just this call.
 	for (const deferred of deferredReads) {
-		const readService = new ItemsService(args.collection, { schema, accountability });
+		const parentService = new ItemsService(deferred.parent.collection, { schema, accountability });
 
-		const items = await readService.readMany([deferred.key], {
-			...sanitizedQuery,
-			version: deferred.versionKey,
+		const childFields = sanitizedQuery['fields']?.length ? sanitizedQuery['fields'] : ['*'];
+
+		const parentItem = await parentService.readOne(deferred.parent.key, {
+			fields: prefixChildFields(deferred.relation, childFields),
+			version: deferred.parent.versionKey,
 			versionRaw: false,
 		});
 
-		results[deferred.index] = items[0] ?? null;
+		results[deferred.index] = parentItem ? extractChildFromParent(deferred.relation, parentItem, deferred.key) : null;
 	}
 
 	return results;
@@ -558,6 +573,46 @@ function formatVersioningRefusal(token: string, message: string) {
 
 function getPrimaryKeyField(schema: SchemaOverview, collection: string) {
 	return schema.collections[collection]?.primary ?? 'id';
+}
+
+function prefixChildFields(relation: ParentRelation, childFields: string[]): string[] {
+	const path =
+		relation.kind === 'm2o' || relation.kind === 'o2m'
+			? relation.parentField
+			: `${relation.parentField}.${relation.junctionField}`;
+
+	return childFields.map((field) => `${path}.${field}`);
+}
+
+function extractChildFromParent(relation: ParentRelation, parentItem: Item, childKey: PrimaryKey): Item | null {
+	const root = (parentItem as Record<string, unknown>)[relation.parentField];
+
+	if (relation.kind === 'm2o') {
+		return isObject(root) ? (root as Item) : null;
+	}
+
+	if (!Array.isArray(root)) return null;
+
+	for (const entry of root) {
+		if (!isObject(entry)) continue;
+
+		if (relation.kind === 'o2m') {
+			if (String((entry as Record<string, unknown>)[relation.childPkField]) === String(childKey)) {
+				return entry as Item;
+			}
+
+			continue;
+		}
+
+		const child = (entry as Record<string, unknown>)[relation.junctionField];
+		if (!isObject(child)) continue;
+
+		if (String((child as Record<string, unknown>)[relation.childPkField]) === String(childKey)) {
+			return child as Item;
+		}
+	}
+
+	return null;
 }
 
 function mergePayloadForSingleSave(target: Item, source: Item, identityFields: string[]) {

--- a/api/src/ai/tools/items/index.ts
+++ b/api/src/ai/tools/items/index.ts
@@ -6,6 +6,7 @@ import { isSystemCollection } from '@directus/system-data';
 import type { Accountability, Item, PrimaryKey, SchemaOverview } from '@directus/types';
 import {
 	buildPayload,
+	findParentRelationCandidates,
 	getSchemaPrimaryKeyFields,
 	isObject,
 	mergeNestedRelationDeltaInto,
@@ -112,7 +113,7 @@ export const items = defineTool<z.infer<typeof ItemsValidateSchema>>({
 		const collectionHasVersioning = createCollectionVersioningResolver(schema, accountability);
 
 		if (args.action === 'create') {
-			if (hasDraftVersionHint(args.query?.version, context)) {
+			if (hasDraftVersionHint(args, context, schema)) {
 				throw new InvalidPayloadError({
 					reason: formatVersioningRefusal(
 						WRITE_TARGET_REFUSAL.VERSIONING_REQUIRED,
@@ -170,7 +171,7 @@ export const items = defineTool<z.infer<typeof ItemsValidateSchema>>({
 		if (args.action === 'update') {
 			const sanitizedQuery = await buildSanitizedQueryFromArgs(args, schema, accountability);
 			const collectionIsVersioned = await collectionHasVersioning(args.collection);
-			const needsVersionRouting = collectionIsVersioned || hasDraftVersionHint(args.query?.version, context);
+			const needsVersionRouting = collectionIsVersioned || hasDraftVersionHint(args, context, schema);
 
 			if (isSingleton) {
 				if (Array.isArray(args.data)) {
@@ -276,7 +277,7 @@ export const items = defineTool<z.infer<typeof ItemsValidateSchema>>({
 		}
 
 		if (args.action === 'delete') {
-			if (hasDraftVersionHint(args.query?.version, context)) {
+			if (hasDraftVersionHint(args, context, schema)) {
 				throw new InvalidPayloadError({
 					reason: formatVersioningRefusal(
 						WRITE_TARGET_REFUSAL.VERSIONING_REQUIRED,
@@ -492,13 +493,25 @@ function getVersionHint(args: ItemsArgs, key: PrimaryKey, context: ChatContext |
 	};
 }
 
-function hasDraftVersionHint(queryVersion: string | null | undefined, context: ChatContext | undefined) {
-	if (isDraftVersionKey(queryVersion)) return true;
-	if (isDraftVersionKey(context?.page?.version)) return true;
+function hasDraftVersionHint(args: ItemsArgs, context: ChatContext | undefined, schema: SchemaOverview) {
+	if (isDraftVersionKey(args.query?.version)) return true;
+
+	if (context?.page?.collection === args.collection && isDraftVersionKey(context.page.version)) {
+		return true;
+	}
+
+	if (
+		context?.page?.collection &&
+		isDraftVersionKey(context.page.version) &&
+		hasParentRelationPath(schema, context.page.collection, args.collection)
+	) {
+		return true;
+	}
 
 	return (
 		context?.attachments?.some((attachment) => {
 			if (attachment.type !== 'visual-element') return false;
+			if (attachment.data.collection !== args.collection) return false;
 			if (isDraftVersionKey(attachment.data.version)) return true;
 
 			return isDraftVersionKey(attachment.data.parent?.version);
@@ -508,6 +521,10 @@ function hasDraftVersionHint(queryVersion: string | null | undefined, context: C
 
 function isDraftVersionKey(versionKey: string | null | undefined) {
 	return Boolean(versionKey && !isPublishedVersionKey(versionKey));
+}
+
+function hasParentRelationPath(schema: SchemaOverview, parentCollection: string, targetCollection: string) {
+	return findParentRelationCandidates(schema, parentCollection, targetCollection).length > 0;
 }
 
 function formatVersioningRefusal(token: string, message: string) {

--- a/api/src/ai/tools/types.ts
+++ b/api/src/ai/tools/types.ts
@@ -1,6 +1,7 @@
 import type { Accountability, SchemaOverview } from '@directus/types';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import type { ZodType } from 'zod';
+import type { ChatContext } from '../chat/models/chat-request.js';
 
 export type ToolResultBase = {
 	type?: 'text' | 'image' | 'audio';
@@ -25,6 +26,7 @@ export type ToolHandler<T> = {
 		args: T;
 		schema: SchemaOverview;
 		accountability: Accountability | undefined;
+		context?: ChatContext;
 	}): Promise<ToolResult | undefined>;
 };
 

--- a/api/src/services/versions.test.ts
+++ b/api/src/services/versions.test.ts
@@ -61,6 +61,8 @@ const schema = new SchemaBuilder()
 	.collection('articles_track_none', (c) => {
 		c.field('id').id();
 		c.field('title').string();
+		c.field('config').json();
+		c.field('blocks').m2a(['block_hero']);
 	})
 	.options({ accountability: null })
 	.build();
@@ -210,6 +212,26 @@ describe('Integration Tests', () => {
 						}),
 					}),
 				);
+			});
+
+			test('should overwrite plain JSON fields instead of merging by identity', async () => {
+				vi.spyOn(ItemsService.prototype, 'readOne').mockResolvedValue({
+					collection: 'articles_track_none',
+					item: 1,
+					delta: {
+						config: { id: 'x', a: 1, b: 2 },
+					},
+				});
+
+				await service.save(1, {
+					config: { id: 'x', a: 1 },
+				});
+
+				const call = vi.mocked(ItemsService.prototype.updateOne).mock.calls[0]!;
+				const storedConfig = (call[1] as { delta: { config: Record<string, unknown> } }).delta.config;
+
+				expect(storedConfig).toMatchObject({ id: 'x', a: 1 });
+				expect(storedConfig).not.toHaveProperty('b');
 			});
 		});
 	});

--- a/api/src/services/versions.test.ts
+++ b/api/src/services/versions.test.ts
@@ -123,6 +123,39 @@ describe('Integration Tests', () => {
 					expect.objectContaining({ collection: 'articles_track_all', item: 2, version: 1, activity: 1 }),
 				);
 			});
+
+			test('should merge detailed nested relation deltas when saving repeatedly', async () => {
+				vi.spyOn(ItemsService.prototype, 'readOne').mockResolvedValue({
+					collection: 'articles_track_none',
+					item: 1,
+					delta: {
+						blocks: {
+							create: [],
+							update: [{ id: 1, title: 'First' }],
+							delete: [],
+						},
+					},
+				});
+
+				await service.save(1, {
+					blocks: {
+						create: [],
+						update: [{ id: 2, title: 'Second' }],
+						delete: [],
+					},
+				});
+
+				expect(ItemsService.prototype.updateOne).toHaveBeenCalledWith(
+					1,
+					expect.objectContaining({
+						delta: expect.objectContaining({
+							blocks: expect.objectContaining({
+								update: [expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 2 })],
+							}),
+						}),
+					}),
+				);
+			});
 		});
 	});
 });

--- a/api/src/services/versions.test.ts
+++ b/api/src/services/versions.test.ts
@@ -156,6 +156,61 @@ describe('Integration Tests', () => {
 					}),
 				);
 			});
+
+			test('should replace repeated detailed updates for the same nested relation row', async () => {
+				vi.spyOn(ItemsService.prototype, 'readOne').mockResolvedValue({
+					collection: 'articles_track_none',
+					item: 1,
+					delta: {
+						blocks: {
+							create: [],
+							update: [
+								{
+									id: 'junction-1',
+									collection: 'block_hero',
+									item: { id: 'block-1', headline: 'Old', tagline: 'Backend + CMS test' },
+								},
+							],
+							delete: [],
+						},
+					},
+				});
+
+				await service.save(1, {
+					blocks: {
+						create: [],
+						update: [
+							{
+								id: 'junction-1',
+								collection: 'block_hero',
+								item: { id: 'block-1', tagline: 'Backend + CMS carlos' },
+							},
+						],
+						delete: [],
+					},
+				});
+
+				expect(ItemsService.prototype.updateOne).toHaveBeenCalledWith(
+					1,
+					expect.objectContaining({
+						delta: expect.objectContaining({
+							blocks: expect.objectContaining({
+								update: [
+									expect.objectContaining({
+										id: 'junction-1',
+										collection: 'block_hero',
+										item: expect.objectContaining({
+											id: 'block-1',
+											headline: 'Old',
+											tagline: 'Backend + CMS carlos',
+										}),
+									}),
+								],
+							}),
+						}),
+					}),
+				);
+			});
 		});
 	});
 });

--- a/api/src/services/versions.ts
+++ b/api/src/services/versions.ts
@@ -14,7 +14,7 @@ import {
 	type Query,
 	type QueryOptions,
 } from '@directus/types';
-import { deepMapWithSchema, mergeNestedRelationDeltaInto } from '@directus/utils';
+import { deepMapWithSchema, getSchemaPrimaryKeyFields, mergeNestedRelationDeltaInto } from '@directus/utils';
 import Joi from 'joi';
 import { get, isEqual, isNil, isPlainObject, pick } from 'lodash-es';
 import objectHash from 'object-hash';
@@ -341,7 +341,9 @@ export class VersionsService extends ItemsService<ContentVersion> {
 			object['_date'] = date;
 		});
 
-		const finalVersionDelta = mergeNestedRelationDeltaInto({ ...(existingDelta ?? {}) }, revisionDelta ?? {});
+		const finalVersionDelta = mergeNestedRelationDeltaInto({ ...(existingDelta ?? {}) }, revisionDelta ?? {}, {
+			identityFields: getSchemaPrimaryKeyFields(this.schema),
+		});
 
 		const sudoService = new ItemsService(this.collection, {
 			knex: this.knex,

--- a/api/src/services/versions.ts
+++ b/api/src/services/versions.ts
@@ -14,9 +14,9 @@ import {
 	type Query,
 	type QueryOptions,
 } from '@directus/types';
-import { deepMapWithSchema } from '@directus/utils';
+import { deepMapWithSchema, mergeNestedRelationDeltaInto } from '@directus/utils';
 import Joi from 'joi';
-import { assign, get, isEqual, isNil, isPlainObject, pick } from 'lodash-es';
+import { get, isEqual, isNil, isPlainObject, pick } from 'lodash-es';
 import objectHash from 'object-hash';
 import { getCache } from '../cache.js';
 import { getHelpers } from '../database/helpers/index.js';
@@ -341,7 +341,7 @@ export class VersionsService extends ItemsService<ContentVersion> {
 			object['_date'] = date;
 		});
 
-		const finalVersionDelta = assign({}, existingDelta, revisionDelta);
+		const finalVersionDelta = mergeNestedRelationDeltaInto({ ...(existingDelta ?? {}) }, revisionDelta ?? {});
 
 		const sudoService = new ItemsService(this.collection, {
 			knex: this.knex,

--- a/api/src/services/versions.ts
+++ b/api/src/services/versions.ts
@@ -341,7 +341,23 @@ export class VersionsService extends ItemsService<ContentVersion> {
 			object['_date'] = date;
 		});
 
-		const finalVersionDelta = mergeNestedRelationDeltaInto({ ...(existingDelta ?? {}) }, revisionDelta ?? {}, {
+		// Only relation-ish fields go through identity-aware merging. Plain scalar/JSON
+		// fields must overwrite, otherwise removed keys in a JSON value with a PK-named
+		// root (`{ id: "x", ... }`) would silently persist across saves.
+		const relationFields = getRelationFieldNames(this.schema, collection);
+		const baseDelta: Item = { ...(existingDelta ?? {}) };
+		const incomingDelta = revisionDelta ?? {};
+		const relationOnlyDelta: Item = {};
+
+		for (const [field, value] of Object.entries(incomingDelta)) {
+			if (relationFields.has(field)) {
+				relationOnlyDelta[field] = value;
+			} else {
+				baseDelta[field] = value;
+			}
+		}
+
+		const finalVersionDelta = mergeNestedRelationDeltaInto(baseDelta, relationOnlyDelta, {
 			identityFields: getSchemaPrimaryKeyFields(this.schema),
 		});
 
@@ -500,6 +516,22 @@ export class VersionsService extends ItemsService<ContentVersion> {
 			{ mapNonExistentFields: true, detailedUpdateSyntax: true },
 		);
 	}
+}
+
+function getRelationFieldNames(schema: VersionsService['schema'], collection: string): Set<string> {
+	const names = new Set<string>();
+
+	for (const [name, field] of Object.entries(schema.collections[collection]?.fields ?? {})) {
+		// alias-typed fields are o2m/m2m/m2a/translations on the local side
+		if (field.type === 'alias') names.add(name);
+	}
+
+	for (const relation of schema.relations) {
+		// m2o/a2o: scalar field on this collection pointing at another
+		if (relation.collection === collection) names.add(relation.field);
+	}
+
+	return names;
 }
 
 /** Deeply maps all objects of a structure. Only calls the callback for objects, not for arrays. Objects in arrays will continued to be mapped. */

--- a/api/src/utils/ensure-version-id.test.ts
+++ b/api/src/utils/ensure-version-id.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test, vi } from 'vitest';
+import type { VersionsService } from '../services/versions.js';
+import { ensureVersionId } from './ensure-version-id.js';
+
+describe('ensureVersionId', () => {
+	test('returns the existing version id when one is found', async () => {
+		const versionsService = {
+			readByQuery: vi.fn().mockResolvedValue([{ id: 'existing-version' }]),
+			createOne: vi.fn(),
+		};
+
+		const id = await ensureVersionId(versionsService as unknown as VersionsService, {
+			collection: 'pages',
+			item: 1,
+			versionKey: 'draft',
+		});
+
+		expect(id).toBe('existing-version');
+		expect(versionsService.createOne).not.toHaveBeenCalled();
+	});
+
+	test('creates a new version when none exists', async () => {
+		const versionsService = {
+			readByQuery: vi.fn().mockResolvedValue([]),
+			createOne: vi.fn().mockResolvedValue('new-version'),
+		};
+
+		const id = await ensureVersionId(versionsService as unknown as VersionsService, {
+			collection: 'pages',
+			item: 1,
+			versionKey: 'draft',
+		});
+
+		expect(id).toBe('new-version');
+
+		expect(versionsService.createOne).toHaveBeenCalledWith({
+			key: 'draft',
+			collection: 'pages',
+			item: '1',
+		});
+	});
+});

--- a/api/src/utils/ensure-version-id.ts
+++ b/api/src/utils/ensure-version-id.ts
@@ -1,3 +1,7 @@
+// Keep this in sync with app/src/utils/ensure-version-id.ts.
+// Phase 1 bridge: AI/visual paths only have { collection, item, versionKey }, but
+// versionsService.save needs a version id. Phase 2 will accept version keys directly.
+
 import type { Item, PrimaryKey } from '@directus/types';
 import type { VersionsService } from '../services/versions.js';
 

--- a/api/src/utils/ensure-version-id.ts
+++ b/api/src/utils/ensure-version-id.ts
@@ -1,0 +1,27 @@
+import type { Item, PrimaryKey } from '@directus/types';
+import type { VersionsService } from '../services/versions.js';
+
+export async function ensureVersionId(
+	versionsService: Pick<VersionsService, 'readByQuery' | 'createOne'>,
+	ref: { collection: string; item: PrimaryKey; versionKey: string },
+): Promise<PrimaryKey> {
+	const existing = ((await versionsService.readByQuery({
+		filter: {
+			collection: { _eq: ref.collection },
+			item: { _eq: String(ref.item) },
+			key: { _eq: ref.versionKey },
+		},
+		limit: 1,
+		fields: ['id'],
+	})) ?? []) as Item[];
+
+	if (existing.length > 0 && existing[0]?.['id'] !== undefined) {
+		return existing[0]['id'] as PrimaryKey;
+	}
+
+	return versionsService.createOne({
+		key: ref.versionKey,
+		collection: ref.collection,
+		item: String(ref.item),
+	});
+}

--- a/api/src/utils/ensure-version-id.ts
+++ b/api/src/utils/ensure-version-id.ts
@@ -1,6 +1,5 @@
 // Keep this in sync with app/src/utils/ensure-version-id.ts.
-// Phase 1 bridge: AI/visual paths only have { collection, item, versionKey }, but
-// versionsService.save needs a version id. Phase 2 will accept version keys directly.
+// versionsService.save requires a resolved version id, not a key.
 
 import type { Item, PrimaryKey } from '@directus/types';
 import type { VersionsService } from '../services/versions.js';

--- a/app/src/ai/composables/use-context-staging.test.ts
+++ b/app/src/ai/composables/use-context-staging.test.ts
@@ -414,62 +414,30 @@ describe('useContextStaging', () => {
 			expect(result).toBe(true);
 		});
 
-		test('uses single field value as display when element has exactly one field', async () => {
-			const aiStore = useAiStore();
+		test('labels single-field element with collection and field', async () => {
 			const contextStore = useAiContextStore();
 			const addSpy = vi.spyOn(contextStore, 'addPendingContext').mockReturnValue(true);
-			vi.spyOn(aiStore, 'focusInput').mockImplementation(() => {});
-			vi.mocked(sdk.request).mockResolvedValue({ headline: 'Breaking News' });
-
-			const sdkSpy = vi.spyOn(sdk, 'request');
+			vi.spyOn(useAiStore(), 'focusInput').mockImplementation(() => {});
 
 			const { stageVisualElement } = useContextStaging();
 
 			await stageVisualElement({ collection: 'posts', item: '1', key: 'key-1', fields: ['headline'] });
 
-			const call = addSpy.mock.calls[0]![0];
-			expect(call.display).toBe('Breaking News');
-			expect(sdkSpy.mock.calls[0]?.[0]()).toEqual({ path: '/items/posts/1', params: { fields: ['headline'] } });
+			expect(addSpy.mock.calls[0]![0].display).toBe('Posts · Headline');
+			expect(sdk.request).not.toHaveBeenCalled();
 		});
 
-		test('uses formatted collection name when no display_template', async () => {
-			const aiStore = useAiStore();
+		test('labels multi-field element with collection only', async () => {
 			const contextStore = useAiContextStore();
 			const addSpy = vi.spyOn(contextStore, 'addPendingContext').mockReturnValue(true);
-			vi.spyOn(aiStore, 'focusInput').mockImplementation(() => {});
-
-			const { useCollectionsStore } = await import('@/stores/collections');
-
-			vi.mocked(useCollectionsStore).mockReturnValueOnce({
-				getCollection: vi.fn((collection) => ({
-					collection,
-					meta: { display_template: null },
-				})),
-			} as any);
+			vi.spyOn(useAiStore(), 'focusInput').mockImplementation(() => {});
 
 			const { stageVisualElement } = useContextStaging();
 
 			await stageVisualElement({ collection: 'blog_posts', item: '1', key: 'key-1' });
 
-			const call = addSpy.mock.calls[0]![0];
-			expect(call.display).toBe('Blog Posts');
+			expect(addSpy.mock.calls[0]![0].display).toBe('Blog Posts');
 			expect(sdk.request).not.toHaveBeenCalled();
-		});
-
-		test('uses fallback display value when fetch fails', async () => {
-			const aiStore = useAiStore();
-			const contextStore = useAiContextStore();
-			const addSpy = vi.spyOn(contextStore, 'addPendingContext').mockReturnValue(true);
-			vi.spyOn(aiStore, 'focusInput').mockImplementation(() => {});
-
-			vi.mocked(sdk.request).mockRejectedValue(new Error('API Error'));
-
-			const { stageVisualElement } = useContextStaging();
-
-			await stageVisualElement({ collection: 'posts', item: '42', key: 'key-1' });
-
-			const call = addSpy.mock.calls[0]![0];
-			expect(call.display).toBe('Posts');
 		});
 	});
 });

--- a/app/src/ai/composables/use-context-staging.ts
+++ b/app/src/ai/composables/use-context-staging.ts
@@ -144,14 +144,12 @@ export function useContextStaging() {
 			return true;
 		}
 
-		const collectionInfo = collectionsStore.getCollection(element.collection);
-
-		if (!collectionInfo) {
+		if (!collectionsStore.getCollection(element.collection)) {
 			notify({ title: t('ai.invalid_collection') });
 			return false;
 		}
 
-		const display = await fetchDisplayValue(element, collectionInfo);
+		const display = buildVisualElementLabel(element);
 
 		const existingContext = contextStore.pendingContext.find(
 			(item) => item.type === 'visual-element' && isSameVisualElement(item.data, element),
@@ -181,48 +179,10 @@ export function useContextStaging() {
 		return true;
 	}
 
-	async function fetchDisplayValue(
-		element: VisualElementContextData,
-		collectionInfo: ReturnType<typeof collectionsStore.getCollection>,
-	): Promise<string> {
-		const fallback = formatTitle(element.collection);
-
-		if (!element.item || element.item === '+') return fallback;
-
-		try {
-			if (element.fields?.length === 1) {
-				const field = element.fields[0]!;
-
-				const item = await sdk.request<Item>(
-					requestEndpoint(`${getEndpoint(element.collection)}/${encodeURIComponent(element.item)}`, {
-						params: { fields: [field] },
-					}),
-				);
-
-				if (item?.[field]) return String(item[field]);
-				return fallback;
-			}
-
-			if (!collectionInfo?.meta?.display_template) {
-				return formatTitle(element.collection);
-			}
-
-			const primaryKey = fieldsStore.getPrimaryKeyFieldForCollection(element.collection)?.field ?? 'id';
-			const displayTemplate = collectionInfo.meta.display_template;
-			const displayFields = getFieldsFromTemplate(displayTemplate);
-
-			const item = await sdk.request<Item>(
-				requestEndpoint(`${getEndpoint(element.collection)}/${encodeURIComponent(element.item)}`, {
-					params: { fields: [primaryKey, ...displayFields] },
-				}),
-			);
-
-			if (!item) return fallback;
-
-			return renderDisplayStringTemplate(element.collection, displayTemplate, item) || fallback;
-		} catch {
-			return fallback;
-		}
+	function buildVisualElementLabel(element: VisualElementContextData): string {
+		const collection = formatTitle(element.collection);
+		if (element.fields?.length === 1) return `${collection} · ${formatTitle(element.fields[0]!)}`;
+		return collection;
 	}
 
 	async function stageFiles(ids: string[]) {

--- a/app/src/ai/stores/use-ai-context.test.ts
+++ b/app/src/ai/stores/use-ai-context.test.ts
@@ -1,5 +1,5 @@
-import { createTestingPinia } from '@pinia/testing';
 import type { Relation } from '@directus/types';
+import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { PendingContextItem } from '../types';
@@ -288,8 +288,42 @@ describe('useAiContextStore', () => {
 			expect(attachments[0]!.snapshot).toEqual({ title: 'Fetched Title' });
 		});
 
+		test('does not pass a stale visual element version when target resolves to published', async () => {
+			const store = useAiContextStore();
+			setupSchema([collection('pages', true), collection('blocks', false)], []);
+			vi.mocked(sdk.request).mockResolvedValue({ title: 'Published Title' });
+
+			store.addPendingContext({
+				id: 'block',
+				type: 'visual-element',
+				data: {
+					collection: 'blocks',
+					item: 1,
+					key: 'block',
+					fields: ['title'],
+					version: 'draft',
+					parent: {
+						collection: 'pages',
+						item: 1,
+						version: 'published',
+					},
+				},
+				display: 'Block',
+			});
+
+			const attachments = await store.fetchContextData();
+
+			expect(attachments[0]!.snapshot).toEqual({ title: 'Published Title' });
+
+			expect(vi.mocked(sdk.request).mock.calls[0]?.[0]()).toEqual({
+				path: '/items/blocks/1',
+				params: { fields: ['title'] },
+			});
+		});
+
 		test('fetches O2M visual elements through the parent version', async () => {
 			const store = useAiContextStore();
+
 			setupSchema(
 				[collection('articles', true), collection('article_translations', false)],
 				[relation('article_translations', 'article_id', 'articles', { oneField: 'translations' })],
@@ -310,6 +344,7 @@ describe('useAiContextStore', () => {
 			const attachments = await store.fetchContextData();
 
 			expect(attachments[0]!.snapshot).toEqual({ id: 5, title: 'Draft title' });
+
 			expect(vi.mocked(sdk.request).mock.calls[1]?.[0]()).toEqual({
 				path: '/items/articles/1',
 				params: { fields: ['translations.id', 'translations.title'], version: 'draft' },
@@ -318,6 +353,7 @@ describe('useAiContextStore', () => {
 
 		test('fetches M2M visual elements through the parent version', async () => {
 			const store = useAiContextStore();
+
 			setupSchema(
 				[collection('articles', true), collection('articles_tags', false), collection('tags', false)],
 				[
@@ -341,6 +377,7 @@ describe('useAiContextStore', () => {
 			const attachments = await store.fetchContextData();
 
 			expect(attachments[0]!.snapshot).toEqual({ id: 5, title: 'Draft tag' });
+
 			expect(vi.mocked(sdk.request).mock.calls[1]?.[0]()).toEqual({
 				path: '/items/articles/1',
 				params: { fields: ['tags.id', 'tags.tags_id.id', 'tags.tags_id.title'], version: 'draft' },
@@ -349,6 +386,7 @@ describe('useAiContextStore', () => {
 
 		test('fetches M2A visual elements through the parent version', async () => {
 			const store = useAiContextStore();
+
 			setupSchema(
 				[collection('pages', true), collection('pages_blocks', false), collection('block_hero', false)],
 				[
@@ -377,6 +415,7 @@ describe('useAiContextStore', () => {
 			const attachments = await store.fetchContextData();
 
 			expect(attachments[0]!.snapshot).toEqual({ id: 9, title: 'Draft block' });
+
 			expect(vi.mocked(sdk.request).mock.calls[1]?.[0]()).toEqual({
 				path: '/items/pages/1',
 				params: {
@@ -405,6 +444,7 @@ describe('useAiContextStore', () => {
 			const attachments = await store.fetchContextData();
 
 			expect(attachments[0]!.snapshot).toEqual({ id: 4, title: 'Draft SEO' });
+
 			expect(vi.mocked(sdk.request).mock.calls[1]?.[0]()).toEqual({
 				path: '/items/pages/1',
 				params: { fields: ['seo.id', 'seo.title'], version: 'draft' },

--- a/app/src/ai/stores/use-ai-context.test.ts
+++ b/app/src/ai/stores/use-ai-context.test.ts
@@ -1,10 +1,13 @@
 import { createTestingPinia } from '@pinia/testing';
+import type { Relation } from '@directus/types';
 import { setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { PendingContextItem } from '../types';
 import { MAX_PENDING_CONTEXT, useAiContextStore } from './use-ai-context';
 import api from '@/api';
 import sdk from '@/sdk';
+import { useCollectionsStore } from '@/stores/collections';
+import { useRelationsStore } from '@/stores/relations';
 import { unexpectedError } from '@/utils/unexpected-error';
 
 vi.mock('@/api', () => ({
@@ -46,6 +49,30 @@ const createVisualElement = (key: string): PendingContextItem => ({
 	display: `Post ${key}`,
 });
 
+function createParentedVisualElement(options: {
+	collection: string;
+	item: string | number;
+	parentCollection: string;
+}): PendingContextItem {
+	return {
+		id: `${options.collection}-${options.item}`,
+		type: 'visual-element',
+		data: {
+			collection: options.collection,
+			item: options.item,
+			key: `${options.collection}-${options.item}`,
+			fields: ['title'],
+			version: 'draft',
+			parent: {
+				collection: options.parentCollection,
+				item: 1,
+				version: 'draft',
+			},
+		},
+		display: `${options.collection} ${options.item}`,
+	};
+}
+
 const createItemContext = (id: string, itemId: string = '1'): PendingContextItem => ({
 	id,
 	type: 'item',
@@ -66,6 +93,52 @@ const createPromptContext = (id: string): PendingContextItem => ({
 	},
 	display: `Prompt ${id}`,
 });
+
+function setupSchema(collections: ReturnType<typeof collection>[], relations: Relation[]) {
+	useCollectionsStore().collections = collections;
+	useRelationsStore().relations = relations;
+}
+
+function collection(collection: string, versioning: boolean) {
+	return {
+		collection,
+		name: collection,
+		type: 'table',
+		meta: { versioning },
+		schema: {},
+	} as any;
+}
+
+function relation(
+	collection: string,
+	field: string,
+	relatedCollection: string | null,
+	options: {
+		oneField?: string | null;
+		junctionField?: string | null;
+		oneCollectionField?: string | null;
+		oneAllowedCollections?: string[] | null;
+	} = {},
+): Relation {
+	return {
+		collection,
+		field,
+		related_collection: relatedCollection,
+		schema: null,
+		meta: {
+			id: 1,
+			many_collection: collection,
+			many_field: field,
+			one_collection: relatedCollection,
+			one_field: options.oneField ?? null,
+			one_collection_field: options.oneCollectionField ?? null,
+			one_allowed_collections: options.oneAllowedCollections ?? null,
+			one_deselect_action: 'nullify',
+			junction_field: options.junctionField ?? null,
+			sort_field: null,
+		},
+	};
+}
 
 describe('useAiContextStore', () => {
 	afterEach(() => {
@@ -213,6 +286,129 @@ describe('useAiContextStore', () => {
 			expect(attachments).toHaveLength(1);
 			expect(attachments[0]!.type).toBe('visual-element');
 			expect(attachments[0]!.snapshot).toEqual({ title: 'Fetched Title' });
+		});
+
+		test('fetches O2M visual elements through the parent version', async () => {
+			const store = useAiContextStore();
+			setupSchema(
+				[collection('articles', true), collection('article_translations', false)],
+				[relation('article_translations', 'article_id', 'articles', { oneField: 'translations' })],
+			);
+
+			vi.mocked(sdk.request)
+				.mockResolvedValueOnce({ translations: [{ id: 5 }] })
+				.mockResolvedValueOnce({ translations: [{ id: 5, title: 'Draft title' }] });
+
+			store.addPendingContext(
+				createParentedVisualElement({
+					collection: 'article_translations',
+					item: 5,
+					parentCollection: 'articles',
+				}),
+			);
+
+			const attachments = await store.fetchContextData();
+
+			expect(attachments[0]!.snapshot).toEqual({ id: 5, title: 'Draft title' });
+			expect(vi.mocked(sdk.request).mock.calls[1]?.[0]()).toEqual({
+				path: '/items/articles/1',
+				params: { fields: ['translations.id', 'translations.title'], version: 'draft' },
+			});
+		});
+
+		test('fetches M2M visual elements through the parent version', async () => {
+			const store = useAiContextStore();
+			setupSchema(
+				[collection('articles', true), collection('articles_tags', false), collection('tags', false)],
+				[
+					relation('articles_tags', 'articles_id', 'articles', { oneField: 'tags', junctionField: 'tags_id' }),
+					relation('articles_tags', 'tags_id', 'tags'),
+				],
+			);
+
+			vi.mocked(sdk.request)
+				.mockResolvedValueOnce({ tags: [{ id: 12, tags_id: { id: 5 } }] })
+				.mockResolvedValueOnce({ tags: [{ id: 12, tags_id: { id: 5, title: 'Draft tag' } }] });
+
+			store.addPendingContext(
+				createParentedVisualElement({
+					collection: 'tags',
+					item: 5,
+					parentCollection: 'articles',
+				}),
+			);
+
+			const attachments = await store.fetchContextData();
+
+			expect(attachments[0]!.snapshot).toEqual({ id: 5, title: 'Draft tag' });
+			expect(vi.mocked(sdk.request).mock.calls[1]?.[0]()).toEqual({
+				path: '/items/articles/1',
+				params: { fields: ['tags.id', 'tags.tags_id.id', 'tags.tags_id.title'], version: 'draft' },
+			});
+		});
+
+		test('fetches M2A visual elements through the parent version', async () => {
+			const store = useAiContextStore();
+			setupSchema(
+				[collection('pages', true), collection('pages_blocks', false), collection('block_hero', false)],
+				[
+					relation('pages_blocks', 'pages_id', 'pages', { oneField: 'blocks', junctionField: 'item' }),
+					relation('pages_blocks', 'item', null, {
+						oneCollectionField: 'collection',
+						oneAllowedCollections: ['block_hero'],
+					}),
+				],
+			);
+
+			const parent = {
+				blocks: [{ id: 7, collection: 'block_hero', item: { id: 9, title: 'Draft block' } }],
+			};
+
+			vi.mocked(sdk.request).mockResolvedValueOnce(parent).mockResolvedValueOnce(parent);
+
+			store.addPendingContext(
+				createParentedVisualElement({
+					collection: 'block_hero',
+					item: 9,
+					parentCollection: 'pages',
+				}),
+			);
+
+			const attachments = await store.fetchContextData();
+
+			expect(attachments[0]!.snapshot).toEqual({ id: 9, title: 'Draft block' });
+			expect(vi.mocked(sdk.request).mock.calls[1]?.[0]()).toEqual({
+				path: '/items/pages/1',
+				params: {
+					fields: ['blocks.id', 'blocks.item.id', 'blocks.item.title', 'blocks.collection'],
+					version: 'draft',
+				},
+			});
+		});
+
+		test('fetches M2O visual elements through the parent version', async () => {
+			const store = useAiContextStore();
+			setupSchema([collection('pages', true), collection('seo', false)], [relation('pages', 'seo', 'seo')]);
+
+			vi.mocked(sdk.request)
+				.mockResolvedValueOnce({ seo: { id: 4 } })
+				.mockResolvedValueOnce({ seo: { id: 4, title: 'Draft SEO' } });
+
+			store.addPendingContext(
+				createParentedVisualElement({
+					collection: 'seo',
+					item: 4,
+					parentCollection: 'pages',
+				}),
+			);
+
+			const attachments = await store.fetchContextData();
+
+			expect(attachments[0]!.snapshot).toEqual({ id: 4, title: 'Draft SEO' });
+			expect(vi.mocked(sdk.request).mock.calls[1]?.[0]()).toEqual({
+				path: '/items/pages/1',
+				params: { fields: ['seo.id', 'seo.title'], version: 'draft' },
+			});
 		});
 
 		test('uses wildcard fields when none specified', async () => {

--- a/app/src/ai/stores/use-ai-context.test.ts
+++ b/app/src/ai/stores/use-ai-context.test.ts
@@ -505,6 +505,55 @@ describe('useAiContextStore', () => {
 			expect(attachments[0]!.snapshot).toEqual({ id: 9, title: 'Draft block' });
 		});
 
+		test('deduplicates concurrent parent version creation for visual elements from the same draft', async () => {
+			const store = useAiContextStore();
+
+			setupSchema(
+				[collection('pages', true), collection('pages_blocks', false), collection('block_hero', false)],
+				[
+					relation('pages_blocks', 'pages_id', 'pages', { oneField: 'blocks', junctionField: 'item' }),
+					relation('pages_blocks', 'item', null, {
+						oneCollectionField: 'collection',
+						oneAllowedCollections: ['block_hero'],
+					}),
+				],
+			);
+
+			vi.mocked(sdk.request).mockResolvedValue({
+				blocks: [
+					{ id: 7, collection: 'block_hero', item: { id: 9, title: 'First block' } },
+					{ id: 8, collection: 'block_hero', item: { id: 10, title: 'Second block' } },
+				],
+			});
+
+			store.addPendingContext(
+				createParentedVisualElement({
+					collection: 'block_hero',
+					item: 9,
+					parentCollection: 'pages',
+				}),
+			);
+
+			store.addPendingContext(
+				createParentedVisualElement({
+					collection: 'block_hero',
+					item: 10,
+					parentCollection: 'pages',
+				}),
+			);
+
+			const attachments = await store.fetchContextData();
+
+			expect(attachments).toHaveLength(2);
+
+			expect(ensureVersionId).toHaveBeenCalledOnce();
+			expect(ensureVersionId).toHaveBeenCalledWith(api, {
+				collection: 'pages',
+				item: 1,
+				versionKey: 'draft',
+			});
+		});
+
 		test('fetches M2O visual elements through the parent version', async () => {
 			const store = useAiContextStore();
 			setupSchema([collection('pages', true), collection('seo', false)], [relation('pages', 'seo', 'seo')]);

--- a/app/src/ai/stores/use-ai-context.test.ts
+++ b/app/src/ai/stores/use-ai-context.test.ts
@@ -8,6 +8,7 @@ import api from '@/api';
 import sdk from '@/sdk';
 import { useCollectionsStore } from '@/stores/collections';
 import { useRelationsStore } from '@/stores/relations';
+import { ensureVersionId } from '@/utils/ensure-version-id';
 import { unexpectedError } from '@/utils/unexpected-error';
 
 vi.mock('@/api', () => ({
@@ -24,6 +25,10 @@ vi.mock('@/sdk', async () => {
 
 vi.mock('@/utils/unexpected-error', () => ({
 	unexpectedError: vi.fn(),
+}));
+
+vi.mock('@/utils/ensure-version-id', () => ({
+	ensureVersionId: vi.fn().mockResolvedValue('version-id'),
 }));
 
 beforeEach(() => {
@@ -288,6 +293,41 @@ describe('useAiContextStore', () => {
 			expect(attachments[0]!.snapshot).toEqual({ title: 'Fetched Title' });
 		});
 
+		test('ensures direct item versions before fetching versioned visual elements', async () => {
+			const store = useAiContextStore();
+			setupSchema([collection('posts', true)], []);
+			vi.mocked(sdk.request).mockResolvedValue({ title: 'Draft Title' });
+
+			store.addPendingContext({
+				id: 'post',
+				type: 'visual-element',
+				data: {
+					collection: 'posts',
+					item: 1,
+					key: 'post',
+					fields: ['title'],
+					version: 'draft',
+				},
+				display: 'Post',
+			});
+
+			const attachments = await store.fetchContextData();
+
+			expect(ensureVersionId).toHaveBeenCalledWith(api, {
+				collection: 'posts',
+				item: 1,
+				versionKey: 'draft',
+			});
+
+			expect(vi.mocked(sdk.request).mock.calls[0]?.[0]()).toEqual({
+				path: '/items/posts/1',
+				params: { fields: ['title'], version: 'draft' },
+			});
+
+			expect(attachments).toHaveLength(1);
+			expect(attachments[0]!.snapshot).toEqual({ title: 'Draft Title' });
+		});
+
 		test('does not pass a stale visual element version when target resolves to published', async () => {
 			const store = useAiContextStore();
 			setupSchema([collection('pages', true), collection('blocks', false)], []);
@@ -423,6 +463,46 @@ describe('useAiContextStore', () => {
 					version: 'draft',
 				},
 			});
+		});
+
+		test('ensures parent versions before resolving parented visual elements', async () => {
+			const store = useAiContextStore();
+
+			setupSchema(
+				[collection('pages', true), collection('pages_blocks', false), collection('block_hero', false)],
+				[
+					relation('pages_blocks', 'pages_id', 'pages', { oneField: 'blocks', junctionField: 'item' }),
+					relation('pages_blocks', 'item', null, {
+						oneCollectionField: 'collection',
+						oneAllowedCollections: ['block_hero'],
+					}),
+				],
+			);
+
+			const parent = {
+				blocks: [{ id: 7, collection: 'block_hero', item: { id: 9, title: 'Draft block' } }],
+			};
+
+			vi.mocked(sdk.request).mockResolvedValueOnce(parent).mockResolvedValueOnce(parent);
+
+			store.addPendingContext(
+				createParentedVisualElement({
+					collection: 'block_hero',
+					item: 9,
+					parentCollection: 'pages',
+				}),
+			);
+
+			const attachments = await store.fetchContextData();
+
+			expect(ensureVersionId).toHaveBeenCalledWith(api, {
+				collection: 'pages',
+				item: 1,
+				versionKey: 'draft',
+			});
+
+			expect(attachments).toHaveLength(1);
+			expect(attachments[0]!.snapshot).toEqual({ id: 9, title: 'Draft block' });
 		});
 
 		test('fetches M2O visual elements through the parent version', async () => {

--- a/app/src/ai/stores/use-ai-context.ts
+++ b/app/src/ai/stores/use-ai-context.ts
@@ -1,6 +1,6 @@
 import type { ContextAttachment, PrimaryKey, ProviderFileRef, VisualElementContextData } from '@directus/ai';
 import type { Item } from '@directus/types';
-import { getEndpoint, resolveWriteTarget, type ParentRelation } from '@directus/utils';
+import { getEndpoint, type ParentRelation, resolveWriteTarget } from '@directus/utils';
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 import {
@@ -18,6 +18,7 @@ import sdk, { requestEndpoint } from '@/sdk';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
+import { extractErrorCode } from '@/utils/extract-error-code';
 import { getSchemaOverview } from '@/utils/get-schema-overview';
 import { notify } from '@/utils/notify';
 import { unexpectedError } from '@/utils/unexpected-error';
@@ -101,6 +102,11 @@ export const useAiContextStore = defineStore('ai-context-store', () => {
 				}),
 			);
 		} catch (error) {
+			// `GET /items/:c/:k?version=X` returns 403 when no directus_versions row exists for
+			// that key — normal state for first-edit drafts. Surface no toast; caller treats as
+			// "no draft context yet". Phase 2 will replace this with a published fallback.
+			if (version && extractErrorCode(error) === 'FORBIDDEN') return null;
+
 			unexpectedError(error);
 			return null;
 		}
@@ -139,7 +145,7 @@ export const useAiContextStore = defineStore('ai-context-store', () => {
 		if (target.kind === 'refuse') return null;
 
 		if (target.kind !== 'parent-version') {
-			const versionKey = target.kind === 'item-version' ? target.versionKey : data.version;
+			const versionKey = target.kind === 'item-version' ? target.versionKey : undefined;
 			return fetchItem(data.collection, data.item, fields, versionKey);
 		}
 

--- a/app/src/ai/stores/use-ai-context.ts
+++ b/app/src/ai/stores/use-ai-context.ts
@@ -26,6 +26,8 @@ import { unexpectedError } from '@/utils/unexpected-error';
 
 export const MAX_PENDING_CONTEXT = 10;
 
+type EnsureVersion = (ref: { collection: string; item: PrimaryKey; versionKey: string }) => Promise<PrimaryKey>;
+
 // Same page, different draft state — not a navigation.
 function stripVersionParam(url: string) {
 	try {
@@ -126,10 +128,14 @@ export const useAiContextStore = defineStore('ai-context-store', () => {
 		}
 	};
 
-	const fetchVisualElementSnapshot = async (data: VisualElementContextData, fields: string[]) => {
+	const fetchVisualElementSnapshot = async (
+		data: VisualElementContextData,
+		fields: string[],
+		ensureVersion: EnsureVersion,
+	) => {
 		if (!data.parent) {
 			if (data.version && collectionsStore.getCollection(data.collection)?.meta?.versioning) {
-				await ensureVersionId(api, {
+				await ensureVersion({
 					collection: data.collection,
 					item: data.item,
 					versionKey: data.version,
@@ -160,7 +166,7 @@ export const useAiContextStore = defineStore('ai-context-store', () => {
 			},
 			collectionHasVersioning: (collection) => Boolean(collectionsStore.getCollection(collection)?.meta?.versioning),
 			readParent: async (parent, readFields) => {
-				await ensureVersionId(api, {
+				await ensureVersion({
 					collection: parent.collection,
 					item: parent.key,
 					versionKey: parent.versionKey,
@@ -190,11 +196,12 @@ export const useAiContextStore = defineStore('ai-context-store', () => {
 
 	const fetchContextData = async (): Promise<ContextAttachment[]> => {
 		const nonFileItems = pendingContext.value.filter((item) => !isFileContext(item) && !isLocalFileContext(item));
+		const ensureVersion = createEnsureVersionOnce();
 
 		const fetches = nonFileItems.map(async (item): Promise<ContextAttachment | null> => {
 			if (isVisualElement(item)) {
 				const fields = item.data.fields?.length ? item.data.fields : ['*'];
-				const snapshot = await fetchVisualElementSnapshot(item.data, fields);
+				const snapshot = await fetchVisualElementSnapshot(item.data, fields, ensureVersion);
 				if (!snapshot) return null;
 				return { type: 'visual-element', data: item.data, display: item.display, snapshot };
 			}
@@ -315,6 +322,25 @@ export const useAiContextStore = defineStore('ai-context-store', () => {
 		dehydrate,
 	};
 });
+
+function createEnsureVersionOnce(): EnsureVersion {
+	const pending = new Map<string, Promise<PrimaryKey>>();
+
+	return (ref) => {
+		const key = `${ref.collection}:${String(ref.item)}:${ref.versionKey}`;
+		const existing = pending.get(key);
+		if (existing) return existing;
+
+		const promise = ensureVersionId(api, ref).catch((error) => {
+			pending.delete(key);
+			throw error;
+		});
+
+		pending.set(key, promise);
+
+		return promise;
+	};
+}
 
 function getParentSnapshotFields(relation: ParentRelation, fields: string[]) {
 	const childFields = fields.includes('*') ? ['*'] : Array.from(new Set([relation.childPkField, ...fields]));

--- a/app/src/ai/stores/use-ai-context.ts
+++ b/app/src/ai/stores/use-ai-context.ts
@@ -18,12 +18,24 @@ import sdk, { requestEndpoint } from '@/sdk';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
+import { ensureVersionId } from '@/utils/ensure-version-id';
 import { extractErrorCode } from '@/utils/extract-error-code';
 import { getSchemaOverview } from '@/utils/get-schema-overview';
 import { notify } from '@/utils/notify';
 import { unexpectedError } from '@/utils/unexpected-error';
 
 export const MAX_PENDING_CONTEXT = 10;
+
+// Same page, different draft state — not a navigation.
+function stripVersionParam(url: string) {
+	try {
+		const u = new URL(url, window.location.origin);
+		u.searchParams.delete('version');
+		return u.toString();
+	} catch {
+		return url;
+	}
+}
 
 export const useAiContextStore = defineStore('ai-context-store', () => {
 	const collectionsStore = useCollectionsStore();
@@ -87,9 +99,11 @@ export const useAiContextStore = defineStore('ai-context-store', () => {
 	 * to the previous page.
 	 */
 	const syncVisualElementContextUrl = (url: string) => {
-		if (visualElementContextUrl.value !== null && visualElementContextUrl.value !== url) {
-			clearVisualElementContext();
-		}
+		const changed =
+			visualElementContextUrl.value !== null &&
+			stripVersionParam(visualElementContextUrl.value) !== stripVersionParam(url);
+
+		if (changed) clearVisualElementContext();
 
 		visualElementContextUrl.value = url;
 	};
@@ -114,6 +128,14 @@ export const useAiContextStore = defineStore('ai-context-store', () => {
 
 	const fetchVisualElementSnapshot = async (data: VisualElementContextData, fields: string[]) => {
 		if (!data.parent) {
+			if (data.version && collectionsStore.getCollection(data.collection)?.meta?.versioning) {
+				await ensureVersionId(api, {
+					collection: data.collection,
+					item: data.item,
+					versionKey: data.version,
+				});
+			}
+
 			return fetchItem(data.collection, data.item, fields, data.version);
 		}
 
@@ -138,6 +160,12 @@ export const useAiContextStore = defineStore('ai-context-store', () => {
 			},
 			collectionHasVersioning: (collection) => Boolean(collectionsStore.getCollection(collection)?.meta?.versioning),
 			readParent: async (parent, readFields) => {
+				await ensureVersionId(api, {
+					collection: parent.collection,
+					item: parent.key,
+					versionKey: parent.versionKey,
+				});
+
 				return fetchItem(parent.collection, parent.key, readFields, parent.versionKey);
 			},
 		});

--- a/app/src/ai/stores/use-ai-context.ts
+++ b/app/src/ai/stores/use-ai-context.ts
@@ -85,11 +85,11 @@ export const useAiContextStore = defineStore('ai-context-store', () => {
 		visualElementContextUrl.value = url;
 	};
 
-	const fetchItem = async (collection: string, id: PrimaryKey, fields: string[] = ['*']) => {
+	const fetchItem = async (collection: string, id: PrimaryKey, fields: string[] = ['*'], version?: string) => {
 		try {
 			return await sdk.request<Item>(
 				requestEndpoint(`${getEndpoint(collection)}/${id}`, {
-					params: { fields },
+					params: { fields, ...(version ? { version } : {}) },
 				}),
 			);
 		} catch (error) {
@@ -104,7 +104,7 @@ export const useAiContextStore = defineStore('ai-context-store', () => {
 		const fetches = nonFileItems.map(async (item): Promise<ContextAttachment | null> => {
 			if (isVisualElement(item)) {
 				const fields = item.data.fields?.length ? item.data.fields : ['*'];
-				const snapshot = await fetchItem(item.data.collection, item.data.item, fields);
+				const snapshot = await fetchItem(item.data.collection, item.data.item, fields, item.data.version);
 				if (!snapshot) return null;
 				return { type: 'visual-element', data: item.data, display: item.display, snapshot };
 			}

--- a/app/src/ai/stores/use-ai-context.ts
+++ b/app/src/ai/stores/use-ai-context.ts
@@ -1,6 +1,6 @@
 import type { ContextAttachment, PrimaryKey, ProviderFileRef, VisualElementContextData } from '@directus/ai';
 import type { Item } from '@directus/types';
-import { getEndpoint } from '@directus/utils';
+import { getEndpoint, resolveWriteTarget, type ParentRelation } from '@directus/utils';
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 import {
@@ -15,12 +15,20 @@ import {
 import api from '@/api';
 import { i18n } from '@/lang';
 import sdk, { requestEndpoint } from '@/sdk';
+import { useCollectionsStore } from '@/stores/collections';
+import { useFieldsStore } from '@/stores/fields';
+import { useRelationsStore } from '@/stores/relations';
+import { getSchemaOverview } from '@/utils/get-schema-overview';
 import { notify } from '@/utils/notify';
 import { unexpectedError } from '@/utils/unexpected-error';
 
 export const MAX_PENDING_CONTEXT = 10;
 
 export const useAiContextStore = defineStore('ai-context-store', () => {
+	const collectionsStore = useCollectionsStore();
+	const fieldsStore = useFieldsStore();
+	const relationsStore = useRelationsStore();
+
 	const pendingContext = ref<PendingContextItem[]>([]);
 
 	const visualElementContextUrl = ref<string | null>(null);
@@ -98,13 +106,61 @@ export const useAiContextStore = defineStore('ai-context-store', () => {
 		}
 	};
 
+	const fetchVisualElementSnapshot = async (data: VisualElementContextData, fields: string[]) => {
+		if (!data.parent) {
+			return fetchItem(data.collection, data.item, fields, data.version);
+		}
+
+		const target = await resolveWriteTarget({
+			schema: getSchemaOverview({
+				collections: collectionsStore.collections,
+				relations: relationsStore.relations,
+				getPrimaryKeyFieldForCollection: fieldsStore.getPrimaryKeyFieldForCollection,
+			}),
+			target: { collection: data.collection, key: data.item },
+			hint: {
+				attachment: {
+					collection: data.collection,
+					item: data.item,
+					version: data.version,
+					parent: {
+						collection: data.parent.collection,
+						key: data.parent.item,
+						versionKey: data.parent.version,
+					},
+				},
+			},
+			collectionHasVersioning: (collection) => Boolean(collectionsStore.getCollection(collection)?.meta?.versioning),
+			readParent: async (parent, readFields) => {
+				return fetchItem(parent.collection, parent.key, readFields, parent.versionKey);
+			},
+		});
+
+		if (target.kind === 'refuse') return null;
+
+		if (target.kind !== 'parent-version') {
+			const versionKey = target.kind === 'item-version' ? target.versionKey : data.version;
+			return fetchItem(data.collection, data.item, fields, versionKey);
+		}
+
+		const parent = await fetchItem(
+			target.parent.collection,
+			target.parent.key,
+			getParentSnapshotFields(target.relation, fields),
+			target.parent.versionKey,
+		);
+
+		if (!parent) return null;
+		return getSnapshotFromParent(parent, target.relation, data.collection, data.item);
+	};
+
 	const fetchContextData = async (): Promise<ContextAttachment[]> => {
 		const nonFileItems = pendingContext.value.filter((item) => !isFileContext(item) && !isLocalFileContext(item));
 
 		const fetches = nonFileItems.map(async (item): Promise<ContextAttachment | null> => {
 			if (isVisualElement(item)) {
 				const fields = item.data.fields?.length ? item.data.fields : ['*'];
-				const snapshot = await fetchItem(item.data.collection, item.data.item, fields, item.data.version);
+				const snapshot = await fetchVisualElementSnapshot(item.data, fields);
 				if (!snapshot) return null;
 				return { type: 'visual-element', data: item.data, display: item.display, snapshot };
 			}
@@ -225,3 +281,62 @@ export const useAiContextStore = defineStore('ai-context-store', () => {
 		dehydrate,
 	};
 });
+
+function getParentSnapshotFields(relation: ParentRelation, fields: string[]) {
+	const childFields = fields.includes('*') ? ['*'] : Array.from(new Set([relation.childPkField, ...fields]));
+
+	if (relation.kind === 'm2o' || relation.kind === 'o2m') {
+		return childFields.map((field) => `${relation.parentField}.${field}`);
+	}
+
+	const parentFields = [
+		`${relation.parentField}.${relation.junctionPkField}`,
+		...childFields.map((field) => `${relation.parentField}.${relation.junctionField}.${field}`),
+	];
+
+	if (relation.kind === 'm2a') {
+		parentFields.push(`${relation.parentField}.${relation.collectionField}`);
+	}
+
+	return parentFields;
+}
+
+function getSnapshotFromParent(
+	parent: Item,
+	relation: ParentRelation,
+	targetCollection: string,
+	targetKey: PrimaryKey,
+): Item | null {
+	if (relation.kind === 'm2o') {
+		const child = parent[relation.parentField];
+		if (!isItem(child)) return null;
+		if (!sameKey(child[relation.childPkField], targetKey)) return null;
+		return child;
+	}
+
+	const relatedItems = parent[relation.parentField];
+	if (!Array.isArray(relatedItems)) return null;
+
+	if (relation.kind === 'o2m') {
+		return relatedItems.find((child) => isItem(child) && sameKey(child[relation.childPkField], targetKey)) ?? null;
+	}
+
+	for (const junctionItem of relatedItems) {
+		if (!isItem(junctionItem)) continue;
+		if (relation.kind === 'm2a' && junctionItem[relation.collectionField] !== targetCollection) continue;
+
+		const child = junctionItem[relation.junctionField];
+		if (!isItem(child)) continue;
+		if (sameKey(child[relation.childPkField], targetKey)) return child;
+	}
+
+	return null;
+}
+
+function isItem(value: unknown): value is Item {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function sameKey(left: unknown, right: PrimaryKey) {
+	return String(left) === String(right);
+}

--- a/app/src/ai/stores/use-ai.ts
+++ b/app/src/ai/stores/use-ai.ts
@@ -149,6 +149,7 @@ export const useAiStore = defineStore('ai-store', () => {
 		const path = route.path;
 		const collection = route.params.collection as string | undefined;
 		const item = route.params.primaryKey as string | number | undefined;
+		const version = Array.isArray(route.query.version) ? route.query.version[0] : route.query.version;
 
 		// Extract module from path (first segment after /)
 		const pathParts = path.split('/').filter(Boolean);
@@ -158,6 +159,7 @@ export const useAiStore = defineStore('ai-store', () => {
 			path,
 			...(collection && { collection }),
 			...(item !== undefined && { item }),
+			...(typeof version === 'string' && { version }),
 			...(module && { module }),
 		};
 	});
@@ -184,7 +186,7 @@ export const useAiStore = defineStore('ai-store', () => {
 			// Build context for system prompt
 			const context: {
 				attachments?: ContextAttachment[];
-				page?: { path: string; collection?: string; item?: string | number; module?: string };
+				page?: { path: string; collection?: string; item?: string | number; version?: string; module?: string };
 			} = {
 				page: currentPageContext.value,
 			};
@@ -518,8 +520,7 @@ export const useAiStore = defineStore('ai-store', () => {
 	const respondToToolCall = (approvalId: string, approved: boolean) => {
 		normalizePendingApprovalState(approvalId);
 
-		void chat
-			.addToolApprovalResponse({ id: approvalId, approved })
+		void Promise.resolve(chat.addToolApprovalResponse({ id: approvalId, approved }))
 			.then(() => {
 				applyLocalApprovalResponseFallback(approvalId, approved);
 				maybeContinueAfterApprovalResponse();

--- a/app/src/composables/use-version-gate.test.ts
+++ b/app/src/composables/use-version-gate.test.ts
@@ -54,7 +54,7 @@ describe('useVersionGate', () => {
 
 		expect(gate.check('articles')).toStrictEqual({
 			allowed: false,
-			redirect: { versionKey: VERSION_KEY_DRAFT, reason: 'collection-versioned' },
+			redirect: { versionKey: VERSION_KEY_DRAFT },
 		});
 	});
 
@@ -68,7 +68,7 @@ describe('useVersionGate', () => {
 
 		expect(gate.check('blocks')).toStrictEqual({
 			allowed: false,
-			redirect: { versionKey: VERSION_KEY_DRAFT, reason: 'parent-versioned' },
+			redirect: { versionKey: VERSION_KEY_DRAFT },
 		});
 	});
 
@@ -78,7 +78,7 @@ describe('useVersionGate', () => {
 
 		const decision = {
 			allowed: false,
-			redirect: { versionKey: VERSION_KEY_DRAFT, reason: 'collection-versioned' },
+			redirect: { versionKey: VERSION_KEY_DRAFT },
 		} as const;
 
 		await expect(gate.requestSwitch(decision)).resolves.toBe('switched');
@@ -99,7 +99,7 @@ describe('useVersionGate', () => {
 
 		const decision = {
 			allowed: false,
-			redirect: { versionKey: VERSION_KEY_DRAFT, reason: 'collection-versioned' },
+			redirect: { versionKey: VERSION_KEY_DRAFT },
 		} as const;
 
 		await expect(gate.requestSwitch(decision)).resolves.toBe('cancelled');

--- a/app/src/composables/use-version-gate.test.ts
+++ b/app/src/composables/use-version-gate.test.ts
@@ -1,0 +1,130 @@
+import { VERSION_KEY_DRAFT } from '@directus/constants';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { ref } from 'vue';
+import { useVersionGate } from './use-version-gate';
+import { useCollectionsStore } from '@/stores/collections';
+import { notify } from '@/utils/notify';
+
+vi.mock('vue-i18n', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('vue-i18n')>();
+
+	return {
+		...actual,
+		useI18n: () => ({
+			t: (key: string) => {
+				return key;
+			},
+		}),
+	};
+});
+
+vi.mock('@/utils/notify', () => ({
+	notify: vi.fn(),
+}));
+
+describe('useVersionGate', () => {
+	beforeEach(() => {
+		setActivePinia(
+			createTestingPinia({
+				createSpy: vi.fn,
+				stubActions: false,
+			}),
+		);
+
+		vi.spyOn(window, 'confirm').mockReturnValue(true);
+		vi.clearAllMocks();
+	});
+
+	test('allows edits when a version is already active', () => {
+		const collectionsStore = useCollectionsStore();
+		collectionsStore.collections = [collection('articles', true)];
+
+		const gate = createGate({ currentVersion: { key: 'draft', name: 'Draft' } });
+
+		expect(gate.check('articles')).toStrictEqual({ allowed: true });
+	});
+
+	test('redirects versioned collection edits to draft from published', () => {
+		const collectionsStore = useCollectionsStore();
+		collectionsStore.collections = [collection('articles', true)];
+
+		const gate = createGate();
+
+		expect(gate.check('articles')).toStrictEqual({
+			allowed: false,
+			redirect: { versionKey: VERSION_KEY_DRAFT, reason: 'collection-versioned' },
+		});
+	});
+
+	test('redirects child edits when the parent collection is versioned', () => {
+		const collectionsStore = useCollectionsStore();
+		collectionsStore.collections = [collection('articles', true), collection('blocks', false)];
+
+		const gate = createGate({
+			parentScope: { collection: 'articles', key: 1 },
+		});
+
+		expect(gate.check('blocks')).toStrictEqual({
+			allowed: false,
+			redirect: { versionKey: VERSION_KEY_DRAFT, reason: 'parent-versioned' },
+		});
+	});
+
+	test('switches to the requested version and notifies', async () => {
+		const switchTo = vi.fn();
+		const gate = createGate({ switchTo });
+		const decision = {
+			allowed: false,
+			redirect: { versionKey: VERSION_KEY_DRAFT, reason: 'collection-versioned' },
+		} as const;
+
+		await expect(gate.requestSwitch(decision)).resolves.toBe('switched');
+		expect(switchTo).toHaveBeenCalledWith(VERSION_KEY_DRAFT);
+		expect(notify).toHaveBeenCalledWith({ title: 'switch_version' });
+	});
+
+	test('cancels when unsaved edits are not discarded', async () => {
+		vi.mocked(window.confirm).mockReturnValue(false);
+
+		const switchTo = vi.fn();
+		const gate = createGate({ hasUnsavedEdits: true, switchTo });
+		const decision = {
+			allowed: false,
+			redirect: { versionKey: VERSION_KEY_DRAFT, reason: 'collection-versioned' },
+		} as const;
+
+		await expect(gate.requestSwitch(decision)).resolves.toBe('cancelled');
+		expect(switchTo).not.toHaveBeenCalled();
+		expect(notify).not.toHaveBeenCalled();
+	});
+});
+
+function createGate(
+	options: {
+		currentVersion?: { key: string; name: string } | null;
+		parentScope?: { collection: string; key: string | number } | null;
+		hasUnsavedEdits?: boolean;
+		switchTo?: (versionKey: string) => Promise<void> | void;
+	} = {},
+) {
+	return useVersionGate({
+		currentVersion: ref(options.currentVersion ?? null),
+		parentScope: ref(options.parentScope ?? null),
+		hasUnsavedEdits: ref(options.hasUnsavedEdits ?? false),
+		switchTo: async (versionKey) => {
+			await options.switchTo?.(versionKey);
+		},
+	});
+}
+
+function collection(collection: string, versioning: boolean) {
+	return {
+		collection,
+		name: collection,
+		type: 'table',
+		meta: { versioning },
+		schema: {},
+	} as any;
+}

--- a/app/src/composables/use-version-gate.test.ts
+++ b/app/src/composables/use-version-gate.test.ts
@@ -82,7 +82,11 @@ describe('useVersionGate', () => {
 
 		await expect(gate.requestSwitch(decision)).resolves.toBe('switched');
 		expect(switchTo).toHaveBeenCalledWith(VERSION_KEY_DRAFT);
-		expect(notify).toHaveBeenCalledWith({ title: 'switch_version' });
+		expect(notify).toHaveBeenCalledWith({
+			title: 'version_switch_required_title',
+			text: 'version_switch_required_text',
+			alwaysShowText: true,
+		});
 	});
 
 	test('cancels when unsaved edits are not discarded', async () => {

--- a/app/src/composables/use-version-gate.test.ts
+++ b/app/src/composables/use-version-gate.test.ts
@@ -75,6 +75,7 @@ describe('useVersionGate', () => {
 	test('switches to the requested version and notifies', async () => {
 		const switchTo = vi.fn();
 		const gate = createGate({ switchTo });
+
 		const decision = {
 			allowed: false,
 			redirect: { versionKey: VERSION_KEY_DRAFT, reason: 'collection-versioned' },
@@ -82,6 +83,7 @@ describe('useVersionGate', () => {
 
 		await expect(gate.requestSwitch(decision)).resolves.toBe('switched');
 		expect(switchTo).toHaveBeenCalledWith(VERSION_KEY_DRAFT);
+
 		expect(notify).toHaveBeenCalledWith({
 			title: 'version_switch_required_title',
 			text: 'version_switch_required_text',
@@ -94,6 +96,7 @@ describe('useVersionGate', () => {
 
 		const switchTo = vi.fn();
 		const gate = createGate({ hasUnsavedEdits: true, switchTo });
+
 		const decision = {
 			allowed: false,
 			redirect: { versionKey: VERSION_KEY_DRAFT, reason: 'collection-versioned' },

--- a/app/src/composables/use-version-gate.ts
+++ b/app/src/composables/use-version-gate.ts
@@ -10,9 +10,7 @@ export type VersionGateParentScope = {
 	key: PrimaryKey;
 };
 
-export type GateDecision =
-	| { allowed: true }
-	| { allowed: false; redirect: { versionKey: string; reason: 'collection-versioned' | 'parent-versioned' } };
+export type GateDecision = { allowed: true } | { allowed: false; redirect: { versionKey: string } };
 
 export function useVersionGate(deps: {
 	currentVersion: Ref<Pick<ContentVersion, 'key' | 'name'> | null>;
@@ -31,10 +29,7 @@ export function useVersionGate(deps: {
 		const target = collectionsStore.getCollection(targetCollection);
 
 		if (target?.meta?.versioning) {
-			return {
-				allowed: false,
-				redirect: { versionKey: VERSION_KEY_DRAFT, reason: 'collection-versioned' },
-			};
+			return { allowed: false, redirect: { versionKey: VERSION_KEY_DRAFT } };
 		}
 
 		const parentScope = parentScopeOverride ?? deps.parentScope.value;
@@ -43,10 +38,7 @@ export function useVersionGate(deps: {
 		const parent = collectionsStore.getCollection(parentScope.collection);
 
 		if (parent?.meta?.versioning) {
-			return {
-				allowed: false,
-				redirect: { versionKey: VERSION_KEY_DRAFT, reason: 'parent-versioned' },
-			};
+			return { allowed: false, redirect: { versionKey: VERSION_KEY_DRAFT } };
 		}
 
 		return { allowed: true };

--- a/app/src/composables/use-version-gate.ts
+++ b/app/src/composables/use-version-gate.ts
@@ -25,7 +25,7 @@ export function useVersionGate(deps: {
 
 	return { check, requestSwitch };
 
-	function check(targetCollection: string): GateDecision {
+	function check(targetCollection: string, parentScopeOverride: VersionGateParentScope | null = null): GateDecision {
 		if (deps.currentVersion.value !== null) return { allowed: true };
 
 		const target = collectionsStore.getCollection(targetCollection);
@@ -37,7 +37,7 @@ export function useVersionGate(deps: {
 			};
 		}
 
-		const parentScope = deps.parentScope.value;
+		const parentScope = parentScopeOverride ?? deps.parentScope.value;
 		if (!parentScope) return { allowed: true };
 
 		const parent = collectionsStore.getCollection(parentScope.collection);
@@ -59,6 +59,7 @@ export function useVersionGate(deps: {
 		}
 
 		await deps.switchTo(decision.redirect.versionKey);
+
 		notify({
 			title: t('version_switch_required_title', { version: decision.redirect.versionKey }),
 			text: t('version_switch_required_text'),

--- a/app/src/composables/use-version-gate.ts
+++ b/app/src/composables/use-version-gate.ts
@@ -59,7 +59,11 @@ export function useVersionGate(deps: {
 		}
 
 		await deps.switchTo(decision.redirect.versionKey);
-		notify({ title: t('switch_version') });
+		notify({
+			title: t('version_switch_required_title', { version: decision.redirect.versionKey }),
+			text: t('version_switch_required_text'),
+			alwaysShowText: true,
+		});
 
 		return 'switched';
 	}

--- a/app/src/composables/use-version-gate.ts
+++ b/app/src/composables/use-version-gate.ts
@@ -1,0 +1,66 @@
+import { VERSION_KEY_DRAFT } from '@directus/constants';
+import type { ContentVersion, PrimaryKey } from '@directus/types';
+import type { Ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useCollectionsStore } from '@/stores/collections';
+import { notify } from '@/utils/notify';
+
+export type VersionGateParentScope = {
+	collection: string;
+	key: PrimaryKey;
+};
+
+export type GateDecision =
+	| { allowed: true }
+	| { allowed: false; redirect: { versionKey: string; reason: 'collection-versioned' | 'parent-versioned' } };
+
+export function useVersionGate(deps: {
+	currentVersion: Ref<Pick<ContentVersion, 'key' | 'name'> | null>;
+	parentScope: Ref<VersionGateParentScope | null>;
+	hasUnsavedEdits: Ref<boolean>;
+	switchTo: (versionKey: string) => Promise<void>;
+}) {
+	const { t } = useI18n();
+	const collectionsStore = useCollectionsStore();
+
+	return { check, requestSwitch };
+
+	function check(targetCollection: string): GateDecision {
+		if (deps.currentVersion.value !== null) return { allowed: true };
+
+		const target = collectionsStore.getCollection(targetCollection);
+
+		if (target?.meta?.versioning) {
+			return {
+				allowed: false,
+				redirect: { versionKey: VERSION_KEY_DRAFT, reason: 'collection-versioned' },
+			};
+		}
+
+		const parentScope = deps.parentScope.value;
+		if (!parentScope) return { allowed: true };
+
+		const parent = collectionsStore.getCollection(parentScope.collection);
+
+		if (parent?.meta?.versioning) {
+			return {
+				allowed: false,
+				redirect: { versionKey: VERSION_KEY_DRAFT, reason: 'parent-versioned' },
+			};
+		}
+
+		return { allowed: true };
+	}
+
+	async function requestSwitch(decision: GateDecision & { allowed: false }): Promise<'switched' | 'cancelled'> {
+		if (deps.hasUnsavedEdits.value) {
+			const confirmed = window.confirm(t('switch_version_copy', { version: decision.redirect.versionKey }));
+			if (!confirmed) return 'cancelled';
+		}
+
+		await deps.switchTo(decision.redirect.versionKey);
+		notify({ title: t('switch_version') });
+
+		return 'switched';
+	}
+}

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -224,6 +224,8 @@ version_name: Version Name
 your_version: Your Version
 switch_version: Switch Version
 switch_version_copy: Are you sure you want to switch to the "{version}" version? Unsaved changes will be lost.
+version_switch_required_title: Switched to {version}
+version_switch_required_text: The published version cannot be edited when content versioning is enabled.
 create_version: Create Version
 rename_version: Rename Version
 reserved_version_key: 'The version key "{key}" is reserved and cannot be used.'

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -226,6 +226,13 @@ switch_version: Switch Version
 switch_version_copy: Are you sure you want to switch to the "{version}" version? Unsaved changes will be lost.
 version_switch_required_title: Switched to {version}
 version_switch_required_text: The published version cannot be edited when content versioning is enabled.
+write_target_refusal:
+  versioning_required: Updates to versioned collections require a draft version.
+  no_parent_context: A parent item is required to save this child item to a version.
+  no_parent_path: No relation path exists from the parent item to this target item.
+  multi_relation: Multiple parent relations contain this target item.
+  related_not_found: The target item was not found in the parent version.
+  stale_attachment: The visual element no longer matches the parent item.
 create_version: Create Version
 rename_version: Rename Version
 reserved_version_key: 'The version key "{key}" is reserved and cannot be used.'

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -1249,6 +1249,7 @@ function useAutoSwitchToDraft() {
 					:version="currentVersion"
 					:parent-scope="livePreviewParentScope"
 					:switch-version="switchToVersion"
+					:has-unsaved-edits="hasEdits"
 					:can-enable-visual-editing="visualEditingEnabled"
 					:show-open-in-visual-editor="visualModuleEnabled"
 					:is-full-width="livePreviewFullWidth"

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -710,6 +710,19 @@ const shouldShowVersioning = computed(() => {
 	return true;
 });
 
+const livePreviewParentScope = computed(() => {
+	if (!resolvedPrimaryKey.value || resolvedPrimaryKey.value === '+') return undefined;
+
+	return {
+		collection: collection.value,
+		key: resolvedPrimaryKey.value,
+	};
+});
+
+async function switchToVersion(versionKey: string) {
+	currentVersion.value = versions.value.find((version) => version.key === versionKey) ?? null;
+}
+
 function enterSingletonDraftContext(
 	newIsSingleton: boolean,
 	newResolvedPK: PrimaryKey | null,
@@ -1234,6 +1247,8 @@ function useAutoSwitchToDraft() {
 					v-if="livePreviewActive && previewUrl"
 					:url="previewUrl"
 					:version="currentVersion"
+					:parent-scope="livePreviewParentScope"
+					:switch-version="switchToVersion"
 					:can-enable-visual-editing="visualEditingEnabled"
 					:show-open-in-visual-editor="visualModuleEnabled"
 					:is-full-width="livePreviewFullWidth"

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -720,7 +720,17 @@ const livePreviewParentScope = computed(() => {
 });
 
 async function switchToVersion(versionKey: string) {
-	currentVersion.value = versions.value.find((version) => version.key === versionKey) ?? null;
+	const target = versions.value.find((version) => version.key === versionKey);
+	if (!target) return;
+
+	const canSwitch =
+		draftVersion.value?.id === '+'
+			? createVersionsAllowed.value
+			: updateVersionsAllowed.value || createVersionsAllowed.value;
+
+	if (!canSwitch) return;
+
+	currentVersion.value = target;
 }
 
 function enterSingletonDraftContext(

--- a/app/src/modules/visual/components/editing-layer.test.ts
+++ b/app/src/modules/visual/components/editing-layer.test.ts
@@ -110,10 +110,10 @@ afterEach(() => {
 	vi.clearAllMocks();
 });
 
-function mountEditingLayer(version: { key: string; name: string } | null = null) {
+function mountEditingLayer(version: { key: string; name: string } | null = null, props: Record<string, unknown> = {}) {
 	mount(EditingLayer, {
 		global: mountOptions,
-		props: { frameSrc: FRAME_SRC, frameEl: mockFrameEl, version },
+		props: { frameSrc: FRAME_SRC, frameEl: mockFrameEl, version, ...props },
 	});
 }
 
@@ -122,6 +122,16 @@ function setupCollection(meta: Record<string, unknown> = {}) {
 		collection: 'articles',
 		meta: { versioning: false, ...meta },
 	} as any);
+}
+
+function setupCollections(versioningByCollection: Record<string, boolean>) {
+	vi.mocked(useCollectionsStore().getCollection).mockImplementation(
+		(collection) =>
+			({
+				collection,
+				meta: { versioning: versioningByCollection[collection] ?? false },
+			}) as any,
+	);
 }
 
 function setupPermission(fields: string[] | null = null, access = 'full') {
@@ -166,6 +176,19 @@ describe('checkFieldAccess', () => {
 		sendCheckFieldAccess(createElements());
 
 		expect(postMessageSpy).toHaveBeenCalledWith({ action: 'activateElements', data: [] }, FRAME_SRC);
+	});
+
+	it('allows non-versioned child elements when version is set and parent scope is versioned', () => {
+		mountEditingLayer({ key: 'draft', name: 'Draft' }, { parentScope: { collection: 'pages', key: '1' } });
+
+		setupCollections({ pages: true, blocks: false });
+		setupNonAdmin();
+		setupPermission(['*']);
+		setupVersionPermissions({ read: true, update: true });
+
+		sendCheckFieldAccess(createElements({ collection: 'blocks' }));
+
+		expect(postMessageSpy).toHaveBeenCalledWith({ action: 'activateElements', data: ['el-0'] }, FRAME_SRC);
 	});
 
 	it('allows elements when version is set and collection has versioning', () => {

--- a/app/src/modules/visual/components/editing-layer.test.ts
+++ b/app/src/modules/visual/components/editing-layer.test.ts
@@ -1,15 +1,20 @@
 import type { CheckFieldAccessData } from '@directus/visual-editing/types';
 import { createTestingPinia } from '@pinia/testing';
-import { mount } from '@vue/test-utils';
+import type { Relation } from '@directus/types';
+import { flushPromises, mount } from '@vue/test-utils';
 import { setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import EditingLayer from './editing-layer.vue';
 import { Tooltip } from '@/__utils__/tooltip';
 import type { GlobalMountOptions } from '@/__utils__/types';
+import api from '@/api';
 import { i18n } from '@/lang';
 import { useCollectionsStore } from '@/stores/collections';
+import { useFieldsStore } from '@/stores/fields';
 import { usePermissionsStore } from '@/stores/permissions';
+import { useRelationsStore } from '@/stores/relations';
 import { useUserStore } from '@/stores/user';
+import { ensureVersionId } from '@/utils/ensure-version-id';
 
 vi.mock('@directus/composables', () => ({
 	useCollection: () => ({
@@ -44,6 +49,14 @@ vi.mock('@/ai/stores/use-ai-tools', () => ({
 
 vi.mock('@/api', () => ({
 	default: { get: vi.fn(), post: vi.fn(), patch: vi.fn() },
+}));
+
+vi.mock('@/utils/ensure-version-id', () => ({
+	ensureVersionId: vi.fn(),
+}));
+
+vi.mock('@/utils/unexpected-error', () => ({
+	unexpectedError: vi.fn(),
 }));
 
 vi.mock('@directus/utils/browser', async (importOriginal) => ({
@@ -111,7 +124,7 @@ afterEach(() => {
 });
 
 function mountEditingLayer(version: { key: string; name: string } | null = null, props: Record<string, unknown> = {}) {
-	mount(EditingLayer, {
+	return mount(EditingLayer, {
 		global: mountOptions,
 		props: { frameSrc: FRAME_SRC, frameEl: mockFrameEl, version, ...props },
 	});
@@ -150,6 +163,87 @@ function setupVersionPermissions({ read = false, create = false, update = false 
 
 function setupNonAdmin() {
 	(useUserStore() as any).isAdmin = false;
+}
+
+function setupParentVersionSaveSchema() {
+	useCollectionsStore().collections = [
+		collection('pages', true),
+		collection('pages_blocks', false),
+		collection('block_hero', false),
+	];
+
+	setupCollections({ pages: true, pages_blocks: false, block_hero: false });
+	vi.mocked(useFieldsStore().getPrimaryKeyFieldForCollection).mockReturnValue({ field: 'id' } as any);
+
+	useRelationsStore().relations = [
+		relation('pages_blocks', 'pages_id', 'pages', { oneField: 'blocks', junctionField: 'item' }),
+		relation('pages_blocks', 'item', null, {
+			oneCollectionField: 'collection',
+			oneAllowedCollections: ['block_hero'],
+		}),
+	];
+}
+
+function collection(collection: string, versioning: boolean) {
+	return {
+		collection,
+		name: collection,
+		type: 'table',
+		meta: { versioning },
+		schema: {},
+	} as any;
+}
+
+function relation(
+	collection: string,
+	field: string,
+	relatedCollection: string | null,
+	options: {
+		oneField?: string | null;
+		junctionField?: string | null;
+		oneCollectionField?: string | null;
+		oneAllowedCollections?: string[] | null;
+	} = {},
+): Relation {
+	return {
+		collection,
+		field,
+		related_collection: relatedCollection,
+		schema: null,
+		meta: {
+			id: 1,
+			many_collection: collection,
+			many_field: field,
+			one_collection: relatedCollection,
+			one_field: options.oneField ?? null,
+			one_collection_field: options.oneCollectionField ?? null,
+			one_allowed_collections: options.oneAllowedCollections ?? null,
+			one_deselect_action: 'nullify',
+			junction_field: options.junctionField ?? null,
+			sort_field: null,
+		},
+	};
+}
+
+function sendEdit() {
+	window.dispatchEvent(
+		new MessageEvent('message', {
+			origin: FRAME_SRC,
+			data: {
+				action: 'edit',
+				data: {
+					key: 'visual-key',
+					editConfig: {
+						collection: 'block_hero',
+						item: 9,
+						fields: ['title'],
+						mode: 'drawer',
+					},
+					rect: { top: 0, left: 0, width: 100, height: 40 },
+				},
+			},
+		}),
+	);
 }
 
 describe('checkFieldAccess', () => {
@@ -352,5 +446,86 @@ describe('checkFieldAccess', () => {
 		sendCheckFieldAccess(createElements());
 
 		expect(postMessageSpy).toHaveBeenCalledWith({ action: 'activateElements', data: ['el-0'] }, FRAME_SRC);
+	});
+});
+
+describe('save', () => {
+	it('ensures the parent version before reading the parent version', async () => {
+		setupParentVersionSaveSchema();
+		vi.mocked(ensureVersionId).mockResolvedValue('version-id');
+		vi.mocked(api.get).mockResolvedValue({
+			data: {
+				data: {
+					blocks: [{ id: 7, collection: 'block_hero', item: { id: 9, title: 'Old' } }],
+				},
+			},
+		});
+		vi.mocked(api.post).mockResolvedValue({ data: { data: {} } });
+
+		const wrapper = mountEditingLayer(
+			{ key: 'draft', name: 'Draft' },
+			{ parentScope: { collection: 'pages', key: 'page-id' } },
+		);
+
+		sendEdit();
+		await flushPromises();
+
+		wrapper.findComponent({ name: 'OverlayItem' }).vm.$emit('input', { title: 'New' });
+
+		await vi.waitFor(() => expect(api.post).toHaveBeenCalled());
+
+		expect(ensureVersionId).toHaveBeenNthCalledWith(1, api, {
+			collection: 'pages',
+			item: 'page-id',
+			versionKey: 'draft',
+		});
+
+		expect(ensureVersionId).toHaveBeenNthCalledWith(2, api, {
+			collection: 'pages',
+			item: 'page-id',
+			versionKey: 'draft',
+		});
+
+		expect(vi.mocked(ensureVersionId).mock.invocationCallOrder[0]!).toBeLessThan(
+			vi.mocked(api.get).mock.invocationCallOrder[0]!,
+		);
+
+		expect(api.get).toHaveBeenCalledWith('/items/pages/page-id', {
+			params: {
+				fields: ['blocks.id', 'blocks.collection', 'blocks.item.*'],
+				version: 'draft',
+			},
+		});
+
+		expect(api.post).toHaveBeenCalledWith('/versions/version-id/save', {
+			blocks: {
+				create: [],
+				update: [{ id: 7, collection: 'block_hero', item: { id: 9, title: 'New' } }],
+				delete: [],
+			},
+		});
+	});
+
+	it('does not retry a failed save when saving finishes', async () => {
+		setupParentVersionSaveSchema();
+		vi.mocked(ensureVersionId).mockResolvedValue('version-id');
+		vi.mocked(api.get).mockRejectedValue(new Error('Forbidden'));
+
+		const wrapper = mountEditingLayer(
+			{ key: 'draft', name: 'Draft' },
+			{ parentScope: { collection: 'pages', key: 'page-id' } },
+		);
+
+		sendEdit();
+		await flushPromises();
+
+		wrapper.findComponent({ name: 'OverlayItem' }).vm.$emit('input', { title: 'New' });
+
+		await vi.waitFor(() => expect(api.get).toHaveBeenCalledTimes(1));
+		await flushPromises();
+		await flushPromises();
+
+		expect(api.get).toHaveBeenCalledTimes(1);
+		expect(api.post).not.toHaveBeenCalled();
 	});
 });

--- a/app/src/modules/visual/components/editing-layer.test.ts
+++ b/app/src/modules/visual/components/editing-layer.test.ts
@@ -124,6 +124,11 @@ beforeEach(() => {
 
 	setActivePinia(pinia);
 
+	vi.mocked(useFieldsStore().getFieldsForCollection).mockReturnValue([
+		{ field: 'id', type: 'integer', schema: {}, meta: {} },
+	] as any);
+	vi.mocked(useFieldsStore().getPrimaryKeyFieldForCollection).mockReturnValue({ field: 'id' } as any);
+
 	mountOptions = {
 		plugins: [i18n, pinia],
 		directives: { tooltip: Tooltip },
@@ -304,14 +309,27 @@ describe('checkFieldAccess', () => {
 	it('allows non-versioned child elements when version is set and parent scope is versioned', () => {
 		mountEditingLayer({ key: 'draft', name: 'Draft' }, { parentScope: { collection: 'pages', key: '1' } });
 
-		setupCollections({ pages: true, blocks: false });
+		setupParentVersionSaveSchema();
 		setupNonAdmin();
 		setupPermission(['*']);
 		setupVersionPermissions({ read: true, update: true });
 
-		sendCheckFieldAccess(createElements({ collection: 'blocks' }));
+		sendCheckFieldAccess(createElements({ collection: 'block_hero' }));
 
 		expect(postMessageSpy).toHaveBeenCalledWith({ action: 'activateElements', data: ['el-0'] }, FRAME_SRC);
+	});
+
+	it('filters non-versioned elements unrelated to the versioned parent scope', () => {
+		mountEditingLayer({ key: 'draft', name: 'Draft' }, { parentScope: { collection: 'pages', key: '1' } });
+
+		setupParentVersionSaveSchema();
+		setupNonAdmin();
+		setupPermission(['*']);
+		setupVersionPermissions({ read: true, update: true });
+
+		sendCheckFieldAccess(createElements({ collection: 'unrelated' }));
+
+		expect(postMessageSpy).toHaveBeenCalledWith({ action: 'activateElements', data: [] }, FRAME_SRC);
 	});
 
 	it('allows elements when version is set and collection has versioning', () => {
@@ -542,7 +560,7 @@ describe('save', () => {
 		sendEdit();
 
 		await vi.waitFor(() => {
-			expect(wrapper.findComponent({ name: 'OverlayItem' }).props('initialValues')).toEqual({
+			expect(wrapper.findComponent({ name: 'OverlayItem' }).props('initialItem')).toEqual({
 				id: 9,
 				title: 'Draft title',
 			});

--- a/app/src/modules/visual/components/editing-layer.test.ts
+++ b/app/src/modules/visual/components/editing-layer.test.ts
@@ -511,6 +511,17 @@ describe('save', () => {
 		expect(wrapper.findComponent({ name: 'OverlayItem' }).props('active')).toBe(true);
 	});
 
+	it('refuses to open the overlay when no switchVersion handler is wired', async () => {
+		setupCollections({ block_hero: true });
+
+		const wrapper = mountEditingLayer(null);
+
+		sendEdit();
+		await flushPromises();
+
+		expect(wrapper.findComponent({ name: 'OverlayItem' }).exists()).toBe(false);
+	});
+
 	it('hydrates the overlay from the parent version before opening', async () => {
 		setupParentVersionSaveSchema();
 		vi.mocked(ensureVersionId).mockResolvedValue('version-id');

--- a/app/src/modules/visual/components/editing-layer.test.ts
+++ b/app/src/modules/visual/components/editing-layer.test.ts
@@ -498,6 +498,19 @@ describe('save', () => {
 		}
 	});
 
+	it('opens the overlay after switching versions in a single click', async () => {
+		setupCollections({ block_hero: true });
+
+		const switchVersion = vi.fn();
+		const wrapper = mountEditingLayer(null, { switchVersion });
+
+		sendEdit();
+		await flushPromises();
+
+		expect(switchVersion).toHaveBeenCalledWith('draft');
+		expect(wrapper.findComponent({ name: 'OverlayItem' }).props('active')).toBe(true);
+	});
+
 	it('hydrates the overlay from the parent version before opening', async () => {
 		setupParentVersionSaveSchema();
 		vi.mocked(ensureVersionId).mockResolvedValue('version-id');

--- a/app/src/modules/visual/components/editing-layer.test.ts
+++ b/app/src/modules/visual/components/editing-layer.test.ts
@@ -1,6 +1,6 @@
+import type { Relation } from '@directus/types';
 import type { CheckFieldAccessData } from '@directus/visual-editing/types';
 import { createTestingPinia } from '@pinia/testing';
-import type { Relation } from '@directus/types';
 import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils';
 import { setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -15,6 +15,11 @@ import { usePermissionsStore } from '@/stores/permissions';
 import { useRelationsStore } from '@/stores/relations';
 import { useUserStore } from '@/stores/user';
 import { ensureVersionId } from '@/utils/ensure-version-id';
+import { notify } from '@/utils/notify';
+
+type CheckFieldAccessDataWithParent = CheckFieldAccessData & {
+	parent?: { collection: string; item: string | number };
+};
 
 vi.mock('@directus/composables', () => ({
 	useCollection: () => ({
@@ -55,6 +60,10 @@ vi.mock('@/utils/ensure-version-id', () => ({
 	ensureVersionId: vi.fn(),
 }));
 
+vi.mock('@/utils/notify', () => ({
+	notify: vi.fn(),
+}));
+
 vi.mock('@/utils/unexpected-error', () => ({
 	unexpectedError: vi.fn(),
 }));
@@ -81,7 +90,7 @@ function sendCheckFieldAccess(elements: CheckFieldAccessData[]) {
 	);
 }
 
-function createElements(...overrides: Partial<CheckFieldAccessData>[]): CheckFieldAccessData[] {
+function createElements(...overrides: Partial<CheckFieldAccessDataWithParent>[]): CheckFieldAccessDataWithParent[] {
 	if (overrides.length === 0) overrides = [{}];
 
 	return overrides.map((o, i) => ({
@@ -232,7 +241,7 @@ function relation(
 	};
 }
 
-function sendEdit() {
+function sendEdit(options: { parent?: { collection: string; item: string | number } } = {}) {
 	window.dispatchEvent(
 		new MessageEvent('message', {
 			origin: FRAME_SRC,
@@ -246,11 +255,24 @@ function sendEdit() {
 						fields: ['title'],
 						mode: 'drawer',
 					},
+					...(options.parent ? { parent: options.parent } : {}),
 					rect: { top: 0, left: 0, width: 100, height: 40 },
 				},
 			},
 		}),
 	);
+}
+
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+
+	return { promise, resolve, reject };
 }
 
 describe('checkFieldAccess', () => {
@@ -457,9 +479,29 @@ describe('checkFieldAccess', () => {
 });
 
 describe('save', () => {
+	it('confirms before switching versions when the parent form has unsaved edits', async () => {
+		setupCollections({ block_hero: true });
+
+		const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false);
+		const switchVersion = vi.fn();
+
+		try {
+			mountEditingLayer(null, { hasUnsavedEdits: true, switchVersion });
+
+			sendEdit();
+			await flushPromises();
+
+			expect(confirm).toHaveBeenCalled();
+			expect(switchVersion).not.toHaveBeenCalled();
+		} finally {
+			confirm.mockRestore();
+		}
+	});
+
 	it('hydrates the overlay from the parent version before opening', async () => {
 		setupParentVersionSaveSchema();
 		vi.mocked(ensureVersionId).mockResolvedValue('version-id');
+
 		vi.mocked(api.get).mockResolvedValue({
 			data: {
 				data: {
@@ -492,9 +534,10 @@ describe('save', () => {
 		});
 	});
 
-	it('ensures the parent version before reading the parent version', async () => {
+	it('ensures the parent version before saving nested edits', async () => {
 		setupParentVersionSaveSchema();
 		vi.mocked(ensureVersionId).mockResolvedValue('version-id');
+
 		vi.mocked(api.get).mockResolvedValue({
 			data: {
 				data: {
@@ -502,6 +545,7 @@ describe('save', () => {
 				},
 			},
 		});
+
 		vi.mocked(api.post).mockResolvedValue({ data: { data: {} } });
 
 		const wrapper = mountEditingLayer(
@@ -517,27 +561,11 @@ describe('save', () => {
 
 		await vi.waitFor(() => expect(api.post).toHaveBeenCalled());
 
-		expect(ensureVersionId).toHaveBeenNthCalledWith(1, api, {
+		expect(ensureVersionId).toHaveBeenCalledWith(api, {
 			collection: 'pages',
 			item: 'page-id',
 			versionKey: 'draft',
 		});
-
-		expect(ensureVersionId).toHaveBeenNthCalledWith(2, api, {
-			collection: 'pages',
-			item: 'page-id',
-			versionKey: 'draft',
-		});
-
-		expect(ensureVersionId).toHaveBeenNthCalledWith(3, api, {
-			collection: 'pages',
-			item: 'page-id',
-			versionKey: 'draft',
-		});
-
-		expect(vi.mocked(ensureVersionId).mock.invocationCallOrder[0]!).toBeLessThan(
-			vi.mocked(api.get).mock.invocationCallOrder[0]!,
-		);
 
 		expect(api.get).toHaveBeenCalledWith('/items/pages/page-id', {
 			params: {
@@ -555,10 +583,62 @@ describe('save', () => {
 		});
 	});
 
+	it('saves edits made while a previous save is in flight', async () => {
+		setupCollections({ block_hero: false });
+
+		const firstPatch = deferred<{ data: { data: { title: string } } }>();
+
+		vi.mocked(api.patch)
+			.mockReturnValueOnce(firstPatch.promise as ReturnType<typeof api.patch>)
+			.mockResolvedValueOnce({ data: { data: { slug: 'second' } } });
+
+		const wrapper = mountEditingLayer();
+
+		sendEdit();
+
+		await vi.waitFor(() => expect(wrapper.findComponent({ name: 'OverlayItem' }).props('active')).toBe(true));
+
+		const overlay = wrapper.findComponent({ name: 'OverlayItem' });
+
+		overlay.vm.$emit('input', { title: 'First' });
+
+		await vi.waitFor(() => expect(api.patch).toHaveBeenCalledTimes(1));
+
+		overlay.vm.$emit('input', { slug: 'second' });
+		await flushPromises();
+
+		expect(api.patch).toHaveBeenCalledTimes(1);
+
+		firstPatch.resolve({ data: { data: { title: 'First' } } });
+
+		await vi.waitFor(() => expect(api.patch).toHaveBeenCalledTimes(2));
+
+		expect(api.patch).toHaveBeenNthCalledWith(1, '/items/block_hero/9', { title: 'First' });
+		expect(api.patch).toHaveBeenNthCalledWith(2, '/items/block_hero/9', { slug: 'second' });
+
+		await vi.waitFor(() => {
+			expect(postMessageSpy).toHaveBeenCalledWith(
+				{
+					action: 'saved',
+					data: { key: 'visual-key', collection: 'block_hero', item: 9, payload: { slug: 'second' } },
+				},
+				FRAME_SRC,
+			);
+		});
+	});
+
 	it('does not retry a failed save when saving finishes', async () => {
 		setupParentVersionSaveSchema();
 		vi.mocked(ensureVersionId).mockResolvedValue('version-id');
+
 		vi.mocked(api.get)
+			.mockResolvedValueOnce({
+				data: {
+					data: {
+						blocks: [{ id: 7, collection: 'block_hero', item: { id: 9, title: 'Old' } }],
+					},
+				},
+			})
 			.mockResolvedValueOnce({
 				data: {
 					data: {
@@ -579,11 +659,33 @@ describe('save', () => {
 
 		wrapper.findComponent({ name: 'OverlayItem' }).vm.$emit('input', { title: 'New' });
 
-		await vi.waitFor(() => expect(api.get).toHaveBeenCalledTimes(2));
+		await vi.waitFor(() => expect(api.get).toHaveBeenCalledTimes(3));
 		await flushPromises();
 		await flushPromises();
 
-		expect(api.get).toHaveBeenCalledTimes(2);
+		expect(api.get).toHaveBeenCalledTimes(3);
 		expect(api.post).not.toHaveBeenCalled();
+	});
+
+	it('shows version refusal messages without machine tokens', async () => {
+		useCollectionsStore().collections = [collection('block_hero', false)];
+		setupCollections({ block_hero: false });
+		vi.mocked(useFieldsStore().getPrimaryKeyFieldForCollection).mockReturnValue({ field: 'id' } as any);
+		useRelationsStore().relations = [];
+
+		const wrapper = mountEditingLayer({ key: 'draft', name: 'Draft' });
+
+		sendEdit();
+
+		await vi.waitFor(() => expect(wrapper.findComponent({ name: 'OverlayItem' }).props('active')).toBe(true));
+
+		wrapper.findComponent({ name: 'OverlayItem' }).vm.$emit('input', { title: 'New' });
+
+		await vi.waitFor(() => {
+			expect(notify).toHaveBeenCalledWith({
+				title: 'A parent item is required to save this child item to a version.',
+				type: 'error',
+			});
+		});
 	});
 });

--- a/app/src/modules/visual/components/editing-layer.test.ts
+++ b/app/src/modules/visual/components/editing-layer.test.ts
@@ -1,7 +1,7 @@
 import type { CheckFieldAccessData } from '@directus/visual-editing/types';
 import { createTestingPinia } from '@pinia/testing';
 import type { Relation } from '@directus/types';
-import { flushPromises, mount } from '@vue/test-utils';
+import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils';
 import { setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import EditingLayer from './editing-layer.vue';
@@ -70,6 +70,8 @@ let postMessageSpy: ReturnType<typeof vi.fn>;
 let mockFrameEl: HTMLIFrameElement;
 let mountOptions: GlobalMountOptions;
 
+enableAutoUnmount(afterEach);
+
 function sendCheckFieldAccess(elements: CheckFieldAccessData[]) {
 	window.dispatchEvent(
 		new MessageEvent('message', {
@@ -92,6 +94,11 @@ function createElements(...overrides: Partial<CheckFieldAccessData>[]): CheckFie
 }
 
 beforeEach(() => {
+	vi.mocked(api.get).mockReset();
+	vi.mocked(api.post).mockReset();
+	vi.mocked(api.patch).mockReset();
+	vi.mocked(ensureVersionId).mockReset();
+
 	postMessageSpy = vi.fn();
 
 	mockFrameEl = {
@@ -450,6 +457,41 @@ describe('checkFieldAccess', () => {
 });
 
 describe('save', () => {
+	it('hydrates the overlay from the parent version before opening', async () => {
+		setupParentVersionSaveSchema();
+		vi.mocked(ensureVersionId).mockResolvedValue('version-id');
+		vi.mocked(api.get).mockResolvedValue({
+			data: {
+				data: {
+					blocks: [{ id: 7, collection: 'block_hero', item: { id: 9, title: 'Draft title' } }],
+				},
+			},
+		});
+
+		const wrapper = mountEditingLayer(
+			{ key: 'draft', name: 'Draft' },
+			{ parentScope: { collection: 'pages', key: 'page-id' } },
+		);
+
+		sendEdit();
+
+		await vi.waitFor(() => {
+			expect(wrapper.findComponent({ name: 'OverlayItem' }).props('initialValues')).toEqual({
+				id: 9,
+				title: 'Draft title',
+			});
+		});
+
+		expect(wrapper.findComponent({ name: 'OverlayItem' }).props('active')).toBe(true);
+
+		expect(api.get).toHaveBeenCalledWith('/items/pages/page-id', {
+			params: {
+				fields: ['blocks.id', 'blocks.collection', 'blocks.item.*'],
+				version: 'draft',
+			},
+		});
+	});
+
 	it('ensures the parent version before reading the parent version', async () => {
 		setupParentVersionSaveSchema();
 		vi.mocked(ensureVersionId).mockResolvedValue('version-id');
@@ -468,7 +510,8 @@ describe('save', () => {
 		);
 
 		sendEdit();
-		await flushPromises();
+
+		await vi.waitFor(() => expect(wrapper.findComponent({ name: 'OverlayItem' }).props('active')).toBe(true));
 
 		wrapper.findComponent({ name: 'OverlayItem' }).vm.$emit('input', { title: 'New' });
 
@@ -481,6 +524,12 @@ describe('save', () => {
 		});
 
 		expect(ensureVersionId).toHaveBeenNthCalledWith(2, api, {
+			collection: 'pages',
+			item: 'page-id',
+			versionKey: 'draft',
+		});
+
+		expect(ensureVersionId).toHaveBeenNthCalledWith(3, api, {
 			collection: 'pages',
 			item: 'page-id',
 			versionKey: 'draft',
@@ -509,7 +558,15 @@ describe('save', () => {
 	it('does not retry a failed save when saving finishes', async () => {
 		setupParentVersionSaveSchema();
 		vi.mocked(ensureVersionId).mockResolvedValue('version-id');
-		vi.mocked(api.get).mockRejectedValue(new Error('Forbidden'));
+		vi.mocked(api.get)
+			.mockResolvedValueOnce({
+				data: {
+					data: {
+						blocks: [{ id: 7, collection: 'block_hero', item: { id: 9, title: 'Old' } }],
+					},
+				},
+			})
+			.mockRejectedValueOnce(new Error('Forbidden'));
 
 		const wrapper = mountEditingLayer(
 			{ key: 'draft', name: 'Draft' },
@@ -517,15 +574,16 @@ describe('save', () => {
 		);
 
 		sendEdit();
-		await flushPromises();
+
+		await vi.waitFor(() => expect(wrapper.findComponent({ name: 'OverlayItem' }).props('active')).toBe(true));
 
 		wrapper.findComponent({ name: 'OverlayItem' }).vm.$emit('input', { title: 'New' });
 
-		await vi.waitFor(() => expect(api.get).toHaveBeenCalledTimes(1));
+		await vi.waitFor(() => expect(api.get).toHaveBeenCalledTimes(2));
 		await flushPromises();
 		await flushPromises();
 
-		expect(api.get).toHaveBeenCalledTimes(1);
+		expect(api.get).toHaveBeenCalledTimes(2);
 		expect(api.post).not.toHaveBeenCalled();
 	});
 });

--- a/app/src/modules/visual/components/editing-layer.vue
+++ b/app/src/modules/visual/components/editing-layer.vue
@@ -1,7 +1,15 @@
 <script setup lang="ts">
 import { useCollection } from '@directus/composables';
 import type { ContentVersion, Item, PrimaryKey } from '@directus/types';
-import { buildPayload, getEndpoint, resolveWriteTarget, type ParentRelation } from '@directus/utils';
+import {
+	buildPayload,
+	findParentInitialValue,
+	getEndpoint,
+	getParentInitialValueFields,
+	resolveWriteTarget,
+	WRITE_TARGET_REFUSAL,
+	type WriteTargetRefusalToken,
+} from '@directus/utils';
 import { sameOrigin } from '@directus/utils/browser';
 import type {
 	AddToContextData,
@@ -13,9 +21,10 @@ import type {
 	VisualEditingTheme,
 } from '@directus/visual-editing/types';
 import { useEventListener } from '@vueuse/core';
+import { cloneDeep, isEqual } from 'lodash';
 import { computed, nextTick, onUnmounted, ref, toRaw, useTemplateRef, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import type { NavigationData, ReceiveData } from '../types';
+import type { EditData, NavigationData, ReceiveData } from '../types';
 import { useContextStaging } from '@/ai/composables/use-context-staging';
 import { useAiStore } from '@/ai/stores/use-ai';
 import { useAiContextStore } from '@/ai/stores/use-ai-context';
@@ -33,20 +42,29 @@ import { useServerStore } from '@/stores/server';
 import { useSettingsStore } from '@/stores/settings';
 import { useUserStore } from '@/stores/user';
 import { ensureVersionId } from '@/utils/ensure-version-id';
-import { getSchemaOverview } from '@/utils/get-schema-overview';
 import { getCollectionRoute, getItemRoute } from '@/utils/get-route';
+import { getSchemaOverview } from '@/utils/get-schema-overview';
 import { notify } from '@/utils/notify';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { PrivateViewHeaderBarActionButton } from '@/views/private';
 import OverlayItem from '@/views/private/components/overlay-item.vue';
 
-const { frameSrc, frameEl, showEditableElements, version, parentScope, switchVersion } = defineProps<{
+const {
+	frameSrc,
+	frameEl,
+	showEditableElements,
+	version,
+	parentScope,
+	switchVersion,
+	hasUnsavedEdits: parentHasUnsavedEdits = false,
+} = defineProps<{
 	frameSrc: string;
 	frameEl?: HTMLIFrameElement;
 	showEditableElements?: boolean;
 	version: Pick<ContentVersion, 'key' | 'name'> | null;
 	parentScope?: VersionGateParentScope;
 	switchVersion?: (versionKey: string) => void | Promise<void>;
+	hasUnsavedEdits?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -55,6 +73,15 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
+
+const writeTargetRefusalMessageKeys = {
+	[WRITE_TARGET_REFUSAL.VERSIONING_REQUIRED]: 'write_target_refusal.versioning_required',
+	[WRITE_TARGET_REFUSAL.NO_PARENT_CONTEXT]: 'write_target_refusal.no_parent_context',
+	[WRITE_TARGET_REFUSAL.NO_PARENT_PATH]: 'write_target_refusal.no_parent_path',
+	[WRITE_TARGET_REFUSAL.MULTI_RELATION]: 'write_target_refusal.multi_relation',
+	[WRITE_TARGET_REFUSAL.RELATED_NOT_FOUND]: 'write_target_refusal.related_not_found',
+	[WRITE_TARGET_REFUSAL.STALE_ATTACHMENT]: 'write_target_refusal.stale_attachment',
+} satisfies Record<WriteTargetRefusalToken, string>;
 
 const {
 	collection,
@@ -87,7 +114,7 @@ function useWebsiteFrame({
 	guardVersionSwitch,
 }: {
 	onClickEdit: (data: unknown) => void;
-	guardVersionSwitch: (collection: string) => Promise<boolean>;
+	guardVersionSwitch: (collection: string, effectiveParentScope?: VersionGateParentScope | null) => Promise<boolean>;
 }) {
 	const serverStore = useServerStore();
 	const settingsStore = useSettingsStore();
@@ -236,9 +263,10 @@ function useWebsiteFrame({
 
 	async function receiveAddToContext(data: unknown) {
 		const { key, editConfig, rect } = data as AddToContextData;
+		const effectiveParentScope = parentScope ?? null;
 
 		if (!key || !editConfig?.collection || editConfig.item == null) return;
-		if ((await guardVersionSwitch(editConfig.collection)) === false) return;
+		if ((await guardVersionSwitch(editConfig.collection, effectiveParentScope)) === false) return;
 
 		stageVisualElement({
 			key,
@@ -246,8 +274,14 @@ function useWebsiteFrame({
 			item: editConfig.item,
 			fields: editConfig.fields,
 			...(version?.key ? { version: version.key } : {}),
-			...(version?.key && parentScope
-				? { parent: { collection: parentScope.collection, item: parentScope.key, version: version.key } }
+			...(version?.key && effectiveParentScope
+				? {
+						parent: {
+							collection: effectiveParentScope.collection,
+							item: effectiveParentScope.key,
+							version: version.key,
+						},
+					}
 				: {}),
 			rect,
 		});
@@ -330,12 +364,13 @@ function useItemWithEdits() {
 	const { info: collectionInfo } = useCollection(collection);
 
 	const editingLayerEl = useTemplateRef<HTMLElement>('editing-layer');
-	const hasUnsavedEdits = computed(() => Object.keys(edits.value).length > 0);
+	const hasOverlayEdits = computed(() => Object.keys(edits.value).length > 0);
+	const hasVersionSwitchEdits = computed(() => parentHasUnsavedEdits || hasOverlayEdits.value);
 
 	const versionGate = useVersionGate({
 		currentVersion: computed(() => version),
 		parentScope: computed(() => parentScope ?? null),
-		hasUnsavedEdits,
+		hasUnsavedEdits: hasVersionSwitchEdits,
 		switchTo: async (versionKey) => {
 			await switchVersion?.(versionKey);
 		},
@@ -345,7 +380,7 @@ function useItemWithEdits() {
 		const hasEdits = Object.keys(newEdits)?.length;
 		if (!hasEdits || saving.value) return;
 
-		void save();
+		void savePendingEdits();
 	});
 
 	return {
@@ -379,21 +414,35 @@ function useItemWithEdits() {
 		return getItemRoute(collection.value, primaryKey.value, version?.key);
 	}
 
-	function resetEdits() {
-		edits.value = {};
-	}
-
-	async function save() {
+	async function savePendingEdits() {
 		saving.value = true;
 
 		try {
+			while (Object.keys(edits.value).length > 0) {
+				const snapshot = cloneDeep(edits.value);
+				const saved = await save(snapshot);
+
+				if (!saved) return;
+
+				removeSavedEdits(snapshot);
+			}
+		} finally {
+			saving.value = false;
+		}
+	}
+
+	async function save(editsSnapshot: Record<string, any>) {
+		try {
 			let response;
 			let shouldReplaceEdits = true;
+			let savedPayload = cloneDeep(editsSnapshot);
 
 			if (isNew.value) {
-				response = await api.post(itemEndpoint.value, edits.value);
+				response = await api.post(itemEndpoint.value, editsSnapshot);
 				notify({ title: t('item_create_success', 1), icon: 'check' });
 			} else {
+				const effectiveParentScope = getEffectiveParentScope();
+
 				const target = await resolveWriteTarget({
 					schema: getSchemaOverview({
 						collections: collectionsStore.collections,
@@ -404,8 +453,8 @@ function useItemWithEdits() {
 					hint: {
 						explicitVersion: version?.key,
 						page:
-							version?.key && parentScope
-								? { collection: parentScope.collection, item: parentScope.key, version: version.key }
+							version?.key && effectiveParentScope
+								? { collection: effectiveParentScope.collection, item: effectiveParentScope.key, version: version.key }
 								: null,
 					},
 					collectionHasVersioning: (collection) =>
@@ -414,12 +463,12 @@ function useItemWithEdits() {
 				});
 
 				if (target.kind === 'refuse') {
-					notify({ title: target.message, type: 'error' });
-					return;
+					notify({ title: getWriteTargetRefusalMessage(target.token), type: 'error' });
+					return false;
 				}
 
 				if (target.kind === 'published') {
-					response = await api.patch(itemEndpoint.value, edits.value);
+					response = await api.patch(itemEndpoint.value, editsSnapshot);
 					notify({ title: t('item_update_success', 1), icon: 'check' });
 				} else if (target.kind === 'item-version') {
 					const versionId = await ensureVersionId(api, {
@@ -428,11 +477,11 @@ function useItemWithEdits() {
 						versionKey: target.versionKey,
 					});
 
-					await api.post(`/versions/${versionId}/save`, buildPayload(target, edits.value, primaryKey.value));
+					await api.post(`/versions/${versionId}/save`, buildPayload(target, editsSnapshot, primaryKey.value));
 
 					response = await api.get(itemEndpoint.value, {
 						params: {
-							fields: Object.keys(edits.value),
+							fields: Object.keys(editsSnapshot),
 							version: target.versionKey,
 						},
 					});
@@ -443,31 +492,41 @@ function useItemWithEdits() {
 						versionKey: target.parent.versionKey,
 					});
 
-					await api.post(`/versions/${versionId}/save`, buildPayload(target, edits.value, primaryKey.value));
+					await api.post(`/versions/${versionId}/save`, buildPayload(target, editsSnapshot, primaryKey.value));
 					shouldReplaceEdits = false;
 				}
 			}
 
 			if (shouldReplaceEdits && response) {
-				const replaceEditsWithResponseData = (key: string) => (edits.value[key] = response.data.data[key]);
-				Object.keys(edits.value).forEach(replaceEditsWithResponseData);
+				savedPayload = Object.fromEntries(Object.keys(editsSnapshot).map((key) => [key, response.data.data[key]]));
 			}
 
 			sendSaved({
 				key: msgKey.value,
 				collection: collection.value,
 				item: primaryKey.value,
-				payload: JSON.parse(JSON.stringify(edits.value)),
+				payload: JSON.parse(JSON.stringify(savedPayload)),
 			});
 
 			emit('saved', { collection: collection.value, primaryKey: primaryKey.value });
 
-			resetEdits();
+			return true;
 		} catch (error) {
 			unexpectedError(error);
-		} finally {
-			saving.value = false;
+			return false;
 		}
+	}
+
+	function removeSavedEdits(savedSnapshot: Record<string, any>) {
+		const nextEdits = { ...edits.value };
+
+		for (const [key, value] of Object.entries(savedSnapshot)) {
+			if (isEqual(nextEdits[key], value)) {
+				delete nextEdits[key];
+			}
+		}
+
+		edits.value = nextEdits;
 	}
 
 	function setEditConfigData(data: unknown, createNew = false) {
@@ -513,8 +572,12 @@ function useItemWithEdits() {
 	}
 
 	async function onClickEdit(data: unknown) {
-		const { editConfig } = data as { editConfig?: EditConfig };
-		if (editConfig?.collection && (await guardVersionSwitch(editConfig.collection)) === false) return;
+		const { editConfig } = data as EditData;
+		const effectiveParentScope = parentScope ?? null;
+
+		if (editConfig?.collection && (await guardVersionSwitch(editConfig.collection, effectiveParentScope)) === false) {
+			return;
+		}
 
 		const success = setEditConfigData(data);
 		if (!success) return;
@@ -535,12 +598,16 @@ function useItemWithEdits() {
 		editOverlayActive.value = true;
 	}
 
-	async function fetchParentVersionInitialValues() {
-		if (!version?.key || !parentScope || isNew.value) return null;
-		if (collectionsStore.getCollection(collection.value)?.meta?.versioning) return null;
-		if (!collectionsStore.getCollection(parentScope.collection)?.meta?.versioning) return null;
+	function getWriteTargetRefusalMessage(token: WriteTargetRefusalToken) {
+		return t(writeTargetRefusalMessageKeys[token]);
+	}
 
-		const readParentResults = new Map<string, Item | null>();
+	async function fetchParentVersionInitialValues() {
+		const effectiveParentScope = getEffectiveParentScope();
+
+		if (!version?.key || !effectiveParentScope || isNew.value) return null;
+		if (collectionsStore.getCollection(collection.value)?.meta?.versioning) return null;
+		if (!collectionsStore.getCollection(effectiveParentScope.collection)?.meta?.versioning) return null;
 
 		const target = await resolveWriteTarget({
 			schema: getSchemaOverview({
@@ -551,34 +618,39 @@ function useItemWithEdits() {
 			target: { collection: collection.value, key: primaryKey.value },
 			hint: {
 				explicitVersion: version.key,
-				page: { collection: parentScope.collection, item: parentScope.key, version: version.key },
+				page: { collection: effectiveParentScope.collection, item: effectiveParentScope.key, version: version.key },
 			},
 			collectionHasVersioning: (collection) => Boolean(collectionsStore.getCollection(collection)?.meta?.versioning),
-			readParent: async (ref, fields) => {
-				const parentItem = await readParent(ref, fields);
-				readParentResults.set(getFieldsKey(fields), parentItem);
-				return parentItem;
-			},
+			readParent,
 		});
 
 		if (target.kind !== 'parent-version') return null;
 
-		const fields = getParentInitialValueFields(target.relation);
-		const parentItem = readParentResults.get(getFieldsKey(fields)) ?? (await readParent(target.parent, fields));
+		const parentItem = await readParent(target.parent, getParentInitialValueFields(target.relation));
 		if (!parentItem) return null;
 
 		return findParentInitialValue(target.relation, parentItem, collection.value, primaryKey.value);
 	}
 
-	async function guardVersionSwitch(targetCollection: string) {
-		const decision = versionGate.check(targetCollection);
+	async function guardVersionSwitch(
+		targetCollection: string,
+		effectiveParentScope: VersionGateParentScope | null = null,
+	) {
+		const decision = versionGate.check(targetCollection, effectiveParentScope);
 		if (decision.allowed) return true;
 
 		await versionGate.requestSwitch(decision);
 		return false;
 	}
 
+	function getEffectiveParentScope() {
+		return parentScope ?? null;
+	}
+
 	async function readParent(ref: { collection: string; key: PrimaryKey; versionKey: string }, fields: string[]) {
+		// Materialize the version row before reading. `GET /items/:c/:k?version=X` returns 403
+		// when no directus_versions row exists for that (collection, item, key). Phase 2 will
+		// teach the API to fall back to published; this call can be removed then.
 		await ensureVersionId(api, {
 			collection: ref.collection,
 			item: ref.key,
@@ -595,72 +667,6 @@ function useItemWithEdits() {
 		});
 
 		return data;
-	}
-
-	function getParentInitialValueFields(relation: ParentRelation) {
-		if (relation.kind === 'm2o') return [`${relation.parentField}.*`];
-		if (relation.kind === 'o2m') return [`${relation.parentField}.*`];
-
-		if (relation.kind === 'm2m') {
-			return [
-				`${relation.parentField}.${relation.junctionPkField}`,
-				`${relation.parentField}.${relation.junctionField}.*`,
-			];
-		}
-
-		return [
-			`${relation.parentField}.${relation.junctionPkField}`,
-			`${relation.parentField}.${relation.collectionField}`,
-			`${relation.parentField}.${relation.junctionField}.*`,
-		];
-	}
-
-	function findParentInitialValue(
-		relation: ParentRelation,
-		parentItem: Item,
-		targetCollection: string,
-		targetKey: PrimaryKey,
-	) {
-		if (relation.kind === 'm2o') {
-			const child = parentItem[relation.parentField];
-			if (!isItem(child)) return null;
-			return sameKey(child[relation.childPkField], targetKey) ? child : null;
-		}
-
-		const relationValue = parentItem[relation.parentField];
-		if (!Array.isArray(relationValue)) return null;
-
-		if (relation.kind === 'o2m') {
-			return relationValue.find((item) => isItem(item) && sameKey(item[relation.childPkField], targetKey)) ?? null;
-		}
-
-		for (const junctionItem of relationValue) {
-			if (!isItem(junctionItem)) continue;
-
-			const child = junctionItem[relation.junctionField];
-			if (!isItem(child)) continue;
-			if (!sameKey(child[relation.childPkField], targetKey)) continue;
-
-			if (relation.kind === 'm2a' && junctionItem[relation.collectionField] !== targetCollection) {
-				continue;
-			}
-
-			return child;
-		}
-
-		return null;
-	}
-
-	function getFieldsKey(fields: string[]) {
-		return fields.join('\0');
-	}
-
-	function sameKey(left: unknown, right: PrimaryKey) {
-		return String(left) === String(right);
-	}
-
-	function isItem(value: unknown): value is Item {
-		return typeof value === 'object' && value !== null && !Array.isArray(value);
 	}
 
 	async function setFocusTemporarily() {

--- a/app/src/modules/visual/components/editing-layer.vue
+++ b/app/src/modules/visual/components/editing-layer.vue
@@ -638,9 +638,13 @@ function useItemWithEdits() {
 	) {
 		const decision = versionGate.check(targetCollection, effectiveParentScope);
 		if (decision.allowed) return true;
+		if (!switchVersion) return false;
 
 		const outcome = await versionGate.requestSwitch(decision);
-		return outcome === 'switched';
+		if (outcome !== 'switched') return false;
+
+		await nextTick();
+		return true;
 	}
 
 	function getEffectiveParentScope() {

--- a/app/src/modules/visual/components/editing-layer.vue
+++ b/app/src/modules/visual/components/editing-layer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useCollection } from '@directus/composables';
 import type { ContentVersion, Item, PrimaryKey } from '@directus/types';
-import { buildPayload, getEndpoint, resolveWriteTarget } from '@directus/utils';
+import { buildPayload, getEndpoint, resolveWriteTarget, type ParentRelation } from '@directus/utils';
 import { sameOrigin } from '@directus/utils/browser';
 import type {
 	AddToContextData,
@@ -62,6 +62,7 @@ const {
 	fields,
 	mode,
 	position,
+	initialValues,
 	isNew,
 	edits,
 	editOverlayActive,
@@ -318,6 +319,7 @@ function useItemWithEdits() {
 	const availableModes: EditConfig['mode'][] = ['drawer', 'modal', 'popover'];
 	const mode = ref<EditConfig['mode']>('drawer');
 	const position = ref<Pick<DOMRect, 'top' | 'left' | 'width' | 'height'>>({ top: 0, left: 0, width: 0, height: 0 });
+	const initialValues = ref<Item | null>(null);
 	const isNew = computed(() => primaryKey.value === '+');
 	const itemEndpoint = computed(getItemEndpoint);
 	const itemRoute = computed(getContentRoute);
@@ -352,6 +354,7 @@ function useItemWithEdits() {
 		fields,
 		mode,
 		position,
+		initialValues,
 		isNew,
 		edits,
 		editOverlayActive,
@@ -505,6 +508,7 @@ function useItemWithEdits() {
 		primaryKey.value = '';
 		fields.value = [];
 		mode.value = 'drawer';
+		initialValues.value = null;
 		position.value = { top: 0, left: 0, width: 0, height: 0 };
 	}
 
@@ -514,12 +518,56 @@ function useItemWithEdits() {
 
 		const success = setEditConfigData(data);
 		if (!success) return;
+
+		try {
+			initialValues.value = await fetchParentVersionInitialValues();
+		} catch (error) {
+			resetEditConfigData();
+			unexpectedError(error);
+			return;
+		}
+
 		await nextTick();
 
 		// `setFocusTemporarily()` makes sure that after clicking an edit button inside the iframe, the :focus moves to the Studio module, so the shortcuts work as expected.
 		setFocusTemporarily();
 
 		editOverlayActive.value = true;
+	}
+
+	async function fetchParentVersionInitialValues() {
+		if (!version?.key || !parentScope || isNew.value) return null;
+		if (collectionsStore.getCollection(collection.value)?.meta?.versioning) return null;
+		if (!collectionsStore.getCollection(parentScope.collection)?.meta?.versioning) return null;
+
+		const readParentResults = new Map<string, Item | null>();
+
+		const target = await resolveWriteTarget({
+			schema: getSchemaOverview({
+				collections: collectionsStore.collections,
+				relations: relationsStore.relations,
+				getPrimaryKeyFieldForCollection: fieldsStore.getPrimaryKeyFieldForCollection,
+			}),
+			target: { collection: collection.value, key: primaryKey.value },
+			hint: {
+				explicitVersion: version.key,
+				page: { collection: parentScope.collection, item: parentScope.key, version: version.key },
+			},
+			collectionHasVersioning: (collection) => Boolean(collectionsStore.getCollection(collection)?.meta?.versioning),
+			readParent: async (ref, fields) => {
+				const parentItem = await readParent(ref, fields);
+				readParentResults.set(getFieldsKey(fields), parentItem);
+				return parentItem;
+			},
+		});
+
+		if (target.kind !== 'parent-version') return null;
+
+		const fields = getParentInitialValueFields(target.relation);
+		const parentItem = readParentResults.get(getFieldsKey(fields)) ?? (await readParent(target.parent, fields));
+		if (!parentItem) return null;
+
+		return findParentInitialValue(target.relation, parentItem, collection.value, primaryKey.value);
 	}
 
 	async function guardVersionSwitch(targetCollection: string) {
@@ -549,6 +597,72 @@ function useItemWithEdits() {
 		return data;
 	}
 
+	function getParentInitialValueFields(relation: ParentRelation) {
+		if (relation.kind === 'm2o') return [`${relation.parentField}.*`];
+		if (relation.kind === 'o2m') return [`${relation.parentField}.*`];
+
+		if (relation.kind === 'm2m') {
+			return [
+				`${relation.parentField}.${relation.junctionPkField}`,
+				`${relation.parentField}.${relation.junctionField}.*`,
+			];
+		}
+
+		return [
+			`${relation.parentField}.${relation.junctionPkField}`,
+			`${relation.parentField}.${relation.collectionField}`,
+			`${relation.parentField}.${relation.junctionField}.*`,
+		];
+	}
+
+	function findParentInitialValue(
+		relation: ParentRelation,
+		parentItem: Item,
+		targetCollection: string,
+		targetKey: PrimaryKey,
+	) {
+		if (relation.kind === 'm2o') {
+			const child = parentItem[relation.parentField];
+			if (!isItem(child)) return null;
+			return sameKey(child[relation.childPkField], targetKey) ? child : null;
+		}
+
+		const relationValue = parentItem[relation.parentField];
+		if (!Array.isArray(relationValue)) return null;
+
+		if (relation.kind === 'o2m') {
+			return relationValue.find((item) => isItem(item) && sameKey(item[relation.childPkField], targetKey)) ?? null;
+		}
+
+		for (const junctionItem of relationValue) {
+			if (!isItem(junctionItem)) continue;
+
+			const child = junctionItem[relation.junctionField];
+			if (!isItem(child)) continue;
+			if (!sameKey(child[relation.childPkField], targetKey)) continue;
+
+			if (relation.kind === 'm2a' && junctionItem[relation.collectionField] !== targetCollection) {
+				continue;
+			}
+
+			return child;
+		}
+
+		return null;
+	}
+
+	function getFieldsKey(fields: string[]) {
+		return fields.join('\0');
+	}
+
+	function sameKey(left: unknown, right: PrimaryKey) {
+		return String(left) === String(right);
+	}
+
+	function isItem(value: unknown): value is Item {
+		return typeof value === 'object' && value !== null && !Array.isArray(value);
+	}
+
 	async function setFocusTemporarily() {
 		if (!editingLayerEl.value) return;
 
@@ -571,6 +685,7 @@ function useItemWithEdits() {
 			:primary-key
 			:selected-fields="fields"
 			:edits="edits"
+			:initial-values="initialValues"
 			:version="version?.key"
 			:popover-props="({ popoverWidth }) => (position.width > popoverWidth ? { arrowPlacement: 'start' } : {})"
 			apply-shortcut="meta+s"

--- a/app/src/modules/visual/components/editing-layer.vue
+++ b/app/src/modules/visual/components/editing-layer.vue
@@ -114,7 +114,10 @@ function useWebsiteFrame({
 	guardVersionSwitch,
 }: {
 	onClickEdit: (data: unknown) => void;
-	guardVersionSwitch: (collection: string, effectiveParentScope?: VersionGateParentScope | null) => Promise<boolean>;
+	guardVersionSwitch: (
+		collection: string,
+		effectiveParentScope?: VersionGateParentScope | null,
+	) => Promise<string | false>;
 }) {
 	const serverStore = useServerStore();
 	const settingsStore = useSettingsStore();
@@ -266,20 +269,22 @@ function useWebsiteFrame({
 		const effectiveParentScope = parentScope ?? null;
 
 		if (!key || !editConfig?.collection || editConfig.item == null) return;
-		if ((await guardVersionSwitch(editConfig.collection, effectiveParentScope)) === false) return;
+
+		const effectiveVersionKey = await guardVersionSwitch(editConfig.collection, effectiveParentScope);
+		if (effectiveVersionKey === false) return;
 
 		stageVisualElement({
 			key,
 			collection: editConfig.collection,
 			item: editConfig.item,
 			fields: editConfig.fields,
-			...(version?.key ? { version: version.key } : {}),
-			...(version?.key && effectiveParentScope
+			...(effectiveVersionKey ? { version: effectiveVersionKey } : {}),
+			...(effectiveVersionKey && effectiveParentScope
 				? {
 						parent: {
 							collection: effectiveParentScope.collection,
 							item: effectiveParentScope.key,
-							version: version.key,
+							version: effectiveVersionKey,
 						},
 					}
 				: {}),
@@ -635,16 +640,16 @@ function useItemWithEdits() {
 	async function guardVersionSwitch(
 		targetCollection: string,
 		effectiveParentScope: VersionGateParentScope | null = null,
-	) {
+	): Promise<string | false> {
 		const decision = versionGate.check(targetCollection, effectiveParentScope);
-		if (decision.allowed) return true;
+		if (decision.allowed) return version?.key ?? '';
 		if (!switchVersion) return false;
 
 		const outcome = await versionGate.requestSwitch(decision);
 		if (outcome !== 'switched') return false;
 
 		await nextTick();
-		return true;
+		return decision.redirect.versionKey;
 	}
 
 	function getEffectiveParentScope() {

--- a/app/src/modules/visual/components/editing-layer.vue
+++ b/app/src/modules/visual/components/editing-layer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useCollection } from '@directus/composables';
-import type { ContentVersion, PrimaryKey } from '@directus/types';
-import { getEndpoint } from '@directus/utils';
+import type { ContentVersion, Item, PrimaryKey, SchemaOverview } from '@directus/types';
+import { buildPayload, getEndpoint, resolveWriteTarget } from '@directus/utils';
 import { sameOrigin } from '@directus/utils/browser';
 import type {
 	AddToContextData,
@@ -23,23 +23,29 @@ import { useAiToolsStore } from '@/ai/stores/use-ai-tools';
 import api from '@/api';
 import VButton from '@/components/v-button.vue';
 import { useCollectionPermissions } from '@/composables/use-permissions';
+import { useVersionGate, type VersionGateParentScope } from '@/composables/use-version-gate';
 import { useCollectionsStore } from '@/stores/collections';
+import { useFieldsStore } from '@/stores/fields';
 import { useNotificationsStore } from '@/stores/notifications';
 import { usePermissionsStore } from '@/stores/permissions';
+import { useRelationsStore } from '@/stores/relations';
 import { useServerStore } from '@/stores/server';
 import { useSettingsStore } from '@/stores/settings';
 import { useUserStore } from '@/stores/user';
+import { ensureVersionId } from '@/utils/ensure-version-id';
 import { getCollectionRoute, getItemRoute } from '@/utils/get-route';
 import { notify } from '@/utils/notify';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { PrivateViewHeaderBarActionButton } from '@/views/private';
 import OverlayItem from '@/views/private/components/overlay-item.vue';
 
-const { frameSrc, frameEl, showEditableElements, version } = defineProps<{
+const { frameSrc, frameEl, showEditableElements, version, parentScope, switchVersion } = defineProps<{
 	frameSrc: string;
 	frameEl?: HTMLIFrameElement;
 	showEditableElements?: boolean;
 	version: Pick<ContentVersion, 'key' | 'name'> | null;
+	parentScope?: VersionGateParentScope;
+	switchVersion?: (versionKey: string) => void | Promise<void>;
 }>();
 
 const emit = defineEmits<{
@@ -49,10 +55,21 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 
-const { collection, primaryKey, fields, mode, position, isNew, edits, editOverlayActive, itemRoute, onClickEdit } =
-	useItemWithEdits();
+const {
+	collection,
+	primaryKey,
+	fields,
+	mode,
+	position,
+	isNew,
+	edits,
+	editOverlayActive,
+	itemRoute,
+	onClickEdit,
+	guardVersionSwitch,
+} = useItemWithEdits();
 
-const { sendSaved, sendHighlightElement } = useWebsiteFrame({ onClickEdit });
+const { sendSaved, sendHighlightElement } = useWebsiteFrame({ onClickEdit, guardVersionSwitch });
 
 useVisualEditingAi({ sendSaved, sendHighlightElement });
 
@@ -63,7 +80,13 @@ watch(editOverlayActive, (isActive) => {
 	}
 });
 
-function useWebsiteFrame({ onClickEdit }: { onClickEdit: (data: unknown) => void }) {
+function useWebsiteFrame({
+	onClickEdit,
+	guardVersionSwitch,
+}: {
+	onClickEdit: (data: unknown) => void;
+	guardVersionSwitch: (collection: string) => Promise<boolean>;
+}) {
 	const serverStore = useServerStore();
 	const settingsStore = useSettingsStore();
 	const userStore = useUserStore();
@@ -97,7 +120,7 @@ function useWebsiteFrame({ onClickEdit }: { onClickEdit: (data: unknown) => void
 
 		if (action === 'edit') onClickEdit(data);
 
-		if (action === 'addToContext') receiveAddToContext(data);
+		if (action === 'addToContext') void receiveAddToContext(data);
 	});
 
 	watch(
@@ -204,16 +227,21 @@ function useWebsiteFrame({ onClickEdit }: { onClickEdit: (data: unknown) => void
 		send('highlightElement', data);
 	}
 
-	function receiveAddToContext(data: unknown) {
+	async function receiveAddToContext(data: unknown) {
 		const { key, editConfig, rect } = data as AddToContextData;
 
 		if (!key || !editConfig?.collection || editConfig.item == null) return;
+		if ((await guardVersionSwitch(editConfig.collection)) === false) return;
 
 		stageVisualElement({
 			key,
 			collection: editConfig.collection,
 			item: editConfig.item,
 			fields: editConfig.fields,
+			...(version?.key ? { version: version.key } : {}),
+			...(version?.key && parentScope
+				? { parent: { collection: parentScope.collection, item: parentScope.key, version: version.key } }
+				: {}),
 			rect,
 		});
 	}
@@ -229,13 +257,19 @@ function useVisualEditingAi({
 	const aiStore = useAiStore();
 	const contextStore = useAiContextStore();
 	const toolsStore = useAiToolsStore();
+	let savedTimer: ReturnType<typeof setTimeout> | null = null;
 
 	// Any non-read mutation should trigger a preview refresh
 	const unsubscribeItemsResult = toolsStore.onSystemToolResult((tool, input) => {
 		if (tool !== 'items') return;
 		if (input.action === 'read') return;
 
-		sendSaved({ key: '', collection: input.collection as string, item: null, payload: {} });
+		if (savedTimer) clearTimeout(savedTimer);
+
+		savedTimer = setTimeout(() => {
+			sendSaved({ key: '', collection: '', item: null, payload: {} });
+			savedTimer = null;
+		}, 250);
 	});
 
 	const unsubscribeHighlight = aiStore.onVisualElementHighlight((data) => {
@@ -260,6 +294,7 @@ function useVisualEditingAi({
 	});
 
 	onUnmounted(() => {
+		if (savedTimer) clearTimeout(savedTimer);
 		unsubscribeItemsResult.off();
 		unsubscribeHighlight.off();
 		contextStore.clearVisualElementContext();
@@ -281,9 +316,22 @@ function useItemWithEdits() {
 	const itemEndpoint = computed(getItemEndpoint);
 	const itemRoute = computed(getContentRoute);
 	const notificationsStore = useNotificationsStore();
+	const collectionsStore = useCollectionsStore();
+	const fieldsStore = useFieldsStore();
+	const relationsStore = useRelationsStore();
 	const { info: collectionInfo } = useCollection(collection);
 
 	const editingLayerEl = useTemplateRef<HTMLElement>('editing-layer');
+	const hasUnsavedEdits = computed(() => Object.keys(edits.value).length > 0);
+
+	const versionGate = useVersionGate({
+		currentVersion: computed(() => version),
+		parentScope: computed(() => parentScope ?? null),
+		hasUnsavedEdits,
+		switchTo: async (versionKey) => {
+			await switchVersion?.(versionKey);
+		},
+	});
 
 	watch([edits, saving], ([newEdits, isSaving]) => {
 		const hasEdits = Object.keys(newEdits)?.length;
@@ -303,6 +351,7 @@ function useItemWithEdits() {
 		editOverlayActive,
 		itemRoute,
 		onClickEdit,
+		guardVersionSwitch,
 	};
 
 	function getItemEndpoint() {
@@ -325,53 +374,66 @@ function useItemWithEdits() {
 		edits.value = {};
 	}
 
-	async function fetchOrCreateVersionId(versionKey: ContentVersion['key']) {
-		const {
-			data: { data: existing },
-		} = await api.get('/versions', {
-			params: {
-				filter: {
-					collection: { _eq: collection.value },
-					item: { _eq: String(primaryKey.value) },
-					key: { _eq: versionKey },
-				},
-				limit: 1,
-				fields: ['id'],
-			},
-		});
-
-		if (existing.length) return existing[0].id;
-
-		const {
-			data: { data: created },
-		} = await api.post('/versions', {
-			key: versionKey,
-			collection: collection.value,
-			item: String(primaryKey.value),
-		});
-
-		return created.id;
-	}
-
 	async function save() {
 		saving.value = true;
 
 		try {
 			let response;
+			let shouldReplaceEdits = true;
 
-			if (version) {
-				const versionId: PrimaryKey = await fetchOrCreateVersionId(version.key);
-				response = await api.post(`/versions/${versionId}/save`, edits.value);
-			} else if (isNew.value) {
+			if (isNew.value) {
 				response = await api.post(itemEndpoint.value, edits.value);
 				notify({ title: t('item_create_success', 1), icon: 'check' });
 			} else {
-				response = await api.patch(itemEndpoint.value, edits.value);
-				notify({ title: t('item_update_success', 1), icon: 'check' });
+				const target = await resolveWriteTarget({
+					schema: getSchemaOverview(),
+					target: { collection: collection.value, key: primaryKey.value },
+					hint: {
+						explicitVersion: version?.key,
+						page:
+							version?.key && parentScope
+								? { collection: parentScope.collection, item: parentScope.key, version: version.key }
+								: null,
+					},
+					collectionHasVersioning: (collection) =>
+						Boolean(collectionsStore.getCollection(collection)?.meta?.versioning),
+					readParent,
+				});
+
+				if (target.kind === 'refuse') {
+					notify({ title: target.message, type: 'error' });
+					return;
+				}
+
+				if (target.kind === 'published') {
+					response = await api.patch(itemEndpoint.value, edits.value);
+					notify({ title: t('item_update_success', 1), icon: 'check' });
+				} else if (target.kind === 'item-version') {
+					const versionId = await ensureVersionId(api, {
+						collection: target.collection,
+						item: target.key,
+						versionKey: target.versionKey,
+					});
+
+					await api.post(`/versions/${versionId}/save`, buildPayload(target, edits.value, primaryKey.value));
+
+					response = await api.get(itemEndpoint.value, {
+						params: {
+							fields: Object.keys(edits.value),
+							version: target.versionKey,
+						},
+					});
+				} else {
+					const versionId = await ensureVersionId(api, target.parent);
+					await api.post(`/versions/${versionId}/save`, buildPayload(target, edits.value, primaryKey.value));
+					shouldReplaceEdits = false;
+				}
 			}
 
-			const replaceEditsWithResponseData = (key: string) => (edits.value[key] = response.data.data[key]);
-			Object.keys(edits.value).forEach(replaceEditsWithResponseData);
+			if (shouldReplaceEdits && response) {
+				const replaceEditsWithResponseData = (key: string) => (edits.value[key] = response.data.data[key]);
+				Object.keys(edits.value).forEach(replaceEditsWithResponseData);
+			}
 
 			sendSaved({
 				key: msgKey.value,
@@ -432,6 +494,9 @@ function useItemWithEdits() {
 	}
 
 	async function onClickEdit(data: unknown) {
+		const { editConfig } = data as { editConfig?: EditConfig };
+		if (editConfig?.collection && (await guardVersionSwitch(editConfig.collection)) === false) return;
+
 		const success = setEditConfigData(data);
 		if (!success) return;
 		await nextTick();
@@ -440,6 +505,53 @@ function useItemWithEdits() {
 		setFocusTemporarily();
 
 		editOverlayActive.value = true;
+	}
+
+	async function guardVersionSwitch(targetCollection: string) {
+		const decision = versionGate.check(targetCollection);
+		if (decision.allowed) return true;
+
+		await versionGate.requestSwitch(decision);
+		return false;
+	}
+
+	function getSchemaOverview(): SchemaOverview {
+		const collections = Object.fromEntries(
+			collectionsStore.collections.map((collection) => {
+				const primary = fieldsStore.getPrimaryKeyFieldForCollection(collection.collection)?.field ?? 'id';
+
+				return [
+					collection.collection,
+					{
+						collection: collection.collection,
+						primary,
+						singleton: collection.meta?.singleton ?? false,
+						sortField: null,
+						note: null,
+						accountability: null,
+						fields: {},
+					},
+				];
+			}),
+		);
+
+		return {
+			collections,
+			relations: relationsStore.relations,
+		} as unknown as SchemaOverview;
+	}
+
+	async function readParent(ref: { collection: string; key: PrimaryKey; versionKey: string }, fields: string[]) {
+		const {
+			data: { data },
+		} = await api.get<{ data: Item }>(`${getEndpoint(ref.collection)}/${encodeURIComponent(String(ref.key))}`, {
+			params: {
+				fields,
+				version: ref.versionKey,
+			},
+		});
+
+		return data;
 	}
 
 	async function setFocusTemporarily() {

--- a/app/src/modules/visual/components/editing-layer.vue
+++ b/app/src/modules/visual/components/editing-layer.vue
@@ -339,11 +339,11 @@ function useItemWithEdits() {
 		},
 	});
 
-	watch([edits, saving], ([newEdits, isSaving]) => {
+	watch(edits, (newEdits) => {
 		const hasEdits = Object.keys(newEdits)?.length;
-		if (!hasEdits || isSaving) return;
+		if (!hasEdits || saving.value) return;
 
-		save();
+		void save();
 	});
 
 	return {
@@ -434,7 +434,12 @@ function useItemWithEdits() {
 						},
 					});
 				} else {
-					const versionId = await ensureVersionId(api, target.parent);
+					const versionId = await ensureVersionId(api, {
+						collection: target.parent.collection,
+						item: target.parent.key,
+						versionKey: target.parent.versionKey,
+					});
+
 					await api.post(`/versions/${versionId}/save`, buildPayload(target, edits.value, primaryKey.value));
 					shouldReplaceEdits = false;
 				}
@@ -526,6 +531,12 @@ function useItemWithEdits() {
 	}
 
 	async function readParent(ref: { collection: string; key: PrimaryKey; versionKey: string }, fields: string[]) {
+		await ensureVersionId(api, {
+			collection: ref.collection,
+			item: ref.key,
+			versionKey: ref.versionKey,
+		});
+
 		const {
 			data: { data },
 		} = await api.get<{ data: Item }>(`${getEndpoint(ref.collection)}/${encodeURIComponent(String(ref.key))}`, {

--- a/app/src/modules/visual/components/editing-layer.vue
+++ b/app/src/modules/visual/components/editing-layer.vue
@@ -700,7 +700,7 @@ function useItemWithEdits() {
 			:primary-key
 			:selected-fields="fields"
 			:edits="edits"
-			:initial-values="initialValues"
+			:initial-item="initialValues"
 			:version="version?.key"
 			:popover-props="({ popoverWidth }) => (position.width > popoverWidth ? { arrowPlacement: 'start' } : {})"
 			apply-shortcut="meta+s"

--- a/app/src/modules/visual/components/editing-layer.vue
+++ b/app/src/modules/visual/components/editing-layer.vue
@@ -4,6 +4,7 @@ import type { ContentVersion, Item, PrimaryKey } from '@directus/types';
 import {
 	buildPayload,
 	findParentInitialValue,
+	findParentRelationCandidates,
 	getEndpoint,
 	getParentInitialValueFields,
 	resolveWriteTarget,
@@ -32,18 +33,16 @@ import { useAiToolsStore } from '@/ai/stores/use-ai-tools';
 import api from '@/api';
 import VButton from '@/components/v-button.vue';
 import { useCollectionPermissions } from '@/composables/use-permissions';
+import { useSchemaOverview } from '@/composables/use-schema';
 import { useVersionGate, type VersionGateParentScope } from '@/composables/use-version-gate';
 import { useCollectionsStore } from '@/stores/collections';
-import { useFieldsStore } from '@/stores/fields';
 import { useNotificationsStore } from '@/stores/notifications';
 import { usePermissionsStore } from '@/stores/permissions';
-import { useRelationsStore } from '@/stores/relations';
 import { useServerStore } from '@/stores/server';
 import { useSettingsStore } from '@/stores/settings';
 import { useUserStore } from '@/stores/user';
 import { ensureVersionId } from '@/utils/ensure-version-id';
 import { getCollectionRoute, getItemRoute } from '@/utils/get-route';
-import { getSchemaOverview } from '@/utils/get-schema-overview';
 import { notify } from '@/utils/notify';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { PrivateViewHeaderBarActionButton } from '@/views/private';
@@ -124,6 +123,7 @@ function useWebsiteFrame({
 	const userStore = useUserStore();
 	const permissionsStore = usePermissionsStore();
 	const collectionsStore = useCollectionsStore();
+	const schema = useSchemaOverview();
 	const contextStore = useAiContextStore();
 	const { stageVisualElement } = useContextStaging();
 
@@ -190,7 +190,13 @@ function useWebsiteFrame({
 		const collectionInfo = collectionsStore.getCollection(collection);
 		if (!collectionInfo) return false;
 
-		if (version && !collectionInfo.meta?.versioning && !parentScopeHasVersioning()) return false;
+		if (
+			version &&
+			!collectionInfo.meta?.versioning &&
+			!parentScopeCanVersionCollection(collection)
+		) {
+			return false;
+		}
 
 		if (userStore.isAdmin) return true;
 
@@ -204,9 +210,11 @@ function useWebsiteFrame({
 		return true;
 	}
 
-	function parentScopeHasVersioning() {
+	function parentScopeCanVersionCollection(collection: string) {
 		if (!parentScope) return false;
-		return Boolean(collectionsStore.getCollection(parentScope.collection)?.meta?.versioning);
+		if (!collectionsStore.getCollection(parentScope.collection)?.meta?.versioning) return false;
+
+		return findParentRelationCandidates(schema.value, parentScope.collection, collection).length > 0;
 	}
 
 	function send(action: SendAction, data: unknown) {
@@ -370,8 +378,7 @@ function useItemWithEdits() {
 	const itemRoute = computed(getContentRoute);
 	const notificationsStore = useNotificationsStore();
 	const collectionsStore = useCollectionsStore();
-	const fieldsStore = useFieldsStore();
-	const relationsStore = useRelationsStore();
+	const schema = useSchemaOverview();
 	const { info: collectionInfo } = useCollection(collection);
 
 	const editingLayerEl = useTemplateRef<HTMLElement>('editing-layer');
@@ -452,14 +459,10 @@ function useItemWithEdits() {
 				response = await api.post(itemEndpoint.value, editsSnapshot);
 				notify({ title: t('item_create_success', 1), icon: 'check' });
 			} else {
-				const effectiveParentScope = getEffectiveParentScope();
+				const effectiveParentScope = parentScope ?? null;
 
 				const target = await resolveWriteTarget({
-					schema: getSchemaOverview({
-						collections: collectionsStore.collections,
-						relations: relationsStore.relations,
-						getPrimaryKeyFieldForCollection: fieldsStore.getPrimaryKeyFieldForCollection,
-					}),
+					schema: schema.value,
 					target: { collection: collection.value, key: primaryKey.value },
 					hint: {
 						explicitVersion: version?.key,
@@ -614,18 +617,14 @@ function useItemWithEdits() {
 	}
 
 	async function fetchParentVersionInitialValues() {
-		const effectiveParentScope = getEffectiveParentScope();
+		const effectiveParentScope = parentScope ?? null;
 
 		if (!version?.key || !effectiveParentScope || isNew.value) return null;
 		if (collectionsStore.getCollection(collection.value)?.meta?.versioning) return null;
 		if (!collectionsStore.getCollection(effectiveParentScope.collection)?.meta?.versioning) return null;
 
 		const target = await resolveWriteTarget({
-			schema: getSchemaOverview({
-				collections: collectionsStore.collections,
-				relations: relationsStore.relations,
-				getPrimaryKeyFieldForCollection: fieldsStore.getPrimaryKeyFieldForCollection,
-			}),
+			schema: schema.value,
 			target: { collection: collection.value, key: primaryKey.value },
 			hint: {
 				explicitVersion: version.key,
@@ -656,10 +655,6 @@ function useItemWithEdits() {
 
 		await nextTick();
 		return decision.redirect.versionKey;
-	}
-
-	function getEffectiveParentScope() {
-		return parentScope ?? null;
 	}
 
 	async function readParent(ref: { collection: string; key: PrimaryKey; versionKey: string }, fields: string[]) {

--- a/app/src/modules/visual/components/editing-layer.vue
+++ b/app/src/modules/visual/components/editing-layer.vue
@@ -159,7 +159,7 @@ function useWebsiteFrame({
 		const collectionInfo = collectionsStore.getCollection(collection);
 		if (!collectionInfo) return false;
 
-		if (version && !collectionInfo.meta?.versioning) return false;
+		if (version && !collectionInfo.meta?.versioning && !parentScopeHasVersioning()) return false;
 
 		if (userStore.isAdmin) return true;
 
@@ -171,6 +171,11 @@ function useWebsiteFrame({
 		}
 
 		return true;
+	}
+
+	function parentScopeHasVersioning() {
+		if (!parentScope) return false;
+		return Boolean(collectionsStore.getCollection(parentScope.collection)?.meta?.versioning);
 	}
 
 	function send(action: SendAction, data: unknown) {

--- a/app/src/modules/visual/components/editing-layer.vue
+++ b/app/src/modules/visual/components/editing-layer.vue
@@ -639,8 +639,8 @@ function useItemWithEdits() {
 		const decision = versionGate.check(targetCollection, effectiveParentScope);
 		if (decision.allowed) return true;
 
-		await versionGate.requestSwitch(decision);
-		return false;
+		const outcome = await versionGate.requestSwitch(decision);
+		return outcome === 'switched';
 	}
 
 	function getEffectiveParentScope() {

--- a/app/src/modules/visual/components/editing-layer.vue
+++ b/app/src/modules/visual/components/editing-layer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useCollection } from '@directus/composables';
-import type { ContentVersion, Item, PrimaryKey, SchemaOverview } from '@directus/types';
+import type { ContentVersion, Item, PrimaryKey } from '@directus/types';
 import { buildPayload, getEndpoint, resolveWriteTarget } from '@directus/utils';
 import { sameOrigin } from '@directus/utils/browser';
 import type {
@@ -33,6 +33,7 @@ import { useServerStore } from '@/stores/server';
 import { useSettingsStore } from '@/stores/settings';
 import { useUserStore } from '@/stores/user';
 import { ensureVersionId } from '@/utils/ensure-version-id';
+import { getSchemaOverview } from '@/utils/get-schema-overview';
 import { getCollectionRoute, getItemRoute } from '@/utils/get-route';
 import { notify } from '@/utils/notify';
 import { unexpectedError } from '@/utils/unexpected-error';
@@ -386,7 +387,11 @@ function useItemWithEdits() {
 				notify({ title: t('item_create_success', 1), icon: 'check' });
 			} else {
 				const target = await resolveWriteTarget({
-					schema: getSchemaOverview(),
+					schema: getSchemaOverview({
+						collections: collectionsStore.collections,
+						relations: relationsStore.relations,
+						getPrimaryKeyFieldForCollection: fieldsStore.getPrimaryKeyFieldForCollection,
+					}),
 					target: { collection: collection.value, key: primaryKey.value },
 					hint: {
 						explicitVersion: version?.key,
@@ -513,32 +518,6 @@ function useItemWithEdits() {
 
 		await versionGate.requestSwitch(decision);
 		return false;
-	}
-
-	function getSchemaOverview(): SchemaOverview {
-		const collections = Object.fromEntries(
-			collectionsStore.collections.map((collection) => {
-				const primary = fieldsStore.getPrimaryKeyFieldForCollection(collection.collection)?.field ?? 'id';
-
-				return [
-					collection.collection,
-					{
-						collection: collection.collection,
-						primary,
-						singleton: collection.meta?.singleton ?? false,
-						sortField: null,
-						note: null,
-						accountability: null,
-						fields: {},
-					},
-				];
-			}),
-		);
-
-		return {
-			collections,
-			relations: relationsStore.relations,
-		} as unknown as SchemaOverview;
 	}
 
 	async function readParent(ref: { collection: string; key: PrimaryKey; versionKey: string }, fields: string[]) {

--- a/app/src/modules/visual/components/editing-layer.vue
+++ b/app/src/modules/visual/components/editing-layer.vue
@@ -314,6 +314,12 @@ function useVisualEditingAi({
 
 		savedTimer = setTimeout(() => {
 			sendSaved({ key: '', collection: '', item: null, payload: {} });
+
+			emit('saved', {
+				collection: parentScope?.collection ?? '',
+				primaryKey: parentScope?.key ?? '',
+			});
+
 			savedTimer = null;
 		}, 250);
 	});

--- a/app/src/modules/visual/routes/visual-editor.vue
+++ b/app/src/modules/visual/routes/visual-editor.vue
@@ -283,7 +283,7 @@ function useVersionSelection() {
 					:frame-el
 					:show-editable-elements
 					:version="selectedVersion"
-					:switch-version="onVersionSelect"
+					:switch-version="isVersionSelectable ? onVersionSelect : undefined"
 					@navigation="onNavigation"
 				/>
 			</template>

--- a/app/src/modules/visual/routes/visual-editor.vue
+++ b/app/src/modules/visual/routes/visual-editor.vue
@@ -283,6 +283,7 @@ function useVersionSelection() {
 					:frame-el
 					:show-editable-elements
 					:version="selectedVersion"
+					:switch-version="onVersionSelect"
 					@navigation="onNavigation"
 				/>
 			</template>

--- a/app/src/styles/_colors.scss
+++ b/app/src/styles/_colors.scss
@@ -38,7 +38,7 @@ $step-mapping: (
 	'50': 50,
 	'75': 75,
 	'90': 90,
-	// Special case, 'none' will result in no suffix
+	/* Special case, 'none' will result in no suffix*/
 	'none': 100,
 	'110': -90,
 	'125': -75,

--- a/app/src/utils/ensure-version-id.test.ts
+++ b/app/src/utils/ensure-version-id.test.ts
@@ -1,0 +1,42 @@
+import type { AxiosInstance } from 'axios';
+import { describe, expect, test, vi } from 'vitest';
+import { ensureVersionId } from './ensure-version-id';
+
+describe('ensureVersionId', () => {
+	test('returns the existing version id when one is found', async () => {
+		const client = {
+			get: vi.fn().mockResolvedValue({ data: { data: [{ id: 'existing-version' }] } }),
+			post: vi.fn(),
+		};
+
+		const id = await ensureVersionId(client as unknown as AxiosInstance, {
+			collection: 'pages',
+			item: 1,
+			versionKey: 'draft',
+		});
+
+		expect(id).toBe('existing-version');
+		expect(client.post).not.toHaveBeenCalled();
+	});
+
+	test('creates a new version when none exists', async () => {
+		const client = {
+			get: vi.fn().mockResolvedValue({ data: { data: [] } }),
+			post: vi.fn().mockResolvedValue({ data: { data: { id: 'new-version' } } }),
+		};
+
+		const id = await ensureVersionId(client as unknown as AxiosInstance, {
+			collection: 'pages',
+			item: 1,
+			versionKey: 'draft',
+		});
+
+		expect(id).toBe('new-version');
+
+		expect(client.post).toHaveBeenCalledWith('/versions', {
+			key: 'draft',
+			collection: 'pages',
+			item: '1',
+		});
+	});
+});

--- a/app/src/utils/ensure-version-id.ts
+++ b/app/src/utils/ensure-version-id.ts
@@ -1,3 +1,7 @@
+// Keep this in sync with api/src/utils/ensure-version-id.ts.
+// Phase 1 bridge: AI/visual paths only have { collection, item, versionKey }, but
+// /versions/save needs a version id. Phase 2 will accept version keys directly.
+
 import type { PrimaryKey } from '@directus/types';
 import type { AxiosInstance } from 'axios';
 
@@ -19,7 +23,7 @@ export async function ensureVersionId(
 		},
 	});
 
-	if (existing.length > 0) return existing[0].id;
+	if (existing.length > 0 && existing[0]?.id !== undefined) return existing[0].id;
 
 	const {
 		data: { data: created },

--- a/app/src/utils/ensure-version-id.ts
+++ b/app/src/utils/ensure-version-id.ts
@@ -1,0 +1,33 @@
+import type { PrimaryKey } from '@directus/types';
+import type { AxiosInstance } from 'axios';
+
+export async function ensureVersionId(
+	client: AxiosInstance,
+	ref: { collection: string; item: PrimaryKey; versionKey: string },
+): Promise<PrimaryKey> {
+	const {
+		data: { data: existing },
+	} = await client.get('/versions', {
+		params: {
+			filter: {
+				collection: { _eq: ref.collection },
+				item: { _eq: String(ref.item) },
+				key: { _eq: ref.versionKey },
+			},
+			limit: 1,
+			fields: ['id'],
+		},
+	});
+
+	if (existing.length > 0) return existing[0].id;
+
+	const {
+		data: { data: created },
+	} = await client.post('/versions', {
+		key: ref.versionKey,
+		collection: ref.collection,
+		item: String(ref.item),
+	});
+
+	return created.id;
+}

--- a/app/src/utils/get-schema-overview.ts
+++ b/app/src/utils/get-schema-overview.ts
@@ -1,0 +1,31 @@
+import type { Relation, SchemaOverview } from '@directus/types';
+
+export function getSchemaOverview(input: {
+	collections: Array<{ collection: string; meta?: { singleton?: boolean | null } | null }>;
+	relations: Relation[];
+	getPrimaryKeyFieldForCollection: (collection: string) => { field: string } | null | undefined;
+}): SchemaOverview {
+	const collections = Object.fromEntries(
+		input.collections.map((collection) => {
+			const primary = input.getPrimaryKeyFieldForCollection(collection.collection)?.field ?? 'id';
+
+			return [
+				collection.collection,
+				{
+					collection: collection.collection,
+					primary,
+					singleton: collection.meta?.singleton ?? false,
+					sortField: null,
+					note: null,
+					accountability: null,
+					fields: {},
+				},
+			];
+		}),
+	);
+
+	return {
+		collections,
+		relations: input.relations,
+	} as unknown as SchemaOverview;
+}

--- a/app/src/views/private/components/live-preview.vue
+++ b/app/src/views/private/components/live-preview.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useElementSize } from '@directus/composables';
-import type { ContentVersion } from '@directus/types';
+import type { ContentVersion, PrimaryKey } from '@directus/types';
 import { sameOrigin } from '@directus/utils/browser';
 import { SplitPanel } from '@directus/vue-split-panel';
 import { computed, type CSSProperties, nextTick, onMounted, ref, useSlots, watch } from 'vue';
@@ -44,6 +44,8 @@ const {
 	sidebarSize,
 	sidebarCollapsed = true,
 	sidebarDisabled = false,
+	parentScope,
+	switchVersion,
 } = defineProps<{
 	url: string | string[];
 	invalidUrl?: boolean;
@@ -63,6 +65,8 @@ const {
 	sidebarSize?: number;
 	sidebarCollapsed?: boolean;
 	sidebarDisabled?: boolean;
+	parentScope?: { collection: string; key: PrimaryKey };
+	switchVersion?: (versionKey: string) => void | Promise<void>;
 }>();
 
 const emit = defineEmits<{
@@ -505,6 +509,8 @@ function useUrls() {
 								:frame-el="frameEl"
 								:frame-src="frameSrc"
 								:version="version"
+								:parent-scope
+								:switch-version
 								:show-editable-elements="showEditableElements"
 								@saved="(data) => emit('saved', data)"
 							/>
@@ -547,6 +553,8 @@ function useUrls() {
 						:frame-el="frameEl"
 						:frame-src="frameSrc"
 						:version="version"
+						:parent-scope
+						:switch-version
 						:show-editable-elements="showEditableElements"
 						@saved="(data) => emit('saved', data)"
 					/>

--- a/app/src/views/private/components/live-preview.vue
+++ b/app/src/views/private/components/live-preview.vue
@@ -46,6 +46,7 @@ const {
 	sidebarDisabled = false,
 	parentScope,
 	switchVersion,
+	hasUnsavedEdits = false,
 } = defineProps<{
 	url: string | string[];
 	invalidUrl?: boolean;
@@ -67,6 +68,7 @@ const {
 	sidebarDisabled?: boolean;
 	parentScope?: { collection: string; key: PrimaryKey };
 	switchVersion?: (versionKey: string) => void | Promise<void>;
+	hasUnsavedEdits?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -511,6 +513,7 @@ function useUrls() {
 								:version="version"
 								:parent-scope
 								:switch-version
+								:has-unsaved-edits="hasUnsavedEdits"
 								:show-editable-elements="showEditableElements"
 								@saved="(data) => emit('saved', data)"
 							/>
@@ -555,6 +558,7 @@ function useUrls() {
 						:version="version"
 						:parent-scope
 						:switch-version
+						:has-unsaved-edits="hasUnsavedEdits"
 						:show-editable-elements="showEditableElements"
 						@saved="(data) => emit('saved', data)"
 					/>

--- a/app/src/views/private/components/overlay-item.test.ts
+++ b/app/src/views/private/components/overlay-item.test.ts
@@ -1,5 +1,5 @@
 import { createTestingPinia } from '@pinia/testing';
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { computed, ref } from 'vue';
 import OverlayItem from './overlay-item.vue';
@@ -7,6 +7,7 @@ import { ClickOutside } from '@/__utils__/click-outside';
 import { Tooltip } from '@/__utils__/tooltip';
 import type { GlobalMountOptions } from '@/__utils__/types';
 import { i18n } from '@/lang';
+import api from '@/api';
 
 const mockCollabConnected = ref<boolean | undefined>(false);
 const mockSaveAllowed = ref(true);
@@ -203,6 +204,27 @@ describe('isSavable', () => {
 
 		const saveButton = getSaveButton(wrapper);
 		expect(saveButton.attributes('disabled')).toBe('true');
+	});
+});
+
+describe('initialValues', () => {
+	it('uses provided initial values instead of fetching the item', async () => {
+		const initialValues = { id: '1', title: 'Draft title' };
+
+		const wrapper = mount(OverlayItem, {
+			props: {
+				collection: 'articles',
+				active: true,
+				primaryKey: '1',
+				initialValues,
+			},
+			global,
+		});
+
+		await flushPromises();
+
+		expect(api.get).not.toHaveBeenCalled();
+		expect(wrapper.findComponent({ name: 'OverlayItemContent' }).props('initialValues')).toEqual(initialValues);
 	});
 });
 

--- a/app/src/views/private/components/overlay-item.test.ts
+++ b/app/src/views/private/components/overlay-item.test.ts
@@ -216,7 +216,7 @@ describe('initialValues', () => {
 				collection: 'articles',
 				active: true,
 				primaryKey: '1',
-				initialValues,
+				initialItem: initialValues,
 			},
 			global,
 		});

--- a/app/src/views/private/components/overlay-item.test.ts
+++ b/app/src/views/private/components/overlay-item.test.ts
@@ -6,8 +6,8 @@ import OverlayItem from './overlay-item.vue';
 import { ClickOutside } from '@/__utils__/click-outside';
 import { Tooltip } from '@/__utils__/tooltip';
 import type { GlobalMountOptions } from '@/__utils__/types';
-import { i18n } from '@/lang';
 import api from '@/api';
+import { i18n } from '@/lang';
 
 const mockCollabConnected = ref<boolean | undefined>(false);
 const mockSaveAllowed = ref(true);

--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -46,6 +46,7 @@ export interface OverlayItemProps {
 	active?: boolean;
 	primaryKey?: PrimaryKey | null;
 	edits?: Record<string, any>;
+	initialValues?: Record<string, any> | null;
 	junctionField?: string | null;
 	disabled?: boolean;
 	nonEditable?: boolean;
@@ -366,6 +367,11 @@ function useItem() {
 
 	async function fetchItem() {
 		if (!props.primaryKey) return;
+
+		if (props.initialValues) {
+			initialValues.value = props.initialValues;
+			return;
+		}
 
 		loading.value = true;
 

--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -46,7 +46,7 @@ export interface OverlayItemProps {
 	active?: boolean;
 	primaryKey?: PrimaryKey | null;
 	edits?: Record<string, any>;
-	initialValues?: Record<string, any> | null;
+	initialItem?: Record<string, any> | null;
 	junctionField?: string | null;
 	disabled?: boolean;
 	nonEditable?: boolean;
@@ -368,8 +368,8 @@ function useItem() {
 	async function fetchItem() {
 		if (!props.primaryKey) return;
 
-		if (props.initialValues) {
-			initialValues.value = props.initialValues;
+		if (props.initialItem) {
+			initialValues.value = props.initialItem;
 			return;
 		}
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -64,6 +64,12 @@ export interface VisualElementContextData {
 	collection: string;
 	item: PrimaryKey;
 	fields?: string[];
+	version?: string;
+	parent?: {
+		collection: string;
+		item: PrimaryKey;
+		version: string;
+	};
 	rect?: { top: number; left: number; width: number; height: number };
 }
 

--- a/packages/utils/shared/index.ts
+++ b/packages/utils/shared/index.ts
@@ -43,3 +43,4 @@ export * from './validate-payload.js';
 export * from './deep-map-filter.js';
 export * from './get-relation-info.js';
 export * from './deep-map-with-schema.js';
+export * from './write-target.js';

--- a/packages/utils/shared/write-target.test.ts
+++ b/packages/utils/shared/write-target.test.ts
@@ -210,7 +210,7 @@ describe('resolveWriteTarget', () => {
 });
 
 describe('mergeNestedRelationDeltaInto', () => {
-	test('deep-merges detailed update syntax and overwrites other fields', () => {
+	test('deep-merges detailed update syntax for different rows and overwrites other fields', () => {
 		const target = {
 			blocks: { create: [{ id: 1 }], update: [{ id: 2 }], delete: [3] },
 			seo: { id: 1, title: 'Old' },
@@ -229,6 +229,44 @@ describe('mergeNestedRelationDeltaInto', () => {
 			},
 			seo: { id: 1, description: 'New' },
 		});
+	});
+
+	test('merges repeated detailed updates for the same row', () => {
+		const target = {
+			blocks: {
+				create: [],
+				update: [
+					{
+						id: 'junction-1',
+						collection: 'block_hero',
+						item: { id: 'block-1', headline: 'Old', tagline: 'Backend + CMS test' },
+					},
+				],
+				delete: [],
+			},
+		};
+
+		mergeNestedRelationDeltaInto(target, {
+			blocks: {
+				create: [],
+				update: [
+					{
+						id: 'junction-1',
+						collection: 'block_hero',
+						item: { id: 'block-1', tagline: 'Backend + CMS carlos' },
+					},
+				],
+				delete: [],
+			},
+		});
+
+		expect(target.blocks.update).toEqual([
+			{
+				id: 'junction-1',
+				collection: 'block_hero',
+				item: { id: 'block-1', headline: 'Old', tagline: 'Backend + CMS carlos' },
+			},
+		]);
 	});
 });
 

--- a/packages/utils/shared/write-target.test.ts
+++ b/packages/utils/shared/write-target.test.ts
@@ -1,6 +1,15 @@
 import type { Relation, SchemaOverview } from '@directus/types';
 import { describe, expect, test, vi } from 'vitest';
-import { buildPayload, mergeNestedRelationDeltaInto, REFUSAL, resolveWriteTarget } from './write-target.js';
+import {
+	buildPayload,
+	findParentInitialValue,
+	getParentInitialValueFields,
+	getSchemaPrimaryKeyFields,
+	mergeNestedRelationDeltaInto,
+	resolveWriteTarget,
+	WRITE_TARGET_REFUSAL,
+	type WriteTarget,
+} from './write-target.js';
 
 describe('resolveWriteTarget', () => {
 	test('routes versioned collection updates to the item version', async () => {
@@ -25,7 +34,7 @@ describe('resolveWriteTarget', () => {
 				readParent: vi.fn(),
 			});
 
-			expect(result).toMatchObject({ kind: 'refuse', token: REFUSAL.VERSIONING_REQUIRED });
+			expect(result).toMatchObject({ kind: 'refuse', token: WRITE_TARGET_REFUSAL.VERSIONING_REQUIRED });
 		}
 	});
 
@@ -45,7 +54,8 @@ describe('resolveWriteTarget', () => {
 		});
 
 		expect(result.kind).toBe('parent-version');
-		expect(buildPayload(result as any, { title: 'New' }, 5)).toEqual({
+
+		expect(buildPayload(result as WriteTarget, { title: 'New' }, 5)).toEqual({
 			translations: {
 				create: [],
 				update: [{ id: 5, title: 'New' }],
@@ -72,7 +82,8 @@ describe('resolveWriteTarget', () => {
 		});
 
 		expect(result.kind).toBe('parent-version');
-		expect(buildPayload(result as any, { name: 'New' }, 5)).toEqual({
+
+		expect(buildPayload(result as WriteTarget, { name: 'New' }, 5)).toEqual({
 			tags: {
 				create: [],
 				update: [{ id: 12, tags_id: { id: 5, name: 'New' } }],
@@ -102,7 +113,8 @@ describe('resolveWriteTarget', () => {
 		});
 
 		expect(result.kind).toBe('parent-version');
-		expect(buildPayload(result as any, { title: 'New' }, 9)).toEqual({
+
+		expect(buildPayload(result as WriteTarget, { title: 'New' }, 9)).toEqual({
 			blocks: {
 				create: [],
 				update: [{ id: 7, collection: 'block_hero', item: { id: 9, title: 'New' } }],
@@ -123,7 +135,26 @@ describe('resolveWriteTarget', () => {
 		});
 
 		expect(result.kind).toBe('parent-version');
-		expect(buildPayload(result as any, { title: 'New' }, 4)).toEqual({
+
+		expect(buildPayload(result as WriteTarget, { title: 'New' }, 4)).toEqual({
+			seo: { id: 4, title: 'New' },
+		});
+	});
+
+	test('routes M2O child updates through the parent version when a reverse alias exists', async () => {
+		const schema = createSchema([relation('pages', 'seo', 'seo', { oneField: 'pages' })]);
+
+		const result = await resolveWriteTarget({
+			schema,
+			target: { collection: 'seo', key: 4 },
+			hint: { page: { collection: 'pages', item: 1, version: 'draft' } },
+			collectionHasVersioning: versionedCollections('pages'),
+			readParent: vi.fn(async () => ({ seo: { id: 4, title: 'Old' } })),
+		});
+
+		expect(result.kind).toBe('parent-version');
+
+		expect(buildPayload(result as WriteTarget, { title: 'New' }, 4)).toEqual({
 			seo: { id: 4, title: 'New' },
 		});
 	});
@@ -193,7 +224,7 @@ describe('resolveWriteTarget', () => {
 			})),
 		});
 
-		expect(result).toMatchObject({ kind: 'refuse', token: REFUSAL.MULTI_RELATION });
+		expect(result).toMatchObject({ kind: 'refuse', token: WRITE_TARGET_REFUSAL.MULTI_RELATION });
 	});
 
 	test('refuses versioned child saves without parent context', async () => {
@@ -205,7 +236,93 @@ describe('resolveWriteTarget', () => {
 			readParent: vi.fn(),
 		});
 
-		expect(result).toMatchObject({ kind: 'refuse', token: REFUSAL.NO_PARENT_CONTEXT });
+		expect(result).toMatchObject({ kind: 'refuse', token: WRITE_TARGET_REFUSAL.NO_PARENT_CONTEXT });
+	});
+
+	test('routes to published when the parent collection is not versioned', async () => {
+		const readParent = vi.fn();
+
+		const result = await resolveWriteTarget({
+			schema: createSchema([relation('pages', 'seo', 'seo')]),
+			target: { collection: 'seo', key: 4 },
+			hint: { page: { collection: 'pages', item: 1, version: 'draft' } },
+			collectionHasVersioning: versionedCollections(),
+			readParent,
+		});
+
+		expect(result).toEqual({ kind: 'published', collection: 'seo', key: 4 });
+		expect(readParent).not.toHaveBeenCalled();
+	});
+
+	test('refuses parent version saves when the target item is not in the parent version', async () => {
+		const result = await resolveWriteTarget({
+			schema: createSchema([relation('pages', 'seo', 'seo')]),
+			target: { collection: 'seo', key: 4 },
+			hint: { page: { collection: 'pages', item: 1, version: 'draft' } },
+			collectionHasVersioning: versionedCollections('pages'),
+			readParent: vi.fn(async () => ({ seo: { id: 5 } })),
+		});
+
+		expect(result).toMatchObject({ kind: 'refuse', token: WRITE_TARGET_REFUSAL.RELATED_NOT_FOUND });
+	});
+
+	test('refuses stale visual attachments when the target item is not in the parent version', async () => {
+		const result = await resolveWriteTarget({
+			schema: createSchema([relation('pages', 'seo', 'seo')]),
+			target: { collection: 'seo', key: 4 },
+			hint: {
+				attachment: {
+					collection: 'seo',
+					item: 4,
+					version: 'draft',
+					parent: { collection: 'pages', key: 1, versionKey: 'draft' },
+				},
+			},
+			collectionHasVersioning: versionedCollections('pages'),
+			readParent: vi.fn(async () => ({ seo: { id: 5 } })),
+		});
+
+		expect(result).toMatchObject({ kind: 'refuse', token: WRITE_TARGET_REFUSAL.STALE_ATTACHMENT });
+	});
+
+	test('returns the parent item from the winning candidate, not a later non-match', async () => {
+		const schema = createSchema([
+			relation('pages_blocks', 'pages_id', 'pages', {
+				oneField: 'blocks',
+				junctionField: 'item',
+			}),
+			relation('pages_blocks', 'item', null, {
+				oneCollectionField: 'collection',
+				oneAllowedCollections: ['block_hero'],
+			}),
+			relation('pages_other_blocks', 'pages_id', 'pages', {
+				oneField: 'other_blocks',
+				junctionField: 'item',
+			}),
+			relation('pages_other_blocks', 'item', null, {
+				oneCollectionField: 'collection',
+				oneAllowedCollections: ['block_hero'],
+			}),
+		]);
+
+		const winningParent = { blocks: [{ id: 7, collection: 'block_hero', item: { id: 9 } }], _marker: 'winner' };
+
+		const nonMatchingParent = {
+			other_blocks: [{ id: 8, collection: 'block_hero', item: { id: 10 } }],
+			_marker: 'loser',
+		};
+
+		const readParent = vi.fn().mockResolvedValueOnce(winningParent).mockResolvedValueOnce(nonMatchingParent);
+
+		const result = await resolveWriteTarget({
+			schema,
+			target: { collection: 'block_hero', key: 9 },
+			hint: { page: { collection: 'pages', item: 1, version: 'draft' } },
+			collectionHasVersioning: versionedCollections('pages'),
+			readParent,
+		});
+
+		expect(result).toMatchObject({ kind: 'parent-version', parentItem: { _marker: 'winner' } });
 	});
 });
 
@@ -267,6 +384,211 @@ describe('mergeNestedRelationDeltaInto', () => {
 				item: { id: 'block-1', headline: 'Old', tagline: 'Backend + CMS carlos' },
 			},
 		]);
+	});
+
+	test('merges repeated detailed updates with custom primary key fields', () => {
+		const target = {
+			blocks: {
+				create: [],
+				update: [{ junction_uuid: 'junction-1', title: 'Old' }],
+				delete: [],
+			},
+		};
+
+		mergeNestedRelationDeltaInto(
+			target,
+			{
+				blocks: {
+					create: [],
+					update: [{ junction_uuid: 'junction-1', title: 'New' }],
+					delete: [],
+				},
+			},
+			{ identityFields: ['junction_uuid'] },
+		);
+
+		expect(target.blocks.update).toEqual([{ junction_uuid: 'junction-1', title: 'New' }]);
+	});
+
+	test('preserves nested custom primary key fields when merging repeated updates', () => {
+		const target = {
+			blocks: {
+				create: [],
+				update: [
+					{
+						junction_uuid: 'junction-1',
+						collection: 'block_hero',
+						item: { block_uuid: 'block-1', headline: 'Old', tagline: 'Old tagline' },
+					},
+				],
+				delete: [],
+			},
+		};
+
+		mergeNestedRelationDeltaInto(
+			target,
+			{
+				blocks: {
+					create: [],
+					update: [
+						{
+							junction_uuid: 'junction-1',
+							collection: 'block_hero',
+							item: { block_uuid: 'block-1', tagline: 'New tagline' },
+						},
+					],
+					delete: [],
+				},
+			},
+			{ identityFields: ['junction_uuid', 'block_uuid'] },
+		);
+
+		expect(target.blocks.update).toEqual([
+			{
+				junction_uuid: 'junction-1',
+				collection: 'block_hero',
+				item: { block_uuid: 'block-1', headline: 'Old', tagline: 'New tagline' },
+			},
+		]);
+	});
+
+	test('derives primary key fields from the schema', () => {
+		const schema = createSchema();
+		schema.collections['pages']!.primary = 'page_uuid';
+		schema.collections['block_hero']!.primary = 'block_uuid';
+
+		expect(getSchemaPrimaryKeyFields(schema)).toEqual(['block_uuid', 'page_uuid', 'id']);
+	});
+});
+
+describe('getParentInitialValueFields', () => {
+	test('uses `.*` projection for o2m and m2m so the form has data to render', () => {
+		// Locks the intentional divergence from the internal `getParentReadFields` — read-time
+		// only needs the child pk to verify the match, but the initial-value preview needs the
+		// full child shape. A future "harmonization" pass that collapses the two would silently
+		// break the form preview for o2m and m2m children.
+		expect(getParentInitialValueFields({ kind: 'o2m', parentField: 'translations', childPkField: 'id' })).toEqual([
+			'translations.*',
+		]);
+
+		expect(
+			getParentInitialValueFields({
+				kind: 'm2m',
+				parentField: 'tags',
+				junctionCollection: 'articles_tags',
+				junctionPkField: 'id',
+				junctionField: 'tags_id',
+				junctionItem: {},
+				childPkField: 'id',
+			}),
+		).toEqual(['tags.id', 'tags.tags_id.*']);
+	});
+
+	test('returns full field paths for m2o and m2a', () => {
+		expect(getParentInitialValueFields({ kind: 'm2o', parentField: 'seo', childPkField: 'id' })).toEqual(['seo.*']);
+
+		expect(
+			getParentInitialValueFields({
+				kind: 'm2a',
+				parentField: 'blocks',
+				junctionCollection: 'pages_blocks',
+				junctionPkField: 'id',
+				junctionField: 'item',
+				collectionField: 'collection',
+				junctionItem: {},
+				childPkField: 'id',
+			}),
+		).toEqual(['blocks.id', 'blocks.collection', 'blocks.item.*']);
+	});
+});
+
+describe('findParentInitialValue', () => {
+	test('returns the matching child for m2o', () => {
+		const child = findParentInitialValue(
+			{ kind: 'm2o', parentField: 'seo', childPkField: 'id' },
+			{ seo: { id: 4, title: 'Hello' } },
+			'seo',
+			4,
+		);
+
+		expect(child).toEqual({ id: 4, title: 'Hello' });
+	});
+
+	test('returns null when the m2o child key does not match', () => {
+		const child = findParentInitialValue(
+			{ kind: 'm2o', parentField: 'seo', childPkField: 'id' },
+			{ seo: { id: 4 } },
+			'seo',
+			99,
+		);
+
+		expect(child).toBeNull();
+	});
+
+	test('returns the matching child for o2m', () => {
+		const child = findParentInitialValue(
+			{ kind: 'o2m', parentField: 'translations', childPkField: 'id' },
+			{
+				translations: [
+					{ id: 5, title: 'Old' },
+					{ id: 6, title: 'Other' },
+				],
+			},
+			'articles_translations',
+			5,
+		);
+
+		expect(child).toEqual({ id: 5, title: 'Old' });
+	});
+
+	test('returns the matching child for m2m', () => {
+		const child = findParentInitialValue(
+			{
+				kind: 'm2m',
+				parentField: 'tags',
+				junctionCollection: 'articles_tags',
+				junctionPkField: 'id',
+				junctionField: 'tags_id',
+				junctionItem: {},
+				childPkField: 'id',
+			},
+			{ tags: [{ id: 12, tags_id: { id: 5, name: 'Featured' } }] },
+			'tags',
+			5,
+		);
+
+		expect(child).toEqual({ id: 5, name: 'Featured' });
+	});
+
+	test('returns the matching child for m2a and rejects mismatching collection', () => {
+		const relation = {
+			kind: 'm2a' as const,
+			parentField: 'blocks',
+			junctionCollection: 'pages_blocks',
+			junctionPkField: 'id',
+			junctionField: 'item',
+			collectionField: 'collection',
+			junctionItem: {},
+			childPkField: 'id',
+		};
+
+		expect(
+			findParentInitialValue(
+				relation,
+				{ blocks: [{ id: 7, collection: 'block_hero', item: { id: 9, headline: 'Hi' } }] },
+				'block_hero',
+				9,
+			),
+		).toEqual({ id: 9, headline: 'Hi' });
+
+		expect(
+			findParentInitialValue(
+				relation,
+				{ blocks: [{ id: 7, collection: 'block_cta', item: { id: 9, headline: 'Hi' } }] },
+				'block_hero',
+				9,
+			),
+		).toBeNull();
 	});
 });
 

--- a/packages/utils/shared/write-target.test.ts
+++ b/packages/utils/shared/write-target.test.ts
@@ -6,6 +6,7 @@ import {
 	getParentInitialValueFields,
 	getSchemaPrimaryKeyFields,
 	mergeNestedRelationDeltaInto,
+	prefixChildFields,
 	resolveWriteTarget,
 	WRITE_TARGET_REFUSAL,
 	type WriteTarget,
@@ -467,6 +468,103 @@ describe('mergeNestedRelationDeltaInto', () => {
 
 		expect(getSchemaPrimaryKeyFields(schema)).toEqual(['block_uuid', 'page_uuid', 'id']);
 	});
+
+	test('drops earlier update when a later save deletes the same identity', () => {
+		const target = {
+			blocks: { create: [], update: [{ id: 5, title: 'A' }], delete: [] },
+		};
+
+		mergeNestedRelationDeltaInto(target, {
+			blocks: { create: [], update: [], delete: [5] },
+		});
+
+		expect(target).toEqual({
+			blocks: { create: [], update: [], delete: [5] },
+		});
+	});
+
+	test('drops earlier create when a later save deletes the same identity', () => {
+		const target = {
+			blocks: { create: [{ id: 5, title: 'A' }], update: [], delete: [] },
+		};
+
+		mergeNestedRelationDeltaInto(target, {
+			blocks: { create: [], update: [], delete: [5] },
+		});
+
+		expect(target).toEqual({
+			blocks: { create: [], update: [], delete: [5] },
+		});
+	});
+
+	test('drops earlier delete when a later save updates the same identity', () => {
+		const target = {
+			blocks: { create: [], update: [], delete: [5] },
+		};
+
+		mergeNestedRelationDeltaInto(target, {
+			blocks: { create: [], update: [{ id: 5, title: 'B' }], delete: [] },
+		});
+
+		expect(target).toEqual({
+			blocks: { create: [], update: [{ id: 5, title: 'B' }], delete: [] },
+		});
+	});
+
+	test('drops earlier delete when a later save creates the same identity', () => {
+		const target = {
+			blocks: { create: [], update: [], delete: [5] },
+		};
+
+		mergeNestedRelationDeltaInto(target, {
+			blocks: { create: [{ id: 5, title: 'B' }], update: [], delete: [] },
+		});
+
+		expect(target).toEqual({
+			blocks: { create: [{ id: 5, title: 'B' }], update: [], delete: [] },
+		});
+	});
+
+	test('reconciles using custom identity fields', () => {
+		const target = {
+			blocks: { create: [], update: [{ junction_uuid: 'j-1', title: 'A' }], delete: [] },
+		};
+
+		mergeNestedRelationDeltaInto(
+			target,
+			{ blocks: { create: [], update: [], delete: ['j-1'] } },
+			{ identityFields: ['junction_uuid'] },
+		);
+
+		expect(target).toEqual({
+			blocks: { create: [], update: [], delete: ['j-1'] },
+		});
+	});
+
+	test('leaves unrelated identities untouched while reconciling overlapping ones', () => {
+		const target = {
+			blocks: {
+				create: [{ id: 1 }],
+				update: [
+					{ id: 2, title: 'Keep' },
+					{ id: 3, title: 'Drop' },
+				],
+				delete: [9],
+			},
+		};
+
+		mergeNestedRelationDeltaInto(target, {
+			blocks: { create: [{ id: 9, title: 'Resurrect' }], update: [], delete: [3] },
+		});
+
+		expect(target).toEqual({
+			blocks: {
+				create: [{ id: 1 }, { id: 9, title: 'Resurrect' }],
+				update: [{ id: 2, title: 'Keep' }],
+				delete: [3],
+			},
+		});
+	});
 });
 
 describe('getParentInitialValueFields', () => {
@@ -507,6 +605,55 @@ describe('getParentInitialValueFields', () => {
 				childPkField: 'id',
 			}),
 		).toEqual(['blocks.id', 'blocks.collection', 'blocks.item.*']);
+	});
+});
+
+describe('prefixChildFields', () => {
+	test('prefixes child fields with the parent field for o2m', () => {
+		expect(
+			prefixChildFields({ kind: 'o2m', parentField: 'translations', childPkField: 'id' }, ['id', 'title', 'body']),
+		).toEqual(['translations.id', 'translations.title', 'translations.body']);
+	});
+
+	test('prefixes child fields with the parent field for m2o', () => {
+		expect(prefixChildFields({ kind: 'm2o', parentField: 'seo', childPkField: 'id' }, ['title'])).toEqual([
+			'seo.title',
+		]);
+	});
+
+	test('prefixes through the junction field for m2m', () => {
+		expect(
+			prefixChildFields(
+				{
+					kind: 'm2m',
+					parentField: 'tags',
+					junctionCollection: 'articles_tags',
+					junctionPkField: 'id',
+					junctionField: 'tags_id',
+					junctionItem: {},
+					childPkField: 'id',
+				},
+				['id', 'name'],
+			),
+		).toEqual(['tags.tags_id.id', 'tags.tags_id.name']);
+	});
+
+	test('prefixes through the junction field for m2a and includes the collection discriminator', () => {
+		expect(
+			prefixChildFields(
+				{
+					kind: 'm2a',
+					parentField: 'blocks',
+					junctionCollection: 'pages_blocks',
+					junctionPkField: 'id',
+					junctionField: 'item',
+					collectionField: 'collection',
+					junctionItem: {},
+					childPkField: 'id',
+				},
+				['id', 'headline'],
+			),
+		).toEqual(['blocks.collection', 'blocks.item.id', 'blocks.item.headline']);
 	});
 });
 

--- a/packages/utils/shared/write-target.test.ts
+++ b/packages/utils/shared/write-target.test.ts
@@ -327,7 +327,7 @@ describe('resolveWriteTarget', () => {
 });
 
 describe('mergeNestedRelationDeltaInto', () => {
-	test('deep-merges detailed update syntax for different rows and overwrites other fields', () => {
+	test('deep-merges detailed update syntax for different rows and accumulates same-identity field edits', () => {
 		const target = {
 			blocks: { create: [{ id: 1 }], update: [{ id: 2 }], delete: [3] },
 			seo: { id: 1, title: 'Old' },
@@ -344,8 +344,16 @@ describe('mergeNestedRelationDeltaInto', () => {
 				update: [{ id: 2 }, { id: 5 }],
 				delete: [3, 6],
 			},
-			seo: { id: 1, description: 'New' },
+			seo: { id: 1, title: 'Old', description: 'New' },
 		});
+	});
+
+	test('overwrites m2o relation when the related row identity changes', () => {
+		const target = { seo: { id: 1, title: 'Old' } };
+
+		mergeNestedRelationDeltaInto(target, { seo: { id: 2, title: 'Other' } });
+
+		expect(target).toEqual({ seo: { id: 2, title: 'Other' } });
 	});
 
 	test('merges repeated detailed updates for the same row', () => {

--- a/packages/utils/shared/write-target.test.ts
+++ b/packages/utils/shared/write-target.test.ts
@@ -1,0 +1,291 @@
+import type { Relation, SchemaOverview } from '@directus/types';
+import { describe, expect, test, vi } from 'vitest';
+import { buildPayload, mergeNestedRelationDeltaInto, REFUSAL, resolveWriteTarget } from './write-target.js';
+
+describe('resolveWriteTarget', () => {
+	test('routes versioned collection updates to the item version', async () => {
+		const result = await resolveWriteTarget({
+			schema: createSchema(),
+			target: { collection: 'pages', key: 1 },
+			hint: { explicitVersion: 'draft' },
+			collectionHasVersioning: versionedCollections('pages'),
+			readParent: vi.fn(),
+		});
+
+		expect(result).toEqual({ kind: 'item-version', collection: 'pages', key: 1, versionKey: 'draft' });
+	});
+
+	test('refuses versioned collection updates without a draft version', async () => {
+		for (const explicitVersion of [undefined, 'published', 'main']) {
+			const result = await resolveWriteTarget({
+				schema: createSchema(),
+				target: { collection: 'pages', key: 1 },
+				hint: { explicitVersion },
+				collectionHasVersioning: versionedCollections('pages'),
+				readParent: vi.fn(),
+			});
+
+			expect(result).toMatchObject({ kind: 'refuse', token: REFUSAL.VERSIONING_REQUIRED });
+		}
+	});
+
+	test('routes O2M child updates through the parent version', async () => {
+		const schema = createSchema([
+			relation('articles_translations', 'articles_id', 'articles', {
+				oneField: 'translations',
+			}),
+		]);
+
+		const result = await resolveWriteTarget({
+			schema,
+			target: { collection: 'articles_translations', key: 5 },
+			hint: { page: { collection: 'articles', item: 1, version: 'draft' } },
+			collectionHasVersioning: versionedCollections('articles'),
+			readParent: vi.fn(async () => ({ translations: [{ id: 5, title: 'Old' }] })),
+		});
+
+		expect(result.kind).toBe('parent-version');
+		expect(buildPayload(result as any, { title: 'New' }, 5)).toEqual({
+			translations: {
+				create: [],
+				update: [{ id: 5, title: 'New' }],
+				delete: [],
+			},
+		});
+	});
+
+	test('routes M2M related item updates through the parent version', async () => {
+		const schema = createSchema([
+			relation('articles_tags', 'articles_id', 'articles', {
+				oneField: 'tags',
+				junctionField: 'tags_id',
+			}),
+			relation('articles_tags', 'tags_id', 'tags'),
+		]);
+
+		const result = await resolveWriteTarget({
+			schema,
+			target: { collection: 'tags', key: 5 },
+			hint: { page: { collection: 'articles', item: 1, version: 'draft' } },
+			collectionHasVersioning: versionedCollections('articles'),
+			readParent: vi.fn(async () => ({ tags: [{ id: 12, tags_id: { id: 5, name: 'Old' } }] })),
+		});
+
+		expect(result.kind).toBe('parent-version');
+		expect(buildPayload(result as any, { name: 'New' }, 5)).toEqual({
+			tags: {
+				create: [],
+				update: [{ id: 12, tags_id: { id: 5, name: 'New' } }],
+				delete: [],
+			},
+		});
+	});
+
+	test('routes M2A child updates through the parent version', async () => {
+		const schema = createSchema([
+			relation('pages_blocks', 'pages_id', 'pages', {
+				oneField: 'blocks',
+				junctionField: 'item',
+			}),
+			relation('pages_blocks', 'item', null, {
+				oneCollectionField: 'collection',
+				oneAllowedCollections: ['block_hero'],
+			}),
+		]);
+
+		const result = await resolveWriteTarget({
+			schema,
+			target: { collection: 'block_hero', key: 9 },
+			hint: { page: { collection: 'pages', item: 1, version: 'draft' } },
+			collectionHasVersioning: versionedCollections('pages'),
+			readParent: vi.fn(async () => ({ blocks: [{ id: 7, collection: 'block_hero', item: { id: 9, title: 'Old' } }] })),
+		});
+
+		expect(result.kind).toBe('parent-version');
+		expect(buildPayload(result as any, { title: 'New' }, 9)).toEqual({
+			blocks: {
+				create: [],
+				update: [{ id: 7, collection: 'block_hero', item: { id: 9, title: 'New' } }],
+				delete: [],
+			},
+		});
+	});
+
+	test('routes M2O child updates through the parent version', async () => {
+		const schema = createSchema([relation('pages', 'seo', 'seo')]);
+
+		const result = await resolveWriteTarget({
+			schema,
+			target: { collection: 'seo', key: 4 },
+			hint: { page: { collection: 'pages', item: 1, version: 'draft' } },
+			collectionHasVersioning: versionedCollections('pages'),
+			readParent: vi.fn(async () => ({ seo: { id: 4, title: 'Old' } })),
+		});
+
+		expect(result.kind).toBe('parent-version');
+		expect(buildPayload(result as any, { title: 'New' }, 4)).toEqual({
+			seo: { id: 4, title: 'New' },
+		});
+	});
+
+	test('disambiguates multiple structural relations after reading the parent', async () => {
+		const schema = createSchema([
+			relation('pages_blocks', 'pages_id', 'pages', {
+				oneField: 'hero_blocks',
+				junctionField: 'item',
+			}),
+			relation('pages_blocks', 'item', null, {
+				oneCollectionField: 'collection',
+				oneAllowedCollections: ['block_hero'],
+			}),
+			relation('pages_other_blocks', 'pages_id', 'pages', {
+				oneField: 'other_blocks',
+				junctionField: 'item',
+			}),
+			relation('pages_other_blocks', 'item', null, {
+				oneCollectionField: 'collection',
+				oneAllowedCollections: ['block_hero'],
+			}),
+		]);
+
+		const result = await resolveWriteTarget({
+			schema,
+			target: { collection: 'block_hero', key: 9 },
+			hint: { page: { collection: 'pages', item: 1, version: 'draft' } },
+			collectionHasVersioning: versionedCollections('pages'),
+			readParent: vi.fn(async () => ({
+				hero_blocks: [{ id: 7, collection: 'block_hero', item: { id: 9 } }],
+				other_blocks: [{ id: 8, collection: 'block_hero', item: { id: 10 } }],
+			})),
+		});
+
+		expect(result).toMatchObject({ kind: 'parent-version', relation: { kind: 'm2a', parentField: 'hero_blocks' } });
+	});
+
+	test('refuses only when multiple relations actually contain the target', async () => {
+		const schema = createSchema([
+			relation('pages_blocks', 'pages_id', 'pages', {
+				oneField: 'blocks',
+				junctionField: 'item',
+			}),
+			relation('pages_blocks', 'item', null, {
+				oneCollectionField: 'collection',
+				oneAllowedCollections: ['block_hero'],
+			}),
+			relation('pages_other_blocks', 'pages_id', 'pages', {
+				oneField: 'other_blocks',
+				junctionField: 'item',
+			}),
+			relation('pages_other_blocks', 'item', null, {
+				oneCollectionField: 'collection',
+				oneAllowedCollections: ['block_hero'],
+			}),
+		]);
+
+		const result = await resolveWriteTarget({
+			schema,
+			target: { collection: 'block_hero', key: 9 },
+			hint: { page: { collection: 'pages', item: 1, version: 'draft' } },
+			collectionHasVersioning: versionedCollections('pages'),
+			readParent: vi.fn(async () => ({
+				blocks: [{ id: 7, collection: 'block_hero', item: { id: 9 } }],
+				other_blocks: [{ id: 8, collection: 'block_hero', item: { id: 9 } }],
+			})),
+		});
+
+		expect(result).toMatchObject({ kind: 'refuse', token: REFUSAL.MULTI_RELATION });
+	});
+
+	test('refuses versioned child saves without parent context', async () => {
+		const result = await resolveWriteTarget({
+			schema: createSchema(),
+			target: { collection: 'blocks', key: 1 },
+			hint: { explicitVersion: 'draft' },
+			collectionHasVersioning: versionedCollections(),
+			readParent: vi.fn(),
+		});
+
+		expect(result).toMatchObject({ kind: 'refuse', token: REFUSAL.NO_PARENT_CONTEXT });
+	});
+});
+
+describe('mergeNestedRelationDeltaInto', () => {
+	test('deep-merges detailed update syntax and overwrites other fields', () => {
+		const target = {
+			blocks: { create: [{ id: 1 }], update: [{ id: 2 }], delete: [3] },
+			seo: { id: 1, title: 'Old' },
+		};
+
+		mergeNestedRelationDeltaInto(target, {
+			blocks: { create: [{ id: 4 }], update: [{ id: 5 }], delete: [6] },
+			seo: { id: 1, description: 'New' },
+		});
+
+		expect(target).toEqual({
+			blocks: {
+				create: [{ id: 1 }, { id: 4 }],
+				update: [{ id: 2 }, { id: 5 }],
+				delete: [3, 6],
+			},
+			seo: { id: 1, description: 'New' },
+		});
+	});
+});
+
+function createSchema(relations: Relation[] = []): SchemaOverview {
+	const collectionNames = [
+		'articles',
+		'articles_tags',
+		'articles_translations',
+		'block_hero',
+		'blocks',
+		'pages',
+		'pages_blocks',
+		'pages_other_blocks',
+		'seo',
+		'tags',
+	];
+
+	return {
+		collections: Object.fromEntries(
+			collectionNames.map((collection) => [collection, { collection, primary: 'id', singleton: false, fields: {} }]),
+		),
+		relations,
+	} as unknown as SchemaOverview;
+}
+
+function relation(
+	collection: string,
+	field: string,
+	relatedCollection: string | null,
+	options: {
+		oneField?: string | null;
+		junctionField?: string | null;
+		oneCollectionField?: string | null;
+		oneAllowedCollections?: string[] | null;
+	} = {},
+): Relation {
+	return {
+		collection,
+		field,
+		related_collection: relatedCollection,
+		schema: null,
+		meta: {
+			id: 1,
+			many_collection: collection,
+			many_field: field,
+			one_collection: relatedCollection,
+			one_field: options.oneField ?? null,
+			one_collection_field: options.oneCollectionField ?? null,
+			one_allowed_collections: options.oneAllowedCollections ?? null,
+			one_deselect_action: 'nullify',
+			junction_field: options.junctionField ?? null,
+			sort_field: null,
+		},
+	};
+}
+
+function versionedCollections(...collections: string[]) {
+	const versioned = new Set(collections);
+	return (collection: string) => versioned.has(collection);
+}

--- a/packages/utils/shared/write-target.ts
+++ b/packages/utils/shared/write-target.ts
@@ -1,20 +1,23 @@
 import { isPublishedVersionKey } from '@directus/constants';
-import type { Item, PrimaryKey, Relation, SchemaOverview } from '@directus/types';
+import type { Item, PrimaryKey, Relation, RelationMeta, SchemaOverview } from '@directus/types';
 import { isDetailedUpdateSyntax } from './is-detailed-update-syntax.js';
 import { isObject } from './is-object.js';
 
-export const REFUSAL = {
-	VERSIONING_REQUIRED: '[VERSIONING_REQUIRED]',
-	NO_KEYS: '[VERSIONING_REQUIRED:NO_KEYS]',
-	NO_PUBLISHED_SINGLETON: '[VERSIONING_REQUIRED:NO_PUBLISHED_SINGLETON]',
-	NO_PARENT_CONTEXT: '[VERSIONING_REQUIRED:NO_PARENT_CONTEXT]',
-	NO_PARENT_PATH: '[VERSIONING_REQUIRED:NO_PARENT_PATH]',
-	MULTI_RELATION: '[VERSIONING_REQUIRED:MULTI_RELATION]',
-	RELATED_NOT_FOUND: '[VERSIONING_REQUIRED:RELATED_ITEM_NOT_FOUND]',
-	STALE_ATTACHMENT: '[VERSIONING_REQUIRED:STALE_ATTACHMENT]',
+type RelationWithOneField = Relation & { meta: RelationMeta & { one_field: string } };
+type ParentJunctionRelation = Relation & {
+	meta: RelationMeta & { one_field: string; junction_field: string };
+};
+
+export const WRITE_TARGET_REFUSAL = {
+	VERSIONING_REQUIRED: 'VERSIONING_REQUIRED',
+	NO_PARENT_CONTEXT: 'NO_PARENT_CONTEXT',
+	NO_PARENT_PATH: 'NO_PARENT_PATH',
+	MULTI_RELATION: 'MULTI_RELATION',
+	RELATED_NOT_FOUND: 'RELATED_ITEM_NOT_FOUND',
+	STALE_ATTACHMENT: 'STALE_ATTACHMENT',
 } as const;
 
-export type RefusalToken = (typeof REFUSAL)[keyof typeof REFUSAL];
+export type WriteTargetRefusalToken = (typeof WRITE_TARGET_REFUSAL)[keyof typeof WRITE_TARGET_REFUSAL];
 
 export type ParentRef = {
 	collection: string;
@@ -67,9 +70,13 @@ export type ParentRelation =
 export type WriteTarget =
 	| { kind: 'published'; collection: string; key: PrimaryKey }
 	| { kind: 'item-version'; collection: string; key: PrimaryKey; versionKey: string }
-	| { kind: 'parent-version'; parent: ParentRef; relation: ParentRelation };
+	| { kind: 'parent-version'; parent: ParentRef; relation: ParentRelation; parentItem: Item };
 
-export type ResolveResult = WriteTarget | { kind: 'refuse'; token: RefusalToken; message: string };
+export type ResolveResult = WriteTarget | { kind: 'refuse'; token: WriteTargetRefusalToken; message: string };
+
+export type MergeNestedRelationDeltaOptions = {
+	identityFields?: Iterable<string>;
+};
 
 type ParentRelationCandidate =
 	| { kind: 'o2m'; parentField: string; childPkField: string }
@@ -105,7 +112,10 @@ export async function resolveWriteTarget(input: {
 
 	if (targetIsVersioned) {
 		if (!versionKey || isPublishedVersionKey(versionKey)) {
-			return refuse(REFUSAL.VERSIONING_REQUIRED, 'Updates to versioned collections require a draft version.');
+			return refuse(
+				WRITE_TARGET_REFUSAL.VERSIONING_REQUIRED,
+				'Updates to versioned collections require a draft version.',
+			);
 		}
 
 		return {
@@ -120,7 +130,10 @@ export async function resolveWriteTarget(input: {
 
 	if (!parent) {
 		if (versionKey && !isPublishedVersionKey(versionKey)) {
-			return refuse(REFUSAL.NO_PARENT_CONTEXT, 'A parent item is required to save this child item to a version.');
+			return refuse(
+				WRITE_TARGET_REFUSAL.NO_PARENT_CONTEXT,
+				'A parent item is required to save this child item to a version.',
+			);
 		}
 
 		return { kind: 'published', collection: input.target.collection, key: input.target.key };
@@ -135,25 +148,29 @@ export async function resolveWriteTarget(input: {
 	const candidates = findParentRelationCandidates(input.schema, parent.collection, input.target.collection);
 
 	if (candidates.length === 0) {
-		return refuse(REFUSAL.NO_PARENT_PATH, 'No relation path exists from the parent item to this target item.');
+		return refuse(
+			WRITE_TARGET_REFUSAL.NO_PARENT_PATH,
+			'No relation path exists from the parent item to this target item.',
+		);
 	}
 
-	const matches: ParentRelation[] = [];
+	const matches: { relation: ParentRelation; parentItem: Item }[] = [];
 
 	for (const candidate of candidates) {
 		const parentItem = await input.readParent(parent, getParentReadFields(candidate));
 		if (!parentItem) continue;
 
 		const relation = findTargetInParentItem(candidate, parentItem, input.target.collection, input.target.key);
-		if (relation) matches.push(relation);
+		if (relation) matches.push({ relation, parentItem });
 	}
 
 	if (matches.length > 1) {
-		return refuse(REFUSAL.MULTI_RELATION, 'Multiple parent relations contain this target item.');
+		return refuse(WRITE_TARGET_REFUSAL.MULTI_RELATION, 'Multiple parent relations contain this target item.');
 	}
 
 	if (matches.length === 0) {
-		const token = hint.attachment ? REFUSAL.STALE_ATTACHMENT : REFUSAL.RELATED_NOT_FOUND;
+		const token = hint.attachment ? WRITE_TARGET_REFUSAL.STALE_ATTACHMENT : WRITE_TARGET_REFUSAL.RELATED_NOT_FOUND;
+
 		const message = hint.attachment
 			? 'The visual element no longer matches the parent item.'
 			: 'The target item was not found in the parent version.';
@@ -161,7 +178,8 @@ export async function resolveWriteTarget(input: {
 		return refuse(token, message);
 	}
 
-	return { kind: 'parent-version', parent, relation: matches[0]! };
+	const winner = matches[0]!;
+	return { kind: 'parent-version', parent, relation: winner.relation, parentItem: winner.parentItem };
 }
 
 export function buildPayload(target: WriteTarget, edits: Item, childPk: PrimaryKey): Item {
@@ -215,14 +233,20 @@ export function buildPayload(target: WriteTarget, edits: Item, childPk: PrimaryK
 	};
 }
 
-export function mergeNestedRelationDeltaInto(target: Item, source: Item): Item {
+export function mergeNestedRelationDeltaInto(
+	target: Item,
+	source: Item,
+	options: MergeNestedRelationDeltaOptions = {},
+): Item {
+	const identityFields = normalizeIdentityFields(options.identityFields);
+
 	for (const [field, incoming] of Object.entries(source)) {
 		const existing = target[field];
 
 		if (isDetailedUpdateSyntax(existing) && isDetailedUpdateSyntax(incoming)) {
 			target[field] = {
 				create: [...existing.create, ...incoming.create],
-				update: mergeDetailedUpdateEntries(existing.update, incoming.update),
+				update: mergeDetailedUpdateEntries(existing.update, incoming.update, identityFields),
 				delete: [...existing.delete, ...incoming.delete],
 			};
 
@@ -235,24 +259,52 @@ export function mergeNestedRelationDeltaInto(target: Item, source: Item): Item {
 	return target;
 }
 
-function mergeDetailedUpdateEntries(existing: unknown[], incoming: unknown[]): unknown[] {
+export function getSchemaPrimaryKeyFields(schema: SchemaOverview): string[] {
+	const fields = new Set<string>();
+
+	for (const collection of Object.values(schema.collections)) {
+		if (collection?.primary) fields.add(collection.primary);
+	}
+
+	return normalizeIdentityFields(fields);
+}
+
+function normalizeIdentityFields(fields: Iterable<string> | undefined): string[] {
+	const normalized = new Set<string>();
+
+	for (const field of fields ?? []) {
+		if (field) normalized.add(field);
+	}
+
+	normalized.add('id');
+
+	return [...normalized].sort((left, right) => {
+		if (left === 'id') return 1;
+		if (right === 'id') return -1;
+		return 0;
+	});
+}
+
+function mergeDetailedUpdateEntries(existing: unknown[], incoming: unknown[], identityFields: string[]): unknown[] {
 	const merged = [...existing];
 
 	for (const incomingEntry of incoming) {
-		const existingIndex = merged.findIndex((existingEntry) => hasSameUpdateIdentity(existingEntry, incomingEntry));
+		const existingIndex = merged.findIndex((existingEntry) =>
+			hasSameUpdateIdentity(existingEntry, incomingEntry, identityFields),
+		);
 
 		if (existingIndex === -1) {
 			merged.push(incomingEntry);
 			continue;
 		}
 
-		merged[existingIndex] = mergeUpdateEntry(merged[existingIndex], incomingEntry);
+		merged[existingIndex] = mergeUpdateEntry(merged[existingIndex], incomingEntry, identityFields);
 	}
 
 	return merged;
 }
 
-function mergeUpdateEntry(existing: unknown, incoming: unknown): unknown {
+function mergeUpdateEntry(existing: unknown, incoming: unknown, identityFields: string[]): unknown {
 	if (!isObject(existing) || !isObject(incoming)) return incoming;
 
 	const merged: Item = { ...existing, ...incoming };
@@ -260,27 +312,30 @@ function mergeUpdateEntry(existing: unknown, incoming: unknown): unknown {
 	for (const [field, incomingValue] of Object.entries(incoming)) {
 		const existingValue = existing[field];
 
-		if (hasSameUpdateIdentity(existingValue, incomingValue)) {
-			merged[field] = mergeUpdateEntry(existingValue, incomingValue);
+		if (hasSameUpdateIdentity(existingValue, incomingValue, identityFields)) {
+			merged[field] = mergeUpdateEntry(existingValue, incomingValue, identityFields);
 		}
 	}
 
 	return merged;
 }
 
-function hasSameUpdateIdentity(existing: unknown, incoming: unknown): boolean {
-	const existingId = getUpdateIdentity(existing);
-	const incomingId = getUpdateIdentity(incoming);
+function hasSameUpdateIdentity(existing: unknown, incoming: unknown, identityFields: string[]): boolean {
+	if (!isObject(existing) || !isObject(incoming)) return false;
 
-	if (existingId === undefined || incomingId === undefined) return false;
+	for (const field of identityFields) {
+		const existingId = getUpdateIdentity(existing, field);
+		const incomingId = getUpdateIdentity(incoming, field);
 
-	return String(existingId) === String(incomingId);
+		if (existingId === undefined || incomingId === undefined) continue;
+		if (String(existingId) === String(incomingId)) return true;
+	}
+
+	return false;
 }
 
-function getUpdateIdentity(value: unknown): unknown {
-	if (!isObject(value)) return undefined;
-
-	const id = value['id'];
+function getUpdateIdentity(value: Item, field: string): unknown {
+	const id = value[field];
 	if (id === null) return undefined;
 
 	return id;
@@ -288,17 +343,17 @@ function getUpdateIdentity(value: unknown): unknown {
 
 function resolveVersionKey(hint: VersionHint): string | undefined {
 	return (
-		normalizeVersionKey(hint.explicitVersion) ??
-		normalizeVersionKey(hint.attachment?.parent?.versionKey) ??
-		normalizeVersionKey(hint.attachment?.version) ??
-		normalizeVersionKey(hint.page?.version)
+		hint.explicitVersion ||
+		hint.attachment?.parent?.versionKey ||
+		hint.attachment?.version ||
+		hint.page?.version ||
+		undefined
 	);
 }
 
 function resolveParentRef(hint: VersionHint): ParentRef | null {
 	const attachmentParent = hint.attachment?.parent;
-	const attachmentParentVersion =
-		normalizeVersionKey(attachmentParent?.versionKey) ?? normalizeVersionKey(hint.attachment?.version);
+	const attachmentParentVersion = attachmentParent?.versionKey || hint.attachment?.version;
 
 	if (attachmentParent && attachmentParentVersion) {
 		return {
@@ -308,7 +363,7 @@ function resolveParentRef(hint: VersionHint): ParentRef | null {
 		};
 	}
 
-	const pageVersion = normalizeVersionKey(hint.page?.version);
+	const pageVersion = hint.page?.version;
 
 	if (hint.page?.collection && hint.page.item !== undefined && pageVersion) {
 		return {
@@ -321,13 +376,8 @@ function resolveParentRef(hint: VersionHint): ParentRef | null {
 	return null;
 }
 
-function normalizeVersionKey(versionKey: string | null | undefined): string | undefined {
-	if (!versionKey) return undefined;
-	return versionKey;
-}
-
-function refuse(token: RefusalToken, message: string): ResolveResult {
-	return { kind: 'refuse', token, message: `${token} ${message}` };
+function refuse(token: WriteTargetRefusalToken, message: string): ResolveResult {
+	return { kind: 'refuse', token, message };
 }
 
 function findParentRelationCandidates(
@@ -341,7 +391,7 @@ function findParentRelationCandidates(
 		if (isO2MRelation(relation, parentCollection, targetCollection)) {
 			candidates.push({
 				kind: 'o2m',
-				parentField: relation.meta.one_field!,
+				parentField: relation.meta.one_field,
 				childPkField: primaryKeyField(schema, targetCollection),
 			});
 
@@ -359,20 +409,20 @@ function findParentRelationCandidates(
 			if (collectionField) {
 				candidates.push({
 					kind: 'm2a',
-					parentField: relation.meta.one_field!,
+					parentField: relation.meta.one_field,
 					junctionCollection: relation.collection,
 					junctionPkField,
-					junctionField: relation.meta.junction_field!,
+					junctionField: relation.meta.junction_field,
 					collectionField,
 					childPkField,
 				});
 			} else {
 				candidates.push({
 					kind: 'm2m',
-					parentField: relation.meta.one_field!,
+					parentField: relation.meta.one_field,
 					junctionCollection: relation.collection,
 					junctionPkField,
-					junctionField: relation.meta.junction_field!,
+					junctionField: relation.meta.junction_field,
 					childPkField,
 				});
 			}
@@ -392,7 +442,11 @@ function findParentRelationCandidates(
 	return candidates;
 }
 
-function isO2MRelation(relation: Relation, parentCollection: string, targetCollection: string) {
+function isO2MRelation(
+	relation: Relation,
+	parentCollection: string,
+	targetCollection: string,
+): relation is RelationWithOneField {
 	return (
 		relation.collection === targetCollection &&
 		relation.related_collection === parentCollection &&
@@ -402,7 +456,7 @@ function isO2MRelation(relation: Relation, parentCollection: string, targetColle
 	);
 }
 
-function isParentJunctionRelation(relation: Relation, parentCollection: string) {
+function isParentJunctionRelation(relation: Relation, parentCollection: string): relation is ParentJunctionRelation {
 	return (
 		relation.related_collection === parentCollection &&
 		typeof relation.meta?.one_field === 'string' &&
@@ -416,8 +470,7 @@ function isM2ORelation(relation: Relation, parentCollection: string, targetColle
 	return (
 		relation.collection === parentCollection &&
 		relation.related_collection === targetCollection &&
-		!relation.meta?.junction_field &&
-		!relation.meta?.one_field
+		!relation.meta?.junction_field
 	);
 }
 
@@ -501,6 +554,61 @@ function findTargetInParentItem(
 		}
 
 		return { ...candidate, junctionItem };
+	}
+
+	return null;
+}
+
+export function getParentInitialValueFields(relation: ParentRelation): string[] {
+	if (relation.kind === 'm2o') return [`${relation.parentField}.*`];
+	if (relation.kind === 'o2m') return [`${relation.parentField}.*`];
+
+	if (relation.kind === 'm2m') {
+		return [
+			`${relation.parentField}.${relation.junctionPkField}`,
+			`${relation.parentField}.${relation.junctionField}.*`,
+		];
+	}
+
+	return [
+		`${relation.parentField}.${relation.junctionPkField}`,
+		`${relation.parentField}.${relation.collectionField}`,
+		`${relation.parentField}.${relation.junctionField}.*`,
+	];
+}
+
+export function findParentInitialValue(
+	relation: ParentRelation,
+	parentItem: Item,
+	targetCollection: string,
+	targetKey: PrimaryKey,
+): Item | null {
+	if (relation.kind === 'm2o') {
+		const child = parentItem[relation.parentField];
+		if (!isObject(child)) return null;
+		return sameKey(child[relation.childPkField], targetKey) ? child : null;
+	}
+
+	const relatedValue = parentItem[relation.parentField];
+	if (!Array.isArray(relatedValue)) return null;
+
+	if (relation.kind === 'o2m') {
+		const child = relatedValue.find((item) => isObject(item) && sameKey(item[relation.childPkField], targetKey));
+		return isObject(child) ? child : null;
+	}
+
+	for (const junctionItem of relatedValue) {
+		if (!isObject(junctionItem)) continue;
+
+		const child = junctionItem[relation.junctionField];
+		if (!isObject(child)) continue;
+		if (!sameKey(child[relation.childPkField], targetKey)) continue;
+
+		if (relation.kind === 'm2a' && junctionItem[relation.collectionField] !== targetCollection) {
+			continue;
+		}
+
+		return child;
 	}
 
 	return null;

--- a/packages/utils/shared/write-target.ts
+++ b/packages/utils/shared/write-target.ts
@@ -253,6 +253,13 @@ export function mergeNestedRelationDeltaInto(
 			continue;
 		}
 
+		// Same-identity plain objects (e.g. m2o relation rewrites) accumulate field-by-field
+		// instead of overwriting, so successive autosaves don't drop earlier draft edits.
+		if (hasSameUpdateIdentity(existing, incoming, identityFields)) {
+			target[field] = mergeUpdateEntry(existing, incoming, identityFields);
+			continue;
+		}
+
 		target[field] = incoming;
 	}
 

--- a/packages/utils/shared/write-target.ts
+++ b/packages/utils/shared/write-target.ts
@@ -78,7 +78,7 @@ export type MergeNestedRelationDeltaOptions = {
 	identityFields?: Iterable<string>;
 };
 
-type ParentRelationCandidate =
+export type ParentRelationCandidate =
 	| { kind: 'o2m'; parentField: string; childPkField: string }
 	| {
 			kind: 'm2m';
@@ -380,7 +380,7 @@ function refuse(token: WriteTargetRefusalToken, message: string): ResolveResult 
 	return { kind: 'refuse', token, message };
 }
 
-function findParentRelationCandidates(
+export function findParentRelationCandidates(
 	schema: SchemaOverview,
 	parentCollection: string,
 	targetCollection: string,

--- a/packages/utils/shared/write-target.ts
+++ b/packages/utils/shared/write-target.ts
@@ -1,0 +1,460 @@
+import { isPublishedVersionKey } from '@directus/constants';
+import type { Item, PrimaryKey, Relation, SchemaOverview } from '@directus/types';
+import { isDetailedUpdateSyntax } from './is-detailed-update-syntax.js';
+import { isObject } from './is-object.js';
+
+export const REFUSAL = {
+	VERSIONING_REQUIRED: '[VERSIONING_REQUIRED]',
+	NO_KEYS: '[VERSIONING_REQUIRED:NO_KEYS]',
+	NO_PUBLISHED_SINGLETON: '[VERSIONING_REQUIRED:NO_PUBLISHED_SINGLETON]',
+	NO_PARENT_CONTEXT: '[VERSIONING_REQUIRED:NO_PARENT_CONTEXT]',
+	NO_PARENT_PATH: '[VERSIONING_REQUIRED:NO_PARENT_PATH]',
+	MULTI_RELATION: '[VERSIONING_REQUIRED:MULTI_RELATION]',
+	RELATED_NOT_FOUND: '[VERSIONING_REQUIRED:RELATED_ITEM_NOT_FOUND]',
+	STALE_ATTACHMENT: '[VERSIONING_REQUIRED:STALE_ATTACHMENT]',
+} as const;
+
+export type RefusalToken = (typeof REFUSAL)[keyof typeof REFUSAL];
+
+export type ParentRef = {
+	collection: string;
+	key: PrimaryKey;
+	versionKey: string;
+};
+
+export type VersionHint = {
+	explicitVersion?: string | null;
+	page?: {
+		collection?: string;
+		item?: PrimaryKey;
+		version?: string | null;
+	} | null;
+	attachment?: {
+		collection?: string;
+		item?: PrimaryKey;
+		version?: string | null;
+		parent?: {
+			collection: string;
+			key: PrimaryKey;
+			versionKey?: string | null;
+		} | null;
+	} | null;
+};
+
+export type ParentRelation =
+	| { kind: 'o2m'; parentField: string; childPkField: string }
+	| {
+			kind: 'm2m';
+			parentField: string;
+			junctionCollection: string;
+			junctionPkField: string;
+			junctionField: string;
+			junctionItem: Item;
+			childPkField: string;
+	  }
+	| {
+			kind: 'm2a';
+			parentField: string;
+			junctionCollection: string;
+			junctionPkField: string;
+			junctionField: string;
+			collectionField: string;
+			junctionItem: Item;
+			childPkField: string;
+	  }
+	| { kind: 'm2o'; parentField: string; childPkField: string };
+
+export type WriteTarget =
+	| { kind: 'published'; collection: string; key: PrimaryKey }
+	| { kind: 'item-version'; collection: string; key: PrimaryKey; versionKey: string }
+	| { kind: 'parent-version'; parent: ParentRef; relation: ParentRelation };
+
+export type ResolveResult = WriteTarget | { kind: 'refuse'; token: RefusalToken; message: string };
+
+type ParentRelationCandidate =
+	| { kind: 'o2m'; parentField: string; childPkField: string }
+	| {
+			kind: 'm2m';
+			parentField: string;
+			junctionCollection: string;
+			junctionPkField: string;
+			junctionField: string;
+			childPkField: string;
+	  }
+	| {
+			kind: 'm2a';
+			parentField: string;
+			junctionCollection: string;
+			junctionPkField: string;
+			junctionField: string;
+			collectionField: string;
+			childPkField: string;
+	  }
+	| { kind: 'm2o'; parentField: string; childPkField: string };
+
+export async function resolveWriteTarget(input: {
+	schema: SchemaOverview;
+	target: { collection: string; key: PrimaryKey };
+	hint?: VersionHint;
+	collectionHasVersioning: (collection: string) => boolean | Promise<boolean>;
+	readParent: (ref: ParentRef, fields: string[]) => Promise<Item | null>;
+}): Promise<ResolveResult> {
+	const hint = input.hint ?? {};
+	const versionKey = resolveVersionKey(hint);
+	const targetIsVersioned = await input.collectionHasVersioning(input.target.collection);
+
+	if (targetIsVersioned) {
+		if (!versionKey || isPublishedVersionKey(versionKey)) {
+			return refuse(REFUSAL.VERSIONING_REQUIRED, 'Updates to versioned collections require a draft version.');
+		}
+
+		return {
+			kind: 'item-version',
+			collection: input.target.collection,
+			key: input.target.key,
+			versionKey,
+		};
+	}
+
+	const parent = resolveParentRef(hint);
+
+	if (!parent) {
+		if (versionKey && !isPublishedVersionKey(versionKey)) {
+			return refuse(REFUSAL.NO_PARENT_CONTEXT, 'A parent item is required to save this child item to a version.');
+		}
+
+		return { kind: 'published', collection: input.target.collection, key: input.target.key };
+	}
+
+	const parentIsVersioned = await input.collectionHasVersioning(parent.collection);
+
+	if (!parentIsVersioned || isPublishedVersionKey(parent.versionKey)) {
+		return { kind: 'published', collection: input.target.collection, key: input.target.key };
+	}
+
+	const candidates = findParentRelationCandidates(input.schema, parent.collection, input.target.collection);
+
+	if (candidates.length === 0) {
+		return refuse(REFUSAL.NO_PARENT_PATH, 'No relation path exists from the parent item to this target item.');
+	}
+
+	const matches: ParentRelation[] = [];
+
+	for (const candidate of candidates) {
+		const parentItem = await input.readParent(parent, getParentReadFields(candidate));
+		if (!parentItem) continue;
+
+		const relation = findTargetInParentItem(candidate, parentItem, input.target.collection, input.target.key);
+		if (relation) matches.push(relation);
+	}
+
+	if (matches.length > 1) {
+		return refuse(REFUSAL.MULTI_RELATION, 'Multiple parent relations contain this target item.');
+	}
+
+	if (matches.length === 0) {
+		const token = hint.attachment ? REFUSAL.STALE_ATTACHMENT : REFUSAL.RELATED_NOT_FOUND;
+		const message = hint.attachment
+			? 'The visual element no longer matches the parent item.'
+			: 'The target item was not found in the parent version.';
+
+		return refuse(token, message);
+	}
+
+	return { kind: 'parent-version', parent, relation: matches[0]! };
+}
+
+export function buildPayload(target: WriteTarget, edits: Item, childPk: PrimaryKey): Item {
+	if (target.kind !== 'parent-version') return edits;
+
+	const relation = target.relation;
+
+	if (relation.kind === 'o2m') {
+		return {
+			[relation.parentField]: {
+				create: [],
+				update: [{ [relation.childPkField]: childPk, ...edits }],
+				delete: [],
+			},
+		};
+	}
+
+	if (relation.kind === 'm2m') {
+		return {
+			[relation.parentField]: {
+				create: [],
+				update: [
+					{
+						[relation.junctionPkField]: relation.junctionItem[relation.junctionPkField],
+						[relation.junctionField]: { [relation.childPkField]: childPk, ...edits },
+					},
+				],
+				delete: [],
+			},
+		};
+	}
+
+	if (relation.kind === 'm2a') {
+		return {
+			[relation.parentField]: {
+				create: [],
+				update: [
+					{
+						[relation.junctionPkField]: relation.junctionItem[relation.junctionPkField],
+						[relation.collectionField]: relation.junctionItem[relation.collectionField],
+						[relation.junctionField]: { [relation.childPkField]: childPk, ...edits },
+					},
+				],
+				delete: [],
+			},
+		};
+	}
+
+	return {
+		[relation.parentField]: { [relation.childPkField]: childPk, ...edits },
+	};
+}
+
+export function mergeNestedRelationDeltaInto(target: Item, source: Item): Item {
+	for (const [field, incoming] of Object.entries(source)) {
+		const existing = target[field];
+
+		if (isDetailedUpdateSyntax(existing) && isDetailedUpdateSyntax(incoming)) {
+			target[field] = {
+				create: [...existing.create, ...incoming.create],
+				update: [...existing.update, ...incoming.update],
+				delete: [...existing.delete, ...incoming.delete],
+			};
+
+			continue;
+		}
+
+		target[field] = incoming;
+	}
+
+	return target;
+}
+
+function resolveVersionKey(hint: VersionHint): string | undefined {
+	return (
+		normalizeVersionKey(hint.explicitVersion) ??
+		normalizeVersionKey(hint.attachment?.parent?.versionKey) ??
+		normalizeVersionKey(hint.attachment?.version) ??
+		normalizeVersionKey(hint.page?.version)
+	);
+}
+
+function resolveParentRef(hint: VersionHint): ParentRef | null {
+	const attachmentParent = hint.attachment?.parent;
+	const attachmentParentVersion =
+		normalizeVersionKey(attachmentParent?.versionKey) ?? normalizeVersionKey(hint.attachment?.version);
+
+	if (attachmentParent && attachmentParentVersion) {
+		return {
+			collection: attachmentParent.collection,
+			key: attachmentParent.key,
+			versionKey: attachmentParentVersion,
+		};
+	}
+
+	const pageVersion = normalizeVersionKey(hint.page?.version);
+
+	if (hint.page?.collection && hint.page.item !== undefined && pageVersion) {
+		return {
+			collection: hint.page.collection,
+			key: hint.page.item,
+			versionKey: pageVersion,
+		};
+	}
+
+	return null;
+}
+
+function normalizeVersionKey(versionKey: string | null | undefined): string | undefined {
+	if (!versionKey) return undefined;
+	return versionKey;
+}
+
+function refuse(token: RefusalToken, message: string): ResolveResult {
+	return { kind: 'refuse', token, message: `${token} ${message}` };
+}
+
+function findParentRelationCandidates(
+	schema: SchemaOverview,
+	parentCollection: string,
+	targetCollection: string,
+): ParentRelationCandidate[] {
+	const candidates: ParentRelationCandidate[] = [];
+
+	for (const relation of schema.relations) {
+		if (isO2MRelation(relation, parentCollection, targetCollection)) {
+			candidates.push({
+				kind: 'o2m',
+				parentField: relation.meta.one_field!,
+				childPkField: primaryKeyField(schema, targetCollection),
+			});
+
+			continue;
+		}
+
+		if (isParentJunctionRelation(relation, parentCollection)) {
+			const partner = findJunctionPartner(schema.relations, relation, targetCollection);
+			if (!partner) continue;
+
+			const junctionPkField = primaryKeyField(schema, relation.collection);
+			const childPkField = primaryKeyField(schema, targetCollection);
+			const collectionField = partner.meta?.one_collection_field;
+
+			if (collectionField) {
+				candidates.push({
+					kind: 'm2a',
+					parentField: relation.meta.one_field!,
+					junctionCollection: relation.collection,
+					junctionPkField,
+					junctionField: relation.meta.junction_field!,
+					collectionField,
+					childPkField,
+				});
+			} else {
+				candidates.push({
+					kind: 'm2m',
+					parentField: relation.meta.one_field!,
+					junctionCollection: relation.collection,
+					junctionPkField,
+					junctionField: relation.meta.junction_field!,
+					childPkField,
+				});
+			}
+
+			continue;
+		}
+
+		if (isM2ORelation(relation, parentCollection, targetCollection)) {
+			candidates.push({
+				kind: 'm2o',
+				parentField: relation.field,
+				childPkField: primaryKeyField(schema, targetCollection),
+			});
+		}
+	}
+
+	return candidates;
+}
+
+function isO2MRelation(relation: Relation, parentCollection: string, targetCollection: string) {
+	return (
+		relation.collection === targetCollection &&
+		relation.related_collection === parentCollection &&
+		typeof relation.meta?.one_field === 'string' &&
+		relation.meta.one_field.length > 0 &&
+		!relation.meta.junction_field
+	);
+}
+
+function isParentJunctionRelation(relation: Relation, parentCollection: string) {
+	return (
+		relation.related_collection === parentCollection &&
+		typeof relation.meta?.one_field === 'string' &&
+		relation.meta.one_field.length > 0 &&
+		typeof relation.meta?.junction_field === 'string' &&
+		relation.meta.junction_field.length > 0
+	);
+}
+
+function isM2ORelation(relation: Relation, parentCollection: string, targetCollection: string) {
+	return (
+		relation.collection === parentCollection &&
+		relation.related_collection === targetCollection &&
+		!relation.meta?.junction_field &&
+		!relation.meta?.one_field
+	);
+}
+
+function findJunctionPartner(relations: Relation[], relation: Relation, targetCollection: string) {
+	const junctionField = relation.meta?.junction_field;
+	if (!junctionField) return null;
+
+	return (
+		relations.find((candidate) => {
+			if (candidate.collection !== relation.collection) return false;
+			if (candidate.field !== junctionField) return false;
+
+			const allowedCollections = candidate.meta?.one_allowed_collections;
+
+			if (candidate.meta?.one_collection_field && allowedCollections) {
+				return allowedCollections.includes(targetCollection);
+			}
+
+			return candidate.related_collection === targetCollection;
+		}) ?? null
+	);
+}
+
+function primaryKeyField(schema: SchemaOverview, collection: string) {
+	return schema.collections[collection]?.primary ?? 'id';
+}
+
+function getParentReadFields(candidate: ParentRelationCandidate): string[] {
+	if (candidate.kind === 'm2o') return [`${candidate.parentField}.*`];
+
+	if (candidate.kind === 'o2m') {
+		return [`${candidate.parentField}.${candidate.childPkField}`];
+	}
+
+	if (candidate.kind === 'm2m') {
+		return [
+			`${candidate.parentField}.${candidate.junctionPkField}`,
+			`${candidate.parentField}.${candidate.junctionField}.${candidate.childPkField}`,
+		];
+	}
+
+	return [
+		`${candidate.parentField}.${candidate.junctionPkField}`,
+		`${candidate.parentField}.${candidate.collectionField}`,
+		`${candidate.parentField}.${candidate.junctionField}.*`,
+	];
+}
+
+function findTargetInParentItem(
+	candidate: ParentRelationCandidate,
+	parentItem: Item,
+	targetCollection: string,
+	targetKey: PrimaryKey,
+): ParentRelation | null {
+	if (candidate.kind === 'm2o') {
+		const child = parentItem[candidate.parentField];
+		if (!isObject(child)) return null;
+		if (!sameKey(child[candidate.childPkField], targetKey)) return null;
+
+		return candidate;
+	}
+
+	const relatedValue = parentItem[candidate.parentField];
+	if (!Array.isArray(relatedValue)) return null;
+
+	if (candidate.kind === 'o2m') {
+		const child = relatedValue.find((item) => isObject(item) && sameKey(item[candidate.childPkField], targetKey));
+		if (!child) return null;
+		return candidate;
+	}
+
+	for (const junctionItem of relatedValue) {
+		if (!isObject(junctionItem)) continue;
+
+		const child = junctionItem[candidate.junctionField];
+		if (!isObject(child)) continue;
+		if (!sameKey(child[candidate.childPkField], targetKey)) continue;
+
+		if (candidate.kind === 'm2a' && junctionItem[candidate.collectionField] !== targetCollection) {
+			continue;
+		}
+
+		return { ...candidate, junctionItem };
+	}
+
+	return null;
+}
+
+function sameKey(left: unknown, right: PrimaryKey): boolean {
+	return String(left) === String(right);
+}

--- a/packages/utils/shared/write-target.ts
+++ b/packages/utils/shared/write-target.ts
@@ -360,7 +360,7 @@ function resolveVersionKey(hint: VersionHint): string | undefined {
 
 function resolveParentRef(hint: VersionHint): ParentRef | null {
 	const attachmentParent = hint.attachment?.parent;
-	const attachmentParentVersion = attachmentParent?.versionKey || hint.attachment?.version;
+	const attachmentParentVersion = hint.explicitVersion || attachmentParent?.versionKey || hint.attachment?.version;
 
 	if (attachmentParent && attachmentParentVersion) {
 		return {
@@ -370,7 +370,7 @@ function resolveParentRef(hint: VersionHint): ParentRef | null {
 		};
 	}
 
-	const pageVersion = hint.page?.version;
+	const pageVersion = hint.explicitVersion || hint.page?.version;
 
 	if (hint.page?.collection && hint.page.item !== undefined && pageVersion) {
 		return {

--- a/packages/utils/shared/write-target.ts
+++ b/packages/utils/shared/write-target.ts
@@ -222,7 +222,7 @@ export function mergeNestedRelationDeltaInto(target: Item, source: Item): Item {
 		if (isDetailedUpdateSyntax(existing) && isDetailedUpdateSyntax(incoming)) {
 			target[field] = {
 				create: [...existing.create, ...incoming.create],
-				update: [...existing.update, ...incoming.update],
+				update: mergeDetailedUpdateEntries(existing.update, incoming.update),
 				delete: [...existing.delete, ...incoming.delete],
 			};
 
@@ -233,6 +233,57 @@ export function mergeNestedRelationDeltaInto(target: Item, source: Item): Item {
 	}
 
 	return target;
+}
+
+function mergeDetailedUpdateEntries(existing: unknown[], incoming: unknown[]): unknown[] {
+	const merged = [...existing];
+
+	for (const incomingEntry of incoming) {
+		const existingIndex = merged.findIndex((existingEntry) => hasSameUpdateIdentity(existingEntry, incomingEntry));
+
+		if (existingIndex === -1) {
+			merged.push(incomingEntry);
+			continue;
+		}
+
+		merged[existingIndex] = mergeUpdateEntry(merged[existingIndex], incomingEntry);
+	}
+
+	return merged;
+}
+
+function mergeUpdateEntry(existing: unknown, incoming: unknown): unknown {
+	if (!isObject(existing) || !isObject(incoming)) return incoming;
+
+	const merged: Item = { ...existing, ...incoming };
+
+	for (const [field, incomingValue] of Object.entries(incoming)) {
+		const existingValue = existing[field];
+
+		if (hasSameUpdateIdentity(existingValue, incomingValue)) {
+			merged[field] = mergeUpdateEntry(existingValue, incomingValue);
+		}
+	}
+
+	return merged;
+}
+
+function hasSameUpdateIdentity(existing: unknown, incoming: unknown): boolean {
+	const existingId = getUpdateIdentity(existing);
+	const incomingId = getUpdateIdentity(incoming);
+
+	if (existingId === undefined || incomingId === undefined) return false;
+
+	return String(existingId) === String(incomingId);
+}
+
+function getUpdateIdentity(value: unknown): unknown {
+	if (!isObject(value)) return undefined;
+
+	const id = value['id'];
+	if (id === null) return undefined;
+
+	return id;
 }
 
 function resolveVersionKey(hint: VersionHint): string | undefined {

--- a/packages/utils/shared/write-target.ts
+++ b/packages/utils/shared/write-target.ts
@@ -244,11 +244,7 @@ export function mergeNestedRelationDeltaInto(
 		const existing = target[field];
 
 		if (isDetailedUpdateSyntax(existing) && isDetailedUpdateSyntax(incoming)) {
-			target[field] = {
-				create: [...existing.create, ...incoming.create],
-				update: mergeDetailedUpdateEntries(existing.update, incoming.update, identityFields),
-				delete: [...existing.delete, ...incoming.delete],
-			};
+			target[field] = reconcileDetailedUpdate(existing, incoming, identityFields);
 
 			continue;
 		}
@@ -290,6 +286,82 @@ function normalizeIdentityFields(fields: Iterable<string> | undefined): string[]
 		if (right === 'id') return -1;
 		return 0;
 	});
+}
+
+function reconcileDetailedUpdate(
+	existing: { create: unknown[]; update: unknown[]; delete: unknown[] },
+	incoming: { create: unknown[]; update: unknown[]; delete: unknown[] },
+	identityFields: string[],
+): { create: unknown[]; update: unknown[]; delete: unknown[] } {
+	// Incoming wins across buckets: a later delete supersedes earlier create/update for
+	// the same identity, and a later create/update supersedes an earlier delete.
+	const incomingDeleteIds = collectScalarIdentities(incoming.delete);
+	const incomingMutateIds = collectEntryIdentities([incoming.create, incoming.update], identityFields);
+
+	return {
+		create: [
+			...existing.create.filter((entry) => !entryMatchesIdentity(entry, identityFields, incomingDeleteIds)),
+			...incoming.create,
+		],
+		update: mergeDetailedUpdateEntries(
+			existing.update.filter((entry) => !entryMatchesIdentity(entry, identityFields, incomingDeleteIds)),
+			incoming.update,
+			identityFields,
+		),
+		delete: [
+			...existing.delete.filter((value) => {
+				const id = scalarIdentity(value);
+				return id === undefined || !incomingMutateIds.has(id);
+			}),
+			...incoming.delete,
+		],
+	};
+}
+
+function collectScalarIdentities(values: unknown[]): Set<string> {
+	const ids = new Set<string>();
+
+	for (const value of values) {
+		const id = scalarIdentity(value);
+		if (id !== undefined) ids.add(id);
+	}
+
+	return ids;
+}
+
+function collectEntryIdentities(buckets: unknown[][], identityFields: string[]): Set<string> {
+	const ids = new Set<string>();
+
+	for (const bucket of buckets) {
+		for (const entry of bucket) {
+			if (!isObject(entry)) continue;
+
+			for (const field of identityFields) {
+				const value = entry[field];
+				if (value !== null && value !== undefined) ids.add(String(value));
+			}
+		}
+	}
+
+	return ids;
+}
+
+function entryMatchesIdentity(entry: unknown, identityFields: string[], ids: Set<string>): boolean {
+	if (ids.size === 0 || !isObject(entry)) return false;
+
+	for (const field of identityFields) {
+		const value = entry[field];
+		if (value === null || value === undefined) continue;
+		if (ids.has(String(value))) return true;
+	}
+
+	return false;
+}
+
+function scalarIdentity(value: unknown): string | undefined {
+	if (value === null || value === undefined) return undefined;
+	if (typeof value === 'object') return undefined;
+	return String(value);
 }
 
 function mergeDetailedUpdateEntries(existing: unknown[], incoming: unknown[], identityFields: string[]): unknown[] {
@@ -564,6 +636,23 @@ function findTargetInParentItem(
 	}
 
 	return null;
+}
+
+export function prefixChildFields(relation: ParentRelation, childFields: string[]): string[] {
+	if (relation.kind === 'm2o' || relation.kind === 'o2m') {
+		return childFields.map((field) => `${relation.parentField}.${field}`);
+	}
+
+	const path = `${relation.parentField}.${relation.junctionField}`;
+	const prefixed = childFields.map((field) => `${path}.${field}`);
+
+	// M2A junctions are polymorphic; include the collection discriminator so post-save
+	// readback can reject entries that point at another collection sharing the child PK.
+	if (relation.kind === 'm2a') {
+		return [`${relation.parentField}.${relation.collectionField}`, ...prefixed];
+	}
+
+	return prefixed;
 }
 
 export function getParentInitialValueFields(relation: ParentRelation): string[] {


### PR DESCRIPTION
## Scope

What's changed:

- Routed AI item updates and visual editor saves through content versions when a draft is active.
- Added parent-version write targeting for related rows, including O2M, M2M, M2A, and M2O paths.
- Reworked visual context snapshots and readback so child edits come from the parent version and repeated relation deltas merge by identity.

## Potential Risks / Drawbacks

- Versioned relation handling has a few moving parts, especially polymorphic M2A paths and singleton drafts.
- AI and visual edit flows now create draft version records on demand, so permission edge cases are worth another pass.

## Tested Scenarios

- `pnpm --filter @directus/utils test -- write-target.test.ts`
- `pnpm --filter @directus/api test -- api/src/ai/tools/items/index.test.ts api/src/services/versions.test.ts api/src/utils/ensure-version-id.test.ts`
- `pnpm --filter @directus/app test -- src/modules/visual/components/editing-layer.test.ts src/modules/visual/routes/visual-editor.test.ts`

## Review Notes / Questions

- I would look closest at the shared write-target resolution and the parent-version save/readback paths.
- The app test command broadened to the app suite locally and passed.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #
