### PR TITLE
Fix MCP OAuth DCR metadata handling

### DIFF
--- a/.changeset/mcp-oauth-dcr-metadata.md
+++ b/.changeset/mcp-oauth-dcr-metadata.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed MCP OAuth dynamic client registration defaults and metadata responses.

--- a/api/src/services/mcp-oauth/index.test.ts
+++ b/api/src/services/mcp-oauth/index.test.ts
@@ -266,9 +266,9 @@ describe('McpOAuthService', () => {
 			expect(meta.authorization_servers).toContain('https://example.com/directus');
 		});
 
-		it('does NOT include bearer_methods_supported', () => {
+		it('includes bearer_methods_supported: ["header"]', () => {
 			const meta = service.getProtectedResourceMetadata();
-			expect(meta).not.toHaveProperty('bearer_methods_supported');
+			expect(meta.bearer_methods_supported).toEqual(['header']);
 		});
 
 		it('subpath: PUBLIC_URL=https://example.com/directus produces correct resource', async () => {
@@ -606,10 +606,34 @@ describe('McpOAuthService', () => {
 			});
 		});
 
-		it('omitted grant_types rejected with invalid_client_metadata', async () => {
-			await assertOAuthError(() => service.registerClient(createTestClient({ grant_types: undefined })), {
+		it('omitted grant_types defaults to authorization_code per RFC 7591', async () => {
+			tracker.on.select('directus_oauth_clients').response([{ count: 0 }]);
+			tracker.on.insert('directus_oauth_clients').response([]);
+
+			const result = await service.registerClient(createTestClient({ grant_types: undefined }));
+
+			expect(result.grant_types).toEqual(['authorization_code']);
+		});
+
+		it('non-array grant_types rejected with invalid_client_metadata', async () => {
+			await assertOAuthError(() => service.registerClient(createTestClient({ grant_types: 'authorization_code' })), {
 				error: 'invalid_client_metadata',
 			});
+		});
+
+		it('null grant_types rejected with invalid_client_metadata', async () => {
+			await assertOAuthError(() => service.registerClient(createTestClient({ grant_types: null })), {
+				error: 'invalid_client_metadata',
+			});
+		});
+
+		it('non-string grant_types rejected with invalid_client_metadata', async () => {
+			await assertOAuthError(
+				() => service.registerClient(createTestClient({ grant_types: ['authorization_code', 123] })),
+				{
+					error: 'invalid_client_metadata',
+				},
+			);
 		});
 
 		it('unknown grant type rejected', async () => {
@@ -834,7 +858,7 @@ describe('McpOAuthService', () => {
 			});
 		});
 
-		it('missing client_name rejected', async () => {
+		it('missing client_name rejected by Directus policy for consent UX', async () => {
 			await assertOAuthError(() => service.registerClient(createTestClient({ client_name: undefined })), {
 				error: 'invalid_client_metadata',
 			});
@@ -855,7 +879,7 @@ describe('McpOAuthService', () => {
 			tracker.on.select('directus_oauth_clients').response([{ count: 0 }]);
 			tracker.on.insert('directus_oauth_clients').response([]);
 
-			await service.registerClient(
+			const result = await service.registerClient(
 				createTestClient({
 					client_uri: 'https://example.com',
 					logo_uri: 'https://example.com/logo.png',
@@ -864,10 +888,12 @@ describe('McpOAuthService', () => {
 				}),
 			);
 
-			const insertHistory = queryHistory('insert', 'directus_oauth_clients');
-			expect(insertHistory.length).toBe(1);
-			expect(insertHistory[0]!.bindings).toContain('https://example.com');
-			expect(insertHistory[0]!.bindings).toContain('https://example.com/logo.png');
+			expect(result).toMatchObject({
+				client_uri: 'https://example.com',
+				logo_uri: 'https://example.com/logo.png',
+				tos_uri: 'https://example.com/tos',
+				policy_uri: 'https://example.com/policy',
+			});
 		});
 
 		it('rejects non-HTTPS client_uri', async () => {

--- a/api/src/services/mcp-oauth/index.ts
+++ b/api/src/services/mcp-oauth/index.ts
@@ -64,6 +64,10 @@ export interface DCRResponse {
 	client_id_issued_at: number;
 	client_secret?: string;
 	client_secret_expires_at?: number;
+	client_uri?: string;
+	logo_uri?: string;
+	tos_uri?: string;
+	policy_uri?: string;
 }
 
 /** Authorization validation result. `signed_params` is an HMAC-SHA256 consent JWT. */
@@ -218,6 +222,7 @@ export class McpOAuthService {
 			resource: resourceUrl,
 			authorization_servers: [issuerUrl],
 			scopes_supported: [MCP_ACCESS_SCOPE],
+			bearer_methods_supported: ['header'],
 		};
 	}
 
@@ -280,8 +285,8 @@ export class McpOAuthService {
 	 * Called by `POST /mcp-oauth/register`. This is how MCP clients self-register before
 	 * starting the authorization flow. No authentication required.
 	 *
-	 * Validates: client_name, redirect_uris (HTTPS or localhost, no fragments),
-	 * grant_types (must include authorization_code), token_endpoint_auth_method (only "none").
+	 * Validates: client_name (Directus policy), redirect_uris (HTTPS or localhost, no fragments),
+	 * grant_types (defaults to authorization_code), token_endpoint_auth_method.
 	 * Enforces a global cap via MCP_OAUTH_MAX_CLIENTS (default 10,000). client_id is a random UUID (not a secret).
 	 *
 	 * @param body - Raw request body (validated internally)
@@ -329,7 +334,7 @@ export class McpOAuthService {
 
 		const input = body;
 
-		// RFC 7591 Section 2: client_name is REQUIRED
+		// Directus policy: client_name is required for consent UX.
 		const clientName = input['client_name'];
 
 		if (typeof clientName !== 'string' || clientName.length === 0) {
@@ -370,10 +375,10 @@ export class McpOAuthService {
 			}
 		}
 
-		// RFC 7591 Section 2: grant_types determines what grants the client can use
-		const grantTypes = input['grant_types'];
+		// RFC 7591 Section 2: omitted grant_types defaults to authorization_code
+		const grantTypes = input['grant_types'] === undefined ? ['authorization_code'] : input['grant_types'];
 
-		if (!Array.isArray(grantTypes) || grantTypes.length === 0) {
+		if (!Array.isArray(grantTypes) || grantTypes.length === 0 || grantTypes.some((gt) => typeof gt !== 'string')) {
 			rejectRegistration('invalid_client_metadata', 'grant_types is required and must include authorization_code');
 		}
 
@@ -483,6 +488,10 @@ export class McpOAuthService {
 			response_types: ['code'],
 			token_endpoint_auth_method: authMethod as string,
 			client_id_issued_at: now,
+			...(optionalUris['client_uri'] ? { client_uri: optionalUris['client_uri'] } : {}),
+			...(optionalUris['logo_uri'] ? { logo_uri: optionalUris['logo_uri'] } : {}),
+			...(optionalUris['tos_uri'] ? { tos_uri: optionalUris['tos_uri'] } : {}),
+			...(optionalUris['policy_uri'] ? { policy_uri: optionalUris['policy_uri'] } : {}),
 			...(isConfidential ? { client_secret: clientSecret, client_secret_expires_at: 0 } : {}),
 		};
 	}

--- a/tests/e2e/tests/auth/mcp-oauth.test.ts
+++ b/tests/e2e/tests/auth/mcp-oauth.test.ts
@@ -38,6 +38,7 @@ describe('/mcp-oauth discovery endpoints', () => {
 			resource: getResourceUrl(),
 			authorization_servers: [baseUrl],
 			scopes_supported: ['mcp:access'],
+			bearer_methods_supported: ['header'],
 		});
 	});
 
@@ -49,6 +50,7 @@ describe('/mcp-oauth discovery endpoints', () => {
 			resource: getResourceUrl(),
 			authorization_servers: [baseUrl],
 			scopes_supported: ['mcp:access'],
+			bearer_methods_supported: ['header'],
 		});
 	});
 
@@ -101,6 +103,10 @@ describe('POST /mcp-oauth/register', () => {
 			redirect_uris: [`${baseUrl}/callback`],
 			grant_types: ['authorization_code', 'refresh_token'],
 			token_endpoint_auth_method: 'none',
+			client_uri: 'https://client.example.com',
+			logo_uri: 'https://client.example.com/logo.png',
+			tos_uri: 'https://client.example.com/terms',
+			policy_uri: 'https://client.example.com/privacy',
 		});
 
 		const body = await expectJsonResponse(response, 201);
@@ -113,6 +119,26 @@ describe('POST /mcp-oauth/register', () => {
 			response_types: ['code'],
 			token_endpoint_auth_method: 'none',
 			client_id_issued_at: expect.any(Number),
+			client_uri: 'https://client.example.com',
+			logo_uri: 'https://client.example.com/logo.png',
+			tos_uri: 'https://client.example.com/terms',
+			policy_uri: 'https://client.example.com/privacy',
+		});
+	});
+
+	test('defaults omitted grant_types to authorization_code', async () => {
+		const response = await postJson('/mcp-oauth/register', {
+			client_name: 'Default Grant MCP Client',
+			redirect_uris: [`${baseUrl}/callback-default-grant`],
+			token_endpoint_auth_method: 'none',
+		});
+
+		const body = await expectJsonResponse(response, 201);
+
+		expect(body).toMatchObject({
+			client_id: expect.any(String),
+			grant_types: ['authorization_code'],
+			response_types: ['code'],
 		});
 	});
 


### PR DESCRIPTION
## Overview

Related to #27069

Prior to this PR, MCP OAuth DCR rejected registrations that omitted `grant_types`, even though RFC 7591 defaults that field to `["authorization_code"]`. It also validated and stored optional client URI metadata, but did not return those accepted fields in the registration response.

This PR makes DCR follow that shape: an absent `grant_types` defaults to `["authorization_code"]`, while explicit invalid values like `null`, non-arrays, non-string arrays, or unsupported grants still fail validation. It also echoes accepted `client_uri`, `logo_uri`, `tos_uri`, and `policy_uri` values in the DCR response.

The `client_name` requirement is intentionally unchanged because the consent page needs a display name. The comments and tests now describe that as Directus policy instead of an RFC 7591 requirement.

Finally, protected resource metadata now advertises `bearer_methods_supported: ["header"]`.