### PR TITLE
feat: update AI provider model lists

### DIFF
--- a/.changeset/update-ai-provider-models.md
+++ b/.changeset/update-ai-provider-models.md
@@ -1,0 +1,7 @@
+---
+'@directus/api': patch
+'@directus/ai': patch
+'@directus/system-data': patch
+---
+
+Updated the built-in OpenAI and Anthropic AI model lists to use the latest available API models.

--- a/api/src/database/migrations/20260110A-add-ai-provider-settings.ts
+++ b/api/src/database/migrations/20260110A-add-ai-provider-settings.ts
@@ -1,7 +1,7 @@
 import type { Knex } from 'knex';
 
-const DEFAULT_OPENAI_MODELS = ['gpt-5-nano', 'gpt-5-mini', 'gpt-5'];
-const DEFAULT_ANTHROPIC_MODELS = ['claude-haiku-4-5', 'claude-sonnet-4-5'];
+const DEFAULT_OPENAI_MODELS = ['gpt-5.4-nano', 'gpt-5.4-mini', 'gpt-5.4'];
+const DEFAULT_ANTHROPIC_MODELS = ['claude-haiku-4-5', 'claude-sonnet-4-6'];
 const DEFAULT_GOOGLE_MODELS = ['gemini-3-pro-preview', 'gemini-3-flash-preview', 'gemini-2.5-pro', 'gemini-2.5-flash'];
 
 export async function up(knex: Knex): Promise<void> {

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -114,6 +114,36 @@ export const DEFAULT_AI_MODELS: ModelDefinition[] = [
 	},
 	{
 		provider: 'openai',
+		model: 'gpt-5.1',
+		name: 'GPT-5.1',
+		limit: {
+			context: 400_000,
+			output: 128_000,
+		},
+		cost: {
+			input: 1.25,
+			output: 10.0,
+		},
+		attachment: true,
+		reasoning: true,
+	},
+	{
+		provider: 'openai',
+		model: 'gpt-5.1-chat-latest',
+		name: 'GPT-5.1 Chat',
+		limit: {
+			context: 128_000,
+			output: 16_384,
+		},
+		cost: {
+			input: 1.25,
+			output: 10.0,
+		},
+		attachment: true,
+		reasoning: true,
+	},
+	{
+		provider: 'openai',
 		model: 'gpt-5.2',
 		name: 'GPT-5.2',
 		limit: {
@@ -159,6 +189,36 @@ export const DEFAULT_AI_MODELS: ModelDefinition[] = [
 	},
 	{
 		provider: 'openai',
+		model: 'gpt-5.4-nano',
+		name: 'GPT-5.4 Nano',
+		limit: {
+			context: 400_000,
+			output: 128_000,
+		},
+		cost: {
+			input: 0.2,
+			output: 1.25,
+		},
+		attachment: true,
+		reasoning: true,
+	},
+	{
+		provider: 'openai',
+		model: 'gpt-5.4-mini',
+		name: 'GPT-5.4 Mini',
+		limit: {
+			context: 400_000,
+			output: 128_000,
+		},
+		cost: {
+			input: 0.75,
+			output: 4.5,
+		},
+		attachment: true,
+		reasoning: true,
+	},
+	{
+		provider: 'openai',
 		model: 'gpt-5.4',
 		name: 'GPT-5.4',
 		limit: {
@@ -176,6 +236,36 @@ export const DEFAULT_AI_MODELS: ModelDefinition[] = [
 		provider: 'openai',
 		model: 'gpt-5.4-pro',
 		name: 'GPT-5.4 Pro',
+		limit: {
+			context: 1_050_000,
+			output: 128_000,
+		},
+		cost: {
+			input: 30.0,
+			output: 180.0,
+		},
+		attachment: true,
+		reasoning: true,
+	},
+	{
+		provider: 'openai',
+		model: 'gpt-5.5',
+		name: 'GPT-5.5',
+		limit: {
+			context: 1_050_000,
+			output: 128_000,
+		},
+		cost: {
+			input: 5.0,
+			output: 30.0,
+		},
+		attachment: true,
+		reasoning: true,
+	},
+	{
+		provider: 'openai',
+		model: 'gpt-5.5-pro',
+		name: 'GPT-5.5 Pro',
 		limit: {
 			context: 1_050_000,
 			output: 128_000,
@@ -205,36 +295,6 @@ export const DEFAULT_AI_MODELS: ModelDefinition[] = [
 	},
 	{
 		provider: 'anthropic',
-		model: 'claude-sonnet-4-5',
-		name: 'Claude Sonnet 4.5',
-		limit: {
-			context: 200_000,
-			output: 64_000,
-		},
-		cost: {
-			input: 3.0,
-			output: 15.0,
-		},
-		attachment: true,
-		reasoning: true,
-	},
-	{
-		provider: 'anthropic',
-		model: 'claude-opus-4-5',
-		name: 'Claude Opus 4.5',
-		limit: {
-			context: 200_000,
-			output: 64_000,
-		},
-		cost: {
-			input: 5.0,
-			output: 25.0,
-		},
-		attachment: true,
-		reasoning: true,
-	},
-	{
-		provider: 'anthropic',
 		model: 'claude-sonnet-4-6',
 		name: 'Claude Sonnet 4.6',
 		limit: {
@@ -244,6 +304,21 @@ export const DEFAULT_AI_MODELS: ModelDefinition[] = [
 		cost: {
 			input: 3.0,
 			output: 15.0,
+		},
+		attachment: true,
+		reasoning: true,
+	},
+	{
+		provider: 'anthropic',
+		model: 'claude-opus-4-7',
+		name: 'Claude Opus 4.7',
+		limit: {
+			context: 200_000,
+			output: 128_000,
+		},
+		cost: {
+			input: 5.0,
+			output: 25.0,
 		},
 		attachment: true,
 		reasoning: true,

--- a/packages/system-data/src/fields/settings.yaml
+++ b/packages/system-data/src/fields/settings.yaml
@@ -790,16 +790,28 @@ fields:
           value: gpt-5-mini
         - text: GPT-5
           value: gpt-5
+        - text: GPT-5.1
+          value: gpt-5.1
+        - text: GPT-5.1 Chat
+          value: gpt-5.1-chat-latest
         - text: GPT-5.2
           value: gpt-5.2
         - text: GPT-5.2 Chat
           value: gpt-5.2-chat-latest
         - text: GPT-5.2 Pro
           value: gpt-5.2-pro
+        - text: GPT-5.4 Nano
+          value: gpt-5.4-nano
+        - text: GPT-5.4 Mini
+          value: gpt-5.4-mini
         - text: GPT-5.4
           value: gpt-5.4
         - text: GPT-5.4 Pro
           value: gpt-5.4-pro
+        - text: GPT-5.5
+          value: gpt-5.5
+        - text: GPT-5.5 Pro
+          value: gpt-5.5-pro
     width: half
     group: ai_group
 
@@ -823,12 +835,10 @@ fields:
       choices:
         - text: Claude Haiku 4.5
           value: claude-haiku-4-5
-        - text: Claude Sonnet 4.5
-          value: claude-sonnet-4-5
-        - text: Claude Opus 4.5
-          value: claude-opus-4-5
         - text: Claude Sonnet 4.6
           value: claude-sonnet-4-6
+        - text: Claude Opus 4.7
+          value: claude-opus-4-7
         - text: Claude Opus 4.6
           value: claude-opus-4-6
     width: half


### PR DESCRIPTION
## Overview

This PR refreshes the built-in AI provider model lists for v12.

OpenAI now includes the current GPT-5.1, GPT-5.4, and GPT-5.5 models. The migration defaults use the cost-conscious GPT-5.4 nano/mini/default set so new installs get current models without silently enabling GPT-5.5 or pro-tier pricing.

Note that this only affects the defaults seeded when the v12 AI settings migration runs. Existing configured allowed-model lists are not rewritten.

Anthropic removes older Claude 4.5 Sonnet/Opus entries and defaults to Haiku 4.5 + Sonnet 4.6, while keeping Opus 4.6/4.7 available as explicit choices.

Related issue: not provided
