### PR TITLE
Add notice for core tier regarding the oig grant

### DIFF
--- a/.changeset/late-dolls-enjoy.md
+++ b/.changeset/late-dolls-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added notice on license page with oig link

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1650,7 +1650,7 @@ license:
       'You have {daysLeft} in your grace period — until {date}. After that, Core tier resource limits will apply.
       {retrieveLicenseKey} or {upgrade} to increase your limits. You might be eligible for an {oig}.'
     grace_days_left: '{days} day left | {days} days left'
-    retrieve_license_key: Retrieve license key
+    retrieve_license_key: Retrieve license key
     upgrade: Upgrade
     oig_eligible: 'You might be eligible for an {oig}. Apply and get full access to Directus for free.'
   locked_status_notice: 'Your Directus instance is locked. Manage license or {contactSupport} to resolve.'

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1652,7 +1652,7 @@ license:
     grace_days_left: '{days} day left | {days} days left'
     retrieve_license_key: Retrieve license key
     upgrade: Upgrade
-    oig_eligible: 'You might be eligible for an {oig}. Apply and get full access to Directus for free.'
+    oig_eligible: 'You might be eligible for our {oig}. Apply and get full access to Directus for free.'
   locked_status_notice: 'Your Directus instance is locked. Manage license or {contactSupport} to resolve.'
   pinned_status_notice:
     grace_period_title: 'Grace Period ({days}d left)'

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1648,7 +1648,7 @@ license:
   unlicensed_status_notice:
     grace_period:
       'You have {daysLeft} in your grace period — until {date}. After that, Core tier resource limits will apply.
-      {retrieveLicenseKey} or {upgrade} to increase your limits. You might be eligible for an {oig}.'
+      {retrieveLicenseKey} or {upgrade} to increase your limits.
     grace_days_left: '{days} day left | {days} days left'
     retrieve_license_key: Retrieve license key
     upgrade: Upgrade

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1652,7 +1652,7 @@ license:
     grace_days_left: '{days} day left | {days} days left'
     retrieve_license_key: Retrieve license key
     upgrade: Upgrade
-    oig_eligible: 'You might be eligible for an {oig}.'
+    oig_eligible: 'You might be eligible for an {oig}. Apply and get full access to Directus for free.'
   locked_status_notice: 'Your Directus instance is locked. Manage license or {contactSupport} to resolve.'
   pinned_status_notice:
     grace_period_title: 'Grace Period ({days}d left)'

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1648,7 +1648,7 @@ license:
   unlicensed_status_notice:
     grace_period:
       'You have {daysLeft} in your grace period — until {date}. After that, Core tier resource limits will apply.
-      {retrieveLicenseKey} or {upgrade} to increase your limits.
+      {retrieveLicenseKey} or {upgrade} to increase your limits.'
     grace_days_left: '{days} day left | {days} days left'
     retrieve_license_key: Retrieve license key
     upgrade: Upgrade

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1648,10 +1648,11 @@ license:
   unlicensed_status_notice:
     grace_period:
       'You have {daysLeft} in your grace period — until {date}. After that, Core tier resource limits will apply.
-      {retrieveLicenseKey} or {upgrade} to increase your limits.'
+      {retrieveLicenseKey} or {upgrade} to increase your limits. You might be eligible for an {oig}.'
     grace_days_left: '{days} day left | {days} days left'
     retrieve_license_key: Retrieve license key
     upgrade: Upgrade
+    oig_eligible: 'You might be eligible for an {oig}.'
   locked_status_notice: 'Your Directus instance is locked. Manage license or {contactSupport} to resolve.'
   pinned_status_notice:
     grace_period_title: 'Grace Period ({days}d left)'

