### PR TITLE
Show AI translations resolution checkbox when losing the entitlement

### DIFF
--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1519,6 +1519,9 @@ licensing:
   resolve_custom_permissions_confirm: Confirm Custom Access Rules Deactivation
   resolve_custom_permissions_caption:
     Any access policies/permissions governed by custom rules will fall back to “No Access”.
+  resolve_section_ai_translations: AI Translations
+  resolve_ai_translations_confirm: Confirm AI Translations Deactivation
+  resolve_ai_translations_caption: AI Translation will be disabled and your translation settings will no longer be used.
   env_managed: Your license key is managed via an environment variable and can't be updated here.
   key_management: License Key Management
   key: License Key

--- a/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
+++ b/app/src/modules/settings/routes/license/components/license-resolution-dialog.vue
@@ -165,6 +165,10 @@ const customPermissionRules = computed<LicensePendingResolutionFeatureGateCustom
 			| undefined,
 );
 
+const aiTranslations = computed(
+	() => (scope.value === 'manual' || scope.value === 'no_resolution') && licenseStore.aiTranslationsEnabled,
+);
+
 function find(kind: LicensePendingResolution['kind'], key: string): LicensePendingResolution | undefined {
 	return pendingResolution.value?.find((entry: LicensePendingResolution) => entry.kind === kind && entry.key === key);
 }
@@ -184,6 +188,7 @@ const selected = reactive({
 	sso: false,
 	customLLMs: false,
 	customPermissionRules: false,
+	aiTranslations: false,
 });
 
 const adminCreds = ref<{ email?: string; password?: string }>({});
@@ -214,6 +219,7 @@ const isValid = computed(() => {
 	if (sso.value && !selected.sso) return false;
 	if (customLLMs.value && !selected.customLLMs) return false;
 	if (customPermissionRules.value && !selected.customPermissionRules) return false;
+	if (aiTranslations.value && !selected.aiTranslations) return false;
 	return true;
 });
 
@@ -313,7 +319,7 @@ function onEsc() {
 					{{ t('licensing.resolve_countdown', graceCountdown, graceCountdown.days) }}
 				</p>
 
-				<div v-if="sso || customLLMs || customPermissionRules" class="feature-gate-grid">
+				<div v-if="sso || customLLMs || customPermissionRules || aiTranslations" class="feature-gate-grid">
 					<ResolutionSsoSection v-if="sso" v-model="selected.sso" @open-admin-dialog="ssoAdminDialogOpen = true" />
 
 					<section v-if="customLLMs" class="resolution-feature-section">
@@ -346,6 +352,22 @@ function onEsc() {
 							<span>{{ t('licensing.resolve_custom_permissions_confirm') }}</span>
 						</button>
 						<p class="feature-caption">{{ t('licensing.resolve_custom_permissions_caption') }}</p>
+					</section>
+
+					<section v-if="aiTranslations" class="resolution-feature-section">
+						<header class="section-header">
+							<span class="section-title">{{ t('licensing.resolve_section_ai_translations') }}</span>
+						</header>
+						<button
+							type="button"
+							class="confirm"
+							:class="{ selected: selected.aiTranslations }"
+							@click="selected.aiTranslations = !selected.aiTranslations"
+						>
+							<VCheckbox :checked="selected.aiTranslations" style="pointer-events: none" />
+							<span>{{ t('licensing.resolve_ai_translations_confirm') }}</span>
+						</button>
+						<p class="feature-caption">{{ t('licensing.resolve_ai_translations_caption') }}</p>
 					</section>
 				</div>
 

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -200,7 +200,7 @@ async function handleDeactivateClick() {
 	try {
 		await licenseStore.hydratePendingResolution({ license_key: null });
 
-		if ((licenseStore.pendingResolution?.length ?? 0) === 0) {
+		if ((licenseStore.pendingResolution?.length ?? 0) === 0 && !licenseStore.aiTranslationsEnabled) {
 			deactivateConfirmOpen.value = true;
 		} else {
 			resolutionDialogOpen.value = true;


### PR DESCRIPTION
Use existing `aiTranslationsEnabled` from license store.