### PR TITLE
fix: add global type declarations for RequestCredentials and CloseEvent

### DIFF
--- a/.changeset/ce5711df-fa72-4d53-8c0a-e08857a9ae0d.md
+++ b/.changeset/ce5711df-fa72-4d53-8c0a-e08857a9ae0d.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Added global type declarations for `RequestCredentials` and `CloseEvent` to support consumers without DOM lib

--- a/contributors.yml
+++ b/contributors.yml
@@ -273,3 +273,4 @@
 - yogeshwaran-c
 - sanskar-soni-9
 - kropsi
+  - xxiaoxiong

--- a/sdk/src/env.d.ts
+++ b/sdk/src/env.d.ts
@@ -1,0 +1,29 @@
+// Global type declarations for browser APIs used in the SDK.
+// These provide fallback typings when the consumer's tsconfig does not include "DOM" in "lib",
+// which is common in ESM / Node.js environments.
+
+declare var RequestCredentials: 'omit' | 'same-origin' | 'include';
+
+interface CloseEventInit extends EventInit {
+	wasClean?: boolean;
+	code?: number;
+	reason?: string;
+}
+
+declare var CloseEvent: {
+	prototype: CloseEvent;
+	new (type: string, eventInitDict?: CloseEventInit): CloseEvent;
+	readonly NONE: number;
+	readonly NORMAL_CLOSURE: number;
+	readonly GOING_AWAY: number;
+	readonly PROTOCOL_ERROR: number;
+	readonly UNSUPPORTED_DATA: number;
+	readonly NO_STATUS_RECEIVED: number;
+	readonly ABNORMAL_CLOSURE: number;
+	readonly INVALID_FRAME_ERROR: number;
+	readonly POLICY_VIOLATION: number;
+	readonly MESSAGING_ERROR: number;
+	readonly SECURITY_ERROR: number;
+	readonly TIMEOUT_ERROR: number;
+	readonly CLOSED: number;
+};


### PR DESCRIPTION
## Description

The SDK uses `RequestCredentials` (in auth, rest, and graphql types) and `CloseEvent` (in realtime types) which are browser DOM APIs. When consumers use the SDK in an ESM / Node.js environment where `"DOM"` is not included in their `tsconfig.json` `lib` array, TypeScript reports `TS2304: Cannot find name 'RequestCredentials'` / `TS2304: Cannot find name 'CloseEvent'`.

Users currently have to work around this by setting `"skipLibCheck": true`.

## Fix

Adds `sdk/src/env.d.ts` which provides global ambient declarations for both types so they resolve correctly regardless of the consumer's `tsconfig` `lib` configuration.

## Related Issue

Fixes #26850

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update