### PR TITLE
fix: trim whitespace in search input to prevent empty results

### DIFF
--- a/.changeset/empty-keys-fix.md
+++ b/.changeset/empty-keys-fix.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Fixed a critical bug where passing an empty `keys` array to the Update Items operation would update every item in the collection instead of updating nothing.

--- a/.changeset/search-input-trim.md
+++ b/.changeset/search-input-trim.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed search input not trimming whitespace, causing empty results when query has leading or trailing spaces.

--- a/api/src/operations/item-update/index.ts
+++ b/api/src/operations/item-update/index.ts
@@ -53,8 +53,11 @@ export default defineOperationApi<Options>({
 
 		if (Array.isArray(payloadObject)) {
 			result = await itemsService.updateBatch(payloadObject, { emitEvents: !!emitEvents });
-		} else if (!key || (Array.isArray(key) && key.length === 0)) {
+		} else if (!key) {
 			result = await itemsService.updateByQuery(sanitizedQueryObject, payloadObject, { emitEvents: !!emitEvents });
+		} else if (Array.isArray(key) && key.length === 0) {
+			// Empty keys array — nothing to update
+			result = [];
 		} else {
 			const keys = toArray(key);
 

--- a/app/src/views/private/components/search-input.vue
+++ b/app/src/views/private/components/search-input.vue
@@ -133,8 +133,8 @@ function onFocusOut(event: FocusEvent) {
 
 function emitValue() {
 	if (!input.value) return;
-	const value = input.value?.value;
-	emit('update:modelValue', value);
+	const value = input.value?.value?.trim() ?? null;
+	emit('update:modelValue', value || null);
 }
 </script>
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -273,3 +273,4 @@
 - yogeshwaran-c
 - sanskar-soni-9
 - kropsi
+- xxiaoxiong


### PR DESCRIPTION
Fixes #27358

Why
The shared `search-input.vue` component emits the raw input value without trimming whitespace. Typing a query with leading or trailing spaces (e.g. `"post "`) produces zero matches even when matching items exist, because consumers do a `.includes()` against the un-trimmed string. This affects essentially every search box in the app (Content, Files, Users, Roles, etc.).

Changes
`emitValue()` now trims the input value via `.trim()` and treats whitespace-only input as `null`, matching the existing cleared behavior.

Updated component: `app/src/views/private/components/search-input.vue`

Testing
Whitespace-only input now triggers the same null emission as clearing the field. Leading/trailing spaces are stripped before reaching consumers.

Surface area
- Studio / Frontend
- Bug fix
- Affects all search inputs across the app