### PR TITLE
Fix nested `deep` query parameters being dropped when filters use dynamic variables

### DIFF
--- a/.changeset/await-nested-deep-query.md
+++ b/.changeset/await-nested-deep-query.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed nested `deep` query parameters sometimes being dropped on authenticated requests
+Fixed nested `deep` query parameters being dropped when filters use dynamic variables

--- a/.changeset/await-nested-deep-query.md
+++ b/.changeset/await-nested-deep-query.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed nested `deep` query parameters sometimes being dropped on authenticated requests

--- a/api/src/utils/sanitize-query.test.ts
+++ b/api/src/utils/sanitize-query.test.ts
@@ -399,6 +399,28 @@ describe('deep', () => {
 
 		expect(sanitizedQuery.deep).toEqual({ deep: { relational_field_a: { _limit: 100, _sort: ['name'] } } });
 	});
+
+	test('should convert nested filters with dynamic variables to corresponding values', async () => {
+		const deep = {
+			deep: {
+				relational_field: {
+					_filter: { name: { _eq: '$CURRENT_USER.something' } },
+				},
+			},
+		};
+
+		vi.mocked(fetchDynamicVariableData).mockResolvedValue({ $CURRENT_USER: { something: 'test' } });
+
+		const sanitizedQuery = await sanitizeQuery({ deep }, null as any, {} as any);
+
+		expect(sanitizedQuery.deep).toEqual({
+			deep: {
+				relational_field: {
+					_filter: { name: { _eq: 'test' } },
+				},
+			},
+		});
+	});
 });
 
 describe('alias', () => {

--- a/api/src/utils/sanitize-query.ts
+++ b/api/src/utils/sanitize-query.ts
@@ -267,7 +267,7 @@ async function sanitizeDeep(deep: Record<string, any>, schema: SchemaOverview, a
 				// Collect all sub query parameters without the leading underscore
 				subQuery[key.substring(1)] = value;
 			} else if (isPlainObject(value)) {
-				parse(value, [...path, key]);
+				await parse(value, [...path, key]);
 			}
 		}
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -1,3 +1,4 @@
+- mazen-salah
 - yassilah
 - abdonrd
 - benhaynes


### PR DESCRIPTION
 The inner parse() in sanitizeDeep is async — it awaits sanitizeQuery,
  which for authenticated requests transitively awaits
  dynamic-variable/DB lookups. The recursive descent into nested
  relational deep levels called parse() without awaiting it, so
  sanitizeDeep could return `result` before those nested levels finished
  writing to it, dropping sanitized values for deeply nested deep
  queries.

  Await the recursive call so every nested level is written before
  returning.

  ## Scope

  What's changed:

  - `api/src/utils/sanitize-query.ts` — `await` the recursive `parse()`
  call inside `sanitizeDeep` so each nested deep level is written to
  `result` before it's returned.

  No public API or schema changes — this is a one-line behavior fix.

  ## Potential Risks / Drawbacks

  - The recursive `parse()` calls now run sequentially (awaited) inside
  the existing `for...of` loop instead of being fire-and-forget. For
  deeply/widely nested `deep` objects that's a negligible serialization
  cost, and the prior behavior was incorrect rather than faster.
  - Single-level deep queries are unaffected — the top-level
  `parse(deep)` was already awaited, so only nested (2+ level) deep
  queries change behavior.

  ## Tested Scenarios

  - `pnpm lint` and Prettier pass on the change.
  - Traced the async flow (`sanitizeDeep` → async `parse` → recursive
  `parse`) and confirmed the missing `await` let `sanitizeDeep` resolve
  before the nested `set(result, …)` writes completed for authenticated
  requests.
  - I wasn't able to run the full `@directus/api` vitest suite locally
  (it pulls in `isolated-vm`, which needs native build tools I don't
  have set up), so I'm relying on CI for the unit tests.

  ## Review Notes / Questions

  - I kept the fix minimal (sequential `await` in the existing loop). If
  you'd prefer the nested levels resolved in parallel I can switch to
  `await Promise.all(...)` over collected promises.
  - Happy to add a regression test if you'd like — a deterministic test
  for the ordering is a bit awkward, so I left it out for now.

  ## Checklist

  - [x] Added or updated tests
  - [ ] Documentation PR created
  [here](https://github.com/directus/docs) or not required
  - [ ] OpenAPI package PR created
  [here](https://github.com/directus/openapi) or not required