### PR TITLE
fix(app): trim whitespace from search input value

### DIFF
--- a/.changeset/warm-ducks-call.md
+++ b/.changeset/warm-ducks-call.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed search input not trimming whitespace, which caused empty results when query had leading or trailing spaces

--- a/app/src/views/private/components/search-input.vue
+++ b/app/src/views/private/components/search-input.vue
@@ -107,7 +107,7 @@ function onFocusOut(event: FocusEvent) {
 
 function emitValue() {
 	if (!input.value) return;
-	const value = input.value?.value;
+	const value = input.value.value.trim();
 	emit('update:modelValue', value);
 }
 </script>

--- a/contributors.yml
+++ b/contributors.yml
@@ -273,3 +273,4 @@
 - yogeshwaran-c
 - sanskar-soni-9
 - kropsi
+- levgiorg


### PR DESCRIPTION
## Scope

What's changed:

- `app/src/views/private/components/search-input.vue`: Added `.trim()` to the search input value in `emitValue()`, so leading/trailing whitespace is stripped before emitting the search query to consumers using `.includes()` matching.

## Potential Risks / Drawbacks

- Users who intentionally search for strings with leading/trailing whitespace will no longer be able to do so. This edge case is extremely unlikely and the current behavior (invisible whitespace causing zero results) is far more confusing.

## Tested Scenarios

- The change is a single `.trim()` call added to `emitValue()` — no control flow or logic changes
- Existing search-input tests should be unaffected (they test click/focus behavior)

## Review Notes / Questions

- None

## Checklist

- [x] Added or updated tests — not needed, existing coverage suffices
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #27358
