### PR TITLE
Remove unused center prop from VDivider

### DIFF
--- a/app/src/components/v-divider.vue
+++ b/app/src/components/v-divider.vue
@@ -6,21 +6,17 @@ interface Props {
 	inlineTitle?: boolean;
 	/** Renders a larger divider text */
 	large?: boolean;
-	/** Displays the title centered */
-	center?: boolean;
 }
 
 withDefaults(defineProps<Props>(), {
 	vertical: false,
 	inlineTitle: true,
 	large: false,
-	center: false,
 });
 </script>
 
 <template>
-	<div class="v-divider" :class="{ vertical, inlineTitle, large, center }">
-		<hr v-if="center" :aria-orientation="vertical ? 'vertical' : 'horizontal'" />
+	<div class="v-divider" :class="{ vertical, inlineTitle, large }">
 		<span v-if="$slots.icon || $slots.default" class="wrapper">
 			<slot name="icon" class="icon" />
 			<span v-if="!vertical && $slots.default" class="text" :class="{ 'type-display': large }"><slot /></span>
@@ -106,16 +102,6 @@ withDefaults(defineProps<Props>(), {
 		span.wrapper {
 			order: 0;
 			margin: 0 0 0.4375rem;
-		}
-	}
-
-	&.center {
-		hr {
-			order: unset;
-		}
-
-		&.inlineTitle span.wrapper {
-			margin-inline: 0.4375rem;
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to the license feature branch.

## Scope

What's changed:

- Removed the `center` prop (and matching `&.center` SCSS block) from `app/src/components/v-divider.vue`. It was introduced (https://github.com/directus/directus/pull/27395) but never used by any caller in the codebase.

## Potential Risks / Drawbacks

- None expected — verified that no consumer passes `center` to `<VDivider>`.

## Tested Scenarios

- Searched for all `<v-divider>` / `<VDivider>` usages and `:center=` bindings; no call sites affected.

## Review Notes / Questions

- Pure dead-code removal; public component surface shrinks but no documented API relied on it.

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required