### PR TITLE
feat(sdk): add deleteExtension command

### DIFF
--- a/.changeset/sdk-delete-extension-27311.md
+++ b/.changeset/sdk-delete-extension-27311.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': minor
+---
+
+Added `deleteExtension` SDK command to delete extensions by UUID

--- a/contributors.yml
+++ b/contributors.yml
@@ -273,3 +273,4 @@
 - yogeshwaran-c
 - sanskar-soni-9
 - kropsi
+- xxiaoxiong

--- a/sdk/src/rest/commands/delete/extensions.ts
+++ b/sdk/src/rest/commands/delete/extensions.ts
@@ -1,0 +1,21 @@
+import type { RestCommand } from '../../types.js';
+import { throwIfEmpty } from '../../utils/index.js';
+
+/**
+ * Delete an existing extension.
+ *
+ * @param id The UUID of the extension to delete
+ *
+ * @returns Nothing
+ * @throws Will throw if id is empty
+ */
+export const deleteExtension =
+	<Schema>(id: string): RestCommand<void, Schema> =>
+	() => {
+		throwIfEmpty(id, 'ID cannot be empty');
+
+		return {
+			path: `/extensions/${id}`,
+			method: 'DELETE',
+		};
+	};

--- a/sdk/src/rest/commands/delete/index.ts
+++ b/sdk/src/rest/commands/delete/index.ts
@@ -2,6 +2,7 @@ export * from './collections.js';
 export * from './comments.js';
 export * from './dashboards.js';
 export * from './deployment.js';
+export * from './extensions.js';
 export * from './fields.js';
 export * from './files.js';
 export * from './flows.js';


### PR DESCRIPTION
Adds the `deleteExtension` SDK command that routes to `DELETE /extensions/{id}` for deleting extensions by their UUID identifier.

Closes #27311

## Changes

- New `sdk/src/rest/commands/delete/extensions.ts` exporting `deleteExtension(id: string)`
- Added export to `sdk/src/rest/commands/delete/index.ts`
- Added changeset