### PR TITLE
License design update 3

### DIFF
--- a/app/src/views/private/components/license/max-capacity-alert.vue
+++ b/app/src/views/private/components/license/max-capacity-alert.vue
@@ -19,38 +19,26 @@ const licenseStore = useLicenseStore();
 		v-if="!licenseStore.limits[props.entitlementKey].hasRemaining"
 		type="danger"
 		icon="dangerous"
-		multiline
 		class="max-capacity-alert"
 	>
-		<template #title>
-			<span class="message">
-				{{ $t('license.max_capacity.alert_danger_prefix') }}
-				<RouterLink class="manage-plan-link" :to="{ name: 'settings-license' }" target="_blank">
-					{{ $t('license.manage_plan') }}
-				</RouterLink>
-				{{ $t('license.max_capacity.alert_danger_suffix') }}
-			</span>
-		</template>
+		{{ $t('license.max_capacity.alert_danger_prefix') }}
+		<RouterLink class="manage-plan-link" :to="{ name: 'settings-license' }" target="_blank">
+			{{ $t('license.manage_plan') }}
+		</RouterLink>
+		{{ $t('license.max_capacity.alert_danger_suffix') }}
 	</VNotice>
 </template>
 
 <style scoped>
 .max-capacity-alert {
-	margin-block-end: 2.25rem;
-}
+	--v-notice-color: var(--theme--foreground);
 
-.max-capacity-alert :deep(.v-notice-title) {
-	flex: 1;
-	gap: 0.5rem;
-}
-
-.message {
-	flex: 1;
-	color: var(--theme--foreground);
+	margin-block-end: var(--content-padding);
 }
 
 .manage-plan-link {
 	cursor: pointer;
 	text-decoration: underline;
+	color: var(--theme--primary);
 }
 </style>

--- a/app/src/views/private/components/license/status-notice.vue
+++ b/app/src/views/private/components/license/status-notice.vue
@@ -31,43 +31,32 @@ const lockedSupportUrl = computed(
 </script>
 
 <template>
-	<VNotice v-if="show && isLocked" type="danger" multiline class="status-notice">
-		<template #title>
-			<span class="message">
-				<I18nT keypath="license.locked_status_notice" tag="span">
-					<template #contactSupport>
-						<a :href="lockedSupportUrl" target="_blank" rel="noopener noreferrer">{{ t('contact_support') }}</a>
-					</template>
-				</I18nT>
-			</span>
-		</template>
+	<VNotice v-if="show && isLocked" type="danger" class="status-notice">
+		<I18nT keypath="license.locked_status_notice" tag="span">
+			<template #contactSupport>
+				<a :href="lockedSupportUrl" target="_blank" rel="noopener noreferrer">{{ t('contact_support') }}</a>
+			</template>
+		</I18nT>
 	</VNotice>
-	<VNotice v-else-if="show && isCoreGrace" type="warning" multiline class="status-notice">
-		<template #title>
-			<span class="message">{{ t('license.unlicensed_status_notice.grace_period') }}</span>
-		</template>
+	<VNotice v-else-if="show && isCoreGrace" type="warning" class="status-notice">
+		{{ t('license.unlicensed_status_notice.grace_period') }}
 	</VNotice>
-	<VNotice v-else-if="show" :type="severity" multiline class="status-notice">
-		<template #title>
-			<span class="message">
-				{{ t('license.status_notice.grace_period_prefix') }}
-				<strong>
-					{{ t('license.status_notice.grace_days', { days: gracePeriodDaysRemaining }, gracePeriodDaysRemaining ?? 0) }}
-				</strong>
-				{{ t('license.status_notice.grace_period_suffix') }}
-			</span>
-		</template>
+	<VNotice v-else-if="show" :type="severity" class="status-notice">
+		{{ t('license.status_notice.grace_period_prefix') }}
+		<strong>
+			{{ t('license.status_notice.grace_days', { days: gracePeriodDaysRemaining }, gracePeriodDaysRemaining ?? 0) }}
+		</strong>
+		{{ t('license.status_notice.grace_period_suffix') }}
 	</VNotice>
 </template>
 
-<style scoped>
-.status-notice :deep(.v-notice-title) {
-	flex: 1;
-}
+<style lang="scss" scoped>
+.status-notice {
+	--v-notice-color: var(--theme--foreground);
 
-.message {
-	flex: 1;
-	font-weight: normal;
-	color: var(--theme--foreground);
+	a {
+		text-decoration: underline;
+		color: var(--theme--primary);
+	}
 }
 </style>


### PR DESCRIPTION
Follow-up to the license feature branch.

## Scope

What's changed:

- Match the design `max-capacity-alert.vue` and `status-notice.vue` by moving content into `VNotice`'s default slot and dropping the `multiline` + `#title` slot wrapper
- Replace `:deep()` style overrides with `--v-notice-color`
- Color inline links with `--theme--primary` and underline so they stand out

## Potential Risks / Drawbacks

- Purely visual cleanup

## Tested Scenarios

- Max-capacity alert when an entitlement is exhausted
- Status notice in locked, core-grace, and grace-period states

## Review Notes / Questions

—

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required
