### PR TITLE
Show collection name in item header when display template is set

### DIFF
--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -1025,13 +1025,16 @@ function useAutoSwitchToDraft() {
 		<template v-else-if="isNew === false && collectionInfo.meta && collectionInfo.meta.display_template" #title>
 			<VSkeletonLoader v-if="loading" class="title-loader" type="text" />
 
-			<h1 v-else class="type-title">
-				<RenderTemplate
-					:collection="collectionInfo.collection"
-					:item="templateData"
-					:template="collectionInfo.meta!.display_template"
-				/>
-			</h1>
+			<template v-else>
+				<span class="collection-breadcrumb">{{ collectionInfo.name }}</span>
+				<h1 class="type-title">
+					<RenderTemplate
+						:collection="collectionInfo.collection"
+						:item="templateData"
+						:template="collectionInfo.meta!.display_template"
+					/>
+				</h1>
+			</template>
 		</template>
 
 		<template v-if="shouldShowVersioning" #title-outer:append>
@@ -1394,6 +1397,20 @@ function useAutoSwitchToDraft() {
 
 .title-loader {
 	inline-size: 14.625rem;
+}
+
+.collection-breadcrumb {
+	color: var(--theme--foreground-subdued);
+	font-family: var(--theme--header--title--font-family);
+	font-size: 1rem;
+	line-height: 1.375rem;
+	white-space: nowrap;
+	flex-shrink: 0;
+
+	&::after {
+		content: '/';
+		margin-inline: 0.375rem;
+	}
 }
 
 :deep(.type-title) {


### PR DESCRIPTION
## Scope

### What's Changed

Added the collection name as a breadcrumb-style prefix in the item header when a **Display Template** is configured for the collection.

**Before**

```
My First Project
```

**After**

```
Projects / My First Project
```

### Behavior

* When a collection has a Display Template:
  * The collection name is displayed first in a subdued/muted color.
  * A `/` separator is shown between the collection name and the rendered Display Template value.
  * The Display Template value remains the primary title.
* When a collection does **not** have a Display Template:
  * Existing behavior is unchanged.
  * Header continues to display:

    ```
    Editing Item in Projects
    ```

## Potential Risks / Drawbacks

* Minor visual change to item headers for collections that use a Display Template.
* Collections with very long names combined with long Display Template values may cause header overflow on narrow viewports.
  * Mitigated by existing text-overflow handling.

## Tested Scenarios

* ✅ Collection with a Display Template:
  * Header displays `Projects / My First Project`.
* ✅ Collection without a Display Template:
  * Header remains `Editing Item in Projects`.
* ✅ Singleton collections:
  * Unaffected; collection name continues to be shown as before.
* ✅ New item (`+`) state:
  * Unaffected; breadcrumb rendering only applies to existing items with a Display Template.

## Review Notes

* Implemented the collection name inline on the same row as the title to preserve the existing header layout and avoid introducing structural UI changes.
* Used `var(--theme--foreground-subdued)` for the collection name styling to ensure it remains visually secondary to the item title.
* Open to feedback on whether a stacked (two-line) breadcrumb/title layout would provide a better user experience.

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created in [https://github.com/directus/docs](<https://github.com/directus/docs>) (or not required)
- [ ] OpenAPI package PR created in [https://github.com/directus/openapi](<https://github.com/directus/openapi>) (or not required)

---

Fixes directus/directus#27680