### PR TITLE
License design update 4

### DIFF
--- a/app/src/components/v-license-badge.vue
+++ b/app/src/components/v-license-badge.vue
@@ -43,15 +43,19 @@ const link = computed(() => {
 a {
 	position: fixed;
 	z-index: 99;
-	inset-block-end: 4rem;
-	inset-inline-end: 4rem;
-	background-color: var(--theme--background);
+	inset-block-end: var(--public-view--container--padding-y);
+	inset-inline-end: var(--public-view--container--padding-x);
+	background-color: var(--theme--background-normal);
 	border-radius: var(--theme--border-radius);
 	padding: 0.375rem 1.2rem;
 	font-size: 0.6875rem;
 	line-height: 1rem;
 	font-weight: 600;
 	cursor: pointer;
+
+	&:hover {
+		background-color: var(--theme--background-accent);
+	}
 
 	div {
 		display: flex;
@@ -79,7 +83,6 @@ a {
 		position: relative;
 		inset-block-end: unset;
 		inset-inline-end: unset;
-		background-color: var(--theme--background-normal);
 		display: flex;
 		justify-content: space-around;
 		inline-size: 100%;

--- a/app/src/views/public/public-view.vue
+++ b/app/src/views/public/public-view.vue
@@ -107,6 +107,14 @@ const logoURL = computed<string | null>(() => {
 @use '@/styles/mixins';
 
 .public-view {
+	--public-view--container--padding-x: 1.125rem;
+	--public-view--container--padding-y: 1.125rem;
+
+	@media (width >= 28.125rem) {
+		--public-view--container--padding-x: 4.5rem;
+		--public-view--container--padding-y: 2.25rem;
+	}
+
 	display: flex;
 	inline-size: 100%;
 	block-size: 100%;
@@ -144,7 +152,7 @@ const logoURL = computed<string | null>(() => {
 		inline-size: 100%;
 		max-inline-size: var(--public-view--container--max-width);
 		block-size: 100%;
-		padding: 1.125rem;
+		padding: var(--public-view--container--padding-y) var(--public-view--container--padding-x);
 		overflow: hidden auto;
 		background: var(--theme--public--background);
 		color: var(--theme--public--foreground);
@@ -169,10 +177,6 @@ const logoURL = computed<string | null>(() => {
 		&.wide {
 			--public-view--container--max-width: 49.0625rem;
 			--public-view--container--content--width: 40.0625rem;
-		}
-
-		@media (width >= 28.125rem) {
-			padding: 2.25rem 4.5rem;
 		}
 	}
 


### PR DESCRIPTION
## Scope

What's changed:

- Promoted public view container padding to CSS custom properties, with the existing responsive breakpoint now switching variable values instead of the `padding` declaration
- Anchored the floating license badge to those variables so it stays flush with the container edge across breakpoints
- Refreshed the badge's background token and added a hover state

## Potential Risks / Drawbacks

—

## Tested Scenarios

- Public view at narrow and wide viewports
- License badge resting and hover states in public and private contexts

## Review Notes / Questions

- All visual decisions in this PR were agreed with the design team

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required
