### PR TITLE
Replace hardcoded `https://directus.io` to `https://directus.com` with new constant

### DIFF
--- a/.changeset/add-directus-homepage-constant.md
+++ b/.changeset/add-directus-homepage-constant.md
@@ -3,4 +3,4 @@
 '@directus/app': patch
 ---
 
-Added `DIRECTUS_HOMEPAGE` constant and replaced hardcoded `https://directus.io` to `https://directus.com` using the new constant
+Added `DIRECTUS_DOMAIN` constant and replaced hardcoded `directus.io` to `directus.com` using the new constant

--- a/.changeset/add-directus-homepage-constant.md
+++ b/.changeset/add-directus-homepage-constant.md
@@ -1,0 +1,6 @@
+---
+'@directus/constants': patch 
+'@directus/app': patch
+---
+
+Added `DIRECTUS_HOMEPAGE` constant and replaced hardcoded `https://directus.io` to `https://directus.com` using the new constant

--- a/api/license
+++ b/api/license
@@ -25,7 +25,7 @@ Change Date:          Three years from release date
 Change License:       GNU General Public License (GPL) v3
 
 For information about alternative licensing arrangements, please visit
-https://directus.io/pricing.
+https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 

--- a/api/package.json
+++ b/api/package.json
@@ -21,7 +21,7 @@
 		"framework",
 		"vue"
 	],
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/app/license
+++ b/app/license
@@ -25,7 +25,7 @@ Change Date:          Three years from release date
 Change License:       GNU General Public License (GPL) v3
 
 For information about alternative licensing arrangements, please visit
-https://directus.io/pricing.
+https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 

--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/app",
 	"version": "15.10.0",
 	"description": "App dashboard for Directus",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/app/src/components/v-license-badge.test.ts
