### PR TITLE
fix(sdk): skip non-finite query numbers

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -273,3 +273,4 @@
 - yogeshwaran-c
 - sanskar-soni-9
 - kropsi
+- Mthize

--- a/sdk/src/utils/query-to-params.test.ts
+++ b/sdk/src/utils/query-to-params.test.ts
@@ -79,6 +79,16 @@ describe('queryToParams', () => {
 		});
 	});
 
+	test('should skip non-finite numeric parameters', () => {
+		const result = queryToParams({
+			limit: Number.NaN,
+			offset: Number.POSITIVE_INFINITY,
+			page: Number.NEGATIVE_INFINITY,
+		});
+
+		expect(result).toEqual({});
+	});
+
 	test('should format query.fields parameter', () => {
 		const result = queryToParams({
 			fields: ['id', 'name', { author: ['name'] }],

--- a/sdk/src/utils/query-to-params.ts
+++ b/sdk/src/utils/query-to-params.ts
@@ -23,7 +23,7 @@ const knownQueryKeys = [
  */
 const isBoolean = (value: unknown): value is boolean => typeof value === 'boolean';
 const isString = (value: unknown): value is string => typeof value === 'string' && Boolean(value);
-const isNumber = (value: unknown): value is number => typeof value === 'number';
+const isNumber = (value: unknown): value is number => typeof value === 'number' && Number.isFinite(value);
 const isArray = (value: unknown): value is unknown[] => Array.isArray(value) && value.length > 0;
 
 const isObject = (value: unknown): value is Record<string, unknown> =>


### PR DESCRIPTION
## Scope

What's changed:

- Updated the SDK query parameter formatter to only accept finite numbers
- Prevented `NaN`, `Infinity`, and `-Infinity` from being serialized into query params
- Added a test case for non-finite numeric query parameters

## Potential Risks / Drawbacks

- Low risk: this only affects invalid numeric query values
- Existing valid values like `limit: -1`, `offset: 0`, and `page: 1` continue to work

## Tested Scenarios

- `pnpm --filter @directus/sdk test`
- `pnpm lint`
- Confirmed SDK tests pass with 75 tests

## Review Notes / Questions

- This keeps the existing behavior for valid numeric values and string workarounds
- The change only skips non-finite numbers before they can be added to request query parameters

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required