### PR TITLE
Add wildcard to visual editing package workspace deps

### DIFF
--- a/packages/visual-editing/package.json
+++ b/packages/visual-editing/package.json
@@ -71,8 +71,8 @@
 	},
 	"devDependencies": {
 		"@directus/tsconfig": "catalog:",
-		"@directus/types": "workspace:",
-		"@directus/utils": "workspace:",
+		"@directus/types": "workspace:*",
+		"@directus/utils": "workspace:*",
 		"happy-dom": "catalog:",
 		"tsdown": "catalog:",
 		"typescript": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3199,10 +3199,10 @@ importers:
         specifier: 'catalog:'
         version: 4.0.0
       '@directus/types':
-        specifier: 'workspace:'
+        specifier: workspace:*
         version: link:../types
       '@directus/utils':
-        specifier: 'workspace:'
+        specifier: workspace:*
         version: link:../utils
       happy-dom:
         specifier: 'catalog:'


### PR DESCRIPTION
## Scope

What's changed:

- Updated `@directus/visual-editing` workspace dependencies to use wildcard
- Blackbox and e2e were failing in RC release branch

<img width="969" height="222" alt="image" src="https://github.com/user-attachments/assets/c39f9eff-4449-4a5f-9b71-f6e02ab8824a" />

