### PR TITLE
Fix search input whitespace handling

### DIFF
--- a/.changeset/trim-search-input.md
+++ b/.changeset/trim-search-input.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Trimmed search input values before emitting them, treating whitespace-only searches as empty.

--- a/app/src/views/private/components/search-input.test.ts
+++ b/app/src/views/private/components/search-input.test.ts
@@ -56,6 +56,38 @@ describe('Component', () => {
 		expect(wrapper.find('input').attributes('disabled')).toBe('');
 	});
 
+	it('should trim surrounding whitespace from emitted search values', async () => {
+		const wrapper = mount(SearchInput, {
+			props: {
+				modelValue: '',
+			},
+			global,
+		});
+
+		const input = wrapper.find('input');
+
+		await input.setValue('  test  ');
+
+		const emitted = wrapper.emitted('update:modelValue');
+		expect(emitted?.[emitted.length - 1]).toEqual(['test']);
+	});
+
+	it('should emit null when search value only contains whitespace', async () => {
+		const wrapper = mount(SearchInput, {
+			props: {
+				modelValue: '',
+			},
+			global,
+		});
+
+		const input = wrapper.find('input');
+
+		await input.setValue('   ');
+
+		const emitted = wrapper.emitted('update:modelValue');
+		expect(emitted?.[emitted.length - 1]).toEqual([null]);
+	});
+
 	describe('focusout behavior', () => {
 		let wrapper: VueWrapper;
 		let search: DOMWrapper<Element>;

--- a/app/src/views/private/components/search-input.vue
+++ b/app/src/views/private/components/search-input.vue
@@ -133,8 +133,8 @@ function onFocusOut(event: FocusEvent) {
 
 function emitValue() {
 	if (!input.value) return;
-	const value = input.value?.value;
-	emit('update:modelValue', value);
+	const value = input.value.value.trim();
+	emit('update:modelValue', value || null);
 }
 </script>
 


### PR DESCRIPTION
## Scope

What's changed:

- Trim shared search input values before emitting them
- Treat whitespace-only search input as an empty search by emitting `null`
- Added regression coverage for trimmed and whitespace-only input values

## Potential Risks / Drawbacks

- Search boxes using this shared component will no longer preserve intentional leading or trailing spaces in search terms

## Tested Scenarios

- `pnpm --filter @directus/app test app/src/views/private/components/search-input.test.ts`
- `pnpm exec eslint app/src/views/private/components/search-input.vue app/src/views/private/components/search-input.test.ts`
- `pnpm exec prettier --check app/src/views/private/components/search-input.vue app/src/views/private/components/search-input.test.ts .changeset/trim-search-input.md`

## Review Notes / Questions

- This keeps the existing `clear()` behavior aligned with whitespace-only input by emitting `null` in both cases

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #27358