### PR TITLE
Prevent setting a custom user `provider` when not entitled to SSO

### DIFF
--- a/.changeset/block-sso-provider-without-entitlement.md
+++ b/.changeset/block-sso-provider-without-entitlement.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Prevented setting a custom user `provider` when the current license isn't entitled to SSO

--- a/.changeset/block-sso-provider-without-entitlement.md
+++ b/.changeset/block-sso-provider-without-entitlement.md
@@ -1,5 +1,0 @@
----
-'@directus/api': patch
----
-
-Prevented setting a custom user `provider` when the current license isn't entitled to SSO

--- a/.changeset/olive-dryers-draw.md
+++ b/.changeset/olive-dryers-draw.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Prevented setting a custom user `provider` when not entitled
+Prevented setting a custom user `provider` when not entitled to SSO

--- a/.changeset/olive-dryers-draw.md
+++ b/.changeset/olive-dryers-draw.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Prevented setting a custom user `provider` when not entitled

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -6,6 +6,7 @@ import jwt from 'jsonwebtoken';
 import knex from 'knex';
 import { createTracker, MockClient } from 'knex-mock-client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_AUTH_PROVIDER } from '../constants.js';
 import { validateRemainingAdminUsers } from '../permissions/modules/validate-remaining-admin/validate-remaining-admin-users.js';
 import { _cache } from '../utils/get-secret.js';
 import { verifyJWT } from '../utils/jwt.js';
@@ -36,6 +37,16 @@ vi.mock('@directus/env', () => ({
 }));
 
 vi.mock('../permissions/modules/validate-remaining-admin/validate-remaining-admin-users.js');
