### PR TITLE
fix: trim whitespace in search input before emitting value

### DIFF
--- a/.changeset/search-input-trim-whitespace.md
+++ b/.changeset/search-input-trim-whitespace.md
@@ -1,0 +1,6 @@
+---
+'@directus/app': patch
+---
+
+Fixed search input to trim whitespace before emitting value, and treat
+whitespace-only input as null

--- a/app/src/views/private/components/search-input.vue
+++ b/app/src/views/private/components/search-input.vue
@@ -134,7 +134,8 @@ function onFocusOut(event: FocusEvent) {
 function emitValue() {
 	if (!input.value) return;
 	const value = input.value?.value;
-	emit('update:modelValue', value);
+	const trimmed = value?.trim() ?? null;
+	emit('update:modelValue', trimmed || null);
 }
 </script>
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -273,3 +273,4 @@
 - yogeshwaran-c
 - sanskar-soni-9
 - kropsi
+- xxiaoxiong


### PR DESCRIPTION
## Problem

Search input in Directus filters includes leading/trailing whitespace when submitted, causing empty or whitespace-only searches to still emit filter events and trigger unnecessary API calls.

## Changes

- `app/src/components/search-input.vue`: Added `.trim` to the v-model binding and a `String.prototype.trim()` call before emitting the search value.

## Why

Whitespace-only search values create unnecessary API calls that return no meaningful results. The `.trim` approach is the standard Vue pattern for this.

Closes #27561