### PR TITLE
fix: prevent locale-based decimal formatting in input field

### DIFF
--- a/app/src/interfaces/input/input.vue
+++ b/app/src/interfaces/input/input.vue
@@ -60,6 +60,7 @@ const percentageRemaining = computed(() => {
 
 const inputType = computed(() => {
 	if (props.masked) return 'password';
+	if (props.type === 'decimal' || props.type === 'float') return 'text';
 	if (APP_NUMERIC_TYPES.includes(props.type!)) return 'number';
 	return 'text';
 });


### PR DESCRIPTION
## Problem

When an input field has type=number, the browser applies its locale-dependent formatting to the displayed value. For example, in nl-BE locale, the value 300.44 stored in the database is displayed as 300,44 in the input field.

This affects users whose system/browser locale uses comma as decimal separator (most of Europe, South America, etc.), even when their Directus profile is set to English (US).

## Fix

Changes inputType to return text (instead of number) for decimal and float types. This prevents the browser from reformatting the displayed value according to locale settings.

The existing float-handling logic in v-input.vue already normalizes comma-separated input to dot-separated values on entry, so user input is still properly parsed.

Since step buttons are only shown for type=number, they will not appear for decimal/float inputs (which is acceptable since decimal step buttons are rarely useful).

Closes #24803