### PR TITLE
Fix bulk creation of itemless drafts fails

### DIFF
--- a/.changeset/curly-squids-create.md
+++ b/.changeset/curly-squids-create.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed bulk creation of itemless drafts always fails

--- a/api/src/services/versions.test.ts
+++ b/api/src/services/versions.test.ts
@@ -242,5 +242,29 @@ describe('Integration Tests', () => {
 				expect(RevisionsService.prototype.createOne).not.toHaveBeenCalled();
 			});
 		});
+
+		describe('createMany duplicate-key check', () => {
+			test('allows multiple itemless versions sharing the same key + collection', async () => {
+				await expect(
+					service.createMany([
+						{ key: 'draft', name: 'bulk A', collection: 'articles_track_all' },
+						{ key: 'draft', name: 'bulk B', collection: 'articles_track_all' },
+					]),
+				).resolves.toBeDefined();
+
+				expect(ItemsService.prototype.createMany).toHaveBeenCalledTimes(1);
+			});
+
+			test('still rejects duplicate key + collection + item within the batch', async () => {
+				await expect(
+					service.createMany([
+						{ key: 'draft', collection: 'articles_track_all', item: '1' },
+						{ key: 'draft', collection: 'articles_track_all', item: '1' },
+					]),
+				).rejects.toThrow(/Cannot create multiple versions/);
+
+				expect(ItemsService.prototype.createMany).not.toHaveBeenCalled();
+			});
+		});
 	});
 });

--- a/api/src/services/versions.ts
+++ b/api/src/services/versions.ts
@@ -198,6 +198,9 @@ export class VersionsService extends ItemsService<ContentVersion> {
 		const keyCombos = new Set();
 
 		for (const item of data) {
+			// Itemless versions are allowed to share a key within a collection
+			if (isNil(item['item'])) continue;
+
 			const keyCombo = `${item['key']}-${item['collection']}-${item['item']}`;
 
 			if (keyCombos.has(keyCombo)) {


### PR DESCRIPTION
## Scope

What's changed:

- We skip any duplicate key/collection/item combo on createMany for versions, same as we do for createOne and updateMany

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Tested Scenarios

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #\<num\>
