### PR TITLE
Cap datepicker year to prevent invalid date

### DIFF
--- a/.changeset/gold-queens-jog.md
+++ b/.changeset/gold-queens-jog.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Capped datepicker year to prevent invalid date

--- a/app/src/components/v-date-picker/v-date-picker.test.ts
+++ b/app/src/components/v-date-picker/v-date-picker.test.ts
@@ -841,6 +841,40 @@ describe('v-date-picker', () => {
 			expect(finalCallCount).toBe(initialCallCount);
 		});
 
+		it('ignores out-of-range year values (too large) to avoid NaN day', async () => {
+			let capturedCalendarValue: { year?: number; month?: number; day?: number } | undefined;
+
+			vi.mocked(formatDatePickerModelValue).mockImplementation((_type, options) => {
+				if (options.calendarValue && 'year' in options.calendarValue) {
+					capturedCalendarValue = options.calendarValue as { year: number; month: number; day: number };
+				}
+
+				return '2024-01-15';
+			});
+
+			const wrapper = createWrapper({
+				type: 'date',
+				modelValue: '2024-01-15',
+			});
+
+			await nextTick();
+
+			const initialCallCount = vi.mocked(formatDatePickerModelValue).mock.calls.length;
+
+			const yearInput = wrapper.find('.calendar-year-input');
+
+			// Entering many digits produces a year beyond what JS Date can represent,
+			// which previously made `new Date(year, month, 0).getDate()` return NaN and
+			// emitted an invalid ISO string like "9999-06-NaN".
+			await yearInput.setValue('999999999');
+			await nextTick();
+
+			// The out-of-range year must be ignored: no new emission, and no NaN day leaks through.
+			const finalCallCount = vi.mocked(formatDatePickerModelValue).mock.calls.length;
+			expect(finalCallCount).toBe(initialCallCount);
+			expect(capturedCalendarValue?.day).not.toBeNaN();
+		});
+
 		it('clamps day when changing to month with fewer days', async () => {
 			let capturedDay: number | undefined;
 

--- a/app/src/components/v-date-picker/v-date-picker.test.ts
+++ b/app/src/components/v-date-picker/v-date-picker.test.ts
@@ -869,10 +869,11 @@ describe('v-date-picker', () => {
 			await yearInput.setValue('999999999');
 			await nextTick();
 
-			// The out-of-range year must be ignored: no new emission, and no NaN day leaks through.
+			// The out-of-range year must be ignored: no emission happens, so no invalid value
+			// (and no NaN day) can leak through.
 			const finalCallCount = vi.mocked(formatDatePickerModelValue).mock.calls.length;
 			expect(finalCallCount).toBe(initialCallCount);
-			expect(capturedCalendarValue?.day).not.toBeNaN();
+			expect(capturedCalendarValue).toBeUndefined();
 		});
 
 		it('clamps day when changing to month with fewer days', async () => {

--- a/app/src/components/v-date-picker/v-date-picker.vue
+++ b/app/src/components/v-date-picker/v-date-picker.vue
@@ -240,9 +240,19 @@ function handleMonthChange(value: number | null): void {
 	setCalendarMonth(value);
 }
 
+/**
+ * Largest year the picker accepts.
+ *
+ * Bounded to a 4-digit ISO 8601 year.
+ * Without this cap, typing many digits yields a year
+ * beyond JS Date's representable range, making `new Date(year, month, 0).getDate()` return NaN
+ * in `setCalendarYear` and emitting an invalid string like "9999-06-NaN".
+ */
+const MAX_YEAR = 9999;
+
 function handleYearChange(value: number | string | undefined): void {
 	const numValue = typeof value === 'string' ? Number.parseInt(value, 10) : value;
-	if (numValue === undefined || !Number.isFinite(numValue) || numValue < 1) return;
+	if (numValue === undefined || !Number.isFinite(numValue) || numValue < 1 || numValue > MAX_YEAR) return;
 	setCalendarYear(numValue);
 }
 

--- a/app/src/components/v-date-picker/v-date-picker.vue
+++ b/app/src/components/v-date-picker/v-date-picker.vue
@@ -301,11 +301,12 @@ function setToNow() {
 							@update:model-value="handleMonthChange"
 						/>
 						<VInput
-							type="number"
+							type="text"
+							inputmode="numeric"
 							:model-value="date?.year"
+							:max-length="4"
 							class="calendar-year-input"
 							:full-width="false"
-							hide-arrows
 							@update:model-value="handleYearChange"
 						/>
 					</div>


### PR DESCRIPTION
## Scope

What's changed:

- Cap the datepicker year input at 9999 (the 4-digit ISO 8601 limit) in `v-date-picker.vue`, so out-of-range years are ignored at the input boundary — consistent with how `handleMonthChange` already rejects months > 12.
- Add a regression test verifying that entering an oversized year (e.g. `999999999`) is ignored and never emits a value with a `NaN` day.

## Potential Risks / Drawbacks

- Years above 9999 are silently ignored rather than clamped to 9999. This matches the existing month-out-of-range behavior, but a reviewer may prefer clamping for a more visible UX response.

## Tested Scenarios

- Enter a year beyond JS `Date`'s representable range (`999999999`) and confirm no `update:modelValue` is emitted and no `NaN` day is produced (previously emitted `9999-06-NaN`, throwing "Invalid ISO 8601 date time string").
- Confirmed existing year-input behavior still works: valid year `2025` updates the calendar, and zero/negative/non-numeric values remain ignored.

## Review Notes / Questions

- I would like reviewers to confirm the choice of **ignore** vs **clamp-to-9999** for out-of-range years — both are defensible; I chose ignore for consistency with the month handler.

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes [CMS-2573](https://linear.app/directus/issue/CMS-2573/vdatepicker-adding-a-year-above-limit-crash-the-interface)