--- a/app/src/stores/license.ts
+++ b/app/src/stores/license.ts
@@ -74,6 +74,8 @@ export const useLicenseStore = defineStore('licenseStore', () => {
 
 	const isCoreGrace = computed(() => info.value?.status === 'grace' && !isLicensed.value);
 
+	const isCore = computed(() => info.value?.source === null);
+
 	const wasDowngraded = computed(() => info.value?.downgrade_reason != null);
 
 	const customPermissionRulesEnabled = computed(() => isEntitlementEnabled('custom_permission_rules_enabled'));
@@ -243,6 +245,7 @@ export const useLicenseStore = defineStore('licenseStore', () => {
 		limits,
 		isLocked,
 		isCoreGrace,
+		isCore,
 		wasDowngraded,
 		customPermissionRulesEnabled,
 		isLicensed,

--- a/app/src/views/private/components/license/status-notice.vue
+++ b/app/src/views/private/components/license/status-notice.vue
@@ -23,7 +23,7 @@ const show = computed(
 	() => isAdmin.value && (gracePeriodDaysRemaining.value !== null || isLocked.value || isCoreGrace.value),
 );
 
-const showOig = computed(() => isAdmin.value && isCore.value && !isCoreGrace.value && !isLocked.value);
+const showOig = computed(() => isAdmin.value && isCore.value && !isLocked.value);
 
 const severity = computed(() =>
 	gracePeriodDaysRemaining.value !== null && gracePeriodDaysRemaining.value <= GRACE_DANGER_THRESHOLD_DAYS

--- a/app/src/views/private/components/license/status-notice.vue
+++ b/app/src/views/private/components/license/status-notice.vue
@@ -94,7 +94,7 @@ const oigUrl = computed(
 			</template>
 		</I18nT>
 	</VNotice>
-	<VNotice v-else-if="showOig" type="info" class="status-notice">
+	<VNotice v-if="showOig" type="info" class="status-notice">
 		<I18nT keypath="license.unlicensed_status_notice.oig_eligible" tag="span">
 			<template #oig>
 				<a :href="oigUrl" target="_blank" rel="noopener noreferrer">{{ $t('open_innovation_grant') }}</a>

--- a/app/src/views/private/components/license/status-notice.vue
+++ b/app/src/views/private/components/license/status-notice.vue
@@ -106,10 +106,10 @@ const oigUrl = computed(
 <style lang="scss" scoped>
 .status-notice {
 	--v-notice-color: var(--theme--foreground);
-	margin-block: 2.25rem 1rem;
+	margin-block: 2.25rem 0.5rem;
 
 	& + .status-notice {
-		margin-block-start: 1rem;
+		margin-block-start: 0.5rem;
 	}
 
 	a {

--- a/app/src/views/private/components/license/status-notice.vue
+++ b/app/src/views/private/components/license/status-notice.vue
@@ -106,6 +106,7 @@ const oigUrl = computed(
 <style lang="scss" scoped>
 .status-notice {
 	--v-notice-color: var(--theme--foreground);
+	margin-block: 1rem;
 
 	a {
 		text-decoration: underline;

--- a/app/src/views/private/components/license/status-notice.vue
+++ b/app/src/views/private/components/license/status-notice.vue
@@ -106,7 +106,11 @@ const oigUrl = computed(
 <style lang="scss" scoped>
 .status-notice {
 	--v-notice-color: var(--theme--foreground);
-	margin-block: 1rem;
+	margin-block: 2.25rem 1rem;
+
+	& + .status-notice {
+		margin-block-start: 1rem;
+	}
 
 	a {
 		text-decoration: underline;

--- a/app/src/views/private/components/license/status-notice.vue
+++ b/app/src/views/private/components/license/status-notice.vue
@@ -9,7 +9,7 @@ import { useServerStore } from '@/stores/server';
 import { useUserStore } from '@/stores/user';
 
 const serverStore = useServerStore();
-const { gracePeriodDaysRemaining, isLocked, isCoreGrace, graceDeadline } = storeToRefs(useLicenseStore());
+const { gracePeriodDaysRemaining, isLocked, isCoreGrace, isCore, graceDeadline } = storeToRefs(useLicenseStore());
 
 const formattedCoreGraceDate = computed(() =>
 	graceDeadline.value
@@ -23,6 +23,8 @@ const show = computed(
 	() => isAdmin.value && (gracePeriodDaysRemaining.value !== null || isLocked.value || isCoreGrace.value),
 );
 
+const showOig = computed(() => isAdmin.value && isCore.value && !isCoreGrace.value && !isLocked.value);
+
 const severity = computed(() =>
 	gracePeriodDaysRemaining.value !== null && gracePeriodDaysRemaining.value <= GRACE_DANGER_THRESHOLD_DAYS
 		? 'danger'
@@ -35,6 +37,11 @@ const lockedSupportUrl = computed(
 );
 
 const coreGraceLicensingUrl = `https://${DIRECTUS_DOMAIN}/docs/licensing/overview`;
+
+const oigUrl = computed(
+	() =>
+		`https://${DIRECTUS_DOMAIN}/oig?utm_source=self_hosted&utm_medium=product&utm_campaign=2026_05_licensing&utm_term=${serverStore.info?.version}&utm_content=status_notice_open_innovation_grant_link`,
+);
 </script>
 
 <template>
@@ -71,6 +78,9 @@ const coreGraceLicensingUrl = `https://${DIRECTUS_DOMAIN}/docs/licensing/overvie
 					{{ $t('license.unlicensed_status_notice.upgrade') }}
 				</a>
 			</template>
+			<template #oig>
+				<a :href="oigUrl" target="_blank" rel="noopener noreferrer">{{ $t('open_innovation_grant') }}</a>
+			</template>
 		</I18nT>
 	</VNotice>
 	<VNotice v-else-if="show" :type="severity" class="status-notice">
@@ -81,6 +91,13 @@ const coreGraceLicensingUrl = `https://${DIRECTUS_DOMAIN}/docs/licensing/overvie
 						$t('license.status_notice.grace_days', { days: gracePeriodDaysRemaining }, gracePeriodDaysRemaining ?? 0)
 					}}
 				</strong>
+			</template>
+		</I18nT>
+	</VNotice>
+	<VNotice v-else-if="showOig" type="info" class="status-notice">
+		<I18nT keypath="license.unlicensed_status_notice.oig_eligible" tag="span">
+			<template #oig>
+				<a :href="oigUrl" target="_blank" rel="noopener noreferrer">{{ $t('open_innovation_grant') }}</a>
 			</template>
 		</I18nT>
 	</VNotice>

--- a/app/src/views/private/components/license/status-notice.vue
+++ b/app/src/views/private/components/license/status-notice.vue
@@ -94,7 +94,7 @@ const oigUrl = computed(
 			</template>
 		</I18nT>
 	</VNotice>
-	<VNotice v-if="showOig" type="info" class="status-notice">
+	<VNotice v-if="showOig" type="info" class="status-notice" icon="workspace_premium">
 		<I18nT keypath="license.unlicensed_status_notice.oig_eligible" tag="span">
 			<template #oig>
 				<a :href="oigUrl" target="_blank" rel="noopener noreferrer">{{ $t('open_innovation_grant') }}</a>


### PR DESCRIPTION
## Scope

  What's changed:

  - Adds an Open Innovation Grant (OIG) eligibility notice to the Settings → License page for Core tier
  - When **not** in a grace period, shows a standalone info `v-notice`: "You might be eligible for an Open Innovation Grant"
  - When **in** a grace period, appends the same eligibility line to the existing Core grace-period notice rather than rendering a second notice

  ## Potential Risks / Drawbacks

  - None I can think of

  ## Tested Scenarios

  - Core, no grace period: standalone OIG notice renders below the plan header
  - Core, in grace period: OIG sentence appears at the end of the existing grace notice as a single notice
  - Licensed plan and non-admin users: no OIG notice shown

  ## Review Notes / Questions

  ## Checklist

  - [ ] Added or updated tests
  - [x] Documentation PR created [here](https://github.com/directus/docs) or not required
  - [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

Fixes [CMS-2562](https://linear.app/directus/issue/CMS-2562/add-a-notice-in-core-relating-to-oig-to-help-with-awareness)
