### PR TITLE
License design update 2

### DIFF
--- a/app/src/components/v-non-production-badge.vue
+++ b/app/src/components/v-non-production-badge.vue
@@ -12,7 +12,7 @@ const displayPoweredBy = computed(() => serverStore.info?.license?.entitlements?
 <template>
 	<template v-if="displayPoweredBy === 'NON_PROD'">
 		<hr class="badge-divider" />
-		<VChip small :label="false" kind="info" class="non-production-badge">
+		<VChip small :label="false" kind="primary" class="non-production-badge">
 			<VIcon name="code" small />
 			{{ $t('licensing.badge.non_prod') }}
 		</VChip>
@@ -21,7 +21,7 @@ const displayPoweredBy = computed(() => serverStore.info?.license?.entitlements?
 
 <style lang="scss" scoped>
 .badge-divider {
-	inline-size: calc(100% - 1.375rem);
+	inline-size: calc(100% - 0.875rem);
 	align-self: center;
 	border: solid;
 	border-color: var(--theme--navigation--list--divider--border-color);
@@ -31,7 +31,7 @@ const displayPoweredBy = computed(() => serverStore.info?.license?.entitlements?
 .non-production-badge {
 	font-weight: 600;
 	inline-size: fit-content;
-	margin: 0.3125rem 1rem;
+	margin: 0.3125rem 0.4375rem;
 
 	:deep(.chip-content) {
 		gap: 0.25rem;

--- a/app/src/components/v-radio-cards.vue
+++ b/app/src/components/v-radio-cards.vue
@@ -69,7 +69,7 @@ const emit = defineEmits(['update:modelValue']);
 .v-radio-cards {
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
-	gap: 0.5rem;
+	gap: 1rem;
 }
 
 .v-radio-card {

--- a/app/src/routes/setup/form.vue
+++ b/app/src/routes/setup/form.vue
@@ -139,29 +139,32 @@ const mergedErrors = computed<ValidationError[]>(() => {
 			</I18nT>
 		</VNotice>
 
-		<VCheckbox v-if="!skipLicense" v-model="license">
-			<I18nT keypath="setup_accept_license" tag="span">
-				<template #directusMscl>
-					<a
-						:href="`https://${DIRECTUS_DOMAIN}/mscl?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=mscl_1.0_gpl_link`"
-						target="_blank"
-					>
-						{{ $t('directus_mscl') }}
-					</a>
-				</template>
-				<template #privacyPolicy>
-					<a
-						:href="`https://${DIRECTUS_DOMAIN}/privacy?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=privacy_link`"
-						target="_blank"
-					>
-						{{ $t('privacy_policy') }}
-					</a>
-				</template>
-			</I18nT>
-		</VCheckbox>
-		<VCheckbox v-model="product_updates">
-			<span v-md="$t('setup_marketing_emails')"></span>
-		</VCheckbox>
+		<div class="toggle-group">
+			<VCheckbox v-if="!skipLicense" v-model="license">
+				<I18nT keypath="setup_accept_license" tag="span">
+					<template #directusMscl>
+						<a
+							:href="`https://${DIRECTUS_DOMAIN}/mscl?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=mscl_1.0_gpl_link`"
+							target="_blank"
+						>
+							{{ $t('directus_mscl') }}
+						</a>
+					</template>
+					<template #privacyPolicy>
+						<a
+							:href="`https://${DIRECTUS_DOMAIN}/privacy?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${info.version}&utm_content=privacy_link`"
+							target="_blank"
+						>
+							{{ $t('privacy_policy') }}
+						</a>
+					</template>
+				</I18nT>
+			</VCheckbox>
+
+			<VCheckbox v-model="product_updates">
+				<span v-md="$t('setup_marketing_emails')"></span>
+			</VCheckbox>
+		</div>
 	</div>
 </template>
 
@@ -191,8 +194,11 @@ const mergedErrors = computed<ValidationError[]>(() => {
 	margin-block: 1.8125rem;
 }
 
-.v-form + .v-checkbox {
+.toggle-group {
 	margin-block-start: 1.8125rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
 }
 
 .v-checkbox {

--- a/app/src/routes/setup/setup.vue
+++ b/app/src/routes/setup/setup.vue
@@ -100,12 +100,12 @@ const setupComplete = computed(() => SetupValidator.safeParse(form.value).succes
 
 <template>
 	<PublicView wide>
-		<h1>{{ $t('setup_welcome') }}</h1>
+		<h1 class="type-display type-display-public">{{ $t('setup_welcome') }}</h1>
 
 		<template v-if="page === 'setup' && showAdminStep">
 			<p>{{ $t('setup_info') }}</p>
 			<SetupForm v-model="form" :errors="errors" utm-location="onboarding"></SetupForm>
-			<VButton full-width secondary :disabled="!setupComplete" @click="showLicenseStep ? (page = 'license') : launch()">
+			<VButton full-width :disabled="!setupComplete" @click="showLicenseStep ? (page = 'license') : launch()">
 				{{ showLicenseStep ? $t('continue') : $t('setup_launch') }}
 			</VButton>
 		</template>
@@ -145,19 +145,11 @@ const setupComplete = computed(() => SetupValidator.safeParse(form.value).succes
 
 <style scoped>
 h1 {
-	color: var(--theme--foreground-accent);
-	font-size: 2.25rem;
-	font-weight: 600;
-	line-height: 1.1944;
-
 	margin-block: 5.625rem 1.375rem;
 }
 
 p {
-	font-size: 0.8125rem;
-	font-weight: 500;
-	line-height: 1.3846;
-	margin-block-end: 1.8125rem;
+	margin-block-end: 2rem;
 }
 
 .v-button {
@@ -180,7 +172,7 @@ p {
 .actions {
 	display: flex;
 	justify-content: flex-end;
-	gap: 1.8125rem;
+	gap: 0.625rem;
 }
 
 :deep(p a) {


### PR DESCRIPTION
What's changed:

- Refined spacing and layout on the setup/onboarding page
- Grouped the license and product-updates checkboxes into a single toggle group
- Replaced inline setup headline styles with shared `type-display` utility classes
- Switched the setup continue/launch button from secondary to primary styling
- Widened the grid gap in the shared `v-radio-cards` component to match the design

## Potential Risks / Drawbacks

-

## Tested Scenarios

- Onboarding/setup flow on desktop and narrow viewports
- Existing `v-radio-cards` call sites with the new gap

## Review Notes / Questions

- Confirm the wider `v-radio-cards` gap works globally, not just in setup
- Confirm primary (instead of secondary) button on the setup step matches the design intent

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required