### PR TITLE
fix: empty keys array should not update all items in update operation

### DIFF
--- a/.changeset/empty-keys-fix.md
+++ b/.changeset/empty-keys-fix.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed a critical bug where passing an empty `keys` array to the Update Items operation would update every item in the collection instead of updating nothing.

--- a/api/src/operations/item-update/index.ts
+++ b/api/src/operations/item-update/index.ts
@@ -53,8 +53,15 @@ export default defineOperationApi<Options>({
 
 		if (Array.isArray(payloadObject)) {
 			result = await itemsService.updateBatch(payloadObject, { emitEvents: !!emitEvents });
-		} else if (!key || (Array.isArray(key) && key.length === 0)) {
+		} else if (!key) {
 			result = await itemsService.updateByQuery(sanitizedQueryObject, payloadObject, { emitEvents: !!emitEvents });
+		} else if (Array.isArray(key) && key.length === 0) {
+			// Empty keys array — only update via query if a filter is explicitly provided
+			if (queryObject && Object.keys(queryObject).length > 0) {
+				result = await itemsService.updateByQuery(sanitizedQueryObject, payloadObject, { emitEvents: !!emitEvents });
+			} else {
+				result = [];
+			}
 		} else {
 			const keys = toArray(key);
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -273,3 +273,4 @@
 - yogeshwaran-c
 - sanskar-soni-9
 - kropsi
+- xxiaoxiong


### PR DESCRIPTION
Fixes #27514

Why
When passing an empty array as `keys` to the Update Items operation in a Flow, the handler falls through to `updateByQuery` with no filter, causing every item in the collection to be updated. This is a destructive bug that can silently modify all records. The SDK already rejects empty keys, so this behavior is inconsistent.

Changes
Add an explicit guard for empty keys array (`[]`) before the query-based fallback path:
- Empty keys with no query filter → return `[]`, no records updated
- Empty keys with explicit query filter → still use `updateByQuery`
- `undefined`/`null` keys → preserve original `updateByQuery` behavior

Updated component: `api/src/operations/item-update/index.ts`

Testing
All existing unit tests pass. The test case `should call updateByQuery with correct query when key is $payload` continues to work because `[]` + query filter still routes to `updateByQuery`.

Surface area
- Engine / Flows
- Bug fix