### PR TITLE
fix(api): make deployment migrations idempotent on retry 

### DIFF
--- a/.changeset/idempotent-deployment-migrations.md
+++ b/.changeset/idempotent-deployment-migrations.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed `directus_deployments` migration failing with `ER_TABLE_EXISTS_ERROR` after a partial run by guarding each table and column creation with existence checks.

--- a/api/src/database/migrations/20260204A-add-deployment.ts
+++ b/api/src/database/migrations/20260204A-add-deployment.ts
@@ -1,33 +1,39 @@
 import type { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
-	await knex.schema.createTable('directus_deployments', (table) => {
-		table.uuid('id').primary().notNullable();
-		table.string('provider').notNullable().unique();
-		table.text('credentials');
-		table.text('options');
-		table.timestamp('date_created').defaultTo(knex.fn.now());
-		table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');
-	});
+	if (!(await knex.schema.hasTable('directus_deployments'))) {
+		await knex.schema.createTable('directus_deployments', (table) => {
+			table.uuid('id').primary().notNullable();
+			table.string('provider').notNullable().unique();
+			table.text('credentials');
+			table.text('options');
+			table.timestamp('date_created').defaultTo(knex.fn.now());
+			table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');
+		});
+	}
 
-	await knex.schema.createTable('directus_deployment_projects', (table) => {
-		table.uuid('id').primary().notNullable();
-		table.uuid('deployment').notNullable().references('id').inTable('directus_deployments').onDelete('CASCADE');
-		table.string('external_id').notNullable();
-		table.string('name').notNullable();
-		table.timestamp('date_created').defaultTo(knex.fn.now());
-		table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');
-		table.unique(['deployment', 'external_id']);
-	});
+	if (!(await knex.schema.hasTable('directus_deployment_projects'))) {
+		await knex.schema.createTable('directus_deployment_projects', (table) => {
+			table.uuid('id').primary().notNullable();
+			table.uuid('deployment').notNullable().references('id').inTable('directus_deployments').onDelete('CASCADE');
+			table.string('external_id').notNullable();
+			table.string('name').notNullable();
+			table.timestamp('date_created').defaultTo(knex.fn.now());
+			table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');
+			table.unique(['deployment', 'external_id']);
+		});
+	}
 
-	await knex.schema.createTable('directus_deployment_runs', (table) => {
-		table.uuid('id').primary().notNullable();
-		table.uuid('project').notNullable().references('id').inTable('directus_deployment_projects').onDelete('CASCADE');
-		table.string('external_id').notNullable();
-		table.string('target').notNullable(); // 'production' or 'preview'
-		table.timestamp('date_created').defaultTo(knex.fn.now());
-		table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');
-	});
+	if (!(await knex.schema.hasTable('directus_deployment_runs'))) {
+		await knex.schema.createTable('directus_deployment_runs', (table) => {
+			table.uuid('id').primary().notNullable();
+			table.uuid('project').notNullable().references('id').inTable('directus_deployment_projects').onDelete('CASCADE');
+			table.string('external_id').notNullable();
+			table.string('target').notNullable(); // 'production' or 'preview'
+			table.timestamp('date_created').defaultTo(knex.fn.now());
+			table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');
+		});
+	}
 }
 
 export async function down(knex: Knex): Promise<void> {

--- a/api/src/database/migrations/20260211A-add-deployment-webhooks.ts
+++ b/api/src/database/migrations/20260211A-add-deployment-webhooks.ts
@@ -1,24 +1,49 @@
 import type { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
-	await knex.schema.alterTable('directus_deployments', (table) => {
-		table.json('webhook_ids').nullable();
-		table.string('webhook_secret').nullable();
-		table.timestamp('last_synced_at').nullable();
-	});
+	const deploymentsHas = {
+		webhook_ids: await knex.schema.hasColumn('directus_deployments', 'webhook_ids'),
+		webhook_secret: await knex.schema.hasColumn('directus_deployments', 'webhook_secret'),
+		last_synced_at: await knex.schema.hasColumn('directus_deployments', 'last_synced_at'),
+	};
 
-	await knex.schema.alterTable('directus_deployment_projects', (table) => {
-		table.string('url').nullable();
-		table.string('framework').nullable();
-		table.boolean('deployable').notNullable().defaultTo(true);
-	});
+	if (Object.values(deploymentsHas).some((exists) => !exists)) {
+		await knex.schema.alterTable('directus_deployments', (table) => {
+			if (!deploymentsHas.webhook_ids) table.json('webhook_ids').nullable();
+			if (!deploymentsHas.webhook_secret) table.string('webhook_secret').nullable();
+			if (!deploymentsHas.last_synced_at) table.timestamp('last_synced_at').nullable();
+		});
+	}
 
-	await knex.schema.alterTable('directus_deployment_runs', (table) => {
-		table.string('status').nullable();
-		table.string('url').nullable();
-		table.timestamp('started_at').nullable();
-		table.timestamp('completed_at').nullable();
-	});
+	const projectsHas = {
+		url: await knex.schema.hasColumn('directus_deployment_projects', 'url'),
+		framework: await knex.schema.hasColumn('directus_deployment_projects', 'framework'),
+		deployable: await knex.schema.hasColumn('directus_deployment_projects', 'deployable'),
+	};
+
+	if (Object.values(projectsHas).some((exists) => !exists)) {
+		await knex.schema.alterTable('directus_deployment_projects', (table) => {
+			if (!projectsHas.url) table.string('url').nullable();
+			if (!projectsHas.framework) table.string('framework').nullable();
+			if (!projectsHas.deployable) table.boolean('deployable').notNullable().defaultTo(true);
+		});
+	}
+
+	const runsHas = {
+		status: await knex.schema.hasColumn('directus_deployment_runs', 'status'),
+		url: await knex.schema.hasColumn('directus_deployment_runs', 'url'),
+		started_at: await knex.schema.hasColumn('directus_deployment_runs', 'started_at'),
+		completed_at: await knex.schema.hasColumn('directus_deployment_runs', 'completed_at'),
+	};
+
+	if (Object.values(runsHas).some((exists) => !exists)) {
+		await knex.schema.alterTable('directus_deployment_runs', (table) => {
+			if (!runsHas.status) table.string('status').nullable();
+			if (!runsHas.url) table.string('url').nullable();
+			if (!runsHas.started_at) table.timestamp('started_at').nullable();
+			if (!runsHas.completed_at) table.timestamp('completed_at').nullable();
+		});
+	}
 
 	await knex('directus_deployment_runs').delete();
 }


### PR DESCRIPTION
## Scope

What's changed:

- Gated each `createTable` call in `20260204A-add-deployment.ts` behind `knex.schema.hasTable(...)` so the migration can re-run after a partial failure without throwing `ER_TABLE_EXISTS_ERROR`.
- Gated each new column in `20260211A-add-deployment-webhooks.ts` behind `knex.schema.hasColumn(...)` so the follow-up migration is safe to re-run if a user manually unstuck the first one.
- Kept the `await knex('directus_deployment_runs').delete()` call unconditional — it's a one-shot data wipe that must always run.
- Added a `@directus/api` patch changeset.

## Potential Risks / Drawbacks

- The `hasTable` / `hasColumn` guards mean the migration won't reconcile divergent schemas — if a user already has these tables with different column types, the migration will skip them rather than error or migrate. In practice this is the desired behaviour: the column shapes from the original `CREATE` (e.g. `timestamp default CURRENT_TIMESTAMP`) match what Knex would produce on MariaDB/MySQL, so a partial run that left tables behind is the only realistic skip case.
- No transaction wrapper around the DDL — MySQL/MariaDB don't support transactional DDL, so the guards (not a transaction) are the correct mechanism here.

## Tested Scenarios

- Re-read the migrations after the edit to confirm the order of `createTable` calls and the `delete()` semantics are preserved.
- Verified Prettier passes on the two migration files and the changeset (`prettier --check` — all matched files use Prettier code style).
- Could not run the API test suite or a live MariaDB migration in this environment (no network for `pnpm install`); flagging here so a reviewer can sanity-check on a fresh DB and on the half-applied DB from the issue.

## Review Notes / Questions

- Existing precedent for guarding migrations is `api/src/database/migrations/20240806A-permissions-policies.ts:71` — same `if (await knex.schema.hasTable(...))` idiom, just inverted here per-table instead of a single early return so each of the three tables is handled independently.
- The `20260211A` guard groups the `hasColumn` checks per table and skips the `alterTable` call entirely when nothing is missing, avoiding empty `ALTER TABLE` statements on databases that complain about them.

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #27192.