### PR TITLE
License design update 1

### DIFF
--- a/app/src/components/v-license-badge.vue
+++ b/app/src/components/v-license-badge.vue
@@ -33,7 +33,7 @@ const link = computed(() => {
 
 <style lang="scss" scoped>
 .badge-divider {
-	inline-size: calc(100% - 1.375rem);
+	inline-size: calc(100% - 0.875rem);
 	align-self: center;
 	border: solid;
 	border-color: var(--theme--navigation--list--divider--border-color);

--- a/app/src/modules/settings/routes/license/components/license-addon-item.vue
+++ b/app/src/modules/settings/routes/license/components/license-addon-item.vue
@@ -64,6 +64,7 @@ function onClick() {
 		<VButton
 			v-if="buttonState === 'contact_sales'"
 			secondary
+			small
 			:href="salesHref"
 			target="_blank"
 			rel="noopener noreferrer"
@@ -71,7 +72,7 @@ function onClick() {
 			<VIcon :name="buttonIcon" left />
 			{{ buttonLabel }}
 		</VButton>
-		<VButton v-else secondary @click="onClick">
+		<VButton v-else secondary small @click="onClick">
 			<VIcon :name="buttonIcon" left />
 			{{ buttonLabel }}
 		</VButton>

--- a/app/src/modules/settings/routes/license/components/license-entitlement-item.vue
+++ b/app/src/modules/settings/routes/license/components/license-entitlement-item.vue
@@ -36,6 +36,7 @@ const slots = useSlots();
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
+	gap: 1rem;
 	padding: 0.5rem 0.625rem;
 	font-weight: 600;
 	background-color: var(--theme--background-subdued);

--- a/app/src/modules/settings/routes/license/components/license-entitlement-item.vue
+++ b/app/src/modules/settings/routes/license/components/license-entitlement-item.vue
@@ -16,15 +16,15 @@ const slots = useSlots();
 <template>
 	<div class="license-entitlement-item">
 		<div class="label">
-			<VIcon :name="icon" small />
+			<VIcon :name="icon" />
 			<span>{{ title }}</span>
 		</div>
 		<div class="value">
-			<VChip v-if="unlimited" x-small class="unlimited">
+			<VChip v-if="unlimited" x-small :label="false" kind="success">
 				{{ $t('licensing.unlimited') }}
 			</VChip>
 			<slot v-else-if="slots.default" />
-			<VChip v-else x-small :class="{ included }">
+			<VChip v-else x-small :label="false" :kind="included ? 'success' : 'neutral'">
 				{{ included ? $t('licensing.included') : $t('licensing.not_included') }}
 			</VChip>
 		</div>
@@ -37,37 +37,17 @@ const slots = useSlots();
 	align-items: center;
 	justify-content: space-between;
 	padding: 0.5rem 0.625rem;
+	font-weight: 600;
 	background-color: var(--theme--background-subdued);
-	border-radius: 6px;
+	border-radius: var(--theme--border-radius);
 }
 
 .label {
+	--v-icon-color: var(--theme--foreground-subdued);
+
 	display: flex;
 	align-items: center;
-	font-weight: 600;
 	gap: 0.5rem;
 	color: var(--theme--foreground);
-}
-
-.label :deep(.v-icon) {
-	color: var(--theme--foreground-subdued);
-}
-
-.value {
-	color: var(--theme--foreground);
-}
-
-.value :deep(.v-chip) {
-	--v-chip-background-color: var(--theme--background-accent);
-	--v-chip-color: var(--theme--foreground);
-	--v-chip-padding: 0 0.625rem;
-	border-radius: 9999px;
-	font-weight: 600;
-}
-
-.value :deep(.v-chip.included),
-.value :deep(.v-chip.unlimited) {
-	--v-chip-background-color: var(--theme--success-subdued);
-	--v-chip-color: var(--theme--success-accent);
 }
 </style>

--- a/app/src/modules/settings/routes/license/components/license-section.vue
+++ b/app/src/modules/settings/routes/license/components/license-section.vue
@@ -1,51 +1,25 @@
 <script setup lang="ts">
-import VDivider from '@/components/v-divider.vue';
-import VIcon from '@/components/v-icon/v-icon.vue';
+import InterfacePresentationDivider from '@/interfaces/presentation-divider/presentation-divider.vue';
 
-const props = defineProps<{
+const { kind = 'neutral' } = defineProps<{
 	icon: string;
 	title: string;
-	variant?: 'default' | 'danger';
+	kind?: 'neutral' | 'danger';
 }>();
 </script>
 
 <template>
-	<div class="section">
-		<div class="section-header">
-			<span class="section-title">
-				<VIcon :name="icon" :class="props.variant" small />
-				{{ title }}
-			</span>
-			<VDivider />
-		</div>
-		<slot />
-	</div>
+	<InterfacePresentationDivider :title :icon class="section-header" :class="[kind]" />
+
+	<slot />
 </template>
 
-<style scoped>
-.section {
-	margin-block-start: 2.5rem;
-}
-
+<style lang="scss" scoped>
 .section-header {
-	display: flex;
-	flex-direction: column;
-	gap: 1rem;
 	margin-block-end: 1.5rem;
-}
 
-.section-title {
-	display: flex;
-	align-items: center;
-	gap: 0.5rem;
-	font-size: 1.375rem;
-	font-weight: var(--theme--fonts--display--font-weight);
-	font-family: var(--theme--fonts--display--font-family);
-	color: var(--theme--foreground-accent);
-	line-height: 1;
-}
-
-.danger {
-	--v-icon-color: var(--theme--danger);
+	&.danger {
+		--v-icon-color: var(--theme--danger);
+	}
 }
 </style>

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -324,7 +324,7 @@ async function handleDeactivateConfirm() {
 					</VList>
 				</LicenseSection>
 
-				<LicenseSection v-if="license.source !== null" icon="emergency_home" :title="t('danger_zone')" variant="danger">
+				<LicenseSection v-if="license.source !== null" icon="emergency_home" :title="t('danger_zone')" kind="danger">
 					<div class="danger-zone-content">
 						<VNotice v-if="isEnvManaged" type="info">
 							{{ t('licensing.env_managed') }}

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -246,8 +246,12 @@ async function handleDeactivateConfirm() {
 					<div class="plan-title">
 						<span class="plan-name">{{ planDisplayName }}</span>
 						<div class="plan-status">
-							<VChip v-if="license.source === null" x-small>{{ t('licensing.unlicensed') }}</VChip>
-							<VChip v-else kind="primary" x-small>{{ t('licensing.current_plan') }}</VChip>
+							<VChip v-if="license.source === null" class="status-chip" x-small :label="false">
+								{{ t('licensing.unlicensed') }}
+							</VChip>
+							<VChip v-else class="status-chip" kind="primary" x-small :label="false">
+								{{ t('licensing.current_plan') }}
+							</VChip>
 							<span v-if="boundaryDate" class="boundary-date">
 								{{
 									boundary?.type === 'expiration'
@@ -326,7 +330,7 @@ async function handleDeactivateConfirm() {
 
 				<LicenseSection v-if="license.source !== null" icon="emergency_home" :title="t('danger_zone')" kind="danger">
 					<div class="danger-zone-content">
-						<VNotice v-if="isEnvManaged" type="info">
+						<VNotice v-if="isEnvManaged" type="info" class="danger-zone-notice">
 							{{ t('licensing.env_managed') }}
 						</VNotice>
 						<VButton :disabled="isEnvManaged" :loading="deactivateLoading" danger @click="handleDeactivateClick">
@@ -433,6 +437,10 @@ async function handleDeactivateConfirm() {
 	gap: 0.5rem;
 }
 
+.status-chip {
+	font-weight: 600;
+}
+
 .plan-actions {
 	display: flex;
 	gap: 0.5rem;
@@ -482,9 +490,9 @@ async function handleDeactivateConfirm() {
 }
 
 .entitlements-title {
+	@include mixins.type-label;
+
 	grid-column: 1 / -1;
-	font-size: 0.9375rem;
-	font-weight: 600;
 	color: var(--theme--foreground);
 }
 
@@ -502,6 +510,10 @@ async function handleDeactivateConfirm() {
 	flex-direction: column;
 	align-items: flex-start;
 	gap: 1rem;
+
+	.danger-zone-notice.v-notice {
+		inline-size: 100%;
+	}
 }
 
 .drawer-content {

--- a/app/src/modules/settings/routes/license/license.vue
+++ b/app/src/modules/settings/routes/license/license.vue
@@ -409,6 +409,7 @@ async function handleDeactivateConfirm() {
 @use '@/styles/mixins';
 
 .license {
+	container-type: inline-size;
 	padding: var(--content-padding);
 	padding-block-end: var(--content-padding-bottom);
 	max-inline-size: 67.5rem;
@@ -447,17 +448,6 @@ async function handleDeactivateConfirm() {
 	flex-wrap: wrap;
 }
 
-@include mixins.breakpoint-down('sm') {
-	.plan-header {
-		flex-direction: column;
-		align-items: stretch;
-	}
-
-	.plan-actions {
-		justify-content: flex-end;
-	}
-}
-
 .boundary-date {
 	font-size: 0.875rem;
 	font-weight: 500;
@@ -481,10 +471,8 @@ async function handleDeactivateConfirm() {
 	grid-template-columns: 1fr 1fr;
 	gap: 0.5rem;
 	margin-block-start: 2.25rem;
-}
 
-@include mixins.breakpoint-down('sm') {
-	.entitlements {
+	@container (width <= 36rem) {
 		grid-template-columns: 1fr;
 	}
 }

--- a/app/src/views/private/private-view/components/private-view-nav-project-name.vue
+++ b/app/src/views/private/private-view/components/private-view-nav-project-name.vue
@@ -36,6 +36,7 @@ const navBarStore = useNavBarStore();
 	align-items: center;
 	inline-size: 100%;
 	block-size: 3.375rem;
+	flex-shrink: 0;
 	padding-inline: 1.25rem 0.75rem;
 	color: var(--theme--navigation--project--foreground);
 	text-align: start;


### PR DESCRIPTION
Follow-up to the `license` feature branch

## Scope

What's changed:

- Reuse the shared section divider component so license headings match the rest of the admin app and stop carrying duplicated layout/typography CSS
- Move chips onto built-in `VChip` variants (`kind` + `:label="false"`) and drop ad-hoc CSS overrides that hand-rolled background, padding, and border-radius
- Align prop naming on `LicenseSection` (`variant` → `kind`) with conventions used elsewhere (e.g. `VChip`)
- Smaller spacing, sizing, and token fixes to bring the page in line with the design system (theme border-radius, type-label mixin, small action buttons, full-width notice in danger zone)
- Improve responsive behavior of the license page on narrow widths
- Refine the sidebar license badge spacing and stop the project name container from shrinking in the nav when resizing

## Potential Risks / Drawbacks

—

## Tested Scenarios

- License settings renders correctly across unlicensed, active, and env-managed states
- Danger zone notice spans full width when license is env-managed
- Entitlement chips reflect included / not-included / unlimited with the new `kind` variants

## Review Notes / Questions

- Prop rename `variant` → `kind` on `LicenseSection` is intentional, mirroring `VChip`

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required
