### PR TITLE
Update `directus_oauth_*` system collection visibility to match other system collections

### DIFF
--- a/.changeset/oauth-collection-notes.md
+++ b/.changeset/oauth-collection-notes.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added missing collection note translations for the `directus_oauth_*` system collections

--- a/.changeset/unhide-oauth-system-collections.md
+++ b/.changeset/unhide-oauth-system-collections.md
@@ -2,4 +2,4 @@
 '@directus/system-data': minor
 ---
 
-Unhid the `directus_oauth_*` system collections so they follow the same visibility convention as other system tables
+Updated `directus_oauth_*` system collection visibility to match other system collections

--- a/.changeset/unhide-oauth-system-collections.md
+++ b/.changeset/unhide-oauth-system-collections.md
@@ -1,0 +1,5 @@
+---
+'@directus/system-data': minor
+---
+
+Unhid the `directus_oauth_*` system collections so they follow the same visibility convention as other system tables

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1704,6 +1704,10 @@ directus_collection:
   directus_translations: Custom translations
   directus_versions: Content Versions for items
   directus_extensions: Configuration of extensions
+  directus_oauth_clients: Registered OAuth client applications
+  directus_oauth_codes: Authorization codes for OAuth flows
+  directus_oauth_consents: User consent grants for OAuth clients
+  directus_oauth_tokens: Access and refresh tokens for OAuth clients
 fields:
   directus_activity:
     item: Item Primary Key

--- a/packages/system-data/src/collections/collections.yaml
+++ b/packages/system-data/src/collections/collections.yaml
@@ -125,19 +125,15 @@ data:
   - collection: directus_oauth_clients
     note: $t:directus_collection.directus_oauth_clients
     accountability: null
-    hidden: true
 
   - collection: directus_oauth_codes
     note: $t:directus_collection.directus_oauth_codes
     accountability: null
-    hidden: true
 
   - collection: directus_oauth_consents
     note: $t:directus_collection.directus_oauth_consents
     accountability: null
-    hidden: true
 
   - collection: directus_oauth_tokens
     note: $t:directus_collection.directus_oauth_tokens
     accountability: null
-    hidden: true


### PR DESCRIPTION
The new `directus_oauth_*` system collections were added with `hidden: true`, unlike every other Directus system collection. This removes the override so they inherit the default (`hidden: false`), matching existing system tables.