### PR TITLE
Fix issue causing duplicate admin roles during setup

### DIFF
--- a/.changeset/wicked-rooms-look.md
+++ b/.changeset/wicked-rooms-look.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed issue causing duplicate admin roles
+Fixed issue causing duplicate admin roles on first admin creation

--- a/.changeset/wicked-rooms-look.md
+++ b/.changeset/wicked-rooms-look.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed issue causing duplicate admin roles

--- a/api/src/utils/create-admin.ts
+++ b/api/src/utils/create-admin.ts
@@ -39,6 +39,12 @@ export async function createAdmin(
 	const logger = useLogger();
 	const env = useEnv();
 
+	const adminEmail = admin?.email ?? env['ADMIN_EMAIL'];
+	const adminPassword = admin?.password ?? env['ADMIN_PASSWORD'];
+
+	// Without credentials there's no admin user to create. Will happen in onboarding flow.
+	if (!adminEmail || !adminPassword) return;
+
 	logger.info('Setting up first admin role...');
 	const accessService = new AccessService({ schema });
 	const policiesService = new PoliciesService({ schema });
@@ -50,11 +56,6 @@ export async function createAdmin(
 	await accessService.createOne({ policy, role });
 
 	const usersService = new UsersService({ schema });
-
-	const adminEmail = admin?.email ?? env['ADMIN_EMAIL'];
-	const adminPassword = admin?.password ?? env['ADMIN_PASSWORD'];
-
-	if (!adminEmail || !adminPassword) return;
 
 	const token = env['ADMIN_TOKEN'] ?? null;
 


### PR DESCRIPTION
  ## Scope

  What's changed:

  - Moved the `ADMIN_EMAIL`/`ADMIN_PASSWORD` credential check to the top of `createAdmin` (`api/src/utils/create-admin.ts`), so the
  function returns early before creating any role, policy, or access records when no credentials are present

  ## Potential Risks / Drawbacks

  - None I can think of

  ## Tested Scenarios                                                                                              

  - Fresh bootstrap with no `ADMIN_EMAIL`/`ADMIN_PASSWORD`: no admin role/policy is created, leaving onboarding to create a single
  admin (no duplicate)
  - Bootstrap with credentials provided via env or arguments: admin role, policy, access, and user are created as before

  ## Review Notes / Questions

  ## Checklist

  - [ ] Added or updated tests
  - [x] Documentation PR created [here](https://github.com/directus/docs) or not required
  - [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

  ---

Fixes #27333 