+++ b/app/src/components/v-license-badge.test.ts
@@ -49,7 +49,7 @@ describe('v-license-badge', () => {
 		const wrapper = mount(VLicenseBadge, { global });
 
 		expect(wrapper.find('a').exists()).toBe(true);
-		expect(wrapper.find('a').attributes('href')).toBe('https://directus.io/');
+		expect(wrapper.find('a').attributes('href')).toBe('https://directus.com/');
 	});
 
 	it('renders badge linking to directus.io/oig when display_powered_by is OIG', () => {
@@ -58,7 +58,7 @@ describe('v-license-badge', () => {
 		const wrapper = mount(VLicenseBadge, { global });
 
 		expect(wrapper.find('a').exists()).toBe(true);
-		expect(wrapper.find('a').attributes('href')).toBe('https://directus.io/oig');
+		expect(wrapper.find('a').attributes('href')).toBe('https://directus.com/oig');
 	});
 
 	it('adds private class to anchor when private prop is true', () => {

--- a/app/src/components/v-license-badge.vue
+++ b/app/src/components/v-license-badge.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { DIRECTUS_HOMEPAGE } from '@directus/constants';
 import { computed } from 'vue';
 import VIcon from './v-icon/v-icon.vue';
 import { useServerStore } from '@/stores/server';
@@ -10,9 +11,9 @@ const serverStore = useServerStore();
 const displayPoweredBy = computed(() => serverStore.info?.license?.entitlements?.display_powered_by);
 
 const link = computed(() => {
-	if (displayPoweredBy.value === 'DIRECTUS') return 'https://directus.io/';
+	if (displayPoweredBy.value === 'DIRECTUS') return `${DIRECTUS_HOMEPAGE}/`;
 
-	if (displayPoweredBy.value === 'OIG') return 'https://directus.io/oig';
+	if (displayPoweredBy.value === 'OIG') return `${DIRECTUS_HOMEPAGE}/oig`;
 
 	return '';
 });

--- a/app/src/components/v-license-badge.vue
+++ b/app/src/components/v-license-badge.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { DIRECTUS_HOMEPAGE } from '@directus/constants';
+import { DIRECTUS_DOMAIN } from '@directus/constants';
 import { computed } from 'vue';
 import VIcon from './v-icon/v-icon.vue';
 import { useServerStore } from '@/stores/server';
@@ -11,9 +11,9 @@ const serverStore = useServerStore();
 const displayPoweredBy = computed(() => serverStore.info?.license?.entitlements?.display_powered_by);
 
 const link = computed(() => {
-	if (displayPoweredBy.value === 'DIRECTUS') return `${DIRECTUS_HOMEPAGE}/`;
+	if (displayPoweredBy.value === 'DIRECTUS') return `https://${DIRECTUS_DOMAIN}/`;
 
-	if (displayPoweredBy.value === 'OIG') return `${DIRECTUS_HOMEPAGE}/oig`;
+	if (displayPoweredBy.value === 'OIG') return `https://${DIRECTUS_DOMAIN}/oig`;
 
 	return '';
 });

--- a/app/src/interfaces/_system/system-license-key/system-license-key.vue
+++ b/app/src/interfaces/_system/system-license-key/system-license-key.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { DIRECTUS_HOMEPAGE } from '@directus/constants';
 import { LICENSE_KEY, normalizeLicenseKey } from '@directus/license';
 import { throttle } from 'lodash';
 import { computed, onMounted, ref, watch } from 'vue';
@@ -157,7 +158,9 @@ onMounted(() => {
 
 			<div>
 				<VIcon name="check_circle" />
-				<span>{{ $t('environment') }}: {{ licenseInfo.production_enabled ? $t('production') : $t('non_production') }}</span>
+				<span>
+					{{ $t('environment') }}: {{ licenseInfo.production_enabled ? $t('production') : $t('non_production') }}
+				</span>
 			</div>
 		</div>
 
@@ -169,7 +172,7 @@ onMounted(() => {
 			<I18nT keypath="setup_license_invalid" tag="span">
 				<template #contactSupport>
 					<a
-						:href="`https://directus.io/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=license_key_invalid_contact_support_link`"
+						:href="`${DIRECTUS_HOMEPAGE}/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=license_key_invalid_contact_support_link`"
 						target="_blank"
 						rel="noopener noreferrer"
 					>

--- a/app/src/interfaces/_system/system-license-key/system-license-key.vue
+++ b/app/src/interfaces/_system/system-license-key/system-license-key.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { DIRECTUS_HOMEPAGE } from '@directus/constants';
+import { DIRECTUS_DOMAIN } from '@directus/constants';
 import { LICENSE_KEY, normalizeLicenseKey } from '@directus/license';
 import { throttle } from 'lodash';
 import { computed, onMounted, ref, watch } from 'vue';
@@ -172,7 +172,7 @@ onMounted(() => {
 			<I18nT keypath="setup_license_invalid" tag="span">
 				<template #contactSupport>
 					<a
-						:href="`${DIRECTUS_HOMEPAGE}/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=license_key_invalid_contact_support_link`"
+						:href="`https://${DIRECTUS_DOMAIN}/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=license_key_invalid_contact_support_link`"
 						target="_blank"
 						rel="noopener noreferrer"
 					>

--- a/app/src/modules/settings/routes/license/components/license-addon-item.vue
+++ b/app/src/modules/settings/routes/license/components/license-addon-item.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { DIRECTUS_HOMEPAGE } from '@directus/constants';
+import { DIRECTUS_DOMAIN } from '@directus/constants';
 import type { LicenseAddon } from '@directus/license';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -45,7 +45,7 @@ const buttonIcon = computed(() => {
 	}
 });
 
-const salesHref = `${DIRECTUS_HOMEPAGE}/sales`;
+const salesHref = `https://${DIRECTUS_DOMAIN}/sales`;
 
 function onClick() {
 	dialogOpen.value = true;

--- a/app/src/modules/settings/routes/license/components/license-addon-item.vue
+++ b/app/src/modules/settings/routes/license/components/license-addon-item.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { DIRECTUS_HOMEPAGE } from '@directus/constants';
 import type { LicenseAddon } from '@directus/license';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -44,7 +45,7 @@ const buttonIcon = computed(() => {
 	}
 });
 
-const salesHref = 'https://directus.io/sales';
+const salesHref = `${DIRECTUS_HOMEPAGE}/sales`;
 
 function onClick() {
 	dialogOpen.value = true;

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { DIRECTUS_HOMEPAGE } from '@directus/constants';
+import { DIRECTUS_DOMAIN } from '@directus/constants';
 import { deactivateLicense, type Entitlements } from '@directus/license';
 import { storeToRefs } from 'pinia';
 import { computed, onMounted, ref } from 'vue';
@@ -262,7 +262,7 @@ async function handleDeactivateConfirm() {
 							</VButton>
 							<VButton
 								small
-								:href="`${DIRECTUS_HOMEPAGE}/pricing?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=settings_license_upgrade_plan_link`"
+								:href="`https://${DIRECTUS_DOMAIN}/pricing?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=settings_license_upgrade_plan_link`"
 								target="_blank"
 								rel="noopener noreferrer"
 							>
@@ -371,7 +371,7 @@ async function handleDeactivateConfirm() {
 				<I18nT keypath="setup_license_key_notice" tag="span">
 					<template #oig>
 						<a
-							:href="`${DIRECTUS_HOMEPAGE}/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=settings_license_drawer_open_innovation_grant_link`"
+							:href="`https://${DIRECTUS_DOMAIN}/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=settings_license_drawer_open_innovation_grant_link`"
 							target="_blank"
 							rel="noopener noreferrer"
 						>

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { DIRECTUS_HOMEPAGE } from '@directus/constants';
 import { deactivateLicense, type Entitlements } from '@directus/license';
 import { storeToRefs } from 'pinia';
 import { computed, onMounted, ref } from 'vue';
@@ -261,7 +262,7 @@ async function handleDeactivateConfirm() {
 							</VButton>
 							<VButton
 								small
-								:href="`https://directus.io/pricing?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=settings_license_upgrade_plan_link`"
+								:href="`${DIRECTUS_HOMEPAGE}/pricing?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=settings_license_upgrade_plan_link`"
 								target="_blank"
 								rel="noopener noreferrer"
 							>
@@ -370,7 +371,7 @@ async function handleDeactivateConfirm() {
 				<I18nT keypath="setup_license_key_notice" tag="span">
 					<template #oig>
 						<a
-							:href="`https://directus.io/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=settings_license_drawer_open_innovation_grant_link`"
+							:href="`${DIRECTUS_HOMEPAGE}/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=settings_license_drawer_open_innovation_grant_link`"
 							target="_blank"
 							rel="noopener noreferrer"
 						>

--- a/app/src/routes/setup/form.vue
+++ b/app/src/routes/setup/form.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { DIRECTUS_HOMEPAGE } from '@directus/constants';
+import { DIRECTUS_DOMAIN } from '@directus/constants';
 import { SetupForm } from '@directus/types';
 import { storeToRefs } from 'pinia';
 import { computed, toRef } from 'vue';
@@ -122,7 +122,7 @@ const mergedErrors = computed<ValidationError[]>(() => {
 			<I18nT keypath="setup_save_accept_license" tag="span">
 				<template #directusMscl>
 					<a
-						:href="`${DIRECTUS_HOMEPAGE}/mscl?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=${utmLocation}_mscl_1.0_gpl_link`"
+						:href="`https://${DIRECTUS_DOMAIN}/mscl?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=${utmLocation}_mscl_1.0_gpl_link`"
 						target="_blank"
 					>
 						{{ $t('directus_mscl') }}
@@ -130,7 +130,7 @@ const mergedErrors = computed<ValidationError[]>(() => {
 				</template>
 				<template #privacyPolicy>
 					<a
-						:href="`${DIRECTUS_HOMEPAGE}/privacy?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=${utmLocation}_privacy_link`"
+						:href="`https://${DIRECTUS_DOMAIN}/privacy?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=${utmLocation}_privacy_link`"
 						target="_blank"
 					>
 						{{ $t('privacy_policy') }}
@@ -143,7 +143,7 @@ const mergedErrors = computed<ValidationError[]>(() => {
 			<I18nT keypath="setup_accept_license" tag="span">
 				<template #directusMscl>
 					<a
-						:href="`${DIRECTUS_HOMEPAGE}/mscl?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=mscl_1.0_gpl_link`"
+						:href="`https://${DIRECTUS_DOMAIN}/mscl?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=mscl_1.0_gpl_link`"
 						target="_blank"
 					>
 						{{ $t('directus_mscl') }}
@@ -151,7 +151,7 @@ const mergedErrors = computed<ValidationError[]>(() => {
 				</template>
 				<template #privacyPolicy>
 					<a
-						:href="`${DIRECTUS_HOMEPAGE}/privacy?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=privacy_link`"
+						:href="`https://${DIRECTUS_DOMAIN}/privacy?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=privacy_link`"
 						target="_blank"
 					>
 						{{ $t('privacy_policy') }}

--- a/app/src/routes/setup/form.vue
+++ b/app/src/routes/setup/form.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { DIRECTUS_HOMEPAGE } from '@directus/constants';
 import { SetupForm } from '@directus/types';
 import { storeToRefs } from 'pinia';
 import { computed, toRef } from 'vue';
@@ -121,7 +122,7 @@ const mergedErrors = computed<ValidationError[]>(() => {
 			<I18nT keypath="setup_save_accept_license" tag="span">
 				<template #directusMscl>
 					<a
-						:href="`https://directus.io/mscl?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=${utmLocation}_mscl_1.0_gpl_link`"
+						:href="`${DIRECTUS_HOMEPAGE}/mscl?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=${utmLocation}_mscl_1.0_gpl_link`"
 						target="_blank"
 					>
 						{{ $t('directus_mscl') }}
@@ -129,7 +130,7 @@ const mergedErrors = computed<ValidationError[]>(() => {
 				</template>
 				<template #privacyPolicy>
 					<a
-						:href="`https://directus.io/privacy?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=${utmLocation}_privacy_link`"
+						:href="`${DIRECTUS_HOMEPAGE}/privacy?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=${utmLocation}_privacy_link`"
 						target="_blank"
 					>
 						{{ $t('privacy_policy') }}
@@ -142,7 +143,7 @@ const mergedErrors = computed<ValidationError[]>(() => {
 			<I18nT keypath="setup_accept_license" tag="span">
 				<template #directusMscl>
 					<a
-						:href="`https://directus.io/mscl?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=mscl_1.0_gpl_link`"
+						:href="`${DIRECTUS_HOMEPAGE}/mscl?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=mscl_1.0_gpl_link`"
 						target="_blank"
 					>
 						{{ $t('directus_mscl') }}
@@ -150,7 +151,7 @@ const mergedErrors = computed<ValidationError[]>(() => {
 				</template>
 				<template #privacyPolicy>
 					<a
-						:href="`https://directus.io/privacy?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=privacy_link`"
+						:href="`${DIRECTUS_HOMEPAGE}/privacy?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=privacy_link`"
 						target="_blank"
 					>
 						{{ $t('privacy_policy') }}

--- a/app/src/routes/setup/license.vue
+++ b/app/src/routes/setup/license.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { DIRECTUS_HOMEPAGE } from '@directus/constants';
 import { SetupForm } from '@directus/types';
 import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -118,7 +119,7 @@ defineExpose({ canProceed });
 			{{ $t('no_license_key') }}
 			<VButton
 				secondary
-				:href="`https://directus.io/docs/licensing/overview?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=onboarding_get_license_link`"
+				:href="`${DIRECTUS_HOMEPAGE}/docs/licensing/overview?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=onboarding_get_license_link`"
 				target="_blank"
 			>
 				<VIcon name="key" />

--- a/app/src/routes/setup/license.vue
+++ b/app/src/routes/setup/license.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { DIRECTUS_HOMEPAGE } from '@directus/constants';
+import { DIRECTUS_DOMAIN } from '@directus/constants';
 import { SetupForm } from '@directus/types';
 import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -119,7 +119,7 @@ defineExpose({ canProceed });
 			{{ $t('no_license_key') }}
 			<VButton
 				secondary
-				:href="`${DIRECTUS_HOMEPAGE}/docs/licensing/overview?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=onboarding_get_license_link`"
+				:href="`https://${DIRECTUS_DOMAIN}/docs/licensing/overview?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=onboarding_get_license_link`"
 				target="_blank"
 			>
 				<VIcon name="key" />

--- a/app/src/routes/setup/setup.vue
+++ b/app/src/routes/setup/setup.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { DIRECTUS_HOMEPAGE } from '@directus/constants';
 import { SetupForm as Form } from '@directus/types';
 import { useHead } from '@unhead/vue';
 import { storeToRefs } from 'pinia';
@@ -112,7 +113,7 @@ const setupComplete = computed(() => SetupValidator.safeParse(form.value).succes
 			<I18nT keypath="setup_license_key_notice" tag="p">
 				<template #oig>
 					<a
-						:href="`https://directus.io/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=onboarding_contact_our_team_link`"
+						:href="`${DIRECTUS_HOMEPAGE}/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=onboarding_contact_our_team_link`"
 						target="_blank"
 					>
 						{{ $t('open_innovation_grant') }}

--- a/app/src/routes/setup/setup.vue
+++ b/app/src/routes/setup/setup.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { DIRECTUS_HOMEPAGE } from '@directus/constants';
+import { DIRECTUS_DOMAIN } from '@directus/constants';
 import { SetupForm as Form } from '@directus/types';
 import { useHead } from '@unhead/vue';
 import { storeToRefs } from 'pinia';
@@ -113,7 +113,7 @@ const setupComplete = computed(() => SetupValidator.safeParse(form.value).succes
 			<I18nT keypath="setup_license_key_notice" tag="p">
 				<template #oig>
 					<a
-						:href="`${DIRECTUS_HOMEPAGE}/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=onboarding_contact_our_team_link`"
+						:href="`https://${DIRECTUS_DOMAIN}/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=onboarding_contact_our_team_link`"
 						target="_blank"
 					>
 						{{ $t('open_innovation_grant') }}

--- a/app/src/views/private/components/license-onboarding.vue
+++ b/app/src/views/private/components/license-onboarding.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { DIRECTUS_HOMEPAGE } from '@directus/constants';
 import { LICENSE_KEY } from '@directus/license';
 import { useCookies } from '@vueuse/integrations/useCookies';
 import { computed, ref, watch } from 'vue';
@@ -107,7 +108,7 @@ function dismiss() {
 					<I18nT keypath="license_onboarding_desc" tag="p">
 						<template #oig>
 							<a
-								:href="`https://directus.io/oig?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=license_onboarding_open_innovation_grant_link`"
+								:href="`${DIRECTUS_HOMEPAGE}/oig?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=license_onboarding_open_innovation_grant_link`"
 								target="_blank"
 							>
 								{{ $t('open_innovation_grant') }}

--- a/app/src/views/private/components/license-onboarding.vue
+++ b/app/src/views/private/components/license-onboarding.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { DIRECTUS_HOMEPAGE } from '@directus/constants';
+import { DIRECTUS_DOMAIN } from '@directus/constants';
 import { LICENSE_KEY } from '@directus/license';
 import { useCookies } from '@vueuse/integrations/useCookies';
 import { computed, ref, watch } from 'vue';
@@ -108,7 +108,7 @@ function dismiss() {
 					<I18nT keypath="license_onboarding_desc" tag="p">
 						<template #oig>
 							<a
-								:href="`${DIRECTUS_HOMEPAGE}/oig?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=license_onboarding_open_innovation_grant_link`"
+								:href="`https://${DIRECTUS_DOMAIN}/oig?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=license_onboarding_open_innovation_grant_link`"
 								target="_blank"
 							>
 								{{ $t('open_innovation_grant') }}

--- a/app/src/views/private/components/license/license-login-modal.vue
+++ b/app/src/views/private/components/license/license-login-modal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { DIRECTUS_HOMEPAGE } from '@directus/constants';
+import { DIRECTUS_DOMAIN } from '@directus/constants';
 import { useCookies } from '@vueuse/integrations/useCookies';
 import { storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
@@ -59,7 +59,7 @@ function dismiss() {
 
 function openGetLicenseKey() {
 	window.open(
-		`${DIRECTUS_HOMEPAGE}/docs/licensing/overview?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=upgrade_modal_open_get_license`,
+		`https://${DIRECTUS_DOMAIN}/docs/licensing/overview?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=upgrade_modal_open_get_license`,
 		'_blank',
 		'noopener,noreferrer',
 	);
@@ -76,7 +76,7 @@ function openGetLicenseKey() {
 					<I18nT keypath="license_onboarding_desc" tag="p">
 						<template #oig>
 							<a
-								:href="`${DIRECTUS_HOMEPAGE}/oig?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=upgrade_modal_open_innovation_grant_link`"
+								:href="`https://${DIRECTUS_DOMAIN}/oig?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=upgrade_modal_open_innovation_grant_link`"
 								target="_blank"
 								rel="noopener noreferrer"
 							>

--- a/app/src/views/private/components/license/license-login-modal.vue
+++ b/app/src/views/private/components/license/license-login-modal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { DIRECTUS_HOMEPAGE } from '@directus/constants';
 import { useCookies } from '@vueuse/integrations/useCookies';
 import { storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
@@ -58,7 +59,7 @@ function dismiss() {
 
 function openGetLicenseKey() {
 	window.open(
-		`https://directus.io/docs/licensing/overview?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=upgrade_modal_open_get_license`,
+		`${DIRECTUS_HOMEPAGE}/docs/licensing/overview?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=upgrade_modal_open_get_license`,
 		'_blank',
 		'noopener,noreferrer',
 	);
@@ -75,7 +76,7 @@ function openGetLicenseKey() {
 					<I18nT keypath="license_onboarding_desc" tag="p">
 						<template #oig>
 							<a
-								:href="`https://directus.io/oig?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=upgrade_modal_open_innovation_grant_link`"
+								:href="`${DIRECTUS_HOMEPAGE}/oig?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info.version}&utm_content=upgrade_modal_open_innovation_grant_link`"
 								target="_blank"
 								rel="noopener noreferrer"
 							>

--- a/app/src/views/private/components/license/status-notice.vue
+++ b/app/src/views/private/components/license/status-notice.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { DIRECTUS_HOMEPAGE } from '@directus/constants';
+import { DIRECTUS_DOMAIN } from '@directus/constants';
 import { storeToRefs } from 'pinia';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -26,7 +26,7 @@ const severity = computed(() =>
 
 const lockedSupportUrl = computed(
 	() =>
-		`${DIRECTUS_HOMEPAGE}/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info?.version}&utm_content=status_notice_locked_contact_support_link`,
+		`https://${DIRECTUS_DOMAIN}/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info?.version}&utm_content=status_notice_locked_contact_support_link`,
 );
 </script>
 

--- a/app/src/views/private/components/license/status-notice.vue
+++ b/app/src/views/private/components/license/status-notice.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { DIRECTUS_HOMEPAGE } from '@directus/constants';
 import { storeToRefs } from 'pinia';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -25,7 +26,7 @@ const severity = computed(() =>
 
 const lockedSupportUrl = computed(
 	() =>
-		`https://directus.io/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info?.version}&utm_content=status_notice_locked_contact_support_link`,
+		`${DIRECTUS_HOMEPAGE}/license-request?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info?.version}&utm_content=status_notice_locked_contact_support_link`,
 );
 </script>
 

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,7 +1,7 @@
 # Code of Conduct
 
 Please see our code of conduct on
-[https://docs.directus.io/contributing/code-of-conduct](https://docs.directus.io/contributing/code-of-conduct)
+[https://docs.directus.com/contributing/code-of-conduct](https://docs.directus.com/contributing/code-of-conduct)
 
 For guidelines on the use of AI tools when contributing to this project, please review our
 [AI Usage Policy](ai_policy.md).

--- a/contributing.md
+++ b/contributing.md
@@ -1,4 +1,4 @@
 # Contributing
 
 Please see our contributing guidelines on
-[https://docs.directus.io/contributing/introduction](https://docs.directus.io/contributing/introduction)
+[https://docs.directus.com/contributing/introduction](https://docs.directus.com/contributing/introduction)

--- a/directus/license
+++ b/directus/license
@@ -25,7 +25,7 @@ Change Date:          Three years from release date
 Change License:       GNU General Public License (GPL) v3
 
 For information about alternative licensing arrangements, please visit
-https://directus.io/pricing.
+https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 

--- a/directus/package.json
+++ b/directus/package.json
@@ -21,7 +21,7 @@
 		"framework",
 		"vue"
 	],
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git"

--- a/directus/readme.md
+++ b/directus/readme.md
@@ -21,7 +21,7 @@ Directus is a real-time API and App dashboard for managing SQL database content.
 - **Completely Extensible.** Built to white-label, it is easy to customize our modular platform.
 - **A Modern Dashboard.** Our no-code Vue.js app is safe and intuitive for non-technical users, no training required.
 
-**[Learn more about Directus](https://directus.com)** • **[Documentation](https://docs.directus.com)**
+**[Learn more about Directus](https://directus.com)** • **[Documentation](https://directus.com/docs)**
 
 <br />
 

--- a/directus/readme.md
+++ b/directus/readme.md
@@ -17,17 +17,17 @@ Directus is a real-time API and App dashboard for managing SQL database content.
 - **Manage Pure SQL.** Works with new or existing SQL databases, no migration required.
 - **Choose your Database.** Supports PostgreSQL, MySQL, SQLite, OracleDB, CockroachDB, MariaDB, and MS-SQL.
 - **On-Prem or Cloud.** Run locally, install on-premises, or use our
-  [self-service Cloud service](https://directus.io/pricing).
+  [self-service Cloud service](https://directus.com/pricing).
 - **Completely Extensible.** Built to white-label, it is easy to customize our modular platform.
 - **A Modern Dashboard.** Our no-code Vue.js app is safe and intuitive for non-technical users, no training required.
 
-**[Learn more about Directus](https://directus.io)** • **[Documentation](https://docs.directus.io)**
+**[Learn more about Directus](https://directus.com)** • **[Documentation](https://docs.directus.com)**
 
 <br />
 
 ## 🚀 Directus Cloud
 
-[Directus Cloud](https://directus.io/pricing) allows you to create projects, hosted by the Directus team, from
+[Directus Cloud](https://directus.com/pricing) allows you to create projects, hosted by the Directus team, from
 $15/month.
 
 - A self-service dashboard to create and monitor all your projects in one place.
@@ -53,7 +53,7 @@ storage, all connected via Railway's private network for secure, zero-egress com
 
 ## 🤔 Community Help
 
-[The Directus Documentation](https://docs.directus.io) is a great place to start, or explore these other channels:
+[The Directus Documentation](https://directus.com/docs) is a great place to start, or explore these other channels:
 
 - [Community](https://community.directus.io) (Questions, Discussions)
 - [Discord](https://directus.chat) (Live Chat)
@@ -69,7 +69,7 @@ storage, all connected via Railway's private network for secure, zero-egress com
 Please read our [Contributing Guide](./contributing.md) before submitting Pull Requests.
 
 All security vulnerabilities should be reported in accordance with our
-[Security Policy](https://docs.directus.io/contributing/introduction/#reporting-security-vulnerabilities).
+[Security Policy](https://docs.directus.com/contributing/introduction/#reporting-security-vulnerabilities).
 
 Directus is made possible with support from our passionate core team, talented contributors, and amazing
 [GitHub Sponsors](https://github.com/sponsors/directus). Thank you all!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,10 @@
 # ONLY FOR DEBUGGING. THIS IS NOT INTENDED FOR PRODUCTION USE.
 #
 # For production use see the docker compose file example in the docs:
-#     https://docs.directus.io/self-hosted/docker-guide.html#example-docker-compose
+#     https://docs.directus.com/self-hosted/docker-guide.html#example-docker-compose
 #
 # For receiving emails via MailDev, you'll need to add the following to your env:
-#   EMAIL_FROM=directus@directus.io
+#   EMAIL_FROM=directus@directus.com
 #   EMAIL_TRANSPORT=smtp
 #   EMAIL_SMTP_HOST=0.0.0.0
 #   EMAIL_SMTP_PORT=1025

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@
 #     https://docs.directus.com/self-hosted/docker-guide.html#example-docker-compose
 #
 # For receiving emails via MailDev, you'll need to add the following to your env:
-#   EMAIL_FROM=directus@directus.com
+#   EMAIL_FROM=directus@directus.io
 #   EMAIL_TRANSPORT=smtp
 #   EMAIL_SMTP_HOST=0.0.0.0
 #   EMAIL_SMTP_PORT=1025

--- a/license
+++ b/license
@@ -25,7 +25,7 @@ Change Date:          Three years from release date
 Change License:       GNU General Public License (GPL) v3
 
 For information about alternative licensing arrangements, please visit
-https://directus.io/pricing.
+https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "directus-monorepo",
 	"private": true,
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"type": "module",
 	"scripts": {
 		"build": "pnpm --recursive run build",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/ai",
 	"version": "1.3.1",
 	"description": "Shared AI types and model definitions for Directus AI",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/composables",
 	"version": "11.4.1",
 	"description": "Shared Vue composables for Directus use",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/composables/readme.md
+++ b/packages/composables/readme.md
@@ -6,7 +6,7 @@ Shared Vue composables for Directus use
 
 This package provides shared Vue composables for use within Directus, an open-source headless CMS.
 
-For more information about Directus, visit the [official website](https://directus.io).
+For more information about Directus, visit the [official website](https://directus.com).
 
 ## Installation
 
@@ -21,5 +21,5 @@ This package is licensed under the MIT License. See the
 
 ## Additional Resources
 
-- [Directus Website](https://directus.io)
+- [Directus Website](https://directus.com)
 - [Directus GitHub Repository](https://github.com/directus/directus)

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/constants",
 	"version": "14.3.0",
 	"description": "Shared constants for Directus",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/constants/readme.md
+++ b/packages/constants/readme.md
@@ -6,7 +6,7 @@ Shared Constants for Directus use
 
 This package exports shared constants for use within Directus, an open-source headless CMS.
 
-For more information about Directus, visit the [official website](https://directus.io).
+For more information about Directus, visit the [official website](https://directus.com).
 
 ## Installation
 
@@ -21,5 +21,5 @@ This package is licensed under the MIT License. See the
 
 ## Additional Resources
 
-- [Directus Website](https://directus.io)
+- [Directus Website](https://directus.com)
 - [Directus GitHub Repository](https://github.com/directus/directus)

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -7,4 +7,5 @@ export * from './number.js';
 export * from './permissions.js';
 export * from './regex.js';
 export * from './user.js';
+export * from './urls.js';
 export * from './versions.js';

--- a/packages/constants/src/urls.ts
+++ b/packages/constants/src/urls.ts
@@ -1,1 +1,1 @@
-export const DIRECTUS_HOMEPAGE = 'https://directus.com';
+export const DIRECTUS_DOMAIN = 'directus.com';

--- a/packages/constants/src/urls.ts
+++ b/packages/constants/src/urls.ts
@@ -1,0 +1,1 @@
+export const DIRECTUS_HOMEPAGE = 'https://directus.com';

--- a/packages/create-directus-extension/package.json
+++ b/packages/create-directus-extension/package.json
@@ -6,7 +6,7 @@
 		"directus",
 		"extensions"
 	],
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/env",
 	"version": "5.8.0",
 	"description": "Utilities around using global env configuration",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/env/readme.md
+++ b/packages/env/readme.md
@@ -7,7 +7,7 @@ Environment variable configuration extraction for Directus.
 This package exports utilities for environment variable configuration extraction that are used within Directus, an
 open-source headless CMS.
 
-For more information about Directus, visit the [official website](https://directus.io).
+For more information about Directus, visit the [official website](https://directus.com).
 
 ## License
 
@@ -16,5 +16,5 @@ This package is licensed under the MIT License. See the
 
 ## Additional Resources
 
-- [Directus Website](https://directus.io)
+- [Directus Website](https://directus.com)
 - [Directus GitHub Repository](https://github.com/directus/directus)

--- a/packages/extensions-registry/package.json
+++ b/packages/extensions-registry/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/extensions-registry",
 	"version": "3.0.26",
 	"description": "Abstraction for exploring Directus extensions on a package registry",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/extensions-sdk/package.json
+++ b/packages/extensions-sdk/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/extensions-sdk",
 	"version": "17.1.4",
 	"description": "A toolkit to develop extensions to extend Directus",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/extensions-sdk/readme.md
+++ b/packages/extensions-sdk/readme.md
@@ -6,7 +6,7 @@ A toolkit to develop extensions to extend Directus
 
 This package is a toolkit to help developers create extensions for use in Directus, an open-source headless CMS.
 
-For more information about Directus, visit the [official website](https://directus.io).
+For more information about Directus, visit the [official website](https://directus.com).
 
 ## License
 
@@ -15,5 +15,5 @@ This package is licensed under the MIT License. See the
 
 ## Additional Resources
 
-- [Directus Website](https://directus.io)
+- [Directus Website](https://directus.com)
 - [Directus GitHub Repository](https://github.com/directus/directus)

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/extensions",
 	"version": "3.0.25",
 	"description": "Utilities and types for Directus extensions",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/extensions/readme.md
+++ b/packages/extensions/readme.md
@@ -9,5 +9,5 @@ This package is licensed under the MIT License. See the
 
 ## Additional Resources
 
-- [Directus Website](https://directus.io)
+- [Directus Website](https://directus.com)
 - [Directus GitHub Repository](https://github.com/directus/directus)

--- a/packages/format-title/package.json
+++ b/packages/format-title/package.json
@@ -13,7 +13,7 @@
 		"conjunctions",
 		"prepositions"
 	],
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/format-title/readme.md
+++ b/packages/format-title/readme.md
@@ -45,5 +45,5 @@ This package is licensed under the MIT License. See the
 
 ## Additional Resources
 
-- [Directus Website](https://directus.io)
+- [Directus Website](https://directus.com)
 - [Directus GitHub Repository](https://github.com/directus/directus)

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/memory",
 	"version": "3.1.8",
 	"description": "Memory / Redis abstraction for Directus",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/pressure/package.json
+++ b/packages/pressure/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/pressure",
 	"version": "3.0.22",
 	"description": "Pressure based rate limiter",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/pressure/readme.md
+++ b/packages/pressure/readme.md
@@ -6,7 +6,7 @@ Pressure based rate limiter
 
 This package exports a pressure based rate limiter that is used within Directus, an open-source headless CMS.
 
-For more information about Directus, visit the [official website](https://directus.io).
+For more information about Directus, visit the [official website](https://directus.com).
 
 ## Installation
 
@@ -55,5 +55,5 @@ This package is licensed under the MIT License. See the
 
 ## Additional Resources
 
-- [Directus Website](https://directus.io)
+- [Directus Website](https://directus.com)
 - [Directus GitHub Repository](https://github.com/directus/directus)

--- a/packages/release-notes-generator/package.json
+++ b/packages/release-notes-generator/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/release-notes-generator",
 	"version": "2.0.4",
 	"description": "Directus tailored release notes generator for changesets",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"type": "module",
 	"repository": {
 		"type": "git",

--- a/packages/schema-builder/license
+++ b/packages/schema-builder/license
@@ -25,7 +25,7 @@ Change Date:          Three years from release date
 Change License:       GNU General Public License (GPL) v3
 
 For information about alternative licensing arrangements, please visit
-https://directus.io/pricing.
+https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 

--- a/packages/schema-builder/package.json
+++ b/packages/schema-builder/package.json
@@ -12,7 +12,7 @@
 		"sqlite3",
 		"javascript"
 	],
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/schema/license
+++ b/packages/schema/license
@@ -25,7 +25,7 @@ Change Date:          Three years from release date
 Change License:       GNU General Public License (GPL) v3
 
 For information about alternative licensing arrangements, please visit
-https://directus.io/pricing.
+https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -12,7 +12,7 @@
 		"sqlite3",
 		"javascript"
 	],
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/specs/license
+++ b/packages/specs/license
@@ -25,7 +25,7 @@ Change Date:          Three years from release date
 Change License:       GNU General Public License (GPL) v3
 
 For information about alternative licensing arrangements, please visit
-https://directus.io/pricing.
+https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 

--- a/packages/specs/package.json
+++ b/packages/specs/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/specs",
 	"version": "13.0.0",
 	"description": "OpenAPI Specification of the Directus API",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/specs/src/components/activity.yaml
+++ b/packages/specs/src/components/activity.yaml
@@ -38,7 +38,7 @@ properties:
     type: string
   origin:
     description: Origin of the request when the action took place.
-    example: https://directus.io
+    example: https://directus.com
     type: string
   collection:
     description: Collection identifier in which the item resides.

--- a/packages/specs/src/openapi.yaml
+++ b/packages/specs/src/openapi.yaml
@@ -6,7 +6,7 @@ info:
     email: contact@directus.io
   license:
     name: BUSL-1.1
-    url: 'https://directus.io/bsl'
+    url: 'https://directus.com/bsl'
   version: '10'
 externalDocs:
   description: Directus Docs

--- a/packages/storage-driver-azure/license
+++ b/packages/storage-driver-azure/license
@@ -25,7 +25,7 @@ Change Date:          Three years from release date
 Change License:       GNU General Public License (GPL) v3
 
 For information about alternative licensing arrangements, please visit
-https://directus.io/pricing.
+https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 

--- a/packages/storage-driver-azure/package.json
+++ b/packages/storage-driver-azure/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/storage-driver-azure",
 	"version": "12.0.22",
 	"description": "Azure file storage abstraction for `@directus/storage`",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/storage-driver-cloudinary/license
+++ b/packages/storage-driver-cloudinary/license
@@ -25,7 +25,7 @@ Change Date:          Three years from release date
 Change License:       GNU General Public License (GPL) v3
 
 For information about alternative licensing arrangements, please visit
-https://directus.io/pricing.
+https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 

--- a/packages/storage-driver-cloudinary/package.json
+++ b/packages/storage-driver-cloudinary/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/storage-driver-cloudinary",
 	"version": "12.0.22",
 	"description": "Cloudinary file storage abstraction for `@directus/storage`",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/storage-driver-gcs/license
+++ b/packages/storage-driver-gcs/license
@@ -25,7 +25,7 @@ Change Date:          Three years from release date
 Change License:       GNU General Public License (GPL) v3
 
 For information about alternative licensing arrangements, please visit
-https://directus.io/pricing.
+https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 

--- a/packages/storage-driver-gcs/package.json
+++ b/packages/storage-driver-gcs/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/storage-driver-gcs",
 	"version": "12.0.22",
 	"description": "GCS file storage abstraction for `@directus/storage`",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/storage-driver-local/license
+++ b/packages/storage-driver-local/license
@@ -25,7 +25,7 @@ Change Date:          Three years from release date
 Change License:       GNU General Public License (GPL) v3
 
 For information about alternative licensing arrangements, please visit
-https://directus.io/pricing.
+https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 

--- a/packages/storage-driver-local/package.json
+++ b/packages/storage-driver-local/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/storage-driver-local",
 	"version": "12.0.4",
 	"description": "Local file storage abstraction for `@directus/storage`",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/storage-driver-s3/license
+++ b/packages/storage-driver-s3/license
@@ -25,7 +25,7 @@ Change Date:          Three years from release date
 Change License:       GNU General Public License (GPL) v3
 
 For information about alternative licensing arrangements, please visit
-https://directus.io/pricing.
+https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 

--- a/packages/storage-driver-s3/package.json
+++ b/packages/storage-driver-s3/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/storage-driver-s3",
 	"version": "12.1.8",
 	"description": "S3 file storage abstraction for `@directus/storage`",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/storage-driver-supabase/license
+++ b/packages/storage-driver-supabase/license
@@ -25,7 +25,7 @@ Change Date:          Three years from release date
 Change License:       GNU General Public License (GPL) v3
 
 For information about alternative licensing arrangements, please visit
-https://directus.io/pricing.
+https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 

--- a/packages/storage-driver-supabase/package.json
+++ b/packages/storage-driver-supabase/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/storage-driver-supabase",
 	"version": "3.0.22",
 	"description": "Supabase file storage abstraction for `@directus/storage`",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/storage/license
+++ b/packages/storage/license
@@ -25,7 +25,7 @@ Change Date:          Three years from release date
 Change License:       GNU General Public License (GPL) v3
 
 For information about alternative licensing arrangements, please visit
-https://directus.io/pricing.
+https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/storage",
 	"version": "12.0.4",
 	"description": "Object storage abstraction layer for Directus",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/stores",
 	"version": "2.0.1",
 	"description": "Shared Pinia stores used in @directus/app",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/stores/readme.md
+++ b/packages/stores/readme.md
@@ -24,5 +24,5 @@ This package is licensed under the MIT License. See the
 
 ## Additional Resources
 
-- [Directus Website](https://directus.io)
+- [Directus Website](https://directus.com)
 - [Directus GitHub Repository](https://github.com/directus/directus)

--- a/packages/system-data/package.json
+++ b/packages/system-data/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/system-data",
 	"version": "4.4.0",
 	"description": "Definitions and types for Directus system collections",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/system-data/readme.md
+++ b/packages/system-data/readme.md
@@ -15,5 +15,5 @@ This package is licensed under the MIT License. See the
 
 ## Additional Resources
 
-- [Directus Website](https://directus.io)
+- [Directus Website](https://directus.com)
 - [Directus GitHub Repository](https://github.com/directus/directus)

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/themes",
 	"version": "1.3.3",
 	"description": "Themes for Directus",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/types",
 	"version": "15.0.3",
 	"description": "Shared types for Directus",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/types/readme.md
+++ b/packages/types/readme.md
@@ -6,7 +6,7 @@ Shared types for Directus
 
 This package exports shared types for use within Directus, an open-source headless CMS.
 
-For more information about Directus, visit the [official website](https://directus.io).
+For more information about Directus, visit the [official website](https://directus.com).
 
 ## Installation
 
@@ -21,5 +21,5 @@ This package is licensed under the MIT License. See the
 
 ## Additional Resources
 
-- [Directus Website](https://directus.io)
+- [Directus Website](https://directus.com)
 - [Directus GitHub Repository](https://github.com/directus/directus)

--- a/packages/update-check/package.json
+++ b/packages/update-check/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/update-check",
 	"version": "13.0.5",
 	"description": "Check if an update for Directus is available",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/update-check/readme.md
+++ b/packages/update-check/readme.md
@@ -6,7 +6,7 @@ Check if an update for Directus is available
 
 This package is a utility to determine if there is an update available for Directus.
 
-For more information about Directus, visit the [official website](https://directus.io).
+For more information about Directus, visit the [official website](https://directus.com).
 
 ## Installation
 
@@ -21,5 +21,5 @@ This package is licensed under the MIT License. See the
 
 ## Additional Resources
 
-- [Directus Website](https://directus.io)
+- [Directus Website](https://directus.com)
 - [Directus GitHub Repository](https://github.com/directus/directus)

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/utils",
 	"version": "13.4.1",
 	"description": "Utilities shared between the Directus packages",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/visual-editing/package.json
+++ b/packages/visual-editing/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/visual-editing",
 	"version": "2.0.1",
 	"description": "Visual editing library to enable in-place editing of your website’s frontend from within the Visual Editor in Directus",
-	"homepage": "https://directus.io/docs/guides/content/visual-editor",
+	"homepage": "https://directus.com/docs/guides/content/visual-editor",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/packages/visual-editing/readme.md
+++ b/packages/visual-editing/readme.md
@@ -10,7 +10,7 @@ your website.
 ## Documentation
 
 Documentation covering the setup and functionality for both the frontend library and the studio module can be found in
-the [Directus documentation](https://directus.io/docs/guides/content/visual-editor).
+the [Directus documentation](https://directus.com/docs/guides/content/visual-editor).
 
 ## Test Website
 
@@ -26,5 +26,5 @@ This package is licensed under the MIT License. See the LICENSE file for more in
 
 ## Additional Resources
 
-- [Directus Website](https://directus.io)
+- [Directus Website](https://directus.com)
 - [Directus GitHub Repository](https://github.com/directus/directus)

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/sdk",
 	"version": "21.3.0",
 	"description": "Directus JavaScript SDK",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/directus/directus.git",

--- a/security.md
+++ b/security.md
@@ -2,7 +2,7 @@
 
 **If you believe you have discovered a security issue within a Directus product or service, please open a new private
 security vulnerability report through https://github.com/directus/directus/security/advisories/new. Alternatively, reach
-out to us directly over email: [security@directus.io](mailto:security@directus.io).** We will then open a
+out to us directly over email: [security@directus.com](mailto:security@directus.com).** We will then open a
 [GitHub Security Advisory](https://github.com/directus/directus/security/advisories) for tracking the fix on your
 behalf.
 

--- a/security.md
+++ b/security.md
@@ -2,7 +2,7 @@
 
 **If you believe you have discovered a security issue within a Directus product or service, please open a new private
 security vulnerability report through https://github.com/directus/directus/security/advisories/new. Alternatively, reach
-out to us directly over email: [security@directus.com](mailto:security@directus.com).** We will then open a
+out to us directly over email: [security@directus.io](mailto:security@directus.io).** We will then open a
 [GitHub Security Advisory](https://github.com/directus/directus/security/advisories) for tracking the fix on your
 behalf.
 

--- a/tests/mock-license-server/package.json
+++ b/tests/mock-license-server/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/mock-license-server",
 	"version": "1.0.0",
 	"description": "Mock implmentation of the Directus license service",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"scripts": {
 		"build": "tsdown src/index.ts src/run.ts --dts",
 		"start": "node dist/run.js",

--- a/tests/sandbox/package.json
+++ b/tests/sandbox/package.json
@@ -2,7 +2,7 @@
 	"name": "@directus/sandbox",
 	"version": "0.0.0",
 	"description": "Toolkit for spinning up directus test environments",
-	"homepage": "https://directus.io",
+	"homepage": "https://directus.com",
 	"scripts": {
 		"cli": "tsx src/cli.ts",
 		"build": "tsdown src/index.ts src/cli.ts --dts --unbundle && copyfiles src/docker/*.yml dist -u 1",


### PR DESCRIPTION
## Scope

Changed all references of https://directus.io to https://directus.com if used to link to marketing site. Did not change references in tests that use the current url arbitrarily.

---

Fixes [CMS-2522](https://linear.app/directus/issue/CMS-2515/in-app-notifications-for-grace-period-are-missing-team)
