### PR TITLE
Change license to MSCL-1.0-GPL

### DIFF
--- a/.changeset/nice-results-beg.md
+++ b/.changeset/nice-results-beg.md
@@ -1,0 +1,19 @@
+---
+'@directus/schema': major
+'@directus/schema-builder': major
+'@directus/specs': major
+'@directus/storage': major
+'@directus/storage-driver-cloudinary': major
+'@directus/storage-driver-supabase': major
+'@directus/storage-driver-azure': major
+'@directus/storage-driver-gcs': major
+'@directus/storage-driver-local': major
+'@directus/storage-driver-s3': major
+'directus': major
+'@directus/api': major
+'@directus/app': major
+---
+
+Changed license to MSCL-1.0-GPL
+
+

--- a/.changeset/nice-results-beg.md
+++ b/.changeset/nice-results-beg.md
@@ -18,6 +18,6 @@ Changed license to MSCL-1.0-GPL
 
 ::: notice
 
-- Breaking Change: Relicensed from BUSL-1.1 to MSCL-1.0-GPL (Monospace Sustainable Core License, Version 1.0).
+- Breaking Change: Relicensed from BSL-1.1 to MSCL-1.0-GPL (Monospace Sustainable Core License, Version 1.0).
 
 :::

--- a/.changeset/nice-results-beg.md
+++ b/.changeset/nice-results-beg.md
@@ -18,6 +18,6 @@ Changed license to MSCL-1.0-GPL
 
 ::: notice
 
-- Breaking Change: Relicensed from BSL-1.1 to MSCL-1.0-GPL (Monospace Sustainable Core License, Version 1.0).
+- Breaking Change: Relicensed from BUSL-1.1 to MSCL-1.0-GPL (Monospace Sustainable Core License, Version 1.0).
 
 :::

--- a/.changeset/nice-results-beg.md
+++ b/.changeset/nice-results-beg.md
@@ -16,4 +16,8 @@
 
 Changed license to MSCL-1.0-GPL
 
+::: notice
 
+- Breaking Change: Relicensed from BUSL-1.1 to MSCL-1.0-GPL (Monospace Sustainable Core License, Version 1.0).
+
+:::

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -261,4 +261,5 @@ pnpm dev
 
 ## License
 
-Directus is licensed under BUSL-1.1 (Business Source License). Review the license file before contributing.
+Directus is licensed under MSCL-1.0-GPL (Monospace Sustainable Core License). Review the license file before
+contributing.

--- a/api/license
+++ b/api/license
@@ -1,18 +1,12 @@
-Licensor:             Monospace, Inc.
+# Monospace Sustainable Core License, Version 1.0
 
-Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2026 Monospace, Inc.
+## Abbreviation
 
-Change Date:          Four years from release date
+MSCL-1.0-GPL
 
-Change License:       GNU General Public License (GPL) v3
+## Notice
 
-For information about alternative licensing arrangements, please visit
-https://directus.com/pricing.
-
---------------------------------------------------------------------------------
-
-# Monospace Sustainable Core License 1.0
+Copyright 2026 Monospace Inc.
 
 ## Terms and Conditions
 

--- a/api/license
+++ b/api/license
@@ -1,26 +1,9 @@
 Licensor:             Monospace, Inc.
 
 Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2025 Monospace, Inc.
+                      The Licensed Work is Copyright © 2026 Monospace, Inc.
 
-Additional Use Grant: You may use the Licensed Work in production as long as
-                      your Total Finances do not exceed US $5,000,000 for the
-                      most recent 12-month period, provided that Monospace, Inc.
-                      will not be liable to you in any way, including for any
-                      damages, including general, special, incidental or
-                      consequential damages, arising out of such use.
-
-                      References to: “Total Finances” mean the largest of your
-                      aggregate gross revenues, entire budget, and/or funding
-                      (no matter the source); “you” and “your” include (without
-                      limitation) any individual or entity agreeing to these
-                      terms and any affiliates of such individual or entity; and
-                      “production” mean any use other than (i) development of
-                      (including evaluation of the Licensed Work), debugging, or
-                      testing your offerings, or (ii) making the Licensed Work
-                      available standalone in unmodified object code form.
-
-Change Date:          Three years from release date
+Change Date:          Four years from release date
 
 Change License:       GNU General Public License (GPL) v3
 
@@ -29,79 +12,112 @@ https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 
-Business Source License 1.1
+# Monospace Sustainable Core License 1.0
 
-Terms
+## Terms and Conditions
 
-The Licensor hereby grants you the right to copy, modify, create derivative
-works, redistribute, and make non-production use of the Licensed Work. The
-Licensor may make an Additional Use Grant, above, permitting limited production
-use.
+### Licensor ("We")
 
-Effective on the Change Date, or the fourth anniversary of the first publicly
-available distribution of a specific version of the Licensed Work under this
-License, whichever comes first, the Licensor hereby grants you rights under the
-terms of the Change License, and the rights granted in the paragraph above
-terminate.
+The party offering the Software under these Terms and Conditions.
 
-If your use of the Licensed Work does not comply with the requirements currently
-in effect as described in this License, you must purchase a commercial license
-from the Licensor, its affiliated entities, or authorized resellers, or you must
-refrain from using the Licensed Work.
+### The Software
 
-All copies of the original and modified Licensed Work, and derivative works of
-the Licensed Work, are subject to this License. This License applies separately
-for each version of the Licensed Work and the Change Date may vary for each
-version of the Licensed Work released by Licensor.
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
 
-You must conspicuously display this License on each original or modified copy of
-the Licensed Work. If you receive the Licensed Work in original or modified form
-from a third party, the terms and conditions set forth in this License apply to
-your use of that work.
+### License Grant
 
-Any use of the Licensed Work in violation of this License will automatically
-terminate your rights under this License for the current and all other versions
-of the Licensed Work.
+Subject to your compliance with this License Grant and the Limitations, Patents,
+Redistribution, Disclaimer and Trademark clauses below, we hereby grant you the
+right to use, copy, modify, create derivative works, publicly perform, publicly
+display and redistribute the Software for any Permitted Purpose identified
+below.
 
-This License does not grant you any right in any trademark or logo of Licensor
-or its affiliates (provided that you may use a trademark or logo of Licensor as
-expressly required by this License).
+### Permitted Purpose
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
-“AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
-OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+A Permitted Purpose is any purpose other than a Competing Use.
 
-MariaDB hereby grants you permission to use this License’s text to license your
-works, and to refer to it using the trademark “Business Source License”, as long
-as you comply with the Covenants of Licensor below.
+A Competing Use means making the Software available to any party (on a stand
+alone basis or together with your products or services) that competes with the
+Licensor's commercial offerings of the Software itself, where Licensor imposes a
+license fee, royalty, or other charge for exercise of any rights to the
+Software.
 
-Covenants of Licensor
+Permitted Purposes specifically include using the Software, subject to the
+Limitations below:
 
-In consideration of the right to use this License’s text and the “Business
-Source License” name and trademark, Licensor covenants to MariaDB, and to all
-other recipients of the licensed work to be provided by Licensor:
+1. for your internal use and access;
+2. for non-commercial education;
+3. for non-commercial research; and
+4. in connection with professional services that you provide to a licensee using
+   the Software in accordance with these Terms and Conditions, including
+   professional services to deploy the Software or host the Software for the
+   licensee.
 
-1. To specify as the Change License the GPL Version 2.0 or any later version,
-   or a license that is compatible with GPL Version 2.0 or a later version,
-   where “compatible” means that software provided under the Change License can
-   be included in a program with software provided under GPL Version 2.0 or a
-   later version. Licensor may specify additional Change Licenses without
-   limitation.
+### Limitations
 
-2. To either: (a) specify an additional grant of rights to use that does not
-   impose any additional restriction on the right granted in this License, as
-   the Additional Use Grant; or (b) insert the text “None”.
+You must not move, change, disable or circumvent the license key functionality
+of the Software or modify any portion of the Software protected by the license
+key to:
 
-3. To specify a Change Date.
+- enable access to the protected functionality without a valid license key or
+- remove the protected functionality.
 
-4. Not to modify this License in any other way.
+### Patents
 
-Notice
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to the
+infringement of any patent, then your patent license to the Software ends
+immediately.
 
-The Business Source License (this document, or the "License") is not an Open
-Source license. However, the Licensed Work will eventually be made available
-under an Open Source License, as stated in this License.
+### Redistribution
 
-License text copyright © 2023 MariaDB plc, All Rights Reserved.
-“Business Source License” is a trademark of MariaDB plc.
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+then (A) you must include a copy of or a link to these Terms and Conditions and
+not remove any copyright notices provided in or with the Software and (B) you
+may not impose any further restrictions on the exercise of the rights granted or
+affirmed under this License. For example, you may not impose a license fee,
+royalty, or other charge for exercise of rights granted under this License.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN
+IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the GNU General Public License version 3 (GPL-3.0), effective on the fourth
+anniversary of the date we make the Software available.
+
+On or after that date, you may use the Software under GPL-3.0, in which case the
+following will apply:
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+The full text of the GPL-3.0 license is available at:
+https://www.gnu.org/licenses/gpl-3.0.html

--- a/api/package.json
+++ b/api/package.json
@@ -28,7 +28,7 @@
 		"directory": "api"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "BUSL-1.1",
