### PR TITLE
Fix project setup silently ignoring invalid license keys

### DIFF
--- a/.changeset/yummy-badgers-jog.md
+++ b/.changeset/yummy-badgers-jog.md
@@ -1,5 +1,6 @@
 ---
 '@directus/api': patch
+'@directus/app': patch
 ---
 
 Fixed project setup silently ignoring invalid license keys

--- a/.changeset/yummy-badgers-jog.md
+++ b/.changeset/yummy-badgers-jog.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed project setup silently ignoring invalid license keys

--- a/api/src/controllers/server.ts
+++ b/api/src/controllers/server.ts
@@ -130,6 +130,11 @@ router.post(
 		const licenseManager = getLicenseManager();
 
 		try {
+			// If provided ensure the license key is valid before proceeding with setup
+			if (data.license_key) {
+				await licenseManager.activate(data.license_key);
+			}
+
 			await createAdmin(req.schema, {
 				email: data.admin.email,
 				password: data.admin.password,
@@ -138,14 +143,6 @@ router.post(
 			});
 
 			const settingsService = new SettingsService({ schema: req.schema });
-
-			if (data.license_key) {
-				try {
-					await licenseManager.activate(data.license_key);
-				} catch {
-					// ignore
-				}
-			}
 
 			if (data.owner) {
 				settingsService.setOwner(data.owner);

--- a/app/src/components/v-license-badge.vue
+++ b/app/src/components/v-license-badge.vue
@@ -18,15 +18,15 @@ const link = computed(() => {
 </script>
 
 <template>
-	<template v-if="displayPoweredBy === 'DIRECTUS' || displayPoweredBy === 'OIG'">
+	<div v-if="displayPoweredBy === 'DIRECTUS' || displayPoweredBy === 'OIG'" class="license-badge">
 		<hr v-if="isPrivate" class="badge-divider" />
-		<a :href="link" class="license-badge" :class="{ private: isPrivate }" target="_blank" rel="noopener noreferrer">
+		<a :href="link" :class="{ private: isPrivate }" target="_blank" rel="noopener noreferrer">
 			<div class="link-inner">
 				<VIcon name="directus" class="directus-logo" />
 				{{ displayPoweredBy === 'DIRECTUS' ? $t('licensing.badge.directus') : $t('licensing.badge.oig') }}
 			</div>
 		</a>
-	</template>
+	</div>
 </template>
 
 <style lang="scss" scoped>

--- a/app/src/routes/setup/setup.vue
+++ b/app/src/routes/setup/setup.vue
@@ -13,7 +13,6 @@ import api from '@/api';
 import { login } from '@/auth';
 import VButton from '@/components/v-button.vue';
 import VNotice from '@/components/v-notice.vue';
-import { translateAPIError } from '@/lang';
 import { useServerStore } from '@/stores/server';
 import { getDirectusUrlWithUtm } from '@/utils/directus-url';
 import PublicView from '@/views/public';
@@ -92,8 +91,14 @@ async function launch() {
 	}
 }
 
-const errorMessage = computed(() => {
-	return error.value?.response?.data?.errors?.[0]?.message || error.value?.message || t('unexpected_error');
+const errorFormatted = computed(() => {
+	let message = error.value?.response?.data?.errors?.[0]?.message || error.value?.message || t('unexpected_error');
+
+	if (message.length > 200) {
+		message = message.substring(0, 197) + '...';
+	}
+
+	return message;
 });
 
 const setupComplete = computed(() => SetupValidator.safeParse(form.value).success);
@@ -123,6 +128,9 @@ const setupComplete = computed(() => SetupValidator.safeParse(form.value).succes
 			</I18nT>
 
 			<LicenseForm ref="licenseFormRef" v-model="form" :errors="errors"></LicenseForm>
+			<VNotice v-if="error" type="danger">
+				{{ errorFormatted }}
+			</VNotice>
 			<div class="actions">
 				<VButton v-if="showAdminStep" secondary @click="page = 'setup'">
 					{{ $t('back') }}
@@ -132,15 +140,6 @@ const setupComplete = computed(() => SetupValidator.safeParse(form.value).succes
 				</VButton>
 			</div>
 		</template>
-
-		<VNotice v-if="error" type="danger">
-			<p class="error-code">
-				{{ translateAPIError(error) }}
-			</p>
-			<p>
-				{{ errorMessage }}
-			</p>
-		</VNotice>
 	</PublicView>
 </template>
 
@@ -163,11 +162,6 @@ p {
 
 .v-notice {
 	margin-block-start: 1.375rem;
-}
-
-.error-code {
-	font-weight: 700;
-	margin-block-end: 0.25rem;
 }
 
 .actions {

--- a/app/src/routes/setup/setup.vue
+++ b/app/src/routes/setup/setup.vue
@@ -3,7 +3,7 @@ import { DIRECTUS_SUPPORT_URL } from '@directus/constants';
 import { SetupForm as Form } from '@directus/types';
 import { useHead } from '@unhead/vue';
 import { storeToRefs } from 'pinia';
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { I18nT, useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import { buildSetupPayload, defaultValues, SetupValidator, useSetupFields, validate, ValidationError } from './form';
@@ -34,6 +34,15 @@ const errors = ref<ValidationError[]>([]);
 const error = ref<any>(null);
 const isSaving = ref(false);
 const page = ref<'setup' | 'license'>('setup');
+
+watch(
+	form,
+	() => {
+		// Clear error on any form change
+		error.value = null;
+	},
+	{ deep: true },
+);
 
 const showAdminStep = computed(() => !info.value.setupCompleted);
 


### PR DESCRIPTION
## Scope

What's changed:

- Setup no longer swallows license key activation errors

https://github.com/user-attachments/assets/c88a2ae4-af11-4380-91a6-e9054f02ec3f

- Hide powered by badge on smaller screens in public view

https://github.com/user-attachments/assets/b903170b-a17d-462e-bbe7-f816e33fbcd4


## Potential Risks / Drawbacks

- Invalid keys now block setup completion - **intended**

## Tested Scenarios

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes CMS-2578
