### PR TITLE
Fix license badge spacing issue

### DIFF
--- a/.changeset/better-pigs-type.md
+++ b/.changeset/better-pigs-type.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed license badge spacing issue

--- a/app/src/components/v-license-badge.vue
+++ b/app/src/components/v-license-badge.vue
@@ -30,6 +30,12 @@ const link = computed(() => {
 </template>
 
 <style lang="scss" scoped>
+.license-badge {
+	display: flex;
+	flex-direction: column;
+	gap: 0.6565rem;
+}
+
 .badge-divider {
 	inline-size: calc(100% - 0.875rem);
 	align-self: center;


### PR DESCRIPTION
 ## Scope

  What's changed:

  - Restores the spacing between the divider and the link in `v-license-badge.vue`
  
  ## Potential Risks / Drawbacks

  - None I can think of

  ## Tested Scenarios

  - Sidebar (private) badge: divider-to-link spacing and divider centering match the pre-#27671
  rendering

  ## Checklist

  - [x] Added or updated tests or not required
  - [x] Documentation PR created [here](https://github.com/directus/docs) or not required
  - [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes [CMS-2627](https://linear.app/directus/issue/CMS-2627/fix-license-badge-spacing)