+	"license": "MSCL-1.0-GPL",
 	"author": {
 		"name": "Monospace Inc",
 		"email": "info@monospace.io",

--- a/api/package.json
+++ b/api/package.json
@@ -28,7 +28,7 @@
 		"directory": "api"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "MSCL-1.0-GPL",
+	"license": "SEE LICENSE IN license",
 	"author": {
 		"name": "Monospace Inc",
 		"email": "info@monospace.io",

--- a/app/license
+++ b/app/license
@@ -1,18 +1,12 @@
-Licensor:             Monospace, Inc.
+# Monospace Sustainable Core License, Version 1.0
 
-Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2026 Monospace, Inc.
+## Abbreviation
 
-Change Date:          Four years from release date
+MSCL-1.0-GPL
 
-Change License:       GNU General Public License (GPL) v3
+## Notice
 
-For information about alternative licensing arrangements, please visit
-https://directus.com/pricing.
-
---------------------------------------------------------------------------------
-
-# Monospace Sustainable Core License 1.0
+Copyright 2026 Monospace Inc.
 
 ## Terms and Conditions
 

--- a/app/license
+++ b/app/license
@@ -1,26 +1,9 @@
 Licensor:             Monospace, Inc.
 
 Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2025 Monospace, Inc.
+                      The Licensed Work is Copyright © 2026 Monospace, Inc.
 
-Additional Use Grant: You may use the Licensed Work in production as long as
-                      your Total Finances do not exceed US $5,000,000 for the
-                      most recent 12-month period, provided that Monospace, Inc.
-                      will not be liable to you in any way, including for any
-                      damages, including general, special, incidental or
-                      consequential damages, arising out of such use.
-
-                      References to: “Total Finances” mean the largest of your
-                      aggregate gross revenues, entire budget, and/or funding
-                      (no matter the source); “you” and “your” include (without
-                      limitation) any individual or entity agreeing to these
-                      terms and any affiliates of such individual or entity; and
-                      “production” mean any use other than (i) development of
-                      (including evaluation of the Licensed Work), debugging, or
-                      testing your offerings, or (ii) making the Licensed Work
-                      available standalone in unmodified object code form.
-
-Change Date:          Three years from release date
+Change Date:          Four years from release date
 
 Change License:       GNU General Public License (GPL) v3
 
@@ -29,79 +12,112 @@ https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 
-Business Source License 1.1
+# Monospace Sustainable Core License 1.0
 
-Terms
+## Terms and Conditions
 
-The Licensor hereby grants you the right to copy, modify, create derivative
-works, redistribute, and make non-production use of the Licensed Work. The
-Licensor may make an Additional Use Grant, above, permitting limited production
-use.
+### Licensor ("We")
 
-Effective on the Change Date, or the fourth anniversary of the first publicly
-available distribution of a specific version of the Licensed Work under this
-License, whichever comes first, the Licensor hereby grants you rights under the
-terms of the Change License, and the rights granted in the paragraph above
-terminate.
+The party offering the Software under these Terms and Conditions.
 
-If your use of the Licensed Work does not comply with the requirements currently
-in effect as described in this License, you must purchase a commercial license
-from the Licensor, its affiliated entities, or authorized resellers, or you must
-refrain from using the Licensed Work.
+### The Software
 
-All copies of the original and modified Licensed Work, and derivative works of
-the Licensed Work, are subject to this License. This License applies separately
-for each version of the Licensed Work and the Change Date may vary for each
-version of the Licensed Work released by Licensor.
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
 
-You must conspicuously display this License on each original or modified copy of
-the Licensed Work. If you receive the Licensed Work in original or modified form
-from a third party, the terms and conditions set forth in this License apply to
-your use of that work.
+### License Grant
 
-Any use of the Licensed Work in violation of this License will automatically
-terminate your rights under this License for the current and all other versions
-of the Licensed Work.
+Subject to your compliance with this License Grant and the Limitations, Patents,
+Redistribution, Disclaimer and Trademark clauses below, we hereby grant you the
+right to use, copy, modify, create derivative works, publicly perform, publicly
+display and redistribute the Software for any Permitted Purpose identified
+below.
 
-This License does not grant you any right in any trademark or logo of Licensor
-or its affiliates (provided that you may use a trademark or logo of Licensor as
-expressly required by this License).
+### Permitted Purpose
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
-“AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
-OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+A Permitted Purpose is any purpose other than a Competing Use.
 
-MariaDB hereby grants you permission to use this License’s text to license your
-works, and to refer to it using the trademark “Business Source License”, as long
-as you comply with the Covenants of Licensor below.
+A Competing Use means making the Software available to any party (on a stand
+alone basis or together with your products or services) that competes with the
+Licensor's commercial offerings of the Software itself, where Licensor imposes a
+license fee, royalty, or other charge for exercise of any rights to the
+Software.
 
-Covenants of Licensor
+Permitted Purposes specifically include using the Software, subject to the
+Limitations below:
 
-In consideration of the right to use this License’s text and the “Business
-Source License” name and trademark, Licensor covenants to MariaDB, and to all
-other recipients of the licensed work to be provided by Licensor:
+1. for your internal use and access;
+2. for non-commercial education;
+3. for non-commercial research; and
+4. in connection with professional services that you provide to a licensee using
+   the Software in accordance with these Terms and Conditions, including
+   professional services to deploy the Software or host the Software for the
+   licensee.
 
-1. To specify as the Change License the GPL Version 2.0 or any later version,
-   or a license that is compatible with GPL Version 2.0 or a later version,
-   where “compatible” means that software provided under the Change License can
-   be included in a program with software provided under GPL Version 2.0 or a
-   later version. Licensor may specify additional Change Licenses without
-   limitation.
+### Limitations
 
-2. To either: (a) specify an additional grant of rights to use that does not
-   impose any additional restriction on the right granted in this License, as
-   the Additional Use Grant; or (b) insert the text “None”.
+You must not move, change, disable or circumvent the license key functionality
+of the Software or modify any portion of the Software protected by the license
+key to:
 
-3. To specify a Change Date.
+- enable access to the protected functionality without a valid license key or
+- remove the protected functionality.
 
-4. Not to modify this License in any other way.
+### Patents
 
-Notice
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to the
+infringement of any patent, then your patent license to the Software ends
+immediately.
 
-The Business Source License (this document, or the "License") is not an Open
-Source license. However, the Licensed Work will eventually be made available
-under an Open Source License, as stated in this License.
+### Redistribution
 
-License text copyright © 2023 MariaDB plc, All Rights Reserved.
-“Business Source License” is a trademark of MariaDB plc.
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+then (A) you must include a copy of or a link to these Terms and Conditions and
+not remove any copyright notices provided in or with the Software and (B) you
+may not impose any further restrictions on the exercise of the rights granted or
+affirmed under this License. For example, you may not impose a license fee,
+royalty, or other charge for exercise of rights granted under this License.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN
+IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the GNU General Public License version 3 (GPL-3.0), effective on the fourth
+anniversary of the date we make the Software available.
+
+On or after that date, you may use the Software under GPL-3.0, in which case the
+following will apply:
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+The full text of the GPL-3.0 license is available at:
+https://www.gnu.org/licenses/gpl-3.0.html

--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,7 @@
 		"directory": "app"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "MSCL-1.0-GPL",
+	"license": "SEE LICENSE IN license",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"type": "module",
 	"exports": {

--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,7 @@
 		"directory": "app"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "BUSL-1.1",
+	"license": "MSCL-1.0-GPL",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"type": "module",
 	"exports": {

--- a/app/src/lang/translations/es-419.yaml
+++ b/app/src/lang/translations/es-419.yaml
@@ -20,7 +20,7 @@
 #'SIMD', 'ArrayBuffer', 'DataView', 'JSON', 'Promise', 'Generator', 'GeneratorFunction', 'Reflect',
 #'Proxy', 'Intl'
 about: Acerca de
-directus_bsl: BSL de Directus 1.1
+directus_mscl: MSCL de Directus 1.0
 privacy_policy: Política de Privacidad
 contact_our_team: Contacta con nuestro equipo
 setup_welcome: Bienvenido a Directus
@@ -30,8 +30,8 @@ setup_license_notice: >
 setup_license_follow_up: >
   Las entidades que superan este umbral requieren una licencia de pago. Puede continuar evaluando Directus ahora y contactarnos cuando esté listo para hablar sobre el uso en producción.
 setup_save_accept_license: >
-  Al hacer clic en Guardar, acepta los términos de {directusBsl} y {privacyPolicy}.
-setup_accept_license: Acepto los términos de {directusBsl} y {privacyPolicy}
+  Al hacer clic en Guardar, acepta los términos de {directusMscl} y {privacyPolicy}.
+setup_accept_license: Acepto los términos de {directusMscl} y {privacyPolicy}
 setup_marketing_emails: Envíame actualizaciones de productos y notas de lanzamiento
 setup_launch: Iniciar Directus
 setup_project: Configurar Proyecto
@@ -2607,9 +2607,9 @@ search_flow: Buscar Flujo...
 percent: Porciento
 show_password: Mostrar Contraseña
 hide_password: Ocultar Contraseña
-bsl_banner:
+license_banner:
   title: Aún no has establecido un propietario del proyecto.
-  license: Necesitamos esta información para garantizar el cumplimiento de nuestra licencia BSL 1.1. Esta persona debe ser el contacto principal responsable de tu proyecto.
+  license: Necesitamos esta información para garantizar el cumplimiento de nuestra licencia MSCL 1.0. Esta persona debe ser el contacto principal responsable de tu proyecto.
   set_owner: Asignar Propietario
   remind_later: Recordar más tarde
   remind_next_login: Te lo recordaremos nuevamente en tu próximo inicio de sesión.

--- a/app/src/lang/translations/fa-IR.yaml
+++ b/app/src/lang/translations/fa-IR.yaml
@@ -20,7 +20,7 @@
 #'SIMD', 'ArrayBuffer', 'DataView', 'JSON', 'Promise', 'Generator', 'GeneratorFunction', 'Reflect',
 #'Proxy', 'Intl'
 about: درباره
-directus_bsl: BSL 1.1 دایرکتوس
+directus_mscl: MSCL 1.0 دایرکتوس
 privacy_policy: سیاست حریم خصوصی
 contact_our_team: با تیم ما تماس بگیرید
 setup_welcome: به دایرکتوس خوش آمدید
@@ -30,8 +30,8 @@ setup_license_notice: >
 setup_license_follow_up: >
   اشخاص بالاتر از این آستانه نیازمند مجوز پولی هستند. شما می‌توانید حالا به ارزیابی دایرکتوس ادامه دهید و وقتی برای گفتگو درباره استفاده عملیاتی آماده بودید، {contactOurTeam}.
 setup_save_accept_license: >
-  با انتخاب دکمه ذخیره، شما شرایط {directusBsl} و {privacyPolicy} را قبول می‌کنید.
-setup_accept_license: من شرایط {directusBsl} و {privacyPolicy} را قبول می‌کنم
+  با انتخاب دکمه ذخیره، شما شرایط {directusMscl} و {privacyPolicy} را قبول می‌کنید.
+setup_accept_license: من شرایط {directusMscl} و {privacyPolicy} را قبول می‌کنم
 setup_marketing_emails: به‌روزرسانی‌های محصول و یادداشت‌های انتشار را برای من بفرست
 setup_launch: راه‌اندازی دایرکتوس
 setup_project: راه‌اندازی پروژه
@@ -2824,9 +2824,9 @@ search_flow: جستجوی جریان...
 percent: درصد
 show_password: نمایش رمز عبور
 hide_password: مخفی کردن رمز عبور
-bsl_banner:
+license_banner:
   title: شما مالک پروژه‌ای تنظیم نکرده‌اید.
-  license: ما برای اطمینان از انطباق با مجوز BSL 1.1 خود به این نیاز داریم. این باید مخاطب اصلی مسئول در برابر پروژه شما باشد.
+  license: ما برای اطمینان از انطباق با مجوز MSCL 1.0 خود به این نیاز داریم. این باید مخاطب اصلی مسئول در برابر پروژه شما باشد.
   set_owner: تعیین مالک
   remind_later: بعدا یادآوری کن
   remind_next_login: هنگام ورود بعدی شما دوباره یادآوری خواهیم کرد.

--- a/app/src/lang/translations/hu-HU.yaml
+++ b/app/src/lang/translations/hu-HU.yaml
@@ -20,7 +20,7 @@
 #'SIMD', 'ArrayBuffer', 'DataView', 'JSON', 'Promise', 'Generator', 'GeneratorFunction', 'Reflect',
 #'Proxy', 'Intl'
 about: Rólunk
-directus_bsl: Directus BSL 1.1
+directus_mscl: Directus MSCL 1.0
 privacy_policy: Adatvédelmi irányelvek
 contact_our_team: Lépjen kapcsolatba velünk
 setup_welcome: Üdvözöljük a Directusnál
@@ -30,8 +30,8 @@ setup_license_notice: >
 setup_license_follow_up: >
   A küszöbértéket meghaladó cégek kötelesek licencet vásárolni. Folytassa bátran a Directus tesztelését; és amint készen áll a bevezetésre, lépjen kapcsolatba {contactOurTeam}-mel.
 setup_save_accept_license: >
-  A mentés gombra kattintva elfogadja a {directusBsl} és a {privacyPolicy} feltételeit.
-setup_accept_license: Elfogadom a {directusBsl} és a {privacyPolicy} feltételeit.
+  A mentés gombra kattintva elfogadja a {directusMscl} és a {privacyPolicy} feltételeit.
+setup_accept_license: Elfogadom a {directusMscl} és a {privacyPolicy} feltételeit.
 setup_marketing_emails: Küldjenek részemre információkat a termék frissítéséről és az új verziók módosításairól
 setup_launch: Directus indítása
 setup_project: Projekt beállítása

--- a/app/src/lang/translations/ja-JP.yaml
+++ b/app/src/lang/translations/ja-JP.yaml
@@ -20,9 +20,9 @@
 #'SIMD', 'ArrayBuffer', 'DataView', 'JSON', 'Promise', 'Generator', 'GeneratorFunction', 'Reflect',
 #'Proxy', 'Intl'
 about: Directus の概要
-directus_bsl: Directus BSL 1.1
-privacy_policy: プライバシーポリシー 
-contact_our_team: チームへのお問い合わせ  
+directus_mscl: Directus MSCL 1.0
+privacy_policy: プライバシーポリシー
+contact_our_team: チームへのお問い合わせ
 setup_welcome: ようこそ Directus へ
 setup_info: 管理者アカウントを作成して、プロジェクトを開始しましょう。
 setup_license_notice: >
@@ -30,8 +30,8 @@ setup_license_notice: >
 setup_license_follow_up: >
   この上限を超える場合は有料ライセンスが必要です。評価を続けることもできますが、商用利用のご相談は {contactOurTeam} までお願いします。
 setup_save_accept_license: >
-  保存することで、{directusBsl} および {privacyPolicy} に同意したものとみなされます。
-setup_accept_license: '{directusBsl} および {privacyPolicy} に同意します'
+  保存することで、{directusMscl} および {privacyPolicy} に同意したものとみなされます。
+setup_accept_license: '{directusMscl} および {privacyPolicy} に同意します'
 setup_marketing_emails: 製品の更新やリリースノートをメールで受け取る
 setup_launch: Directus を起動
 setup_project: プロジェクトの設定
@@ -2242,9 +2242,9 @@ search_flow: フローを検索 ...
 percent: パーセント
 show_password: パスワードを表示にする
 hide_password: パスワードを非表示にする
-bsl_banner:
+license_banner:
   title: プロジェクトの所有者が設定されていません。
-  license: これは BSL 1.1 ライセンスを遵守するために必要です。プロジェクトに責任を持つ主な担当者を設定してください。
+  license: これは MSCL 1.0 ライセンスを遵守するために必要です。プロジェクトに責任を持つ主な担当者を設定してください。
   set_owner: 所有者を設定
   remind_later: 後で通知
   remind_next_login: 次回のログイン時に再度通知します。

--- a/app/src/lang/translations/ko-KR.yaml
+++ b/app/src/lang/translations/ko-KR.yaml
@@ -2561,9 +2561,9 @@ search_flow: 흐름 검색...
 percent: 퍼센트
 show_password: 비밀번호 보이기
 hide_password: 비밀번호 숨기기
-bsl_banner:
+license_banner:
   title: 프로젝트 담당자를 지정하지 않으셨습니다.
-  license: 이는 BSL 1.1 라이선스 준수를 위해 필요합니다. 해당 담당자가 프로젝트 책임자가 되어야 합니다.
+  license: 이는 MSCL 1.0 라이선스 준수를 위해 필요합니다. 해당 담당자가 프로젝트 책임자가 되어야 합니다.
   remind_next_login: 다음 로그인 시 다시 알려드리겠습니다.
 accepted: 수락됨
 text_direction_auto: 자동(일치 언어)

--- a/app/src/lang/translations/nl-NL.yaml
+++ b/app/src/lang/translations/nl-NL.yaml
@@ -20,7 +20,7 @@
 #'SIMD', 'ArrayBuffer', 'DataView', 'JSON', 'Promise', 'Generator', 'GeneratorFunction', 'Reflect',
 #'Proxy', 'Intl'
 about: Over
-directus_bsl: Directus BSL 1.1
+directus_mscl: Directus MSCL 1.0
 privacy_policy: Privacybeleid
 contact_our_team: Contacteer ons Team
 setup_welcome: Welkom bij Directus
@@ -30,8 +30,8 @@ setup_license_notice: >
 setup_license_follow_up: >
   Voor entiteiten die deze grens overschrijden is een betaalde licentie vereist. Je kunt Directus blijven proberen en {contactOurTeam} wanneer je klaar bent om het productiegebruik te bespreken.
 setup_save_accept_license: >
-  Door op te slaan accepteer je de algemene voorwaarden van de {directusBsl} en {privacyPolicy}.
-setup_accept_license: Ik accepteer de voorwaarden van de {directusBsl} en {privacyPolicy}
+  Door op te slaan accepteer je de algemene voorwaarden van de {directusMscl} en {privacyPolicy}.
+setup_accept_license: Ik accepteer de voorwaarden van de {directusMscl} en {privacyPolicy}
 setup_marketing_emails: Stuur mij productupdates en release-info
 setup_launch: Start Directus
 setup_project: Project Setup

--- a/app/src/lang/translations/pt-BR.yaml
+++ b/app/src/lang/translations/pt-BR.yaml
@@ -20,7 +20,7 @@
 #'SIMD', 'ArrayBuffer', 'DataView', 'JSON', 'Promise', 'Generator', 'GeneratorFunction', 'Reflect',
 #'Proxy', 'Intl'
 about: Sobre
-directus_bsl: Directus BSL 1.1
+directus_mscl: Directus MSCL 1.0
 privacy_policy: Política de Privacidade
 contact_our_team: Contate nosso Time
 setup_welcome: Bem-Vindo ao Directus
@@ -30,8 +30,8 @@ setup_license_notice: >
 setup_license_follow_up: >
   Entidades acima deste limite requerem uma licença paga. Você pode continuar a avaliar a Directus agora e {contactOurTeam} quando estiver pronto para discutir o uso em produção.
 setup_save_accept_license: >
-  Clicando em salvar você aceita os termos de {directusBsl} e {privacyPolicy}.
-setup_accept_license: Eu aceito os termos de {directusBsl} e {privacyPolicy}
+  Clicando em salvar você aceita os termos de {directusMscl} e {privacyPolicy}.
+setup_accept_license: Eu aceito os termos de {directusMscl} e {privacyPolicy}
 setup_marketing_emails: Receber novidades do produto e notas de lançamento
 setup_launch: Iniciar Directus
 setup_project: Configurar Projeto

--- a/app/src/lang/translations/ru-RU.yaml
+++ b/app/src/lang/translations/ru-RU.yaml
@@ -20,7 +20,7 @@
 #'SIMD', 'ArrayBuffer', 'DataView', 'JSON', 'Promise', 'Generator', 'GeneratorFunction', 'Reflect',
 #'Proxy', 'Intl'
 about: О программе
-directus_bsl: Directus BSL 1.1
+directus_mscl: Directus MSCL 1.0
 privacy_policy: Политика конфиденциальности
 contact_our_team: Связаться с нами
 setup_welcome: Добро пожаловать в Directus
@@ -30,8 +30,8 @@ setup_license_notice: >
 setup_license_follow_up: >
   Лица выше данного предела обязаны получить платную лицензию. Теперь вы можете продолжить анализ Directus и {contactOurTeam}, когда вы готовы обсудить использование продукции.
 setup_save_accept_license: >
-  Нажав сохранить, вы принимаете условия [{directusBsl} и {privacyPolicy}.
-setup_accept_license: Я принимаю условия {directusBsl} и {privacyPolicy}
+  Нажав сохранить, вы принимаете условия [{directusMscl} и {privacyPolicy}.
+setup_accept_license: Я принимаю условия {directusMscl} и {privacyPolicy}
 setup_marketing_emails: Присылать мне обновления и заметки к выпуску
 setup_launch: Запустить Directus
 setup_project: Организовать проект

--- a/app/src/lang/translations/uk-UA.yaml
+++ b/app/src/lang/translations/uk-UA.yaml
@@ -20,7 +20,7 @@
 #'SIMD', 'ArrayBuffer', 'DataView', 'JSON', 'Promise', 'Generator', 'GeneratorFunction', 'Reflect',
 #'Proxy', 'Intl'
 about: Інформація про
-directus_bsl: Directus BSL 1,1
+directus_mscl: Directus MSCL 1.0
 privacy_policy: Політика конфіденційності
 contact_our_team: Звʼязок із нашою командою
 setup_welcome: Ласкаво просимо до Directus
@@ -30,8 +30,8 @@ setup_license_notice: >
 setup_license_follow_up: >
   Об’єкти, що перевищують цей поріг, потребують платної ліцензії. Ви можете продовжити оцінку Directus зараз і {contactOurTeam}, коли будете готові обговорити використання у виробництві.
 setup_save_accept_license: >
-  Натискаючи «Зберегти», ви погоджуєтесь з умовами {directusBsl} та {privacyPolicy}.
-setup_accept_license: Я погоджуюсь з умовами {directusBsl} та {privacyPolicy}
+  Натискаючи «Зберегти», ви погоджуєтесь з умовами {directusMscl} та {privacyPolicy}.
+setup_accept_license: Я погоджуюсь з умовами {directusMscl} та {privacyPolicy}
 setup_marketing_emails: Надіслати мені оновлення продукту та нотатки про випуск
 setup_launch: Запустити Directus
 setup_project: Запустити проєкт
@@ -2607,9 +2607,9 @@ search_flow: Пошуковий потік...
 percent: Відсоток
 show_password: Показати пароль
 hide_password: Приховати пароль
-bsl_banner:
+license_banner:
   title: Ви не встановили власника проєкту.
-  license: Нам потрібно це, щоб забезпечити дотримання нашої BSL 1.1 ліцензії. Це має бути основний контакт з відповіддю за ваш проєкт.
+  license: Нам потрібно це, щоб забезпечити дотримання нашої MSCL 1.0 ліцензії. Це має бути основний контакт з відповіддю за ваш проєкт.
   set_owner: Встановити власника
   remind_later: Нагадати пізніше
   remind_next_login: Ми нагадаємо вам про це під час наступного входу.

--- a/app/src/lang/translations/zh-CN.yaml
+++ b/app/src/lang/translations/zh-CN.yaml
@@ -20,7 +20,7 @@
 #'SIMD', 'ArrayBuffer', 'DataView', 'JSON', 'Promise', 'Generator', 'GeneratorFunction', 'Reflect',
 #'Proxy', 'Intl'
 about: 关于
-directus_bsl: Directus BSL 1.1 许可证
+directus_mscl: Directus MSCL 1.0 许可证
 privacy_policy: 隐私政策
 contact_our_team: 联系我们团队
 setup_welcome: 欢迎使用 Directus
@@ -30,8 +30,8 @@ setup_license_notice: >
 setup_license_follow_up: >
   超过此阈值的实体需要付费许可证。您现在可以继续评估 Directus，并在准备讨论生产使用时{contactOurTeam}。
 setup_save_accept_license: >
-  点击保存即表示您接受 {directusBsl} 和 {privacyPolicy} 的条款。
-setup_accept_license: 我接受 {directusBsl} 和 {privacyPolicy} 的条款
+  点击保存即表示您接受 {directusMscl} 和 {privacyPolicy} 的条款。
+setup_accept_license: 我接受 {directusMscl} 和 {privacyPolicy} 的条款
 setup_marketing_emails: 向我发送产品更新和发行说明
 setup_launch: 启动 Directus
 setup_project: 设置项目
@@ -2617,9 +2617,9 @@ search_flow: 搜索流程...
 percent: 百分比
 show_password: 显示密码
 hide_password: 隐藏密码
-bsl_banner:
+license_banner:
   title: 您没有设置项目的所有者。
-  license: 我们需要此信息以确保符合我们的 BSL 1.1 许可证。这应该是负责您项目的主要联系人。
+  license: 我们需要此信息以确保符合我们的 MSCL 1.0 许可证。这应该是负责您项目的主要联系人。
   set_owner: 设置所有者
   remind_later: 稍后提醒
   remind_next_login: 我们会在您下次登录时再次提醒。

--- a/directus/license
+++ b/directus/license
@@ -1,18 +1,12 @@
-Licensor:             Monospace, Inc.
+# Monospace Sustainable Core License, Version 1.0
 
-Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2026 Monospace, Inc.
+## Abbreviation
 
-Change Date:          Four years from release date
+MSCL-1.0-GPL
 
-Change License:       GNU General Public License (GPL) v3
+## Notice
 
-For information about alternative licensing arrangements, please visit
-https://directus.com/pricing.
-
---------------------------------------------------------------------------------
-
-# Monospace Sustainable Core License 1.0
+Copyright 2026 Monospace Inc.
 
 ## Terms and Conditions
 

--- a/directus/license
+++ b/directus/license
@@ -1,26 +1,9 @@
 Licensor:             Monospace, Inc.
 
 Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2025 Monospace, Inc.
+                      The Licensed Work is Copyright © 2026 Monospace, Inc.
 
-Additional Use Grant: You may use the Licensed Work in production as long as
-                      your Total Finances do not exceed US $5,000,000 for the
-                      most recent 12-month period, provided that Monospace, Inc.
-                      will not be liable to you in any way, including for any
-                      damages, including general, special, incidental or
-                      consequential damages, arising out of such use.
-
-                      References to: “Total Finances” mean the largest of your
-                      aggregate gross revenues, entire budget, and/or funding
-                      (no matter the source); “you” and “your” include (without
-                      limitation) any individual or entity agreeing to these
-                      terms and any affiliates of such individual or entity; and
-                      “production” mean any use other than (i) development of
-                      (including evaluation of the Licensed Work), debugging, or
-                      testing your offerings, or (ii) making the Licensed Work
-                      available standalone in unmodified object code form.
-
-Change Date:          Three years from release date
+Change Date:          Four years from release date
 
 Change License:       GNU General Public License (GPL) v3
 
@@ -29,79 +12,112 @@ https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 
-Business Source License 1.1
+# Monospace Sustainable Core License 1.0
 
-Terms
+## Terms and Conditions
 
-The Licensor hereby grants you the right to copy, modify, create derivative
-works, redistribute, and make non-production use of the Licensed Work. The
-Licensor may make an Additional Use Grant, above, permitting limited production
-use.
+### Licensor ("We")
 
-Effective on the Change Date, or the fourth anniversary of the first publicly
-available distribution of a specific version of the Licensed Work under this
-License, whichever comes first, the Licensor hereby grants you rights under the
-terms of the Change License, and the rights granted in the paragraph above
-terminate.
+The party offering the Software under these Terms and Conditions.
 
-If your use of the Licensed Work does not comply with the requirements currently
-in effect as described in this License, you must purchase a commercial license
-from the Licensor, its affiliated entities, or authorized resellers, or you must
-refrain from using the Licensed Work.
+### The Software
 
-All copies of the original and modified Licensed Work, and derivative works of
-the Licensed Work, are subject to this License. This License applies separately
-for each version of the Licensed Work and the Change Date may vary for each
-version of the Licensed Work released by Licensor.
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
 
-You must conspicuously display this License on each original or modified copy of
-the Licensed Work. If you receive the Licensed Work in original or modified form
-from a third party, the terms and conditions set forth in this License apply to
-your use of that work.
+### License Grant
 
-Any use of the Licensed Work in violation of this License will automatically
-terminate your rights under this License for the current and all other versions
-of the Licensed Work.
+Subject to your compliance with this License Grant and the Limitations, Patents,
+Redistribution, Disclaimer and Trademark clauses below, we hereby grant you the
+right to use, copy, modify, create derivative works, publicly perform, publicly
+display and redistribute the Software for any Permitted Purpose identified
+below.
 
-This License does not grant you any right in any trademark or logo of Licensor
-or its affiliates (provided that you may use a trademark or logo of Licensor as
-expressly required by this License).
+### Permitted Purpose
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
-“AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
-OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+A Permitted Purpose is any purpose other than a Competing Use.
 
-MariaDB hereby grants you permission to use this License’s text to license your
-works, and to refer to it using the trademark “Business Source License”, as long
-as you comply with the Covenants of Licensor below.
+A Competing Use means making the Software available to any party (on a stand
+alone basis or together with your products or services) that competes with the
+Licensor's commercial offerings of the Software itself, where Licensor imposes a
+license fee, royalty, or other charge for exercise of any rights to the
+Software.
 
-Covenants of Licensor
+Permitted Purposes specifically include using the Software, subject to the
+Limitations below:
 
-In consideration of the right to use this License’s text and the “Business
-Source License” name and trademark, Licensor covenants to MariaDB, and to all
-other recipients of the licensed work to be provided by Licensor:
+1. for your internal use and access;
+2. for non-commercial education;
+3. for non-commercial research; and
+4. in connection with professional services that you provide to a licensee using
+   the Software in accordance with these Terms and Conditions, including
+   professional services to deploy the Software or host the Software for the
+   licensee.
 
-1. To specify as the Change License the GPL Version 2.0 or any later version,
-   or a license that is compatible with GPL Version 2.0 or a later version,
-   where “compatible” means that software provided under the Change License can
-   be included in a program with software provided under GPL Version 2.0 or a
-   later version. Licensor may specify additional Change Licenses without
-   limitation.
+### Limitations
 
-2. To either: (a) specify an additional grant of rights to use that does not
-   impose any additional restriction on the right granted in this License, as
-   the Additional Use Grant; or (b) insert the text “None”.
+You must not move, change, disable or circumvent the license key functionality
+of the Software or modify any portion of the Software protected by the license
+key to:
 
-3. To specify a Change Date.
+- enable access to the protected functionality without a valid license key or
+- remove the protected functionality.
 
-4. Not to modify this License in any other way.
+### Patents
 
-Notice
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to the
+infringement of any patent, then your patent license to the Software ends
+immediately.
 
-The Business Source License (this document, or the "License") is not an Open
-Source license. However, the Licensed Work will eventually be made available
-under an Open Source License, as stated in this License.
+### Redistribution
 
-License text copyright © 2023 MariaDB plc, All Rights Reserved.
-“Business Source License” is a trademark of MariaDB plc.
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+then (A) you must include a copy of or a link to these Terms and Conditions and
+not remove any copyright notices provided in or with the Software and (B) you
+may not impose any further restrictions on the exercise of the rights granted or
+affirmed under this License. For example, you may not impose a license fee,
+royalty, or other charge for exercise of rights granted under this License.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN
+IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the GNU General Public License version 3 (GPL-3.0), effective on the fourth
+anniversary of the date we make the Software available.
+
+On or after that date, you may use the Software under GPL-3.0, in which case the
+following will apply:
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+The full text of the GPL-3.0 license is available at:
+https://www.gnu.org/licenses/gpl-3.0.html

--- a/directus/package.json
+++ b/directus/package.json
@@ -27,7 +27,7 @@
 		"url": "https://github.com/directus/directus.git"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "BUSL-1.1",
+	"license": "MSCL-1.0-GPL",
 	"author": {
 		"name": "Monospace Inc",
 		"email": "info@monospace.io",

--- a/directus/package.json
+++ b/directus/package.json
@@ -27,7 +27,7 @@
 		"url": "https://github.com/directus/directus.git"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "MSCL-1.0-GPL",
+	"license": "SEE LICENSE IN license",
 	"author": {
 		"name": "Monospace Inc",
 		"email": "info@monospace.io",

--- a/directus/readme.md
+++ b/directus/readme.md
@@ -69,7 +69,9 @@ Directus is made possible with support from our passionate core team, talented c
 
 ## 📄 Understanding Our License
 
-Directus is licensed under the [Monospace Sustainable Core License (MSCL) 1.0](./license), a source-available license derived from the [Fair Core License](https://fcl.dev/).
+Directus is licensed under the [Monospace Sustainable Core License (MSCL) 1.0](./license), a source-available license derived from the [Fair Core License](https://fcl.dev/). 
+
+Read about our [evolving our license](https://directus.io/blog/directus-v12-license-change) from BSL to MSCL for long-term sustainability.
 
 ### Free for Most Builders
 

--- a/directus/readme.md
+++ b/directus/readme.md
@@ -1,14 +1,5 @@
 <p align="center"><img alt="Directus Logo" src="https://user-images.githubusercontent.com/522079/158864859-0fbeae62-9d7a-4619-b35e-f8fa5f68e0c8.png"></p>
 
----
-
-> [!NOTE]\
-> We’re planning an update to the Directus source code license and would love your feedback.\
-> Take a look at our community post and share your thoughts!\
-> [🔗 Directus License Revision: Community Feedback Requested](https://community.directus.io/t/directus-license-revision-community-feedback-requested/2125)
-
----
-
 ## 🐰 Introduction
 
 Directus is a real-time API and App dashboard for managing SQL database content.

--- a/directus/readme.md
+++ b/directus/readme.md
@@ -78,8 +78,8 @@ Directus is made possible with support from our passionate core team, talented c
 
 ## 📄 Understanding Our License
 
-Directus is licensed under [the Business Source License (BSL) 1.1](./license) with a permissive additional use grant.
-For most users, it operates just like open source! Here's what that means for you:
+Directus is licensed under [the Monospace Sustainable Core License (MSCL) 1.0](./license) with a permissive additional
+use grant. For most users, it operates just like open source! Here's what that means for you:
 
 ### Free for Most Users
 

--- a/directus/readme.md
+++ b/directus/readme.md
@@ -69,17 +69,15 @@ Directus is made possible with support from our passionate core team, talented c
 
 ## 📄 Understanding Our License
 
-Directus is licensed under [the Monospace Sustainable Core License (MSCL) 1.0](./license) with a permissive additional
-use grant. For most users, it operates just like open source! Here's what that means for you:
+Directus is licensed under the [Monospace Sustainable Core License (MSCL) 1.0](./license), a source-available license derived from the [Fair Core License](https://fcl.dev/).
 
-### Free for Most Users
+### Free for Most Builders
 
-If your organization has less than $5M in annual revenue and/or funding combined, you can use Directus freely in any way
-you'd like. Build that side project, launch your startup, or experiment with the platform — no strings attached.
+Organizations under **$5M in annual revenue and 50 employees** can use the Directus platform for free under the [Open Innovation Grant](https://directus.com/oig)— no strings attached.
 
-### Enterprise Usage
+### Commercial License
 
-For larger organizations (>$5M in annual revenue/funding) using Directus in production, we require a commercial license.
+Larger organizations using advanced or enterprise features require a commercial license. See [our pricing](https://directus.io/pricing/self-hosted) for details.
 This model helps us maintain a sustainable balance: keeping Directus free for the majority of our community while
 ensuring larger organizations who benefit from the platform contribute to its continued development.
 

--- a/directus/readme.md
+++ b/directus/readme.md
@@ -81,7 +81,7 @@ Even above those thresholds, a free Core tier is available to explore and build 
 
 ### Commercial License
 
-Larger organizations using advanced or enterprise features require a commercial license. See [our pricing](https://directus.io/pricing/self-hosted) for details.
+Larger organizations using advanced or enterprise features require a commercial license. See [our pricing](https://directus.io/pricing) for details.
 This model helps us maintain a sustainable balance: keeping Directus free for the majority of our community while
 ensuring larger organizations who benefit from the platform contribute to its continued development.
 

--- a/directus/readme.md
+++ b/directus/readme.md
@@ -75,6 +75,10 @@ Directus is licensed under the [Monospace Sustainable Core License (MSCL) 1.0](.
 
 Organizations under **$5M in annual revenue and 50 employees** can use the Directus platform for free under the [Open Innovation Grant](https://directus.com/oig)— no strings attached.
 
+### Free Core Tier
+
+Even above those thresholds, a free Core tier is available to explore and build on Directus without a commercial license.
+
 ### Commercial License
 
 Larger organizations using advanced or enterprise features require a commercial license. See [our pricing](https://directus.io/pricing/self-hosted) for details.

--- a/license
+++ b/license
@@ -3,24 +3,7 @@ Licensor:             Monospace, Inc.
 Licensed Work:        Directus
                       The Licensed Work is Copyright © 2026 Monospace, Inc.
 
-Additional Use Grant: You may use the Licensed Work in production as long as
-                      your Total Finances do not exceed US $5,000,000 for the
-                      most recent 12-month period, provided that Monospace, Inc.
-                      will not be liable to you in any way, including for any
-                      damages, including general, special, incidental or
-                      consequential damages, arising out of such use.
-
-                      References to: “Total Finances” mean the largest of your
-                      aggregate gross revenues, entire budget, and/or funding
-                      (no matter the source); “you” and “your” include (without
-                      limitation) any individual or entity agreeing to these
-                      terms and any affiliates of such individual or entity; and
-                      “production” mean any use other than (i) development of
-                      (including evaluation of the Licensed Work), debugging, or
-                      testing your offerings, or (ii) making the Licensed Work
-                      available standalone in unmodified object code form.
-
-Change Date:          Three years from release date
+Change Date:          Four years from release date
 
 Change License:       GNU General Public License (GPL) v3
 
@@ -29,79 +12,112 @@ https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 
-Business Source License 1.1
+# Monospace Sustainable Core License 1.0
 
-Terms
+## Terms and Conditions
 
-The Licensor hereby grants you the right to copy, modify, create derivative
-works, redistribute, and make non-production use of the Licensed Work. The
-Licensor may make an Additional Use Grant, above, permitting limited production
-use.
+### Licensor ("We")
 
-Effective on the Change Date, or the fourth anniversary of the first publicly
-available distribution of a specific version of the Licensed Work under this
-License, whichever comes first, the Licensor hereby grants you rights under the
-terms of the Change License, and the rights granted in the paragraph above
-terminate.
+The party offering the Software under these Terms and Conditions.
 
-If your use of the Licensed Work does not comply with the requirements currently
-in effect as described in this License, you must purchase a commercial license
-from the Licensor, its affiliated entities, or authorized resellers, or you must
-refrain from using the Licensed Work.
+### The Software
 
-All copies of the original and modified Licensed Work, and derivative works of
-the Licensed Work, are subject to this License. This License applies separately
-for each version of the Licensed Work and the Change Date may vary for each
-version of the Licensed Work released by Licensor.
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
 
-You must conspicuously display this License on each original or modified copy of
-the Licensed Work. If you receive the Licensed Work in original or modified form
-from a third party, the terms and conditions set forth in this License apply to
-your use of that work.
+### License Grant
 
-Any use of the Licensed Work in violation of this License will automatically
-terminate your rights under this License for the current and all other versions
-of the Licensed Work.
+Subject to your compliance with this License Grant and the Limitations, Patents,
+Redistribution, Disclaimer and Trademark clauses below, we hereby grant you the
+right to use, copy, modify, create derivative works, publicly perform, publicly
+display and redistribute the Software for any Permitted Purpose identified
+below.
 
-This License does not grant you any right in any trademark or logo of Licensor
-or its affiliates (provided that you may use a trademark or logo of Licensor as
-expressly required by this License).
+### Permitted Purpose
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
-“AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
-OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+A Permitted Purpose is any purpose other than a Competing Use.
 
-MariaDB hereby grants you permission to use this License’s text to license your
-works, and to refer to it using the trademark “Business Source License”, as long
-as you comply with the Covenants of Licensor below.
+A Competing Use means making the Software available to any party (on a stand
+alone basis or together with your products or services) that competes with the
+Licensor's commercial offerings of the Software itself, where Licensor imposes a
+license fee, royalty, or other charge for exercise of any rights to the
+Software.
 
-Covenants of Licensor
+Permitted Purposes specifically include using the Software, subject to the
+Limitations below:
 
-In consideration of the right to use this License’s text and the “Business
-Source License” name and trademark, Licensor covenants to MariaDB, and to all
-other recipients of the licensed work to be provided by Licensor:
+1. for your internal use and access;
+2. for non-commercial education;
+3. for non-commercial research; and
+4. in connection with professional services that you provide to a licensee using
+   the Software in accordance with these Terms and Conditions, including
+   professional services to deploy the Software or host the Software for the
+   licensee.
 
-1. To specify as the Change License the GPL Version 2.0 or any later version,
-   or a license that is compatible with GPL Version 2.0 or a later version,
-   where “compatible” means that software provided under the Change License can
-   be included in a program with software provided under GPL Version 2.0 or a
-   later version. Licensor may specify additional Change Licenses without
-   limitation.
+### Limitations
 
-2. To either: (a) specify an additional grant of rights to use that does not
-   impose any additional restriction on the right granted in this License, as
-   the Additional Use Grant; or (b) insert the text “None”.
+You must not move, change, disable or circumvent the license key functionality
+of the Software or modify any portion of the Software protected by the license
+key to:
 
-3. To specify a Change Date.
+- enable access to the protected functionality without a valid license key or
+- remove the protected functionality.
 
-4. Not to modify this License in any other way.
+### Patents
 
-Notice
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to the
+infringement of any patent, then your patent license to the Software ends
+immediately.
 
-The Business Source License (this document, or the "License") is not an Open
-Source license. However, the Licensed Work will eventually be made available
-under an Open Source License, as stated in this License.
+### Redistribution
 
-License text copyright © 2023 MariaDB plc, All Rights Reserved.
-“Business Source License” is a trademark of MariaDB plc.
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+then (A) you must include a copy of or a link to these Terms and Conditions and
+not remove any copyright notices provided in or with the Software and (B) you
+may not impose any further restrictions on the exercise of the rights granted or
+affirmed under this License. For example, you may not impose a license fee,
+royalty, or other charge for exercise of rights granted under this License.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN
+IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the GNU General Public License version 3 (GPL-3.0), effective on the fourth
+anniversary of the date we make the Software available.
+
+On or after that date, you may use the Software under GPL-3.0, in which case the
+following will apply:
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+The full text of the GPL-3.0 license is available at:
+https://www.gnu.org/licenses/gpl-3.0.html

--- a/license
+++ b/license
@@ -1,18 +1,12 @@
-Licensor:             Monospace, Inc.
+# Monospace Sustainable Core License, Version 1.0
 
-Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2026 Monospace, Inc.
+## Abbreviation
 
-Change Date:          Four years from release date
+MSCL-1.0-GPL
 
-Change License:       GNU General Public License (GPL) v3
+## Notice
 
-For information about alternative licensing arrangements, please visit
-https://directus.com/pricing.
-
---------------------------------------------------------------------------------
-
-# Monospace Sustainable Core License 1.0
+Copyright 2026 Monospace Inc.
 
 ## Terms and Conditions
 

--- a/packages/ai/license
+++ b/packages/ai/license
@@ -1,0 +1,16 @@
+MIT License
+
+Copyright 2025 Monospace, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/ai/license
+++ b/packages/ai/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/composables/license
+++ b/packages/composables/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/constants/license
+++ b/packages/constants/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/create-directus-extension/license
+++ b/packages/create-directus-extension/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/create-directus-project/license
+++ b/packages/create-directus-project/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/env/license
+++ b/packages/env/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/errors/license
+++ b/packages/errors/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/extensions-registry/license
+++ b/packages/extensions-registry/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/extensions-sdk/license
+++ b/packages/extensions-sdk/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/extensions/license
+++ b/packages/extensions/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/format-title/license
+++ b/packages/format-title/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/memory/license
+++ b/packages/memory/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/pressure/license
+++ b/packages/pressure/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/release-notes-generator/license
+++ b/packages/release-notes-generator/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/schema-builder/license
+++ b/packages/schema-builder/license
@@ -1,18 +1,12 @@
-Licensor:             Monospace, Inc.
+# Monospace Sustainable Core License, Version 1.0
 
-Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2026 Monospace, Inc.
+## Abbreviation
 
-Change Date:          Four years from release date
+MSCL-1.0-GPL
 
-Change License:       GNU General Public License (GPL) v3
+## Notice
 
-For information about alternative licensing arrangements, please visit
-https://directus.com/pricing.
-
---------------------------------------------------------------------------------
-
-# Monospace Sustainable Core License 1.0
+Copyright 2026 Monospace Inc.
 
 ## Terms and Conditions
 

--- a/packages/schema-builder/license
+++ b/packages/schema-builder/license
@@ -1,26 +1,9 @@
 Licensor:             Monospace, Inc.
 
 Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2025 Monospace, Inc.
+                      The Licensed Work is Copyright © 2026 Monospace, Inc.
 
-Additional Use Grant: You may use the Licensed Work in production as long as
-                      your Total Finances do not exceed US $5,000,000 for the
-                      most recent 12-month period, provided that Monospace, Inc.
-                      will not be liable to you in any way, including for any
-                      damages, including general, special, incidental or
-                      consequential damages, arising out of such use.
-
-                      References to: “Total Finances” mean the largest of your
-                      aggregate gross revenues, entire budget, and/or funding
-                      (no matter the source); “you” and “your” include (without
-                      limitation) any individual or entity agreeing to these
-                      terms and any affiliates of such individual or entity; and
-                      “production” mean any use other than (i) development of
-                      (including evaluation of the Licensed Work), debugging, or
-                      testing your offerings, or (ii) making the Licensed Work
-                      available standalone in unmodified object code form.
-
-Change Date:          Three years from release date
+Change Date:          Four years from release date
 
 Change License:       GNU General Public License (GPL) v3
 
@@ -29,79 +12,112 @@ https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 
-Business Source License 1.1
+# Monospace Sustainable Core License 1.0
 
-Terms
+## Terms and Conditions
 
-The Licensor hereby grants you the right to copy, modify, create derivative
-works, redistribute, and make non-production use of the Licensed Work. The
-Licensor may make an Additional Use Grant, above, permitting limited production
-use.
+### Licensor ("We")
 
-Effective on the Change Date, or the fourth anniversary of the first publicly
-available distribution of a specific version of the Licensed Work under this
-License, whichever comes first, the Licensor hereby grants you rights under the
-terms of the Change License, and the rights granted in the paragraph above
-terminate.
+The party offering the Software under these Terms and Conditions.
 
-If your use of the Licensed Work does not comply with the requirements currently
-in effect as described in this License, you must purchase a commercial license
-from the Licensor, its affiliated entities, or authorized resellers, or you must
-refrain from using the Licensed Work.
+### The Software
 
-All copies of the original and modified Licensed Work, and derivative works of
-the Licensed Work, are subject to this License. This License applies separately
-for each version of the Licensed Work and the Change Date may vary for each
-version of the Licensed Work released by Licensor.
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
 
-You must conspicuously display this License on each original or modified copy of
-the Licensed Work. If you receive the Licensed Work in original or modified form
-from a third party, the terms and conditions set forth in this License apply to
-your use of that work.
+### License Grant
 
-Any use of the Licensed Work in violation of this License will automatically
-terminate your rights under this License for the current and all other versions
-of the Licensed Work.
+Subject to your compliance with this License Grant and the Limitations, Patents,
+Redistribution, Disclaimer and Trademark clauses below, we hereby grant you the
+right to use, copy, modify, create derivative works, publicly perform, publicly
+display and redistribute the Software for any Permitted Purpose identified
+below.
 
-This License does not grant you any right in any trademark or logo of Licensor
-or its affiliates (provided that you may use a trademark or logo of Licensor as
-expressly required by this License).
+### Permitted Purpose
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
-“AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
-OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+A Permitted Purpose is any purpose other than a Competing Use.
 
-MariaDB hereby grants you permission to use this License’s text to license your
-works, and to refer to it using the trademark “Business Source License”, as long
-as you comply with the Covenants of Licensor below.
+A Competing Use means making the Software available to any party (on a stand
+alone basis or together with your products or services) that competes with the
+Licensor's commercial offerings of the Software itself, where Licensor imposes a
+license fee, royalty, or other charge for exercise of any rights to the
+Software.
 
-Covenants of Licensor
+Permitted Purposes specifically include using the Software, subject to the
+Limitations below:
 
-In consideration of the right to use this License’s text and the “Business
-Source License” name and trademark, Licensor covenants to MariaDB, and to all
-other recipients of the licensed work to be provided by Licensor:
+1. for your internal use and access;
+2. for non-commercial education;
+3. for non-commercial research; and
+4. in connection with professional services that you provide to a licensee using
+   the Software in accordance with these Terms and Conditions, including
+   professional services to deploy the Software or host the Software for the
+   licensee.
 
-1. To specify as the Change License the GPL Version 2.0 or any later version,
-   or a license that is compatible with GPL Version 2.0 or a later version,
-   where “compatible” means that software provided under the Change License can
-   be included in a program with software provided under GPL Version 2.0 or a
-   later version. Licensor may specify additional Change Licenses without
-   limitation.
+### Limitations
 
-2. To either: (a) specify an additional grant of rights to use that does not
-   impose any additional restriction on the right granted in this License, as
-   the Additional Use Grant; or (b) insert the text “None”.
+You must not move, change, disable or circumvent the license key functionality
+of the Software or modify any portion of the Software protected by the license
+key to:
 
-3. To specify a Change Date.
+- enable access to the protected functionality without a valid license key or
+- remove the protected functionality.
 
-4. Not to modify this License in any other way.
+### Patents
 
-Notice
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to the
+infringement of any patent, then your patent license to the Software ends
+immediately.
 
-The Business Source License (this document, or the "License") is not an Open
-Source license. However, the Licensed Work will eventually be made available
-under an Open Source License, as stated in this License.
+### Redistribution
 
-License text copyright © 2023 MariaDB plc, All Rights Reserved.
-“Business Source License” is a trademark of MariaDB plc.
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+then (A) you must include a copy of or a link to these Terms and Conditions and
+not remove any copyright notices provided in or with the Software and (B) you
+may not impose any further restrictions on the exercise of the rights granted or
+affirmed under this License. For example, you may not impose a license fee,
+royalty, or other charge for exercise of rights granted under this License.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN
+IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the GNU General Public License version 3 (GPL-3.0), effective on the fourth
+anniversary of the date we make the Software available.
+
+On or after that date, you may use the Software under GPL-3.0, in which case the
+following will apply:
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+The full text of the GPL-3.0 license is available at:
+https://www.gnu.org/licenses/gpl-3.0.html

--- a/packages/schema-builder/package.json
+++ b/packages/schema-builder/package.json
@@ -19,7 +19,7 @@
 		"directory": "packages/schema-builder"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "MSCL-1.0-GPL",
+	"license": "SEE LICENSE IN license",
 	"author": "Nils Twelker <nils@directus.io>",
 	"type": "module",
 	"exports": {

--- a/packages/schema-builder/package.json
+++ b/packages/schema-builder/package.json
@@ -19,7 +19,7 @@
 		"directory": "packages/schema-builder"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "BUSL-1.1",
+	"license": "MSCL-1.0-GPL",
 	"author": "Nils Twelker <nils@directus.io>",
 	"type": "module",
 	"exports": {

--- a/packages/schema/license
+++ b/packages/schema/license
@@ -1,18 +1,12 @@
-Licensor:             Monospace, Inc.
+# Monospace Sustainable Core License, Version 1.0
 
-Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2026 Monospace, Inc.
+## Abbreviation
 
-Change Date:          Four years from release date
+MSCL-1.0-GPL
 
-Change License:       GNU General Public License (GPL) v3
+## Notice
 
-For information about alternative licensing arrangements, please visit
-https://directus.com/pricing.
-
---------------------------------------------------------------------------------
-
-# Monospace Sustainable Core License 1.0
+Copyright 2026 Monospace Inc.
 
 ## Terms and Conditions
 

--- a/packages/schema/license
+++ b/packages/schema/license
@@ -1,26 +1,9 @@
 Licensor:             Monospace, Inc.
 
 Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2025 Monospace, Inc.
+                      The Licensed Work is Copyright © 2026 Monospace, Inc.
 
-Additional Use Grant: You may use the Licensed Work in production as long as
-                      your Total Finances do not exceed US $5,000,000 for the
-                      most recent 12-month period, provided that Monospace, Inc.
-                      will not be liable to you in any way, including for any
-                      damages, including general, special, incidental or
-                      consequential damages, arising out of such use.
-
-                      References to: “Total Finances” mean the largest of your
-                      aggregate gross revenues, entire budget, and/or funding
-                      (no matter the source); “you” and “your” include (without
-                      limitation) any individual or entity agreeing to these
-                      terms and any affiliates of such individual or entity; and
-                      “production” mean any use other than (i) development of
-                      (including evaluation of the Licensed Work), debugging, or
-                      testing your offerings, or (ii) making the Licensed Work
-                      available standalone in unmodified object code form.
-
-Change Date:          Three years from release date
+Change Date:          Four years from release date
 
 Change License:       GNU General Public License (GPL) v3
 
@@ -29,79 +12,112 @@ https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 
-Business Source License 1.1
+# Monospace Sustainable Core License 1.0
 
-Terms
+## Terms and Conditions
 
-The Licensor hereby grants you the right to copy, modify, create derivative
-works, redistribute, and make non-production use of the Licensed Work. The
-Licensor may make an Additional Use Grant, above, permitting limited production
-use.
+### Licensor ("We")
 
-Effective on the Change Date, or the fourth anniversary of the first publicly
-available distribution of a specific version of the Licensed Work under this
-License, whichever comes first, the Licensor hereby grants you rights under the
-terms of the Change License, and the rights granted in the paragraph above
-terminate.
+The party offering the Software under these Terms and Conditions.
 
-If your use of the Licensed Work does not comply with the requirements currently
-in effect as described in this License, you must purchase a commercial license
-from the Licensor, its affiliated entities, or authorized resellers, or you must
-refrain from using the Licensed Work.
+### The Software
 
-All copies of the original and modified Licensed Work, and derivative works of
-the Licensed Work, are subject to this License. This License applies separately
-for each version of the Licensed Work and the Change Date may vary for each
-version of the Licensed Work released by Licensor.
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
 
-You must conspicuously display this License on each original or modified copy of
-the Licensed Work. If you receive the Licensed Work in original or modified form
-from a third party, the terms and conditions set forth in this License apply to
-your use of that work.
+### License Grant
 
-Any use of the Licensed Work in violation of this License will automatically
-terminate your rights under this License for the current and all other versions
-of the Licensed Work.
+Subject to your compliance with this License Grant and the Limitations, Patents,
+Redistribution, Disclaimer and Trademark clauses below, we hereby grant you the
+right to use, copy, modify, create derivative works, publicly perform, publicly
+display and redistribute the Software for any Permitted Purpose identified
+below.
 
-This License does not grant you any right in any trademark or logo of Licensor
-or its affiliates (provided that you may use a trademark or logo of Licensor as
-expressly required by this License).
+### Permitted Purpose
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
-“AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
-OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+A Permitted Purpose is any purpose other than a Competing Use.
 
-MariaDB hereby grants you permission to use this License’s text to license your
-works, and to refer to it using the trademark “Business Source License”, as long
-as you comply with the Covenants of Licensor below.
+A Competing Use means making the Software available to any party (on a stand
+alone basis or together with your products or services) that competes with the
+Licensor's commercial offerings of the Software itself, where Licensor imposes a
+license fee, royalty, or other charge for exercise of any rights to the
+Software.
 
-Covenants of Licensor
+Permitted Purposes specifically include using the Software, subject to the
+Limitations below:
 
-In consideration of the right to use this License’s text and the “Business
-Source License” name and trademark, Licensor covenants to MariaDB, and to all
-other recipients of the licensed work to be provided by Licensor:
+1. for your internal use and access;
+2. for non-commercial education;
+3. for non-commercial research; and
+4. in connection with professional services that you provide to a licensee using
+   the Software in accordance with these Terms and Conditions, including
+   professional services to deploy the Software or host the Software for the
+   licensee.
 
-1. To specify as the Change License the GPL Version 2.0 or any later version,
-   or a license that is compatible with GPL Version 2.0 or a later version,
-   where “compatible” means that software provided under the Change License can
-   be included in a program with software provided under GPL Version 2.0 or a
-   later version. Licensor may specify additional Change Licenses without
-   limitation.
+### Limitations
 
-2. To either: (a) specify an additional grant of rights to use that does not
-   impose any additional restriction on the right granted in this License, as
-   the Additional Use Grant; or (b) insert the text “None”.
+You must not move, change, disable or circumvent the license key functionality
+of the Software or modify any portion of the Software protected by the license
+key to:
 
-3. To specify a Change Date.
+- enable access to the protected functionality without a valid license key or
+- remove the protected functionality.
 
-4. Not to modify this License in any other way.
+### Patents
 
-Notice
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to the
+infringement of any patent, then your patent license to the Software ends
+immediately.
 
-The Business Source License (this document, or the "License") is not an Open
-Source license. However, the Licensed Work will eventually be made available
-under an Open Source License, as stated in this License.
+### Redistribution
 
-License text copyright © 2023 MariaDB plc, All Rights Reserved.
-“Business Source License” is a trademark of MariaDB plc.
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+then (A) you must include a copy of or a link to these Terms and Conditions and
+not remove any copyright notices provided in or with the Software and (B) you
+may not impose any further restrictions on the exercise of the rights granted or
+affirmed under this License. For example, you may not impose a license fee,
+royalty, or other charge for exercise of rights granted under this License.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN
+IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the GNU General Public License version 3 (GPL-3.0), effective on the fourth
+anniversary of the date we make the Software available.
+
+On or after that date, you may use the Software under GPL-3.0, in which case the
+following will apply:
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+The full text of the GPL-3.0 license is available at:
+https://www.gnu.org/licenses/gpl-3.0.html

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -19,7 +19,7 @@
 		"directory": "packages/schema"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "MSCL-1.0-GPL",
+	"license": "SEE LICENSE IN license",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"type": "module",
 	"exports": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -19,7 +19,7 @@
 		"directory": "packages/schema"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "BUSL-1.1",
+	"license": "MSCL-1.0-GPL",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"type": "module",
 	"exports": {

--- a/packages/specs/license
+++ b/packages/specs/license
@@ -1,18 +1,12 @@
-Licensor:             Monospace, Inc.
+# Monospace Sustainable Core License, Version 1.0
 
-Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2026 Monospace, Inc.
+## Abbreviation
 
-Change Date:          Four years from release date
+MSCL-1.0-GPL
 
-Change License:       GNU General Public License (GPL) v3
+## Notice
 
-For information about alternative licensing arrangements, please visit
-https://directus.com/pricing.
-
---------------------------------------------------------------------------------
-
-# Monospace Sustainable Core License 1.0
+Copyright 2026 Monospace Inc.
 
 ## Terms and Conditions
 

--- a/packages/specs/license
+++ b/packages/specs/license
@@ -1,26 +1,9 @@
 Licensor:             Monospace, Inc.
 
 Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2025 Monospace, Inc.
+                      The Licensed Work is Copyright © 2026 Monospace, Inc.
 
-Additional Use Grant: You may use the Licensed Work in production as long as
-                      your Total Finances do not exceed US $5,000,000 for the
-                      most recent 12-month period, provided that Monospace, Inc.
-                      will not be liable to you in any way, including for any
-                      damages, including general, special, incidental or
-                      consequential damages, arising out of such use.
-
-                      References to: “Total Finances” mean the largest of your
-                      aggregate gross revenues, entire budget, and/or funding
-                      (no matter the source); “you” and “your” include (without
-                      limitation) any individual or entity agreeing to these
-                      terms and any affiliates of such individual or entity; and
-                      “production” mean any use other than (i) development of
-                      (including evaluation of the Licensed Work), debugging, or
-                      testing your offerings, or (ii) making the Licensed Work
-                      available standalone in unmodified object code form.
-
-Change Date:          Three years from release date
+Change Date:          Four years from release date
 
 Change License:       GNU General Public License (GPL) v3
 
@@ -29,79 +12,112 @@ https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 
-Business Source License 1.1
+# Monospace Sustainable Core License 1.0
 
-Terms
+## Terms and Conditions
 
-The Licensor hereby grants you the right to copy, modify, create derivative
-works, redistribute, and make non-production use of the Licensed Work. The
-Licensor may make an Additional Use Grant, above, permitting limited production
-use.
+### Licensor ("We")
 
-Effective on the Change Date, or the fourth anniversary of the first publicly
-available distribution of a specific version of the Licensed Work under this
-License, whichever comes first, the Licensor hereby grants you rights under the
-terms of the Change License, and the rights granted in the paragraph above
-terminate.
+The party offering the Software under these Terms and Conditions.
 
-If your use of the Licensed Work does not comply with the requirements currently
-in effect as described in this License, you must purchase a commercial license
-from the Licensor, its affiliated entities, or authorized resellers, or you must
-refrain from using the Licensed Work.
+### The Software
 
-All copies of the original and modified Licensed Work, and derivative works of
-the Licensed Work, are subject to this License. This License applies separately
-for each version of the Licensed Work and the Change Date may vary for each
-version of the Licensed Work released by Licensor.
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
 
-You must conspicuously display this License on each original or modified copy of
-the Licensed Work. If you receive the Licensed Work in original or modified form
-from a third party, the terms and conditions set forth in this License apply to
-your use of that work.
+### License Grant
 
-Any use of the Licensed Work in violation of this License will automatically
-terminate your rights under this License for the current and all other versions
-of the Licensed Work.
+Subject to your compliance with this License Grant and the Limitations, Patents,
+Redistribution, Disclaimer and Trademark clauses below, we hereby grant you the
+right to use, copy, modify, create derivative works, publicly perform, publicly
+display and redistribute the Software for any Permitted Purpose identified
+below.
 
-This License does not grant you any right in any trademark or logo of Licensor
-or its affiliates (provided that you may use a trademark or logo of Licensor as
-expressly required by this License).
+### Permitted Purpose
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
-“AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
-OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+A Permitted Purpose is any purpose other than a Competing Use.
 
-MariaDB hereby grants you permission to use this License’s text to license your
-works, and to refer to it using the trademark “Business Source License”, as long
-as you comply with the Covenants of Licensor below.
+A Competing Use means making the Software available to any party (on a stand
+alone basis or together with your products or services) that competes with the
+Licensor's commercial offerings of the Software itself, where Licensor imposes a
+license fee, royalty, or other charge for exercise of any rights to the
+Software.
 
-Covenants of Licensor
+Permitted Purposes specifically include using the Software, subject to the
+Limitations below:
 
-In consideration of the right to use this License’s text and the “Business
-Source License” name and trademark, Licensor covenants to MariaDB, and to all
-other recipients of the licensed work to be provided by Licensor:
+1. for your internal use and access;
+2. for non-commercial education;
+3. for non-commercial research; and
+4. in connection with professional services that you provide to a licensee using
+   the Software in accordance with these Terms and Conditions, including
+   professional services to deploy the Software or host the Software for the
+   licensee.
 
-1. To specify as the Change License the GPL Version 2.0 or any later version,
-   or a license that is compatible with GPL Version 2.0 or a later version,
-   where “compatible” means that software provided under the Change License can
-   be included in a program with software provided under GPL Version 2.0 or a
-   later version. Licensor may specify additional Change Licenses without
-   limitation.
+### Limitations
 
-2. To either: (a) specify an additional grant of rights to use that does not
-   impose any additional restriction on the right granted in this License, as
-   the Additional Use Grant; or (b) insert the text “None”.
+You must not move, change, disable or circumvent the license key functionality
+of the Software or modify any portion of the Software protected by the license
+key to:
 
-3. To specify a Change Date.
+- enable access to the protected functionality without a valid license key or
+- remove the protected functionality.
 
-4. Not to modify this License in any other way.
+### Patents
 
-Notice
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to the
+infringement of any patent, then your patent license to the Software ends
+immediately.
 
-The Business Source License (this document, or the "License") is not an Open
-Source license. However, the Licensed Work will eventually be made available
-under an Open Source License, as stated in this License.
+### Redistribution
 
-License text copyright © 2023 MariaDB plc, All Rights Reserved.
-“Business Source License” is a trademark of MariaDB plc.
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+then (A) you must include a copy of or a link to these Terms and Conditions and
+not remove any copyright notices provided in or with the Software and (B) you
+may not impose any further restrictions on the exercise of the rights granted or
+affirmed under this License. For example, you may not impose a license fee,
+royalty, or other charge for exercise of rights granted under this License.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN
+IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the GNU General Public License version 3 (GPL-3.0), effective on the fourth
+anniversary of the date we make the Software available.
+
+On or after that date, you may use the Software under GPL-3.0, in which case the
+following will apply:
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+The full text of the GPL-3.0 license is available at:
+https://www.gnu.org/licenses/gpl-3.0.html

--- a/packages/specs/package.json
+++ b/packages/specs/package.json
@@ -9,7 +9,7 @@
 		"directory": "packages/specs"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "BUSL-1.1",
+	"license": "MSCL-1.0-GPL",
 	"author": "Nils Twelker",
 	"type": "module",
 	"exports": {

--- a/packages/specs/package.json
+++ b/packages/specs/package.json
@@ -9,7 +9,7 @@
 		"directory": "packages/specs"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "MSCL-1.0-GPL",
+	"license": "SEE LICENSE IN license",
 	"author": "Nils Twelker",
 	"type": "module",
 	"exports": {

--- a/packages/specs/src/openapi.yaml
+++ b/packages/specs/src/openapi.yaml
@@ -5,8 +5,8 @@ info:
   contact:
     email: contact@directus.io
   license:
-    name: BUSL-1.1
-    url: 'https://directus.com/bsl'
+    name: MSCL-1.0-GPL
+    url: 'https://directus.com/mscl'
   version: '10'
 externalDocs:
   description: Directus Docs

--- a/packages/storage-driver-azure/license
+++ b/packages/storage-driver-azure/license
@@ -1,18 +1,12 @@
-Licensor:             Monospace, Inc.
+# Monospace Sustainable Core License, Version 1.0
 
-Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2026 Monospace, Inc.
+## Abbreviation
 
-Change Date:          Four years from release date
+MSCL-1.0-GPL
 
-Change License:       GNU General Public License (GPL) v3
+## Notice
 
-For information about alternative licensing arrangements, please visit
-https://directus.com/pricing.
-
---------------------------------------------------------------------------------
-
-# Monospace Sustainable Core License 1.0
+Copyright 2026 Monospace Inc.
 
 ## Terms and Conditions
 

--- a/packages/storage-driver-azure/license
+++ b/packages/storage-driver-azure/license
@@ -1,26 +1,9 @@
 Licensor:             Monospace, Inc.
 
 Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2025 Monospace, Inc.
+                      The Licensed Work is Copyright © 2026 Monospace, Inc.
 
-Additional Use Grant: You may use the Licensed Work in production as long as
-                      your Total Finances do not exceed US $5,000,000 for the
-                      most recent 12-month period, provided that Monospace, Inc.
-                      will not be liable to you in any way, including for any
-                      damages, including general, special, incidental or
-                      consequential damages, arising out of such use.
-
-                      References to: “Total Finances” mean the largest of your
-                      aggregate gross revenues, entire budget, and/or funding
-                      (no matter the source); “you” and “your” include (without
-                      limitation) any individual or entity agreeing to these
-                      terms and any affiliates of such individual or entity; and
-                      “production” mean any use other than (i) development of
-                      (including evaluation of the Licensed Work), debugging, or
-                      testing your offerings, or (ii) making the Licensed Work
-                      available standalone in unmodified object code form.
-
-Change Date:          Three years from release date
+Change Date:          Four years from release date
 
 Change License:       GNU General Public License (GPL) v3
 
@@ -29,79 +12,112 @@ https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 
-Business Source License 1.1
+# Monospace Sustainable Core License 1.0
 
-Terms
+## Terms and Conditions
 
-The Licensor hereby grants you the right to copy, modify, create derivative
-works, redistribute, and make non-production use of the Licensed Work. The
-Licensor may make an Additional Use Grant, above, permitting limited production
-use.
+### Licensor ("We")
 
-Effective on the Change Date, or the fourth anniversary of the first publicly
-available distribution of a specific version of the Licensed Work under this
-License, whichever comes first, the Licensor hereby grants you rights under the
-terms of the Change License, and the rights granted in the paragraph above
-terminate.
+The party offering the Software under these Terms and Conditions.
 
-If your use of the Licensed Work does not comply with the requirements currently
-in effect as described in this License, you must purchase a commercial license
-from the Licensor, its affiliated entities, or authorized resellers, or you must
-refrain from using the Licensed Work.
+### The Software
 
-All copies of the original and modified Licensed Work, and derivative works of
-the Licensed Work, are subject to this License. This License applies separately
-for each version of the Licensed Work and the Change Date may vary for each
-version of the Licensed Work released by Licensor.
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
 
-You must conspicuously display this License on each original or modified copy of
-the Licensed Work. If you receive the Licensed Work in original or modified form
-from a third party, the terms and conditions set forth in this License apply to
-your use of that work.
+### License Grant
 
-Any use of the Licensed Work in violation of this License will automatically
-terminate your rights under this License for the current and all other versions
-of the Licensed Work.
+Subject to your compliance with this License Grant and the Limitations, Patents,
+Redistribution, Disclaimer and Trademark clauses below, we hereby grant you the
+right to use, copy, modify, create derivative works, publicly perform, publicly
+display and redistribute the Software for any Permitted Purpose identified
+below.
 
-This License does not grant you any right in any trademark or logo of Licensor
-or its affiliates (provided that you may use a trademark or logo of Licensor as
-expressly required by this License).
+### Permitted Purpose
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
-“AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
-OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+A Permitted Purpose is any purpose other than a Competing Use.
 
-MariaDB hereby grants you permission to use this License’s text to license your
-works, and to refer to it using the trademark “Business Source License”, as long
-as you comply with the Covenants of Licensor below.
+A Competing Use means making the Software available to any party (on a stand
+alone basis or together with your products or services) that competes with the
+Licensor's commercial offerings of the Software itself, where Licensor imposes a
+license fee, royalty, or other charge for exercise of any rights to the
+Software.
 
-Covenants of Licensor
+Permitted Purposes specifically include using the Software, subject to the
+Limitations below:
 
-In consideration of the right to use this License’s text and the “Business
-Source License” name and trademark, Licensor covenants to MariaDB, and to all
-other recipients of the licensed work to be provided by Licensor:
+1. for your internal use and access;
+2. for non-commercial education;
+3. for non-commercial research; and
+4. in connection with professional services that you provide to a licensee using
+   the Software in accordance with these Terms and Conditions, including
+   professional services to deploy the Software or host the Software for the
+   licensee.
 
-1. To specify as the Change License the GPL Version 2.0 or any later version,
-   or a license that is compatible with GPL Version 2.0 or a later version,
-   where “compatible” means that software provided under the Change License can
-   be included in a program with software provided under GPL Version 2.0 or a
-   later version. Licensor may specify additional Change Licenses without
-   limitation.
+### Limitations
 
-2. To either: (a) specify an additional grant of rights to use that does not
-   impose any additional restriction on the right granted in this License, as
-   the Additional Use Grant; or (b) insert the text “None”.
+You must not move, change, disable or circumvent the license key functionality
+of the Software or modify any portion of the Software protected by the license
+key to:
 
-3. To specify a Change Date.
+- enable access to the protected functionality without a valid license key or
+- remove the protected functionality.
 
-4. Not to modify this License in any other way.
+### Patents
 
-Notice
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to the
+infringement of any patent, then your patent license to the Software ends
+immediately.
 
-The Business Source License (this document, or the "License") is not an Open
-Source license. However, the Licensed Work will eventually be made available
-under an Open Source License, as stated in this License.
+### Redistribution
 
-License text copyright © 2023 MariaDB plc, All Rights Reserved.
-“Business Source License” is a trademark of MariaDB plc.
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+then (A) you must include a copy of or a link to these Terms and Conditions and
+not remove any copyright notices provided in or with the Software and (B) you
+may not impose any further restrictions on the exercise of the rights granted or
+affirmed under this License. For example, you may not impose a license fee,
+royalty, or other charge for exercise of rights granted under this License.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN
+IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the GNU General Public License version 3 (GPL-3.0), effective on the fourth
+anniversary of the date we make the Software available.
+
+On or after that date, you may use the Software under GPL-3.0, in which case the
+following will apply:
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+The full text of the GPL-3.0 license is available at:
+https://www.gnu.org/licenses/gpl-3.0.html

--- a/packages/storage-driver-azure/package.json
+++ b/packages/storage-driver-azure/package.json
@@ -9,7 +9,7 @@
 		"directory": "packages/storage-driver-azure"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "MSCL-1.0-GPL",
+	"license": "SEE LICENSE IN license",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"type": "module",
 	"exports": {

--- a/packages/storage-driver-azure/package.json
+++ b/packages/storage-driver-azure/package.json
@@ -9,7 +9,7 @@
 		"directory": "packages/storage-driver-azure"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "BUSL-1.1",
+	"license": "MSCL-1.0-GPL",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"type": "module",
 	"exports": {

--- a/packages/storage-driver-cloudinary/license
+++ b/packages/storage-driver-cloudinary/license
@@ -1,18 +1,12 @@
-Licensor:             Monospace, Inc.
+# Monospace Sustainable Core License, Version 1.0
 
-Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2026 Monospace, Inc.
+## Abbreviation
 
-Change Date:          Four years from release date
+MSCL-1.0-GPL
 
-Change License:       GNU General Public License (GPL) v3
+## Notice
 
-For information about alternative licensing arrangements, please visit
-https://directus.com/pricing.
-
---------------------------------------------------------------------------------
-
-# Monospace Sustainable Core License 1.0
+Copyright 2026 Monospace Inc.
 
 ## Terms and Conditions
 

--- a/packages/storage-driver-cloudinary/license
+++ b/packages/storage-driver-cloudinary/license
@@ -1,26 +1,9 @@
 Licensor:             Monospace, Inc.
 
 Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2025 Monospace, Inc.
+                      The Licensed Work is Copyright © 2026 Monospace, Inc.
 
-Additional Use Grant: You may use the Licensed Work in production as long as
-                      your Total Finances do not exceed US $5,000,000 for the
-                      most recent 12-month period, provided that Monospace, Inc.
-                      will not be liable to you in any way, including for any
-                      damages, including general, special, incidental or
-                      consequential damages, arising out of such use.
-
-                      References to: “Total Finances” mean the largest of your
-                      aggregate gross revenues, entire budget, and/or funding
-                      (no matter the source); “you” and “your” include (without
-                      limitation) any individual or entity agreeing to these
-                      terms and any affiliates of such individual or entity; and
-                      “production” mean any use other than (i) development of
-                      (including evaluation of the Licensed Work), debugging, or
-                      testing your offerings, or (ii) making the Licensed Work
-                      available standalone in unmodified object code form.
-
-Change Date:          Three years from release date
+Change Date:          Four years from release date
 
 Change License:       GNU General Public License (GPL) v3
 
@@ -29,79 +12,112 @@ https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 
-Business Source License 1.1
+# Monospace Sustainable Core License 1.0
 
-Terms
+## Terms and Conditions
 
-The Licensor hereby grants you the right to copy, modify, create derivative
-works, redistribute, and make non-production use of the Licensed Work. The
-Licensor may make an Additional Use Grant, above, permitting limited production
-use.
+### Licensor ("We")
 
-Effective on the Change Date, or the fourth anniversary of the first publicly
-available distribution of a specific version of the Licensed Work under this
-License, whichever comes first, the Licensor hereby grants you rights under the
-terms of the Change License, and the rights granted in the paragraph above
-terminate.
+The party offering the Software under these Terms and Conditions.
 
-If your use of the Licensed Work does not comply with the requirements currently
-in effect as described in this License, you must purchase a commercial license
-from the Licensor, its affiliated entities, or authorized resellers, or you must
-refrain from using the Licensed Work.
+### The Software
 
-All copies of the original and modified Licensed Work, and derivative works of
-the Licensed Work, are subject to this License. This License applies separately
-for each version of the Licensed Work and the Change Date may vary for each
-version of the Licensed Work released by Licensor.
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
 
-You must conspicuously display this License on each original or modified copy of
-the Licensed Work. If you receive the Licensed Work in original or modified form
-from a third party, the terms and conditions set forth in this License apply to
-your use of that work.
+### License Grant
 
-Any use of the Licensed Work in violation of this License will automatically
-terminate your rights under this License for the current and all other versions
-of the Licensed Work.
+Subject to your compliance with this License Grant and the Limitations, Patents,
+Redistribution, Disclaimer and Trademark clauses below, we hereby grant you the
+right to use, copy, modify, create derivative works, publicly perform, publicly
+display and redistribute the Software for any Permitted Purpose identified
+below.
 
-This License does not grant you any right in any trademark or logo of Licensor
-or its affiliates (provided that you may use a trademark or logo of Licensor as
-expressly required by this License).
+### Permitted Purpose
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
-“AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
-OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+A Permitted Purpose is any purpose other than a Competing Use.
 
-MariaDB hereby grants you permission to use this License’s text to license your
-works, and to refer to it using the trademark “Business Source License”, as long
-as you comply with the Covenants of Licensor below.
+A Competing Use means making the Software available to any party (on a stand
+alone basis or together with your products or services) that competes with the
+Licensor's commercial offerings of the Software itself, where Licensor imposes a
+license fee, royalty, or other charge for exercise of any rights to the
+Software.
 
-Covenants of Licensor
+Permitted Purposes specifically include using the Software, subject to the
+Limitations below:
 
-In consideration of the right to use this License’s text and the “Business
-Source License” name and trademark, Licensor covenants to MariaDB, and to all
-other recipients of the licensed work to be provided by Licensor:
+1. for your internal use and access;
+2. for non-commercial education;
+3. for non-commercial research; and
+4. in connection with professional services that you provide to a licensee using
+   the Software in accordance with these Terms and Conditions, including
+   professional services to deploy the Software or host the Software for the
+   licensee.
 
-1. To specify as the Change License the GPL Version 2.0 or any later version,
-   or a license that is compatible with GPL Version 2.0 or a later version,
-   where “compatible” means that software provided under the Change License can
-   be included in a program with software provided under GPL Version 2.0 or a
-   later version. Licensor may specify additional Change Licenses without
-   limitation.
+### Limitations
 
-2. To either: (a) specify an additional grant of rights to use that does not
-   impose any additional restriction on the right granted in this License, as
-   the Additional Use Grant; or (b) insert the text “None”.
+You must not move, change, disable or circumvent the license key functionality
+of the Software or modify any portion of the Software protected by the license
+key to:
 
-3. To specify a Change Date.
+- enable access to the protected functionality without a valid license key or
+- remove the protected functionality.
 
-4. Not to modify this License in any other way.
+### Patents
 
-Notice
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to the
+infringement of any patent, then your patent license to the Software ends
+immediately.
 
-The Business Source License (this document, or the "License") is not an Open
-Source license. However, the Licensed Work will eventually be made available
-under an Open Source License, as stated in this License.
+### Redistribution
 
-License text copyright © 2023 MariaDB plc, All Rights Reserved.
-“Business Source License” is a trademark of MariaDB plc.
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+then (A) you must include a copy of or a link to these Terms and Conditions and
+not remove any copyright notices provided in or with the Software and (B) you
+may not impose any further restrictions on the exercise of the rights granted or
+affirmed under this License. For example, you may not impose a license fee,
+royalty, or other charge for exercise of rights granted under this License.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN
+IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the GNU General Public License version 3 (GPL-3.0), effective on the fourth
+anniversary of the date we make the Software available.
+
+On or after that date, you may use the Software under GPL-3.0, in which case the
+following will apply:
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+The full text of the GPL-3.0 license is available at:
+https://www.gnu.org/licenses/gpl-3.0.html

--- a/packages/storage-driver-cloudinary/package.json
+++ b/packages/storage-driver-cloudinary/package.json
@@ -9,7 +9,7 @@
 		"directory": "packages/storage-driver-cloudinary"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "MSCL-1.0-GPL",
+	"license": "SEE LICENSE IN license",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"type": "module",
 	"exports": {

--- a/packages/storage-driver-cloudinary/package.json
+++ b/packages/storage-driver-cloudinary/package.json
@@ -9,7 +9,7 @@
 		"directory": "packages/storage-driver-cloudinary"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "BUSL-1.1",
+	"license": "MSCL-1.0-GPL",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"type": "module",
 	"exports": {

--- a/packages/storage-driver-gcs/license
+++ b/packages/storage-driver-gcs/license
@@ -1,18 +1,12 @@
-Licensor:             Monospace, Inc.
+# Monospace Sustainable Core License, Version 1.0
 
-Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2026 Monospace, Inc.
+## Abbreviation
 
-Change Date:          Four years from release date
+MSCL-1.0-GPL
 
-Change License:       GNU General Public License (GPL) v3
+## Notice
 
-For information about alternative licensing arrangements, please visit
-https://directus.com/pricing.
-
---------------------------------------------------------------------------------
-
-# Monospace Sustainable Core License 1.0
+Copyright 2026 Monospace Inc.
 
 ## Terms and Conditions
 

--- a/packages/storage-driver-gcs/license
+++ b/packages/storage-driver-gcs/license
@@ -1,26 +1,9 @@
 Licensor:             Monospace, Inc.
 
 Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2025 Monospace, Inc.
+                      The Licensed Work is Copyright © 2026 Monospace, Inc.
 
-Additional Use Grant: You may use the Licensed Work in production as long as
-                      your Total Finances do not exceed US $5,000,000 for the
-                      most recent 12-month period, provided that Monospace, Inc.
-                      will not be liable to you in any way, including for any
-                      damages, including general, special, incidental or
-                      consequential damages, arising out of such use.
-
-                      References to: “Total Finances” mean the largest of your
-                      aggregate gross revenues, entire budget, and/or funding
-                      (no matter the source); “you” and “your” include (without
-                      limitation) any individual or entity agreeing to these
-                      terms and any affiliates of such individual or entity; and
-                      “production” mean any use other than (i) development of
-                      (including evaluation of the Licensed Work), debugging, or
-                      testing your offerings, or (ii) making the Licensed Work
-                      available standalone in unmodified object code form.
-
-Change Date:          Three years from release date
+Change Date:          Four years from release date
 
 Change License:       GNU General Public License (GPL) v3
 
@@ -29,79 +12,112 @@ https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 
-Business Source License 1.1
+# Monospace Sustainable Core License 1.0
 
-Terms
+## Terms and Conditions
 
-The Licensor hereby grants you the right to copy, modify, create derivative
-works, redistribute, and make non-production use of the Licensed Work. The
-Licensor may make an Additional Use Grant, above, permitting limited production
-use.
+### Licensor ("We")
 
-Effective on the Change Date, or the fourth anniversary of the first publicly
-available distribution of a specific version of the Licensed Work under this
-License, whichever comes first, the Licensor hereby grants you rights under the
-terms of the Change License, and the rights granted in the paragraph above
-terminate.
+The party offering the Software under these Terms and Conditions.
 
-If your use of the Licensed Work does not comply with the requirements currently
-in effect as described in this License, you must purchase a commercial license
-from the Licensor, its affiliated entities, or authorized resellers, or you must
-refrain from using the Licensed Work.
+### The Software
 
-All copies of the original and modified Licensed Work, and derivative works of
-the Licensed Work, are subject to this License. This License applies separately
-for each version of the Licensed Work and the Change Date may vary for each
-version of the Licensed Work released by Licensor.
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
 
-You must conspicuously display this License on each original or modified copy of
-the Licensed Work. If you receive the Licensed Work in original or modified form
-from a third party, the terms and conditions set forth in this License apply to
-your use of that work.
+### License Grant
 
-Any use of the Licensed Work in violation of this License will automatically
-terminate your rights under this License for the current and all other versions
-of the Licensed Work.
+Subject to your compliance with this License Grant and the Limitations, Patents,
+Redistribution, Disclaimer and Trademark clauses below, we hereby grant you the
+right to use, copy, modify, create derivative works, publicly perform, publicly
+display and redistribute the Software for any Permitted Purpose identified
+below.
 
-This License does not grant you any right in any trademark or logo of Licensor
-or its affiliates (provided that you may use a trademark or logo of Licensor as
-expressly required by this License).
+### Permitted Purpose
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
-“AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
-OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+A Permitted Purpose is any purpose other than a Competing Use.
 
-MariaDB hereby grants you permission to use this License’s text to license your
-works, and to refer to it using the trademark “Business Source License”, as long
-as you comply with the Covenants of Licensor below.
+A Competing Use means making the Software available to any party (on a stand
+alone basis or together with your products or services) that competes with the
+Licensor's commercial offerings of the Software itself, where Licensor imposes a
+license fee, royalty, or other charge for exercise of any rights to the
+Software.
 
-Covenants of Licensor
+Permitted Purposes specifically include using the Software, subject to the
+Limitations below:
 
-In consideration of the right to use this License’s text and the “Business
-Source License” name and trademark, Licensor covenants to MariaDB, and to all
-other recipients of the licensed work to be provided by Licensor:
+1. for your internal use and access;
+2. for non-commercial education;
+3. for non-commercial research; and
+4. in connection with professional services that you provide to a licensee using
+   the Software in accordance with these Terms and Conditions, including
+   professional services to deploy the Software or host the Software for the
+   licensee.
 
-1. To specify as the Change License the GPL Version 2.0 or any later version,
-   or a license that is compatible with GPL Version 2.0 or a later version,
-   where “compatible” means that software provided under the Change License can
-   be included in a program with software provided under GPL Version 2.0 or a
-   later version. Licensor may specify additional Change Licenses without
-   limitation.
+### Limitations
 
-2. To either: (a) specify an additional grant of rights to use that does not
-   impose any additional restriction on the right granted in this License, as
-   the Additional Use Grant; or (b) insert the text “None”.
+You must not move, change, disable or circumvent the license key functionality
+of the Software or modify any portion of the Software protected by the license
+key to:
 
-3. To specify a Change Date.
+- enable access to the protected functionality without a valid license key or
+- remove the protected functionality.
 
-4. Not to modify this License in any other way.
+### Patents
 
-Notice
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to the
+infringement of any patent, then your patent license to the Software ends
+immediately.
 
-The Business Source License (this document, or the "License") is not an Open
-Source license. However, the Licensed Work will eventually be made available
-under an Open Source License, as stated in this License.
+### Redistribution
 
-License text copyright © 2023 MariaDB plc, All Rights Reserved.
-“Business Source License” is a trademark of MariaDB plc.
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+then (A) you must include a copy of or a link to these Terms and Conditions and
+not remove any copyright notices provided in or with the Software and (B) you
+may not impose any further restrictions on the exercise of the rights granted or
+affirmed under this License. For example, you may not impose a license fee,
+royalty, or other charge for exercise of rights granted under this License.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN
+IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the GNU General Public License version 3 (GPL-3.0), effective on the fourth
+anniversary of the date we make the Software available.
+
+On or after that date, you may use the Software under GPL-3.0, in which case the
+following will apply:
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+The full text of the GPL-3.0 license is available at:
+https://www.gnu.org/licenses/gpl-3.0.html

--- a/packages/storage-driver-gcs/package.json
+++ b/packages/storage-driver-gcs/package.json
@@ -9,7 +9,7 @@
 		"directory": "packages/storage-driver-gcs"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "MSCL-1.0-GPL",
+	"license": "SEE LICENSE IN license",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"type": "module",
 	"exports": {

--- a/packages/storage-driver-gcs/package.json
+++ b/packages/storage-driver-gcs/package.json
@@ -9,7 +9,7 @@
 		"directory": "packages/storage-driver-gcs"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "BUSL-1.1",
+	"license": "MSCL-1.0-GPL",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"type": "module",
 	"exports": {

--- a/packages/storage-driver-local/license
+++ b/packages/storage-driver-local/license
@@ -1,18 +1,12 @@
-Licensor:             Monospace, Inc.
+# Monospace Sustainable Core License, Version 1.0
 
-Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2026 Monospace, Inc.
+## Abbreviation
 
-Change Date:          Four years from release date
+MSCL-1.0-GPL
 
-Change License:       GNU General Public License (GPL) v3
+## Notice
 
-For information about alternative licensing arrangements, please visit
-https://directus.com/pricing.
-
---------------------------------------------------------------------------------
-
-# Monospace Sustainable Core License 1.0
+Copyright 2026 Monospace Inc.
 
 ## Terms and Conditions
 

--- a/packages/storage-driver-local/license
+++ b/packages/storage-driver-local/license
@@ -1,26 +1,9 @@
 Licensor:             Monospace, Inc.
 
 Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2025 Monospace, Inc.
+                      The Licensed Work is Copyright © 2026 Monospace, Inc.
 
-Additional Use Grant: You may use the Licensed Work in production as long as
-                      your Total Finances do not exceed US $5,000,000 for the
-                      most recent 12-month period, provided that Monospace, Inc.
-                      will not be liable to you in any way, including for any
-                      damages, including general, special, incidental or
-                      consequential damages, arising out of such use.
-
-                      References to: “Total Finances” mean the largest of your
-                      aggregate gross revenues, entire budget, and/or funding
-                      (no matter the source); “you” and “your” include (without
-                      limitation) any individual or entity agreeing to these
-                      terms and any affiliates of such individual or entity; and
-                      “production” mean any use other than (i) development of
-                      (including evaluation of the Licensed Work), debugging, or
-                      testing your offerings, or (ii) making the Licensed Work
-                      available standalone in unmodified object code form.
-
-Change Date:          Three years from release date
+Change Date:          Four years from release date
 
 Change License:       GNU General Public License (GPL) v3
 
@@ -29,79 +12,112 @@ https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 
-Business Source License 1.1
+# Monospace Sustainable Core License 1.0
 
-Terms
+## Terms and Conditions
 
-The Licensor hereby grants you the right to copy, modify, create derivative
-works, redistribute, and make non-production use of the Licensed Work. The
-Licensor may make an Additional Use Grant, above, permitting limited production
-use.
+### Licensor ("We")
 
-Effective on the Change Date, or the fourth anniversary of the first publicly
-available distribution of a specific version of the Licensed Work under this
-License, whichever comes first, the Licensor hereby grants you rights under the
-terms of the Change License, and the rights granted in the paragraph above
-terminate.
+The party offering the Software under these Terms and Conditions.
 
-If your use of the Licensed Work does not comply with the requirements currently
-in effect as described in this License, you must purchase a commercial license
-from the Licensor, its affiliated entities, or authorized resellers, or you must
-refrain from using the Licensed Work.
+### The Software
 
-All copies of the original and modified Licensed Work, and derivative works of
-the Licensed Work, are subject to this License. This License applies separately
-for each version of the Licensed Work and the Change Date may vary for each
-version of the Licensed Work released by Licensor.
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
 
-You must conspicuously display this License on each original or modified copy of
-the Licensed Work. If you receive the Licensed Work in original or modified form
-from a third party, the terms and conditions set forth in this License apply to
-your use of that work.
+### License Grant
 
-Any use of the Licensed Work in violation of this License will automatically
-terminate your rights under this License for the current and all other versions
-of the Licensed Work.
+Subject to your compliance with this License Grant and the Limitations, Patents,
+Redistribution, Disclaimer and Trademark clauses below, we hereby grant you the
+right to use, copy, modify, create derivative works, publicly perform, publicly
+display and redistribute the Software for any Permitted Purpose identified
+below.
 
-This License does not grant you any right in any trademark or logo of Licensor
-or its affiliates (provided that you may use a trademark or logo of Licensor as
-expressly required by this License).
+### Permitted Purpose
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
-“AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
-OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+A Permitted Purpose is any purpose other than a Competing Use.
 
-MariaDB hereby grants you permission to use this License’s text to license your
-works, and to refer to it using the trademark “Business Source License”, as long
-as you comply with the Covenants of Licensor below.
+A Competing Use means making the Software available to any party (on a stand
+alone basis or together with your products or services) that competes with the
+Licensor's commercial offerings of the Software itself, where Licensor imposes a
+license fee, royalty, or other charge for exercise of any rights to the
+Software.
 
-Covenants of Licensor
+Permitted Purposes specifically include using the Software, subject to the
+Limitations below:
 
-In consideration of the right to use this License’s text and the “Business
-Source License” name and trademark, Licensor covenants to MariaDB, and to all
-other recipients of the licensed work to be provided by Licensor:
+1. for your internal use and access;
+2. for non-commercial education;
+3. for non-commercial research; and
+4. in connection with professional services that you provide to a licensee using
+   the Software in accordance with these Terms and Conditions, including
+   professional services to deploy the Software or host the Software for the
+   licensee.
 
-1. To specify as the Change License the GPL Version 2.0 or any later version,
-   or a license that is compatible with GPL Version 2.0 or a later version,
-   where “compatible” means that software provided under the Change License can
-   be included in a program with software provided under GPL Version 2.0 or a
-   later version. Licensor may specify additional Change Licenses without
-   limitation.
+### Limitations
 
-2. To either: (a) specify an additional grant of rights to use that does not
-   impose any additional restriction on the right granted in this License, as
-   the Additional Use Grant; or (b) insert the text “None”.
+You must not move, change, disable or circumvent the license key functionality
+of the Software or modify any portion of the Software protected by the license
+key to:
 
-3. To specify a Change Date.
+- enable access to the protected functionality without a valid license key or
+- remove the protected functionality.
 
-4. Not to modify this License in any other way.
+### Patents
 
-Notice
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to the
+infringement of any patent, then your patent license to the Software ends
+immediately.
 
-The Business Source License (this document, or the "License") is not an Open
-Source license. However, the Licensed Work will eventually be made available
-under an Open Source License, as stated in this License.
+### Redistribution
 
-License text copyright © 2023 MariaDB plc, All Rights Reserved.
-“Business Source License” is a trademark of MariaDB plc.
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+then (A) you must include a copy of or a link to these Terms and Conditions and
+not remove any copyright notices provided in or with the Software and (B) you
+may not impose any further restrictions on the exercise of the rights granted or
+affirmed under this License. For example, you may not impose a license fee,
+royalty, or other charge for exercise of rights granted under this License.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN
+IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the GNU General Public License version 3 (GPL-3.0), effective on the fourth
+anniversary of the date we make the Software available.
+
+On or after that date, you may use the Software under GPL-3.0, in which case the
+following will apply:
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+The full text of the GPL-3.0 license is available at:
+https://www.gnu.org/licenses/gpl-3.0.html

--- a/packages/storage-driver-local/package.json
+++ b/packages/storage-driver-local/package.json
@@ -9,7 +9,7 @@
 		"directory": "packages/storage-driver-local"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "BUSL-1.1",
+	"license": "MSCL-1.0-GPL",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"type": "module",
 	"exports": {

--- a/packages/storage-driver-local/package.json
+++ b/packages/storage-driver-local/package.json
@@ -9,7 +9,7 @@
 		"directory": "packages/storage-driver-local"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "MSCL-1.0-GPL",
+	"license": "SEE LICENSE IN license",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"type": "module",
 	"exports": {

--- a/packages/storage-driver-s3/license
+++ b/packages/storage-driver-s3/license
@@ -1,18 +1,12 @@
-Licensor:             Monospace, Inc.
+# Monospace Sustainable Core License, Version 1.0
 
-Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2026 Monospace, Inc.
+## Abbreviation
 
-Change Date:          Four years from release date
+MSCL-1.0-GPL
 
-Change License:       GNU General Public License (GPL) v3
+## Notice
 
-For information about alternative licensing arrangements, please visit
-https://directus.com/pricing.
-
---------------------------------------------------------------------------------
-
-# Monospace Sustainable Core License 1.0
+Copyright 2026 Monospace Inc.
 
 ## Terms and Conditions
 

--- a/packages/storage-driver-s3/license
+++ b/packages/storage-driver-s3/license
@@ -1,26 +1,9 @@
 Licensor:             Monospace, Inc.
 
 Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2025 Monospace, Inc.
+                      The Licensed Work is Copyright © 2026 Monospace, Inc.
 
-Additional Use Grant: You may use the Licensed Work in production as long as
-                      your Total Finances do not exceed US $5,000,000 for the
-                      most recent 12-month period, provided that Monospace, Inc.
-                      will not be liable to you in any way, including for any
-                      damages, including general, special, incidental or
-                      consequential damages, arising out of such use.
-
-                      References to: “Total Finances” mean the largest of your
-                      aggregate gross revenues, entire budget, and/or funding
-                      (no matter the source); “you” and “your” include (without
-                      limitation) any individual or entity agreeing to these
-                      terms and any affiliates of such individual or entity; and
-                      “production” mean any use other than (i) development of
-                      (including evaluation of the Licensed Work), debugging, or
-                      testing your offerings, or (ii) making the Licensed Work
-                      available standalone in unmodified object code form.
-
-Change Date:          Three years from release date
+Change Date:          Four years from release date
 
 Change License:       GNU General Public License (GPL) v3
 
@@ -29,79 +12,112 @@ https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 
-Business Source License 1.1
+# Monospace Sustainable Core License 1.0
 
-Terms
+## Terms and Conditions
 
-The Licensor hereby grants you the right to copy, modify, create derivative
-works, redistribute, and make non-production use of the Licensed Work. The
-Licensor may make an Additional Use Grant, above, permitting limited production
-use.
+### Licensor ("We")
 
-Effective on the Change Date, or the fourth anniversary of the first publicly
-available distribution of a specific version of the Licensed Work under this
-License, whichever comes first, the Licensor hereby grants you rights under the
-terms of the Change License, and the rights granted in the paragraph above
-terminate.
+The party offering the Software under these Terms and Conditions.
 
-If your use of the Licensed Work does not comply with the requirements currently
-in effect as described in this License, you must purchase a commercial license
-from the Licensor, its affiliated entities, or authorized resellers, or you must
-refrain from using the Licensed Work.
+### The Software
 
-All copies of the original and modified Licensed Work, and derivative works of
-the Licensed Work, are subject to this License. This License applies separately
-for each version of the Licensed Work and the Change Date may vary for each
-version of the Licensed Work released by Licensor.
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
 
-You must conspicuously display this License on each original or modified copy of
-the Licensed Work. If you receive the Licensed Work in original or modified form
-from a third party, the terms and conditions set forth in this License apply to
-your use of that work.
+### License Grant
 
-Any use of the Licensed Work in violation of this License will automatically
-terminate your rights under this License for the current and all other versions
-of the Licensed Work.
+Subject to your compliance with this License Grant and the Limitations, Patents,
+Redistribution, Disclaimer and Trademark clauses below, we hereby grant you the
+right to use, copy, modify, create derivative works, publicly perform, publicly
+display and redistribute the Software for any Permitted Purpose identified
+below.
 
-This License does not grant you any right in any trademark or logo of Licensor
-or its affiliates (provided that you may use a trademark or logo of Licensor as
-expressly required by this License).
+### Permitted Purpose
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
-“AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
-OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+A Permitted Purpose is any purpose other than a Competing Use.
 
-MariaDB hereby grants you permission to use this License’s text to license your
-works, and to refer to it using the trademark “Business Source License”, as long
-as you comply with the Covenants of Licensor below.
+A Competing Use means making the Software available to any party (on a stand
+alone basis or together with your products or services) that competes with the
+Licensor's commercial offerings of the Software itself, where Licensor imposes a
+license fee, royalty, or other charge for exercise of any rights to the
+Software.
 
-Covenants of Licensor
+Permitted Purposes specifically include using the Software, subject to the
+Limitations below:
 
-In consideration of the right to use this License’s text and the “Business
-Source License” name and trademark, Licensor covenants to MariaDB, and to all
-other recipients of the licensed work to be provided by Licensor:
+1. for your internal use and access;
+2. for non-commercial education;
+3. for non-commercial research; and
+4. in connection with professional services that you provide to a licensee using
+   the Software in accordance with these Terms and Conditions, including
+   professional services to deploy the Software or host the Software for the
+   licensee.
 
-1. To specify as the Change License the GPL Version 2.0 or any later version,
-   or a license that is compatible with GPL Version 2.0 or a later version,
-   where “compatible” means that software provided under the Change License can
-   be included in a program with software provided under GPL Version 2.0 or a
-   later version. Licensor may specify additional Change Licenses without
-   limitation.
+### Limitations
 
-2. To either: (a) specify an additional grant of rights to use that does not
-   impose any additional restriction on the right granted in this License, as
-   the Additional Use Grant; or (b) insert the text “None”.
+You must not move, change, disable or circumvent the license key functionality
+of the Software or modify any portion of the Software protected by the license
+key to:
 
-3. To specify a Change Date.
+- enable access to the protected functionality without a valid license key or
+- remove the protected functionality.
 
-4. Not to modify this License in any other way.
+### Patents
 
-Notice
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to the
+infringement of any patent, then your patent license to the Software ends
+immediately.
 
-The Business Source License (this document, or the "License") is not an Open
-Source license. However, the Licensed Work will eventually be made available
-under an Open Source License, as stated in this License.
+### Redistribution
 
-License text copyright © 2023 MariaDB plc, All Rights Reserved.
-“Business Source License” is a trademark of MariaDB plc.
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+then (A) you must include a copy of or a link to these Terms and Conditions and
+not remove any copyright notices provided in or with the Software and (B) you
+may not impose any further restrictions on the exercise of the rights granted or
+affirmed under this License. For example, you may not impose a license fee,
+royalty, or other charge for exercise of rights granted under this License.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN
+IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the GNU General Public License version 3 (GPL-3.0), effective on the fourth
+anniversary of the date we make the Software available.
+
+On or after that date, you may use the Software under GPL-3.0, in which case the
+following will apply:
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+The full text of the GPL-3.0 license is available at:
+https://www.gnu.org/licenses/gpl-3.0.html

--- a/packages/storage-driver-s3/package.json
+++ b/packages/storage-driver-s3/package.json
@@ -9,7 +9,7 @@
 		"directory": "packages/storage-driver-s3"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "BUSL-1.1",
+	"license": "MSCL-1.0-GPL",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"type": "module",
 	"exports": {

--- a/packages/storage-driver-s3/package.json
+++ b/packages/storage-driver-s3/package.json
@@ -9,7 +9,7 @@
 		"directory": "packages/storage-driver-s3"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "MSCL-1.0-GPL",
+	"license": "SEE LICENSE IN license",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"type": "module",
 	"exports": {

--- a/packages/storage-driver-supabase/license
+++ b/packages/storage-driver-supabase/license
@@ -1,18 +1,12 @@
-Licensor:             Monospace, Inc.
+# Monospace Sustainable Core License, Version 1.0
 
-Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2026 Monospace, Inc.
+## Abbreviation
 
-Change Date:          Four years from release date
+MSCL-1.0-GPL
 
-Change License:       GNU General Public License (GPL) v3
+## Notice
 
-For information about alternative licensing arrangements, please visit
-https://directus.com/pricing.
-
---------------------------------------------------------------------------------
-
-# Monospace Sustainable Core License 1.0
+Copyright 2026 Monospace Inc.
 
 ## Terms and Conditions
 

--- a/packages/storage-driver-supabase/license
+++ b/packages/storage-driver-supabase/license
@@ -1,26 +1,9 @@
 Licensor:             Monospace, Inc.
 
 Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2025 Monospace, Inc.
+                      The Licensed Work is Copyright © 2026 Monospace, Inc.
 
-Additional Use Grant: You may use the Licensed Work in production as long as
-                      your Total Finances do not exceed US $5,000,000 for the
-                      most recent 12-month period, provided that Monospace, Inc.
-                      will not be liable to you in any way, including for any
-                      damages, including general, special, incidental or
-                      consequential damages, arising out of such use.
-
-                      References to: “Total Finances” mean the largest of your
-                      aggregate gross revenues, entire budget, and/or funding
-                      (no matter the source); “you” and “your” include (without
-                      limitation) any individual or entity agreeing to these
-                      terms and any affiliates of such individual or entity; and
-                      “production” mean any use other than (i) development of
-                      (including evaluation of the Licensed Work), debugging, or
-                      testing your offerings, or (ii) making the Licensed Work
-                      available standalone in unmodified object code form.
-
-Change Date:          Three years from release date
+Change Date:          Four years from release date
 
 Change License:       GNU General Public License (GPL) v3
 
@@ -29,79 +12,112 @@ https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 
-Business Source License 1.1
+# Monospace Sustainable Core License 1.0
 
-Terms
+## Terms and Conditions
 
-The Licensor hereby grants you the right to copy, modify, create derivative
-works, redistribute, and make non-production use of the Licensed Work. The
-Licensor may make an Additional Use Grant, above, permitting limited production
-use.
+### Licensor ("We")
 
-Effective on the Change Date, or the fourth anniversary of the first publicly
-available distribution of a specific version of the Licensed Work under this
-License, whichever comes first, the Licensor hereby grants you rights under the
-terms of the Change License, and the rights granted in the paragraph above
-terminate.
+The party offering the Software under these Terms and Conditions.
 
-If your use of the Licensed Work does not comply with the requirements currently
-in effect as described in this License, you must purchase a commercial license
-from the Licensor, its affiliated entities, or authorized resellers, or you must
-refrain from using the Licensed Work.
+### The Software
 
-All copies of the original and modified Licensed Work, and derivative works of
-the Licensed Work, are subject to this License. This License applies separately
-for each version of the Licensed Work and the Change Date may vary for each
-version of the Licensed Work released by Licensor.
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
 
-You must conspicuously display this License on each original or modified copy of
-the Licensed Work. If you receive the Licensed Work in original or modified form
-from a third party, the terms and conditions set forth in this License apply to
-your use of that work.
+### License Grant
 
-Any use of the Licensed Work in violation of this License will automatically
-terminate your rights under this License for the current and all other versions
-of the Licensed Work.
+Subject to your compliance with this License Grant and the Limitations, Patents,
+Redistribution, Disclaimer and Trademark clauses below, we hereby grant you the
+right to use, copy, modify, create derivative works, publicly perform, publicly
+display and redistribute the Software for any Permitted Purpose identified
+below.
 
-This License does not grant you any right in any trademark or logo of Licensor
-or its affiliates (provided that you may use a trademark or logo of Licensor as
-expressly required by this License).
+### Permitted Purpose
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
-“AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
-OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+A Permitted Purpose is any purpose other than a Competing Use.
 
-MariaDB hereby grants you permission to use this License’s text to license your
-works, and to refer to it using the trademark “Business Source License”, as long
-as you comply with the Covenants of Licensor below.
+A Competing Use means making the Software available to any party (on a stand
+alone basis or together with your products or services) that competes with the
+Licensor's commercial offerings of the Software itself, where Licensor imposes a
+license fee, royalty, or other charge for exercise of any rights to the
+Software.
 
-Covenants of Licensor
+Permitted Purposes specifically include using the Software, subject to the
+Limitations below:
 
-In consideration of the right to use this License’s text and the “Business
-Source License” name and trademark, Licensor covenants to MariaDB, and to all
-other recipients of the licensed work to be provided by Licensor:
+1. for your internal use and access;
+2. for non-commercial education;
+3. for non-commercial research; and
+4. in connection with professional services that you provide to a licensee using
+   the Software in accordance with these Terms and Conditions, including
+   professional services to deploy the Software or host the Software for the
+   licensee.
 
-1. To specify as the Change License the GPL Version 2.0 or any later version,
-   or a license that is compatible with GPL Version 2.0 or a later version,
-   where “compatible” means that software provided under the Change License can
-   be included in a program with software provided under GPL Version 2.0 or a
-   later version. Licensor may specify additional Change Licenses without
-   limitation.
+### Limitations
 
-2. To either: (a) specify an additional grant of rights to use that does not
-   impose any additional restriction on the right granted in this License, as
-   the Additional Use Grant; or (b) insert the text “None”.
+You must not move, change, disable or circumvent the license key functionality
+of the Software or modify any portion of the Software protected by the license
+key to:
 
-3. To specify a Change Date.
+- enable access to the protected functionality without a valid license key or
+- remove the protected functionality.
 
-4. Not to modify this License in any other way.
+### Patents
 
-Notice
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to the
+infringement of any patent, then your patent license to the Software ends
+immediately.
 
-The Business Source License (this document, or the "License") is not an Open
-Source license. However, the Licensed Work will eventually be made available
-under an Open Source License, as stated in this License.
+### Redistribution
 
-License text copyright © 2023 MariaDB plc, All Rights Reserved.
-“Business Source License” is a trademark of MariaDB plc.
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+then (A) you must include a copy of or a link to these Terms and Conditions and
+not remove any copyright notices provided in or with the Software and (B) you
+may not impose any further restrictions on the exercise of the rights granted or
+affirmed under this License. For example, you may not impose a license fee,
+royalty, or other charge for exercise of rights granted under this License.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN
+IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the GNU General Public License version 3 (GPL-3.0), effective on the fourth
+anniversary of the date we make the Software available.
+
+On or after that date, you may use the Software under GPL-3.0, in which case the
+following will apply:
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+The full text of the GPL-3.0 license is available at:
+https://www.gnu.org/licenses/gpl-3.0.html

--- a/packages/storage-driver-supabase/package.json
+++ b/packages/storage-driver-supabase/package.json
@@ -9,7 +9,7 @@
 		"directory": "packages/storage-driver-supabase"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "BUSL-1.1",
+	"license": "MSCL-1.0-GPL",
 	"author": "Matthew Rollinson <matt@rolley.io>",
 	"type": "module",
 	"exports": {

--- a/packages/storage-driver-supabase/package.json
+++ b/packages/storage-driver-supabase/package.json
@@ -9,7 +9,7 @@
 		"directory": "packages/storage-driver-supabase"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "MSCL-1.0-GPL",
+	"license": "SEE LICENSE IN license",
 	"author": "Matthew Rollinson <matt@rolley.io>",
 	"type": "module",
 	"exports": {

--- a/packages/storage/license
+++ b/packages/storage/license
@@ -1,18 +1,12 @@
-Licensor:             Monospace, Inc.
+# Monospace Sustainable Core License, Version 1.0
 
-Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2026 Monospace, Inc.
+## Abbreviation
 
-Change Date:          Four years from release date
+MSCL-1.0-GPL
 
-Change License:       GNU General Public License (GPL) v3
+## Notice
 
-For information about alternative licensing arrangements, please visit
-https://directus.com/pricing.
-
---------------------------------------------------------------------------------
-
-# Monospace Sustainable Core License 1.0
+Copyright 2026 Monospace Inc.
 
 ## Terms and Conditions
 

--- a/packages/storage/license
+++ b/packages/storage/license
@@ -1,26 +1,9 @@
 Licensor:             Monospace, Inc.
 
 Licensed Work:        Directus
-                      The Licensed Work is Copyright © 2025 Monospace, Inc.
+                      The Licensed Work is Copyright © 2026 Monospace, Inc.
 
-Additional Use Grant: You may use the Licensed Work in production as long as
-                      your Total Finances do not exceed US $5,000,000 for the
-                      most recent 12-month period, provided that Monospace, Inc.
-                      will not be liable to you in any way, including for any
-                      damages, including general, special, incidental or
-                      consequential damages, arising out of such use.
-
-                      References to: “Total Finances” mean the largest of your
-                      aggregate gross revenues, entire budget, and/or funding
-                      (no matter the source); “you” and “your” include (without
-                      limitation) any individual or entity agreeing to these
-                      terms and any affiliates of such individual or entity; and
-                      “production” mean any use other than (i) development of
-                      (including evaluation of the Licensed Work), debugging, or
-                      testing your offerings, or (ii) making the Licensed Work
-                      available standalone in unmodified object code form.
-
-Change Date:          Three years from release date
+Change Date:          Four years from release date
 
 Change License:       GNU General Public License (GPL) v3
 
@@ -29,79 +12,112 @@ https://directus.com/pricing.
 
 --------------------------------------------------------------------------------
 
-Business Source License 1.1
+# Monospace Sustainable Core License 1.0
 
-Terms
+## Terms and Conditions
 
-The Licensor hereby grants you the right to copy, modify, create derivative
-works, redistribute, and make non-production use of the Licensed Work. The
-Licensor may make an Additional Use Grant, above, permitting limited production
-use.
+### Licensor ("We")
 
-Effective on the Change Date, or the fourth anniversary of the first publicly
-available distribution of a specific version of the Licensed Work under this
-License, whichever comes first, the Licensor hereby grants you rights under the
-terms of the Change License, and the rights granted in the paragraph above
-terminate.
+The party offering the Software under these Terms and Conditions.
 
-If your use of the Licensed Work does not comply with the requirements currently
-in effect as described in this License, you must purchase a commercial license
-from the Licensor, its affiliated entities, or authorized resellers, or you must
-refrain from using the Licensed Work.
+### The Software
 
-All copies of the original and modified Licensed Work, and derivative works of
-the Licensed Work, are subject to this License. This License applies separately
-for each version of the Licensed Work and the Change Date may vary for each
-version of the Licensed Work released by Licensor.
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
 
-You must conspicuously display this License on each original or modified copy of
-the Licensed Work. If you receive the Licensed Work in original or modified form
-from a third party, the terms and conditions set forth in this License apply to
-your use of that work.
+### License Grant
 
-Any use of the Licensed Work in violation of this License will automatically
-terminate your rights under this License for the current and all other versions
-of the Licensed Work.
+Subject to your compliance with this License Grant and the Limitations, Patents,
+Redistribution, Disclaimer and Trademark clauses below, we hereby grant you the
+right to use, copy, modify, create derivative works, publicly perform, publicly
+display and redistribute the Software for any Permitted Purpose identified
+below.
 
-This License does not grant you any right in any trademark or logo of Licensor
-or its affiliates (provided that you may use a trademark or logo of Licensor as
-expressly required by this License).
+### Permitted Purpose
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
-“AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
-OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+A Permitted Purpose is any purpose other than a Competing Use.
 
-MariaDB hereby grants you permission to use this License’s text to license your
-works, and to refer to it using the trademark “Business Source License”, as long
-as you comply with the Covenants of Licensor below.
+A Competing Use means making the Software available to any party (on a stand
+alone basis or together with your products or services) that competes with the
+Licensor's commercial offerings of the Software itself, where Licensor imposes a
+license fee, royalty, or other charge for exercise of any rights to the
+Software.
 
-Covenants of Licensor
+Permitted Purposes specifically include using the Software, subject to the
+Limitations below:
 
-In consideration of the right to use this License’s text and the “Business
-Source License” name and trademark, Licensor covenants to MariaDB, and to all
-other recipients of the licensed work to be provided by Licensor:
+1. for your internal use and access;
+2. for non-commercial education;
+3. for non-commercial research; and
+4. in connection with professional services that you provide to a licensee using
+   the Software in accordance with these Terms and Conditions, including
+   professional services to deploy the Software or host the Software for the
+   licensee.
 
-1. To specify as the Change License the GPL Version 2.0 or any later version,
-   or a license that is compatible with GPL Version 2.0 or a later version,
-   where “compatible” means that software provided under the Change License can
-   be included in a program with software provided under GPL Version 2.0 or a
-   later version. Licensor may specify additional Change Licenses without
-   limitation.
+### Limitations
 
-2. To either: (a) specify an additional grant of rights to use that does not
-   impose any additional restriction on the right granted in this License, as
-   the Additional Use Grant; or (b) insert the text “None”.
+You must not move, change, disable or circumvent the license key functionality
+of the Software or modify any portion of the Software protected by the license
+key to:
 
-3. To specify a Change Date.
+- enable access to the protected functionality without a valid license key or
+- remove the protected functionality.
 
-4. Not to modify this License in any other way.
+### Patents
 
-Notice
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to the
+infringement of any patent, then your patent license to the Software ends
+immediately.
 
-The Business Source License (this document, or the "License") is not an Open
-Source license. However, the Licensed Work will eventually be made available
-under an Open Source License, as stated in this License.
+### Redistribution
 
-License text copyright © 2023 MariaDB plc, All Rights Reserved.
-“Business Source License” is a trademark of MariaDB plc.
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+then (A) you must include a copy of or a link to these Terms and Conditions and
+not remove any copyright notices provided in or with the Software and (B) you
+may not impose any further restrictions on the exercise of the rights granted or
+affirmed under this License. For example, you may not impose a license fee,
+royalty, or other charge for exercise of rights granted under this License.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN
+IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the GNU General Public License version 3 (GPL-3.0), effective on the fourth
+anniversary of the date we make the Software available.
+
+On or after that date, you may use the Software under GPL-3.0, in which case the
+following will apply:
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+The full text of the GPL-3.0 license is available at:
+https://www.gnu.org/licenses/gpl-3.0.html

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -9,7 +9,7 @@
 		"directory": "packages/storage"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "MSCL-1.0-GPL",
+	"license": "SEE LICENSE IN license",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"type": "module",
 	"exports": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -9,7 +9,7 @@
 		"directory": "packages/storage"
 	},
 	"funding": "https://github.com/directus/directus?sponsor=1",
-	"license": "BUSL-1.1",
+	"license": "MSCL-1.0-GPL",
 	"author": "Rijk van Zanten <rijkvanzanten@me.com>",
 	"type": "module",
 	"exports": {

--- a/packages/stores/license
+++ b/packages/stores/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/system-data/license
+++ b/packages/system-data/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/themes/license
+++ b/packages/themes/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/types/license
+++ b/packages/types/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/update-check/license
+++ b/packages/update-check/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/utils/license
+++ b/packages/utils/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/packages/validation/license
+++ b/packages/validation/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the

--- a/sdk/license
+++ b/sdk/license
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 Monospace, Inc.
+Copyright 2026 Monospace, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the “Software”), to deal in the Software without restriction, including without limitation the


### PR DESCRIPTION
## Scope

What's changed:

- Replaced the BUSL-1.1 LICENSE text with the new Monospace Sustainable Core License (MSCL) 1.0 across all `license` files in the repo and packages
- Updated `license` field in every `package.json` from `BUSL-1.1` to `SEE LICENSE IN license` (SPDX/npm-compliant — see notes below)
- Updated `packages/specs/src/openapi.yaml` license metadata: `BUSL-1.1` → `MSCL-1.0-GPL`, URL `directus.com/bsl` → `directus.com/mscl`
- Updated `directus/readme.md` to reference MSCL 1.0 instead of BSL 1.1
- Added a dedicated MIT `license` file to `packages/ai`
- Bumped copyright year to 2026

## Potential Risks / Drawbacks

- `MSCL-1.0-GPL` is not (yet) a registered SPDX identifier, so we cannot use it directly in `package.json`. Using the `SEE LICENSE IN license` escape hatch keeps us npm-compliant but means automated license scanners will report the package license as "custom/unknown" until/unless we register MSCL with SPDX.

## Tested Scenarios

- Verified `pnpm install` succeeds with the new `license` field across all workspaces

## Review Notes / Questions

**Please pay special attention to:**

- `directus/readme.md` — wording around the license change
- Changeset
- The `"license": "SEE LICENSE IN license"` choice in every `package.json`

**Why `SEE LICENSE IN license` and not `MSCL-1.0-GPL`?**

To stay SPDX/npm-compliant we must use a registered SPDX identifier OR the `SEE LICENSE IN <filename>` form. Reference:
https://docs.npmjs.com/cli/v11/configuring-npm/package-json#license

Verify yourself:

1. `npm install spdx-expression-validate`
2. `node -e "console.log(require('spdx-expression-validate')('MIT'))"` → `true`
3. `node -e "console.log(require('spdx-expression-validate')('MSCL-1.0-GPL'))"` → `false`
   - Note: `SEE LICENSE IN license` also returns `false` from the validator, but npm explicitly accepts it as the
     documented escape hatch.

Alternative: submitting MSCL to the SPDX registry.

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

