### PR TITLE
fix: remove fallthrough title attribute from RenderTemplate in list-o2m and list-m2m

### DIFF
--- a/.changeset/tooltip-field-path-fix.md
+++ b/.changeset/tooltip-field-path-fix.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed tooltip showing internal relation field path in O2M and M2M table layouts

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -568,7 +568,6 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 			>
 				<template v-for="header in headers" :key="header.value" #[`item.${header.value}`]="{ item }">
 					<RenderTemplate
-						:title="header.value"
 						:collection="relationInfo.junctionCollection.collection"
 						:item="item"
 						:template="`{{${header.value}}}`"

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -531,7 +531,6 @@ const menuActive = computed(() => Boolean(currentlyEditing.value) || selectModal
 			>
 				<template v-for="header in headers" :key="header.value" #[`item.${header.value}`]="{ item }">
 					<RenderTemplate
-						:title="header.value"
 						:collection="relationInfo.relatedCollection.collection"
 						:item="item"
 						:template="`{{${header.value}}}`"

--- a/app/src/views/private/components/render-template.vue
+++ b/app/src/views/private/components/render-template.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Field } from '@directus/types';
 import { get } from '@directus/utils';
-import { computed } from 'vue';
+import { computed, defineOptions } from 'vue';
 import ValueNull from './value-null.vue';
 import VErrorBoundary from '@/components/v-error-boundary.vue';
 import { useExtension } from '@/composables/use-extension';
@@ -9,6 +9,10 @@ import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
 import { getDefaultDisplayForType } from '@/utils/get-default-display-for-type';
 import { translate } from '@/utils/translate-literal';
+
+defineOptions({
+	inheritAttrs: false,
+});
 
 const props = withDefaults(
 	defineProps<{

--- a/contributors.yml
+++ b/contributors.yml
@@ -273,3 +273,5 @@
 - yogeshwaran-c
 - sanskar-soni-9
 - kropsi
+
+ - xxiaoxiong

--- a/contributors.yml
+++ b/contributors.yml
@@ -274,4 +274,4 @@
 - sanskar-soni-9
 - kropsi
 
- - xxiaoxiong
+  - xxiaoxiong

--- a/contributors.yml
+++ b/contributors.yml
@@ -273,5 +273,4 @@
 - yogeshwaran-c
 - sanskar-soni-9
 - kropsi
-
-  - xxiaoxiong
+- xxiaoxiong


### PR DESCRIPTION
Closes #27568

## Bug Description
When using a One-to-Many or Many-to-Many field with Table layout, hovering over a rendered value displays the internal relation field path instead of the actual display value in the tooltip.

Example:
- Displayed: `CA002`
- Tooltip: `hardware_item.asset_tag`

## Root Cause
The `<RenderTemplate>` component does not declare a `title` prop, so the `:title="header.value"` attribute (set to the internal field path, e.g., `hardware_item.hardware_type.name`) falls through to the root `<div class="render-template">` as a native HTML `title` attribute, which the browser renders as a tooltip.

## Fix
1. Remove the spurious `:title="header.value"` attribute from RenderTemplate usage in both `list-o2m.vue` and `list-m2m.vue`.
2. Added `inheritAttrs: false` to the RenderTemplate component as a safety measure to prevent any unintended attribute fallthrough in the future.

The `title` attribute was not used by RenderTemplate for any functional purpose, so removing it has no side effects beyond eliminating the incorrect tooltip.