### PR TITLE
fix(app): resolve translation form WYSIWYG editor race condition

### DIFF
--- a/.changeset/translation-form-wysiwyg-race.md
+++ b/.changeset/translation-form-wysiwyg-race.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed translation form WYSIWYG editor race condition and crash under non-admin roles with per-row update permissions by unmounting and remounting the form during permissions loading state

--- a/app/src/hydrate.test.ts
+++ b/app/src/hydrate.test.ts
@@ -14,6 +14,8 @@ vi.mock('@/lang/set-language', () => ({
 }));
 
 beforeEach(() => {
+	vi.useFakeTimers();
+
 	setActivePinia(
 		createTestingPinia({
 			createSpy: vi.fn,
@@ -23,6 +25,8 @@ beforeEach(() => {
 
 afterEach(() => {
 	vi.clearAllMocks();
+	vi.clearAllTimers();
+	vi.useRealTimers();
 });
 
 describe('setLanguage', () => {

--- a/app/src/interfaces/translations/translation-form.test.ts
+++ b/app/src/interfaces/translations/translation-form.test.ts
@@ -1,16 +1,21 @@
 import { flushPromises, mount } from '@vue/test-utils';
 import { describe, expect, test, vi } from 'vitest';
-import { computed } from 'vue';
 import TranslationForm from './translation-form.vue';
 import type { GlobalMountOptions } from '@/__utils__/types';
 
 vi.mock('@/composables/use-permissions', () => ({
-	usePermissions: () => ({
-		itemPermissions: {
-			saveAllowed: computed(() => true),
-			deleteAllowed: computed(() => true),
-		},
-	}),
+	usePermissions: () => {
+		/* eslint-disable-next-line @typescript-eslint/no-require-imports */
+		const { computed, ref } = require('vue');
+		return {
+			itemPermissions: {
+				saveAllowed: computed(() => true),
+				deleteAllowed: computed(() => true),
+				loading: ref(false),
+				fields: computed(() => []),
+			},
+		};
+	},
 }));
 
 const global: GlobalMountOptions = {

--- a/app/src/interfaces/translations/translation-form.vue
+++ b/app/src/interfaces/translations/translation-form.vue
@@ -62,7 +62,7 @@ const itemPrimaryKey = computed(() => relationInfo && itemInitial.value?.[relati
 const itemNew = computed(() => !!(relationInfo && itemPrimaryKey.value === undefined));
 
 const {
-	itemPermissions: { saveAllowed, fields, deleteAllowed },
+	itemPermissions: { saveAllowed, fields, deleteAllowed, loading: permissionsLoading },
 } = usePermissions(
 	computed(() => relationInfo?.junctionCollection.collection ?? null),
 	itemPrimaryKey,
@@ -72,11 +72,19 @@ const {
 // Unmount the form when fields or lang change to avoid WYSIWYG crashing while Vue manipulates the DOM.
 const formReady = ref(true);
 
-watch([fields, lang], async () => {
-	formReady.value = false;
-	await nextTick();
-	formReady.value = true;
-});
+watch(
+	[fields, lang, permissionsLoading],
+	async () => {
+		if (permissionsLoading.value) {
+			formReady.value = false;
+		} else {
+			formReady.value = false;
+			await nextTick();
+			formReady.value = true;
+		}
+	},
+	{ immediate: true },
+);
 
 const activatorDisabled = computed(() => {
 	return (

--- a/contributors.yml
+++ b/contributors.yml
@@ -273,3 +273,4 @@
 - yogeshwaran-c
 - sanskar-soni-9
 - kropsi
+- theshubh77


### PR DESCRIPTION
## Scope

What's changed:

- Destructured `loading: permissionsLoading` from the `usePermissions` hook in `translation-form.vue`.
- Updated the watch dependency array in the translation form component to monitor `permissionsLoading` along with `fields` and `lang`.
- Safely unmounted the form (`formReady = false`) during active permissions loading stages. Once loading completes and states settle, the form is successfully remounted in `nextTick` with fully-resolved permissions.
- Refactored the `usePermissions` mock in `translation-form.test.ts` to dynamically import and invoke reactive helpers (`computed`, `ref`) during execution, resolving Vitest temporal dead zone warnings.
- Added `vi.useFakeTimers()` cleanup to `hydrate.test.ts` to prevent `universal-cookie` orphaned timeouts from crashing the test environment (`ReferenceError: document is not defined`).

## Potential Risks / Drawbacks

- None. Unmounting/remounting the form during permissions fetch is incredibly safe and guarantees DOM consistency. The only minor difference is a tiny transition phase while permissions load, which actually improves user experience by hiding stale inputs.

## Tested Scenarios

- **Manual Navigation**: Verified record switching under a non-admin role with `access: 'partial'` update permissions and custom collection with Translations junction collection containing a WYSIWYG (TinyMCE) interface. Navigating repeatedly between records mounts and renders the WYSIWYG safely without any `insertBefore` DOM patch errors or console crashes.
- **Unit Testing**: Ran Vitest unit tests in `translation-form.test.ts`. All test cases compiled and passed cleanly with `0` console warnings.

## Review Notes / Questions

- Note that since `fetchedItemPermissions` is configured as a lazy `computedAsync` under the hood, it is only evaluated when read. By watching `fields` (which reads the permission state) alongside `permissionsLoading`, we force the lazy fetch to begin immediately and synchronize the `formReady` state perfectly with the permissions request lifecycle.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #27478
