### PR TITLE
Skip tick rendering in v-slider

### DIFF
--- a/.changeset/busy-pans-dress.md
+++ b/.changeset/busy-pans-dress.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed tick rendering when count exceeds display limit in v-slider

--- a/app/src/components/v-slider.test.ts
+++ b/app/src/components/v-slider.test.ts
@@ -77,3 +77,30 @@ test('defaults to 0% fill when modelValue is undefined', () => {
 	const style = wrapper.find('.v-slider').attributes('style');
 	expect(style).toContain('--_v-slider-percentage: 0');
 });
+
+test('renders ticks when tick count is within limit', () => {
+	const wrapper = mount(VSlider, {
+		props: {
+			showTicks: true,
+			min: 0,
+			max: 10,
+			step: 1,
+		},
+	});
+
+	expect(wrapper.find('.ticks').exists()).toBe(true);
+	expect(wrapper.findAll('.tick')).toHaveLength(11);
+});
+
+test('does not render ticks when tick count exceeds limit', () => {
+	const wrapper = mount(VSlider, {
+		props: {
+			showTicks: true,
+			min: -9999,
+			max: 9999,
+			step: 1,
+		},
+	});
+
+	expect(wrapper.find('.ticks').exists()).toBe(false);
+});

--- a/app/src/components/v-slider.test.ts
+++ b/app/src/components/v-slider.test.ts
@@ -92,6 +92,17 @@ test('renders ticks when tick count is within limit', () => {
 	expect(wrapper.findAll('.tick')).toHaveLength(11);
 });
 
+test('renders ticks with default min, max, and step', () => {
+	const wrapper = mount(VSlider, {
+		props: {
+			showTicks: true,
+		},
+	});
+
+	expect(wrapper.find('.ticks').exists()).toBe(true);
+	expect(wrapper.findAll('.tick')).toHaveLength(101);
+});
+
 test('does not render ticks when tick count exceeds limit', () => {
 	const wrapper = mount(VSlider, {
 		props: {

--- a/app/src/components/v-slider.test.ts
+++ b/app/src/components/v-slider.test.ts
@@ -103,6 +103,33 @@ test('renders ticks with default min, max, and step', () => {
 	expect(wrapper.findAll('.tick')).toHaveLength(101);
 });
 
+test('renders ticks at the threshold (tick count === 101)', () => {
+	const wrapper = mount(VSlider, {
+		props: {
+			showTicks: true,
+			min: 0,
+			max: 200,
+			step: 2,
+		},
+	});
+
+	expect(wrapper.find('.ticks').exists()).toBe(true);
+	expect(wrapper.findAll('.tick')).toHaveLength(101);
+});
+
+test('does not render ticks just past the threshold (tick count === 102)', () => {
+	const wrapper = mount(VSlider, {
+		props: {
+			showTicks: true,
+			min: 0,
+			max: 101,
+			step: 1,
+		},
+	});
+
+	expect(wrapper.find('.ticks').exists()).toBe(false);
+});
+
 test('does not render ticks when tick count exceeds limit', () => {
 	const wrapper = mount(VSlider, {
 		props: {

--- a/app/src/components/v-slider.vue
+++ b/app/src/components/v-slider.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 
+const MAX_TICK_COUNT = 100;
+
 interface Props {
 	/** Disables the slider */
 	disabled?: boolean;
@@ -57,6 +59,8 @@ const styles = computed(() => {
 	return { '--_v-slider-percentage': percentage };
 });
 
+const tickCount = computed(() => Math.floor((props.max - props.min) / props.step) + 1);
+
 function onChange(event: Event) {
 	const target = event.target as HTMLInputElement;
 	emit('change', Number(target.value));
@@ -88,8 +92,8 @@ function onInput(event: Event) {
 				@input="onInput"
 			/>
 			<div class="fill" />
-			<div v-if="showTicks" class="ticks">
-				<span v-for="i in Math.floor((max - min) / step) + 1" :key="i" class="tick" />
+			<div v-if="showTicks && tickCount <= MAX_TICK_COUNT" class="ticks">
+				<span v-for="i in tickCount" :key="i" class="tick" />
 			</div>
 			<div v-if="showThumbLabel" class="thumb-label-wrapper">
 				<div class="thumb-label" :class="{ visible: alwaysShowValue || nonEditable }">

--- a/app/src/components/v-slider.vue
+++ b/app/src/components/v-slider.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 
-const MAX_TICK_COUNT = 100;
+const MAX_TICK_COUNT = 101;
 
 interface Props {
 	/** Disables the slider */


### PR DESCRIPTION
## Scope

What's changed:

- Fix UI lag in `v-slider` caused by rendering thousands of tick mark DOM nodes when `min`/`max` range is large
- Add `MAX_TICK_COUNT = 100` constant to skip tick rendering when the computed tick count exceeds a practical display limit

## Potential Risks / Drawbacks

- Sliders configured with `showTicks: true` and a range/step combination producing more than 100 ticks will silently show no ticks. This is acceptable because beyond this value, individual marks are indistinguishable.

## Tested Scenarios

- Slider with `min=0`, `max=10`, `step=1` (11 ticks) renders the `.ticks` element with 11 tick marks
- Slider with `min=-9999`, `max=9999`, `step=1` (19,999 ticks) renders no `.ticks` element

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes [CMS-2557](https://linear.app/directus/issue/CMS-2557/v-slider-with-large-minmax-range-causes-noticeable-ui-lag-when)
