### PR TITLE
Show only grace login modal when upgrading from v11 to v12

### DIFF
--- a/app/src/views/private/components/license-resolution-prompt.vue
+++ b/app/src/views/private/components/license-resolution-prompt.vue
@@ -8,7 +8,7 @@ import { useUserStore } from '@/stores/user';
 
 const userStore = useUserStore();
 const licenseStore = useLicenseStore();
-const { info, pendingResolution, wasDowngraded, isLocked } = storeToRefs(licenseStore);
+const { info, pendingResolution, wasDowngraded, isLocked, isCoreGrace } = storeToRefs(licenseStore);
 
 const cookies = useCookies(['license-resolution-acknowledged']);
 
@@ -21,7 +21,9 @@ const acknowledgeKey = computed(() => {
 
 const acknowledged = ref<string | null>(cookies.get('license-resolution-acknowledged') ?? null);
 
-const isGracePrompt = computed(() => info.value?.status === 'grace' && (pendingResolution.value?.length ?? 0) > 0);
+const isGracePrompt = computed(
+	() => info.value?.status === 'grace' && !isCoreGrace.value && (pendingResolution.value?.length ?? 0) > 0,
+);
 
 // Downgrade acknowledgement clears server-side after resolve()
 const isDowngradePrompt = computed(() => wasDowngraded.value && !isLocked.value);

--- a/app/src/views/private/private-view/components/private-view.vue
+++ b/app/src/views/private/private-view/components/private-view.vue
@@ -76,6 +76,7 @@ const showLicenseBanner = computed({
 		userStore.isAdmin &&
 		!settingsStore.settings?.project_owner &&
 		!showLicenseOnboarding.value &&
+		!licenseStore.isCoreGrace &&
 		!cookies.get('license-banner-dismissed'),
 	set: () => {
 		// close is handled by cookie and hydrate inside the modal
@@ -88,6 +89,7 @@ const showLicenseOnboarding = computed({
 		serverStore.info.setupCompleted &&
 		!serverStore.info.license?.source &&
 		!settingsStore.settings?.project_usage &&
+		!licenseStore.isCoreGrace &&
 		!cookies.get('license-onboarding-dismissed'),
 	set: () => {
 		// close is handled by cookie and hydrate inside the modal


### PR DESCRIPTION
## Scope

What's changed:

- Suppress the owner-setup banner (`showLicenseBanner`) during core grace so it does not open alongside the login modal on upgraded instances without a `project_owner` set
- Suppress the onboarding split modal (`showLicenseOnboarding`) during core grace so upgraders are not asked to choose between "I'm using core" / "I have a key" — a flow intended for fresh v12 installs only
- Suppress the resolution/acknowledge dialog (`isGracePrompt`) during core grace so upgraders are not confronted with a violation acknowledgement prompt that is irrelevant to the upgrade flow

All three conditions now gate on `!isCoreGrace` (`status === 'grace' && source === null`), leaving only the login modal (enter key / remind later / grace info) visible on first login after an upgrade.

## Tested Scenarios

- Backdated migrations to simulate upgrade scenario (`20201028A` set 60 days ago, `20260507A` set 2 days ago) and confirmed only the login modal appears on admin login

---

Fixes [CMS-2519](https://linear.app/directus/issue/CMS-2519/double-modal-shown-when-upgrading-and-entering-grace-period)
