### PR TITLE
dp ← Avoid version-menu, publish button & collab indicator re-render on auto-save

### DIFF
--- a/app/src/composables/use-versions.ts
+++ b/app/src/composables/use-versions.ts
@@ -18,7 +18,6 @@ export interface PublishVersionOptions {
 export function useVersions(collection: Ref<string>, isSingleton: Ref<boolean>, primaryKey: Ref<PrimaryKey | null>) {
 	const currentVersion = ref<ContentVersionMaybeNew | null>(null);
 	const rawVersions = ref<ContentVersion[] | null>(null);
-	const loading = ref(false);
 	const deleteVersionLoading = ref(false);
 	const publishVersionLoading = ref(false);
 	const validationErrors = ref<any[]>([]);
@@ -77,9 +76,15 @@ export function useVersions(collection: Ref<string>, isSingleton: Ref<boolean>, 
 
 			const previouslySelectedKey = currentVersion.value?.key;
 
-			currentVersion.value = newQueryVersion
+			const newSelected = newQueryVersion
 				? (newVersions.find((version) => version.key === newQueryVersion && isVersionSelectable(version)) ?? null)
 				: null;
+
+			if (newSelected && currentVersion.value && newSelected.id === currentVersion.value.id) {
+				Object.assign(currentVersion.value, newSelected);
+			} else {
+				currentVersion.value = newSelected;
+			}
 
 			if (currentVersion.value?.key !== previouslySelectedKey) {
 				validationErrors.value = [];
@@ -117,8 +122,6 @@ export function useVersions(collection: Ref<string>, isSingleton: Ref<boolean>, 
 			return;
 		}
 
-		loading.value = true;
-
 		try {
 			const filterConditions: Filter[] = [{ collection: { _eq: collection.value } }];
 
@@ -144,8 +147,6 @@ export function useVersions(collection: Ref<string>, isSingleton: Ref<boolean>, 
 			rawVersions.value = response.data;
 		} catch (error) {
 			unexpectedError(error);
-		} finally {
-			loading.value = false;
 		}
 	}
 
@@ -319,7 +320,6 @@ export function useVersions(collection: Ref<string>, isSingleton: Ref<boolean>, 
 		createVersionsAllowed,
 		currentVersion,
 		versions,
-		loading,
 		getVersions,
 		addVersion,
 		updateVersion,

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -119,7 +119,6 @@ const {
 	createVersionsAllowed,
 	currentVersion,
 	versions,
-	loading: versionsLoading,
 	addVersion,
 	updateVersion,
 	deleteVersion,
@@ -720,7 +719,6 @@ function revert(values: Record<string, any>) {
 
 const shouldShowVersioning = computed(() => {
 	if (!collectionInfo.value?.meta?.versioning) return false;
-	if (versionsLoading.value) return false;
 	return true;
 });
 


### PR DESCRIPTION
Follow-up to https://github.com/directus/directus/pull/27449

## Scope

What's changed:

- Drop the unused `loading` ref from `useVersions` and the `versionsLoading` gate from `shouldShowVersioning` so the version-menu and publish/edit button area no longer unmount/remount during the auto-save refresh
- Preserve the `currentVersion` ref identity by mutating in place via `Object.assign` when the post-save refresh yields the same version `id`, instead of swapping the ref to a brand-new object
- This stops `useCollab`'s `watch([..., version, ...])` from firing on every auto-save, which was triggering a `leave()` + `join()` cycle and briefly emptying the collab indicator users

## Potential Risks / Drawbacks

- Initial fetch no longer hides the versioning UI; for items with custom versions the menu now renders with just published/draft for ~one frame before the real versions stream in
- In-place mutation of `currentVersion.value` means consumers can no longer rely on a referential change to detect a "version data refreshed" event — they need to track specific fields (e.g. `date_updated`) instead

## Tested Scenarios

- Auto-save on a versioned item: chip, publish button, and collab indicator stay mounted; no flicker
- Switching versions via the menu: still triggers the full reassignment path (different `id`) and resets `validationErrors`
- Switching collection / primary key: versions reload without showing stale data from the previous context
- `pnpm --filter @directus/app test src/composables/use-versions.test.ts src/composables/use-collab.test.ts` → 59/59 pass

## Review Notes / Questions

- `VersionMenu` still receives a fresh `versions` array on every save (the computed re-runs because `rawVersions` is reassigned). It's a much cheaper re-render than the v-if remount, but happy to add prop-level memoization in a follow-up if desired.

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

Closes CMS-2356 https://linear.app/directus/issue/CMS-2356/flickering-when-autosaving 