### PR TITLE
perf: lazy-load heavy packages (auth drivers, rollup, tus)

### DIFF
--- a/.changeset/lazy-load-packages.md
+++ b/.changeset/lazy-load-packages.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Lazy-load heavy packages (auth drivers, rollup, tus) to improve initial load performance

--- a/.changeset/lazy-load-packages.md
+++ b/.changeset/lazy-load-packages.md
@@ -1,5 +1,5 @@
 ---
-'@directus/app': patch
+'@directus/api': patch
 ---
 
 Lazy-load heavy packages (auth drivers, rollup, tus) to improve initial load performance

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -52,7 +52,6 @@ import serverRouter from './controllers/server.js';
 import settingsRouter from './controllers/settings.js';
 import sharesRouter from './controllers/shares.js';
 import translationsRouter from './controllers/translations.js';
-import tusRouter from './controllers/tus.js';
 import usersRouter from './controllers/users.js';
 import utilsRouter from './controllers/utils.js';
 import versionsRouter from './controllers/versions.js';
@@ -85,7 +84,6 @@ import scheduleOAuthCleanup from './schedules/oauth-cleanup.js';
 import projectSchedule from './schedules/project.js';
 import retentionSchedule from './schedules/retention.js';
 import telemetrySchedule from './schedules/telemetry.js';
-import tusSchedule from './schedules/tus.js';
 import { getConfigFromEnv } from './utils/get-config-from-env.js';
 import { Url } from './utils/url.js';
 import { validateStorage } from './utils/validate-storage.js';
