### PR TITLE
Redirect to settings after submit on license-recovery route

### DIFF
--- a/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
+++ b/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
@@ -243,6 +243,10 @@ async function submit() {
 		unexpectedError(err);
 	} finally {
 		submitting.value = false;
+
+		if (router.currentRoute.value.name === 'license-recovery') {
+			router.push({ name: 'settings-license' });
+		}
 	}
 }
 
@@ -253,7 +257,7 @@ function manageLicense() {
 		emit('update:modelValue', false);
 	}
 
-	router.push('/settings/license');
+	router.push({ name: 'settings-license' });
 }
 
 const cookies = useCookies(['license-resolution-acknowledged']);


### PR DESCRIPTION
Also used the named route instead of path.