### PR TITLE
Correctly identify field for VALUE_OUT_OF_RANGE errors

### DIFF
--- a/.changeset/ten-cooks-repair.md
+++ b/.changeset/ten-cooks-repair.md
@@ -1,0 +1,6 @@
+---
+'@directus/schema': patch
+'@directus/api': patch
+---
+
+correctly identify field for VALUE_OUT_OF_RANGE errors

--- a/api/src/database/errors/dialects/postgres.ts
+++ b/api/src/database/errors/dialects/postgres.ts
@@ -6,7 +6,7 @@ import {
 	ValueOutOfRangeError,
 	ValueTooLongError,
 } from '@directus/errors';
-import type { Item } from '@directus/types';
+import type { Item, SchemaOverview } from '@directus/types';
 import type { PostgresError } from './types.js';
 
 enum PostgresErrorCodes {
@@ -17,7 +17,11 @@ enum PostgresErrorCodes {
 	VALUE_LIMIT_VIOLATION = '22001',
 }
 
-export function extractError(error: PostgresError, data: Partial<Item>): PostgresError | Error {
+export function extractError(
+	error: PostgresError,
+	data: Partial<Item>,
+	schema?: SchemaOverview,
+): PostgresError | Error {
 	switch (error.code) {
 		case PostgresErrorCodes.UNIQUE_VIOLATION:
 			return uniqueViolation();
@@ -58,12 +62,33 @@ export function extractError(error: PostgresError, data: Partial<Item>): Postgre
 		if (!matches) return error;
 
 		const collection = matches[0].slice(1, -1);
-		const field = matches[1]?.slice(1, -1) ?? null;
+
+		let field = matches[1]?.slice(1, -1) ?? null;
+		let inputValue = field ? data[field] : null;
+
+		if (collection && schema && schema.collections[collection]) {
+			for (const [key, value] of Object.entries(data)) {
+				const fieldInfo = schema.collections[collection].fields[key];
+
+				if (fieldInfo?.dbType !== 'numeric' || typeof value !== 'string') continue;
+
+				const [integerPart = '', decimalPart = ''] = value.split('.');
+
+				if (
+					(fieldInfo.precision && integerPart.length > (fieldInfo.precision ?? 0) - (fieldInfo.scale ?? 0)) ||
+					(fieldInfo.scale && decimalPart.length > (fieldInfo.scale ?? 0))
+				) {
+					field = key;
+					inputValue = value;
+					break;
+				}
+			}
+		}
 
 		return new ValueOutOfRangeError({
 			collection,
-			field,
-			value: field ? data[field] : null,
+			field: field,
+			value: inputValue,
 		});
 	}
 
@@ -77,7 +102,6 @@ export function extractError(error: PostgresError, data: Partial<Item>): Postgre
 		const matches = error.message.match(regex);
 
 		if (!matches) return error;
-
 		const collection = matches[0].slice(1, -1);
 		const field = matches[1]?.slice(1, -1) ?? null;
 

--- a/api/src/database/errors/translate.ts
+++ b/api/src/database/errors/translate.ts
@@ -1,4 +1,4 @@
-import type { Item } from '@directus/types';
+import type { Item, SchemaOverview } from '@directus/types';
 import emitter from '../../emitter.js';
 import getDatabase, { getDatabaseClient } from '../index.js';
 import { extractError as mssql } from './dialects/mssql.js';
@@ -17,7 +17,11 @@ import type { SQLError } from './dialects/types.js';
  * - Value Out of Range
  * - Value Too Long
  */
-export async function translateDatabaseError(error: SQLError, data: Partial<Item>): Promise<any> {
+export async function translateDatabaseError(
+	error: SQLError,
+	data: Partial<Item>,
+	schema?: SchemaOverview,
+): Promise<any> {
 	const client = getDatabaseClient();
 	let defaultError: any;
 
@@ -27,7 +31,7 @@ export async function translateDatabaseError(error: SQLError, data: Partial<Item
 			break;
 		case 'cockroachdb':
 		case 'postgres':
-			defaultError = postgres(error, data);
+			defaultError = postgres(error, data, schema);
 			break;
 		case 'sqlite':
 			defaultError = sqlite(error, data);

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -581,7 +581,7 @@ export class FieldsService {
 							});
 						}
 					} catch (err: any) {
-						throw await translateDatabaseError(err, field);
+						throw await translateDatabaseError(err, field, this.schema);
 					}
 				}
 			}

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -272,7 +272,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					primaryKey = primaryKey ?? returnedKey;
 				}
 			} catch (err: any) {
-				const dbError = await translateDatabaseError(err, data);
+				const dbError = await translateDatabaseError(err, data, this.schema);
 
 				if (isDirectusError(dbError, ErrorCode.RecordNotUnique) && dbError.extensions.primaryKey) {
 					// This is a MySQL specific thing we need to handle here, since MySQL does not return the field name
@@ -847,7 +847,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				try {
 					await trx(this.collection).update(payloadWithTypeCasting).whereIn(primaryKeyField, keys);
 				} catch (err: any) {
-					throw await translateDatabaseError(err, data);
+					throw await translateDatabaseError(err, data, this.schema);
 				}
 			}
 

--- a/api/src/services/mcp-oauth/index.ts
+++ b/api/src/services/mcp-oauth/index.ts
@@ -1775,7 +1775,7 @@ export class McpOAuthService {
 			return row;
 		} catch (err: unknown) {
 			// Concurrent INSERT: catch unique constraint violation, SELECT existing
-			const translated = await translateDatabaseError(err, row);
+			const translated = await translateDatabaseError(err, row, this.schema);
 
 			if (translated instanceof RecordNotUniqueError) {
 				logger.debug({ client_id: clientId }, 'CIMD concurrent insert, selecting existing');

--- a/packages/schema/src/dialects/postgres.ts
+++ b/packages/schema/src/dialects/postgres.ts
@@ -93,6 +93,8 @@ export default class Postgres implements SchemaInspector {
 			is_identity: boolean;
 			is_nullable: boolean;
 			is_generated: boolean;
+			numeric_precision: number | null;
+			numeric_scale: number | null;
 		};
 
 		type RawGeometryColumn = {
@@ -110,6 +112,8 @@ export default class Postgres implements SchemaInspector {
 				`
         SELECT c.table_name
           , c.column_name
+		  ,c.numeric_precision
+		  ,c.numeric_scale
           , c.column_default as default_value
           , c.data_type
 			 		, c.character_maximum_length as max_length


### PR DESCRIPTION
## Summary

PostgreSQL does not specify which column caused a `VALUE_OUT_OF_RANGE` error. The previous implementation relied on parsing the first identifier from the database error message, which could incorrectly attribute the error to another field (such as an m2o UUID field).

While investigating this issue, I also found that `numeric_precision` and `numeric_scale` existed in the schema types but were not populated by the schema package. This PR populates those values and uses them to identify the correct field when a numeric value exceeds its allowed range.

fix #27565
