### PR TITLE
fix: remove fallthrough title attribute from RenderTemplate in list-o2m and list-m2m

### DIFF
--- a/.changeset/remove-rendertemplate-title-attribute.md
+++ b/.changeset/remove-rendertemplate-title-attribute.md
@@ -1,0 +1,6 @@
+---
+"@directus/app": patch
+---
+
+Fixed tooltip displaying internal relation field path instead of display value in list-o2m and list-m2m table layouts
+

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -567,7 +567,7 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 				@update:items="sortItems"
 			>
 				<template v-for="header in headers" :key="header.value" #[`item.${header.value}`]="{ item }">
-				<RenderTemplate
+					<RenderTemplate
 						:collection="relationInfo.junctionCollection.collection"
 						:item="item"
 						:template="`{{${header.value}}}`"

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -567,8 +567,7 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 				@update:items="sortItems"
 			>
 				<template v-for="header in headers" :key="header.value" #[`item.${header.value}`]="{ item }">
-					<RenderTemplate
-						:title="header.value"
+				<RenderTemplate
 						:collection="relationInfo.junctionCollection.collection"
 						:item="item"
 						:template="`{{${header.value}}}`"

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -530,7 +530,7 @@ const menuActive = computed(() => Boolean(currentlyEditing.value) || selectModal
 				@update:items="sortItems"
 			>
 				<template v-for="header in headers" :key="header.value" #[`item.${header.value}`]="{ item }">
-				<RenderTemplate
+					<RenderTemplate
 						:collection="relationInfo.relatedCollection.collection"
 						:item="item"
 						:template="`{{${header.value}}}`"

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -530,8 +530,7 @@ const menuActive = computed(() => Boolean(currentlyEditing.value) || selectModal
 				@update:items="sortItems"
 			>
 				<template v-for="header in headers" :key="header.value" #[`item.${header.value}`]="{ item }">
-					<RenderTemplate
-						:title="header.value"
+				<RenderTemplate
 						:collection="relationInfo.relatedCollection.collection"
 						:item="item"
 						:template="`{{${header.value}}}`"

--- a/contributors.yml
+++ b/contributors.yml
@@ -273,3 +273,4 @@
 - yogeshwaran-c
 - sanskar-soni-9
 - kropsi
+- xxiaoxiong


### PR DESCRIPTION
Closes #27568

## Bug Description
When using a One-to-Many or Many-to-Many field with Table layout, hovering over a rendered value displays the internal relation field path instead of the actual display value in the tooltip.

Example:
- Displayed: `CA002`
- Tooltip: `hardware_item.asset_tag`

## Root Cause
The `<RenderTemplate>` component does not declare a `title` prop, so the `:title="header.value"` attribute (set to the internal field path, e.g., `hardware_item.hardware_type.name`) falls through to the root `<div class="render-template">` as a native HTML `title` attribute, which the browser renders as a tooltip.

## Fix
Remove the spurious `:title="header.value"` attribute from RenderTemplate usage in both:
- `list-o2m.vue` (One-to-Many interface)
- `list-m2m.vue` (Many-to-Many interface)

The `title` attribute was not used by RenderTemplate for any functional purpose, so removing it has no side effects beyond eliminating the incorrect tooltip.