### PR TITLE
fix: update broken troubleshooting link in bug report template

### DIFF
--- a/.changeset/ready-kiwis-cheat.md
+++ b/.changeset/ready-kiwis-cheat.md
@@ -1,0 +1,5 @@
+---
+'directus': patch
+---
+
+Fixed broken troubleshooting link in bug report template

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
         Hi, thank you for taking the time to create an issue! Before you get started, please ensure the following are correct:
 
         - I'm using the [latest version of Directus](https://github.com/directus/directus/releases)
-        - I've completed all [Troubleshooting Steps](https://docs.directus.io/getting-started/support/#troubleshooting-steps).
+        - I've completed all [Troubleshooting Steps](https://directus.com/docs/community/reporting-and-support/troubleshooting-steps).
         - There's [no other issue](https://github.com/directus/directus/issues?q=is%3Aissue) that already describes the problem.
 
         _For issues specific to Directus Cloud projects, please reach out through support@directus.io._

--- a/contributors.yml
+++ b/contributors.yml
@@ -275,3 +275,4 @@
 - kropsi
 - Prateet-Github
 - sourav-18
+- valerkahere


### PR DESCRIPTION
## Scope

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


What's changed:

- Updates the outdated troubleshooting documentation URL inside the bug report issue template to point to the live `directus.com` community support path.

## Potential Risks / Drawbacks

- N/A. This is a non-breaking text documentation update.

## Tested Scenarios

- Link now functions correctly and does not return 404.


## Review Notes / Questions

- N/A

## Checklist

- [x] Added or updated tests - not required
- [x] Documentation PR - not required
- [x] OpenAPI package PR - not required

---


