### PR TITLE
Restore open animation on user drawer

### DIFF
--- a/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
+++ b/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
@@ -421,10 +421,9 @@ function onEsc() {
 			/>
 
 			<DrawerItem
-				v-if="editingUserId"
 				v-model:active="userDrawerActive"
 				collection="directus_users"
-				:primary-key="editingUserId"
+				:primary-key="editingUserId || '+'"
 				:selected-fields="[
 					'first_name',
 					'last_name',


### PR DESCRIPTION
Mount `DrawerItem` unconditionally so the active prop toggles it, giving Transition the change it needs to fire the enter animation.