+
+const { isEntitledMock } = vi.hoisted(() => ({ isEntitledMock: vi.fn() }));
+
+vi.mock('../license/index.js', () => ({
+	getEntitlementManager: () => ({
+		isEntitled: isEntitledMock,
+		clearCache: vi.fn(),
+		check: vi.fn().mockResolvedValue({ allowed: true }),
+	}),
+}));
 
 vi.mock('../utils/jwt.js', () => ({
 	verifyJWT: vi.fn(),
@@ -90,6 +101,7 @@ describe('Integration Tests', () => {
 
 		beforeEach(() => {
 			_cache.secret = null;
+			isEntitledMock.mockReturnValue(true);
 		});
 
 		afterEach(() => {
@@ -128,6 +140,37 @@ describe('Integration Tests', () => {
 
 				expect(opts.userIntegrityCheckFlags).toBe(UserIntegrityCheckFlag.UserLimits);
 			});
+
+			describe('SSO provider entitlement', () => {
+				it('should block a custom provider when not entitled to SSO', async () => {
+					isEntitledMock.mockReturnValue(false);
+					const opts: MutationOptions = {};
+
+					await service.createOne({ provider: 'saml' }, opts);
+
+					expect(opts.preMutationError).toStrictEqual(
+						new InvalidPayloadError({ reason: `Setting a custom "provider" isn't included in the current license` }),
+					);
+				});
+
+				it('should allow a custom provider when entitled to SSO', async () => {
+					isEntitledMock.mockReturnValue(true);
+					const opts: MutationOptions = {};
+
+					await service.createOne({ provider: 'saml' }, opts);
+
+					expect(opts.preMutationError).toBeUndefined();
+				});
+
+				it('should allow the default provider when not entitled to SSO', async () => {
+					isEntitledMock.mockReturnValue(false);
+					const opts: MutationOptions = {};
+
+					await service.createOne({ provider: DEFAULT_AUTH_PROVIDER }, opts);
+
+					expect(opts.preMutationError).toBeUndefined();
+				});
+			});
 		});
 
 		describe('createMany', () => {
@@ -163,6 +206,37 @@ describe('Integration Tests', () => {
 				await service.createMany([{}], opts);
 
 				expect(opts.userIntegrityCheckFlags).toBe(UserIntegrityCheckFlag.UserLimits);
+			});
+
+			describe('SSO provider entitlement', () => {
+				it('should block a custom provider in any payload when not entitled to SSO', async () => {
+					isEntitledMock.mockReturnValue(false);
+					const opts: MutationOptions = {};
+
+					await service.createMany([{ provider: DEFAULT_AUTH_PROVIDER }, { provider: 'saml' }], opts);
+
+					expect(opts.preMutationError).toStrictEqual(
+						new InvalidPayloadError({ reason: `Setting a custom "provider" isn't included in the current license` }),
+					);
+				});
+
+				it('should allow a custom provider when entitled to SSO', async () => {
+					isEntitledMock.mockReturnValue(true);
+					const opts: MutationOptions = {};
+
+					await service.createMany([{ provider: 'saml' }], opts);
+
+					expect(opts.preMutationError).toBeUndefined();
+				});
+
+				it('should allow default providers when not entitled to SSO', async () => {
+					isEntitledMock.mockReturnValue(false);
+					const opts: MutationOptions = {};
+
+					await service.createMany([{ provider: DEFAULT_AUTH_PROVIDER }, {}], opts);
+
+					expect(opts.preMutationError).toBeUndefined();
+				});
 			});
 		});
 
@@ -295,6 +369,34 @@ describe('Integration Tests', () => {
 						);
 					});
 				});
+			});
+		});
+
+		describe('updateMany SSO provider entitlement', () => {
+			const service = new UsersService({
+				knex: db,
+				schema,
+				accountability: null,
+			});
+
+			it('should block setting a custom provider when not entitled to SSO', async () => {
+				isEntitledMock.mockReturnValue(false);
+				const opts: MutationOptions = {};
+
+				await service.updateMany(['user-id-14'], { provider: 'saml' }, opts);
+
+				expect(opts.preMutationError).toStrictEqual(
+					new InvalidPayloadError({ reason: `Setting a custom "provider" isn't included in the current license` }),
+				);
+			});
+
+			it('should allow setting the default provider when not entitled to SSO', async () => {
+				isEntitledMock.mockReturnValue(false);
+				const opts: MutationOptions = {};
+
+				await service.updateMany(['user-id-14'], { provider: DEFAULT_AUTH_PROVIDER }, opts);
+
+				expect(opts.preMutationError).toBeUndefined();
 			});
 		});
 

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -187,6 +187,21 @@ export class UsersService extends ItemsService {
 	}
 
 	/**
+	 * Block setting a non-default auth provider when the current license isn't entitled to SSO
+	 */
+	private checkProviderEntitlement(input: string | string[]): void {
+		const providers = Array.isArray(input) ? input : [input];
+
+		const hasCustomProvider = providers.some((provider) => provider && provider !== DEFAULT_AUTH_PROVIDER);
+
+		if (hasCustomProvider && !getEntitlementManager().isEntitled('sso_enabled')) {
+			throw new InvalidPayloadError({
+				reason: `Setting a custom "provider" isn't included in the current license`,
+			});
+		}
+	}
+
+	/**
 	 * Create a new user
 	 */
 	override async createOne(data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey> {
@@ -198,6 +213,10 @@ export class UsersService extends ItemsService {
 
 			if ('password' in data) {
 				await this.checkPasswordPolicy([data['password']]);
+			}
+
+			if ('provider' in data) {
+				this.checkProviderEntitlement(data['provider']);
 			}
 		} catch (err: any) {
 			opts.preMutationError = err;
@@ -220,6 +239,7 @@ export class UsersService extends ItemsService {
 	override async createMany(data: Partial<Item>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
 		const emails = data.map((payload) => payload['email']).filter((email) => email);
 		const passwords = data.map((payload) => payload['password']).filter((password) => password);
+		const providers = data.map((payload) => payload['provider']).filter((provider) => provider);
 		const someActive = data.some((payload) => !('status' in payload) || payload['status'] === 'active');
 
 		try {
@@ -230,6 +250,10 @@ export class UsersService extends ItemsService {
 
 			if (passwords.length) {
 				await this.checkPasswordPolicy(passwords);
+			}
+
+			if (providers.length) {
+				this.checkProviderEntitlement(providers);
 			}
 		} catch (err: any) {
 			opts.preMutationError = err;
@@ -288,6 +312,8 @@ export class UsersService extends ItemsService {
 				if (this.accountability && this.accountability.admin !== true) {
 					throw new InvalidPayloadError({ reason: `You can't change the "provider" value manually` });
 				}
+
+				this.checkProviderEntitlement(data['provider']);
 
 				data['auth_data'] = null;
 			}

--- a/tests/e2e/tests/license/rest.sb.test.ts
+++ b/tests/e2e/tests/license/rest.sb.test.ts
@@ -5,6 +5,7 @@ import {
 	CORE_LICENSE,
 	deactivateLicense,
 	generateLicensePendingResolution,
+	type LicensePendingResolutionOutput,
 	previewLicense,
 	readLicense,
 	readLicenseAddons,
@@ -468,6 +469,8 @@ describe('POST /license/pending-resolution', () => {
 
 		describe('sso_enabled', () => {
 			test('reports gate with empty blockers when admin has email and password', async () => {
+				await api.request(activateLicense({ license_key: unlimitedLicenses.key }));
+
 				const adminMe = await api.request(readMe());
 
 				const ssoUser = await api.request(
@@ -481,7 +484,7 @@ describe('POST /license/pending-resolution', () => {
 					}),
 				);
 
-				await api.request(activateLicense({ license_key: ssoDisabledLicense.key }));
+				await api.request(updateLicense({ license_key: ssoDisabledLicense.key }));
 
 				const result = await api.request(withToken('1234', generateLicensePendingResolution()));
 
@@ -493,6 +496,8 @@ describe('POST /license/pending-resolution', () => {
 			});
 
 			test('reports ADMIN_MISSING_EMAIL when caller has no email', async () => {
+				await api.request(activateLicense({ license_key: unlimitedLicenses.key }));
+
 				const adminMe = await api.request(readMe());
 
 				const ssoUser = await api.request(
@@ -505,7 +510,7 @@ describe('POST /license/pending-resolution', () => {
 					}),
 				);
 
-				await api.request(activateLicense({ license_key: ssoDisabledLicense.key }));
+				await api.request(updateLicense({ license_key: ssoDisabledLicense.key }));
 
 				const result = await api.request(withToken('1234', generateLicensePendingResolution()));
 
@@ -517,6 +522,8 @@ describe('POST /license/pending-resolution', () => {
 			});
 
 			test('reports ADMIN_MISSING_PASSWORD when caller has no password', async () => {
+				await api.request(activateLicense({ license_key: unlimitedLicenses.key }));
+
 				const adminMe = await api.request(readMe());
 
 				const ssoUser = await api.request(
@@ -529,7 +536,7 @@ describe('POST /license/pending-resolution', () => {
 					}),
 				);
 
-				await api.request(activateLicense({ license_key: ssoDisabledLicense.key }));
+				await api.request(updateLicense({ license_key: ssoDisabledLicense.key }));
 
 				const result = await api.request(withToken('1234', generateLicensePendingResolution()));
 
@@ -541,6 +548,8 @@ describe('POST /license/pending-resolution', () => {
 			});
 
 			test('reports both blockers when caller has neither', async () => {
+				await api.request(activateLicense({ license_key: unlimitedLicenses.key }));
+
 				const adminMe = await api.request(readMe());
 
 				const ssoUser = await api.request(
@@ -552,9 +561,11 @@ describe('POST /license/pending-resolution', () => {
 					}),
 				);
 
-				await api.request(activateLicense({ license_key: ssoDisabledLicense.key }));
+				await api.request(updateLicense({ license_key: ssoDisabledLicense.key }));
 
-				const result = await api.request(withToken('1234', generateLicensePendingResolution()));
+				const result = (await api.request(
+					withToken('1234', generateLicensePendingResolution()),
+				)) as LicensePendingResolutionOutput;
 
 				expect(result).toMatchObject([{ key: 'sso_enabled', kind: 'feature_gate' }]);
 				expect((result[0] as any).blockers).toEqual(['ADMIN_MISSING_EMAIL', 'ADMIN_MISSING_PASSWORD']);
@@ -612,7 +623,7 @@ describe('POST /license/pending-resolution', () => {
 
 			await api.request(updateLicense({ license_key: restrictedLicense.key }));
 
-			const result = await api.request(generateLicensePendingResolution());
+			const result = (await api.request(generateLicensePendingResolution())) as LicensePendingResolutionOutput;
 
 			const limitKeys = result.filter((r) => r.kind === 'limit').map((r) => r.key);
 			const gateKeys = result.filter((r) => r.kind === 'feature_gate').map((r) => r.key);
@@ -702,7 +713,7 @@ describe('POST /license/resolve', () => {
 		await api.request(updateSettings({ ai_openai_compatible_name: 'lorem' } as any));
 		await api.request(updateLicense({ license_key: restrictedLicense.key }));
 
-		const before = await api.request(generateLicensePendingResolution());
+		const before = (await api.request(generateLicensePendingResolution())) as LicensePendingResolutionOutput;
 		expect(before.length).toBeGreaterThan(0);
 
 		// action


### PR DESCRIPTION
## Scope

What's changed:

- We now block setting a users provider to anything aside from default when not entitled to sso

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Tested Scenarios

- [x] Not entitled to sso - blocked
- [x] Entitled to sso - allowed

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes CMS-2549