@@ -359,6 +357,7 @@ export default async function createApp(): Promise<express.Application> {
 	app.use('/fields', fieldsRouter);
 
 	if (env['TUS_ENABLED'] === true) {
+		const tusRouter = (await import('./controllers/tus.js')).default;
 		app.use('/files/tus', tusRouter);
 	}
 
@@ -418,6 +417,7 @@ export default async function createApp(): Promise<express.Application> {
 
 	await retentionSchedule();
 	await telemetrySchedule();
+	const tusSchedule = (await import('./schedules/tus.js')).default;
 	await tusSchedule();
 	await metricsSchedule();
 	await projectSchedule();

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -2,13 +2,7 @@ import { useEnv } from '@directus/env';
 import { InvalidProviderConfigError } from '@directus/errors';
 import { toArray, toBoolean } from '@directus/utils';
 import type { AuthDriver } from './auth/auth.js';
-import {
-	LDAPAuthDriver,
-	LocalAuthDriver,
-	OAuth2AuthDriver,
-	OpenIDAuthDriver,
-	SAMLAuthDriver,
-} from './auth/drivers/index.js';
+import { LocalAuthDriver } from './auth/drivers/local.js';
 import { DEFAULT_AUTH_PROVIDER } from './constants.js';
 import getDatabase from './database/index.js';
 import { getEntitlementManager } from './license/index.js';
@@ -47,7 +41,7 @@ export async function registerAuthProviders(): Promise<void> {
 	}
 
 	// Always register default provider
-	const defaultProvider = getProviderInstance('local', options)!;
+	const defaultProvider = (await getProviderInstance('local', options))!;
 	providers.set(DEFAULT_AUTH_PROVIDER, defaultProvider);
 
 	if (!env['AUTH_PROVIDERS']) {
@@ -55,7 +49,7 @@ export async function registerAuthProviders(): Promise<void> {
 	}
 
 	// Register configured providers
-	providerNames.forEach((name: string) => {
+	for (const name of providerNames) {
 		name = name.trim();
 
 		if (name === DEFAULT_AUTH_PROVIDER) {
@@ -67,40 +61,48 @@ export async function registerAuthProviders(): Promise<void> {
 
 		if (!driver) {
 			logger.warn(`Missing driver definition for "${name}" auth provider.`);
-			return;
+			continue;
 		}
 
-		const provider = getProviderInstance(driver, options, { provider: name, ...config });
+		const provider = await getProviderInstance(driver, options, { provider: name, ...config });
 
 		if (!provider) {
 			logger.warn(`Invalid "${driver}" auth driver.`);
-			return;
+			continue;
 		}
 
 		providers.set(name, provider);
-	});
+	}
 }
 
-function getProviderInstance(
+async function getProviderInstance(
 	driver: string,
 	options: AuthDriverOptions,
 	config: Record<string, any> = {},
-): AuthDriver | undefined {
+): Promise<AuthDriver | undefined> {
 	switch (driver) {
 		case 'local':
 			return new LocalAuthDriver(options, config);
 
-		case 'oauth2':
+		case 'oauth2': {
+			const { OAuth2AuthDriver } = await import('./auth/drivers/oauth2.js');
 			return new OAuth2AuthDriver(options, config);
+		}
 
-		case 'openid':
+		case 'openid': {
+			const { OpenIDAuthDriver } = await import('./auth/drivers/openid.js');
 			return new OpenIDAuthDriver(options, config);
+		}
 
-		case 'ldap':
+		case 'ldap': {
+			const { LDAPAuthDriver } = await import('./auth/drivers/ldap.js');
 			return new LDAPAuthDriver(options, config);
+		}
 
-		case 'saml':
+		case 'saml': {
+			const { SAMLAuthDriver } = await import('./auth/drivers/saml.js');
 			return new SAMLAuthDriver(options, config);
+		}
 	}
 
 	return undefined;

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -49,7 +49,7 @@ export async function registerAuthProviders(): Promise<void> {
 	}
 
 	// Register configured providers
-	for (const name of providerNames) {
+	for (let name of providerNames) {
 		name = name.trim();
 
 		if (name === DEFAULT_AUTH_PROVIDER) {

--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -4,13 +4,6 @@ import type { Accountability } from '@directus/types';
 import { toBoolean } from '@directus/utils';
 import type { Request } from 'express';
 import { Router } from 'express';
-import {
-	createLDAPAuthRouter,
-	createLocalAuthRouter,
-	createOAuth2AuthRouter,
-	createOpenIDAuthRouter,
-	createSAMLAuthRouter,
-} from '../auth/drivers/index.js';
 import { DEFAULT_AUTH_PROVIDER, REFRESH_COOKIE_OPTIONS, SESSION_COOKIE_OPTIONS } from '../constants.js';
 import { getEntitlementManager } from '../license/index.js';
 import { isSSOBypassAllowed } from '../license/utils/is-sso-bypass-allowed.js';
@@ -31,31 +24,42 @@ const router = Router();
 const env = useEnv();
 const logger = useLogger();
 
+// Lazy-load auth driver routers to avoid importing heavy SSO dependencies upfront
 const authProviders = getAuthProviders();
 
 for (const authProvider of authProviders) {
 	let authRouter: Router | undefined;
 
 	switch (authProvider.driver) {
-		case 'local':
+		case 'local': {
+			const { createLocalAuthRouter } = await import('../auth/drivers/local.js');
 			authRouter = createLocalAuthRouter(authProvider.name);
 			break;
+		}
 
-		case 'oauth2':
+		case 'oauth2': {
+			const { createOAuth2AuthRouter } = await import('../auth/drivers/oauth2.js');
 			authRouter = createOAuth2AuthRouter(authProvider.name);
 			break;
+		}
 
-		case 'openid':
+		case 'openid': {
+			const { createOpenIDAuthRouter } = await import('../auth/drivers/openid.js');
 			authRouter = createOpenIDAuthRouter(authProvider.name);
 			break;
+		}
 
-		case 'ldap':
+		case 'ldap': {
+			const { createLDAPAuthRouter } = await import('../auth/drivers/ldap.js');
 			authRouter = createLDAPAuthRouter(authProvider.name);
 			break;
+		}
 
-		case 'saml':
+		case 'saml': {
+			const { createSAMLAuthRouter } = await import('../auth/drivers/saml.js');
 			authRouter = createSAMLAuthRouter(authProvider.name);
 			break;
+		}
 	}
 
 	if (!authRouter) {
@@ -100,6 +104,7 @@ function getCurrentRefreshToken(req: Request, mode: AuthenticationMode): string 
 }
 
 // Always register local auth, blocked at runtime when applicable
+const { createLocalAuthRouter } = await import('../auth/drivers/local.js');
 router.use('/login', createLocalAuthRouter(DEFAULT_AUTH_PROVIDER));
 
 router.post(

--- a/api/src/extensions/manager.ts
+++ b/api/src/extensions/manager.ts
@@ -29,16 +29,11 @@ import type {
 } from '@directus/types';
 import { isTypeIn, toBoolean } from '@directus/utils';
 import { pathToRelativeUrl, processId } from '@directus/utils/node';
-import aliasDefault from '@rollup/plugin-alias';
-import nodeResolveDefault from '@rollup/plugin-node-resolve';
-import virtualDefault from '@rollup/plugin-virtual';
 import chokidar, { FSWatcher } from 'chokidar';
 import express, { Router } from 'express';
 import ivm from 'isolated-vm';
 import { clone, debounce, isPlainObject } from 'lodash-es';
 import PQueue from 'p-queue';
-import { rolldown } from 'rolldown';
-import { rollup } from 'rollup';
 import { useBus } from '../bus/index.js';
 import getDatabase from '../database/index.js';
 import emitter, { Emitter } from '../emitter.js';
@@ -60,11 +55,6 @@ import { generateApiExtensionsSandboxEntrypoint } from './lib/sandbox/generate-a
 import { instantiateSandboxSdk } from './lib/sandbox/sdk/instantiate.js';
 import { type ExtensionSyncOptions, syncExtensions } from './lib/sync/sync.js';
 import { wrapEmbeds } from './lib/wrap-embeds.js';
-
-// Workaround for https://github.com/rollup/plugins/issues/1329
-const virtual = virtualDefault as unknown as typeof virtualDefault.default;
-const alias = aliasDefault as unknown as typeof aliasDefault.default;
-const nodeResolve = nodeResolveDefault as unknown as typeof nodeResolveDefault.default;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -583,6 +573,19 @@ export class ExtensionManager {
 		);
 
 		try {
+			// Lazy-load bundler and plugins to avoid importing them when not needed
+			const aliasDefault = await import('@rollup/plugin-alias');
+			const nodeResolveDefault = await import('@rollup/plugin-node-resolve');
+			const virtualDefault = await import('@rollup/plugin-virtual');
+
+			// Workaround for https://github.com/rollup/plugins/issues/1329
+			const virtual = virtualDefault.default as typeof virtualDefault.default;
+			const alias = aliasDefault.default as typeof aliasDefault.default;
+			const nodeResolve = nodeResolveDefault.default as typeof nodeResolveDefault.default;
+
+			const { rolldown } = await import('rolldown');
+			const { rollup } = await import('rollup');
+
 			/** Opt In for now. Should be @deprecated later to always use rolldown! */
 			const rollDirection = (env['EXTENSIONS_ROLLDOWN'] ?? false) ? rolldown : rollup;
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -274,3 +274,4 @@
 - sanskar-soni-9
 - kropsi
 - sourav-18
+- AliMahmoudDev


### PR DESCRIPTION
## Summary

Converts static imports to dynamic imports for packages that are only needed in specific configurations, reducing memory usage on startup.

### Changes

**Auth drivers (`api/src/auth.ts`, `api/src/controllers/auth.ts`)**
- SSO auth drivers (SAML, OpenID, OAuth2, LDAP) are now dynamically imported only when the corresponding `AUTH_PROVIDERS` are configured
- `LocalAuthDriver` remains statically imported as it is always used as the default provider
- This avoids loading heavy dependencies like `openid-client`, `ldapjs`, `@node-saml/node-saml`, etc. on every startup
- `getProviderInstance()` is now async; `registerAuthProviders()` already was async
- Module-level router setup in `controllers/auth.ts` uses top-level await with dynamic imports

**Rollup/Rolldown (`api/src/extensions/manager.ts`)**
- `rollup`, `rolldown`, and their plugins (`@rollup/plugin-alias`, `@rollup/plugin-node-resolve`, `@rollup/plugin-virtual`) are now dynamically imported inside `generateExtensionBundle()`
- This only loads when `SERVE_APP` is enabled, avoiding the bundler cost for API-only deployments

**TUS resumable uploads (`api/src/app.ts`)**
- `tusRouter` and `tusSchedule` are now dynamically imported only when `TUS_ENABLED=true`
- Avoids loading `@tus/server` and related packages when resumable uploads are disabled

### Performance Impact

- **API-only deployments**: Avoids loading rollup, rolldown, and all their plugins
- **No SSO configured**: Avoids loading openid-client, ldapjs, @node-saml/node-saml, etc.
- **No TUS**: Avoids loading @tus/server and its dependencies

Closes #24334