### PR TITLE
fix: presentation fields should not allow required or readonly

### DIFF
--- a/.changeset/presentation-fields-required-readonly.md
+++ b/.changeset/presentation-fields-required-readonly.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed presentation fields incorrectly allowing required and readonly options

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
@@ -35,12 +35,12 @@ const isSearchableType = computed(() => {
 
 <template>
 	<div class="form">
-		<div v-if="!isGenerated" class="field half-left">
+		<div v-if="!isGenerated && localType !== 'presentation'" class="field half-left">
 			<div class="label type-label">{{ $t('readonly') }}</div>
 			<VCheckbox v-model="readonly" :label="$t('readonly_field_label')" block />
 		</div>
 
-		<div v-if="!isGenerated" class="field half-right">
+		<div v-if="!isGenerated && localType !== 'presentation'" class="field half-right">
 			<div class="label type-label">{{ $t('required') }}</div>
 			<VCheckbox v-model="required" :label="$t('require_value_to_be_set')" block />
 		</div>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
@@ -120,7 +120,7 @@ const options = computed({
 						<VInput v-else v-model="defaultValue" class="monospace" placeholder="NULL" />
 					</div>
 
-					<div class="field half-right">
+					<div v-if="localType !== 'presentation'" class="field half-right">
 						<div class="label type-label">
 							{{ $t('required') }}
 						</div>

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/presentation.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/presentation.ts
@@ -8,7 +8,13 @@ export function applyChanges(updates: StateUpdates, state: State, helperFn: Help
 		removeSchema(updates);
 		setTypeToAlias(updates);
 		setSpecialToNoData(updates);
+		clearRequiredAndReadonly(updates);
 	}
+}
+
+export function clearRequiredAndReadonly(updates: StateUpdates) {
+	set(updates, 'field.meta.required', false);
+	set(updates, 'field.meta.readonly', false);
 }
 
 export function removeSchema(updates: StateUpdates) {

--- a/contributors.yml
+++ b/contributors.yml
@@ -273,3 +273,4 @@
 - yogeshwaran-c
 - sanskar-soni-9
 - kropsi
+- xxiaoxiong


### PR DESCRIPTION
## Description

Presentation fields (divider, header, links, notice) are display-only fields with no user input. Currently, they incorrectly allow enabling `required` and `readonly` in the field editor, which causes issues — e.g., setting a divider as required prevents saving records because the form validation complains the field is empty.

## Changes

1. **Advanced field view** (`field-detail-advanced-field.vue`): Hides the required and readonly checkboxes when the field's local type is `presentation`
2. **Simple field view** (`field-configuration.vue`): Hides the required checkbox when the field's local type is `presentation`
3. **Presentation alteration** (`presentation.ts`): Automatically clears `required` and `readonly` from field meta when switching to a presentation local type

## Related Issue

Fixes #26961