### PR TITLE
Add minor copy change to license onboarding and license key interface

### DIFF
--- a/.changeset/small-bottles-call.md
+++ b/.changeset/small-bottles-call.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added minor copy change to license onboarding and license key interface

--- a/app/src/interfaces/_system/system-license-key/system-license-key.vue
+++ b/app/src/interfaces/_system/system-license-key/system-license-key.vue
@@ -145,7 +145,7 @@ onMounted(() => {
 
 			<span v-if="licenseInfo.plan_name">
 				<VIcon name="check_circle" />
-				<span>{{ $t('plan') }}: {{ licenseInfo.plan_name }}</span>
+				<span>{{ $t('plan_prefix', { plan: licenseInfo.plan_name }) }}</span>
 			</span>
 
 			<div v-if="licenseInfo.expires_at ?? licenseInfo.renews_at">

--- a/app/src/interfaces/_system/system-license-key/system-license-key.vue
+++ b/app/src/interfaces/_system/system-license-key/system-license-key.vue
@@ -145,7 +145,7 @@ onMounted(() => {
 
 			<span v-if="licenseInfo.plan_name">
 				<VIcon name="check_circle" />
-				<span>{{ licenseInfo.plan_name }}</span>
+				<span>{{ $t('plan') }}: {{ licenseInfo.plan_name }}</span>
 			</span>
 
 			<div v-if="licenseInfo.expires_at ?? licenseInfo.renews_at">

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -49,7 +49,7 @@ org_name: Organization Name
 org_name_placeholder: Acme Inc.
 license_key_option: I have a license key
 license_key_option_desc: 'OIG, Team, or Enterprise plan'
-core_option: I'm using Core
+core_option: I'm using Core plan
 core_option_desc: Free, no key required
 remind_later: Remind Later
 remind_next_login: We'll remind you next time you log in
@@ -57,6 +57,7 @@ open_innovation_grant: Open Innovation Grant
 setup_project: Setup Project
 enter_license_key: Enter Your License Key
 license_valid: License Valid
+plan: Plan
 license_key: License Key
 no_license_key: Don't have a license key?
 get_license_key: Get License Key

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -57,7 +57,7 @@ open_innovation_grant: Open Innovation Grant
 setup_project: Setup Project
 enter_license_key: Enter Your License Key
 license_valid: License Valid
-plan: Plan
+plan_prefix: 'Plan: {plan}'
 license_key: License Key
 no_license_key: Don't have a license key?
 get_license_key: Get License Key


### PR DESCRIPTION
## Scope

What's changed:

  - Updated the "I'm using Core" license choice label to "I'm using Core plan"
  - Prefixed the validated license plan name with "Plan:"

## Potential Risks / Drawbacks

  - None I can think of

## Tested Scenarios

  - Onboarding screen shows "I'm using Core plan" as the Core option label
  - Entering a valid license key renders the plan entitlement as "Plan: <plan name>" with the green checkmark

## Review Notes / Questions

## Checklist

  - [x] Added or updated tests or not required
  - [x] Documentation PR created [here](https://github.com/directus/docs) or not required
  - [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required