### PR TITLE
Refresh license usage after schema mutations affecting collections

### DIFF
--- a/app/src/interfaces/_system/system-collections-translations/system-collections-translations-dialog.vue
+++ b/app/src/interfaces/_system/system-collections-translations/system-collections-translations-dialog.vue
@@ -13,6 +13,7 @@ import VNotice from '@/components/v-notice.vue';
 import VSelect from '@/components/v-select/v-select.vue';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
+import { useLicenseStore } from '@/stores/license';
 import { useRelationsStore } from '@/stores/relations';
 import { unexpectedError } from '@/utils/unexpected-error';
 
@@ -34,6 +35,7 @@ const active = defineModel<boolean>('active', { default: false });
 
 const collectionsStore = useCollectionsStore();
 const fieldsStore = useFieldsStore();
+const licenseStore = useLicenseStore();
 const relationsStore = useRelationsStore();
 
 const submitting = ref(false);
@@ -353,7 +355,12 @@ async function submit() {
 	submitting.value = false;
 
 	try {
-		await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate(), relationsStore.hydrate()]);
+		await Promise.all([
+			collectionsStore.hydrate(),
+			fieldsStore.hydrate(),
+			licenseStore.hydrate(),
+			relationsStore.hydrate(),
+		]);
 	} catch (error) {
 		unexpectedError(error);
 	}

--- a/app/src/interfaces/_system/system-mcp-prompts-collection-validation/system-mcp-prompts-collection-generate-dialog.vue
+++ b/app/src/interfaces/_system/system-mcp-prompts-collection-validation/system-mcp-prompts-collection-generate-dialog.vue
@@ -15,6 +15,7 @@ import VNotice from '@/components/v-notice.vue';
 import VSkeletonLoader from '@/components/v-skeleton-loader.vue';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
+import { useLicenseStore } from '@/stores/license';
 import { useRelationsStore } from '@/stores/relations';
 import { notify } from '@/utils/notify';
 import { unexpectedError } from '@/utils/unexpected-error';
@@ -23,6 +24,7 @@ const { t } = useI18n();
 
 const collectionsStore = useCollectionsStore();
 const fieldsStore = useFieldsStore();
+const licenseStore = useLicenseStore();
 const relationsStore = useRelationsStore();
 
 const active = defineModel<boolean>('active');
@@ -113,7 +115,7 @@ async function generateCollection() {
 			storeHydrations.push(relationsStore.hydrate());
 		}
 
-		storeHydrations.push(collectionsStore.hydrate(), fieldsStore.hydrate());
+		storeHydrations.push(collectionsStore.hydrate(), fieldsStore.hydrate(), licenseStore.hydrate());
 		await Promise.all(storeHydrations);
 
 		notify({

--- a/app/src/modules/settings/routes/data-model/fields/fields.vue
+++ b/app/src/modules/settings/routes/data-model/fields/fields.vue
@@ -17,6 +17,7 @@ import { useEditsGuard } from '@/composables/use-edits-guard';
 import { useItem } from '@/composables/use-item';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
+import { useLicenseStore } from '@/stores/license';
 import { PrivateViewHeaderBarActionButton } from '@/views/private';
 import { PrivateView } from '@/views/private';
 
@@ -32,6 +33,7 @@ const router = useRouter();
 const { collection } = toRefs(props);
 const collectionsStore = useCollectionsStore();
 const fieldsStore = useFieldsStore();
+const licenseStore = useLicenseStore();
 
 const { edits, item, saving, loading, save, remove, deleting } = useItem(ref('directus_collections'), collection);
 
@@ -52,19 +54,19 @@ async function deleteAndQuit() {
 	if (deleting.value) return;
 
 	await remove();
-	await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate()]);
+	await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate(), licenseStore.hydrate()]);
 	edits.value = {};
 	router.replace({ name: 'settings-collections' });
 }
 
 async function saveAndStay() {
 	await save();
-	await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate()]);
+	await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate(), licenseStore.hydrate()]);
 }
 
 async function saveAndQuit() {
 	await save();
-	await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate()]);
+	await Promise.all([collectionsStore.hydrate(), fieldsStore.hydrate(), licenseStore.hydrate()]);
 	router.push({ name: 'settings-collections' });
 }
 


### PR DESCRIPTION
- Fix stale "collections remaining" count in the UI after schema mutations that implicitly create junction collections (e.g. enabling translations on a collection)
- Add `licenseStore.hydrate()` to post-save/delete hydration in the fields editor (`fields.vue`)
- Add `licenseStore.hydrate()` to post-submit hydration in `system-collections-translations-dialog.vue`
- Add `licenseStore.hydrate()` to post-generate hydration in `system-mcp-prompts-collection-generate-dialog.vue`

Fixes [CMS-2499](https://linear.app/directus/issue/CMS-2499/collection-limit-count-stays-stale-after-adding-translations)