### PR TITLE
Fix license modal being impossible to dismiss over a route drawer

### DIFF
--- a/.changeset/fix-license-modal-dismiss.md
+++ b/.changeset/fix-license-modal-dismiss.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed license modals being impossible to dismiss when shown above a route drawer (e.g. field detail pages) by keeping dialog focus traps stacked in visual order, and scoped license dismissal cookies to the whole app so dismissals persist across navigation

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -73,8 +73,8 @@ export async function login({ credentials, provider, share }: LoginParams): Prom
 	}
 
 	appStore.accessTokenExpiry = Date.now() + (response.expires ?? 0);
-	cookies.remove('license-banner-dismissed');
-	cookies.remove('license-login-modal-dismissed');
+	cookies.remove('license-banner-dismissed', { path: '/' });
+	cookies.remove('license-login-modal-dismissed', { path: '/' });
 	appStore.authenticated = true;
 
 	// Reload server store to get authenticated data

--- a/app/src/components/v-dialog.vue
+++ b/app/src/components/v-dialog.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
 import { useShortcut } from '@directus/composables';
 import { useFocusTrap } from '@vueuse/integrations/useFocusTrap';
-import { computed, nextTick, ref, useTemplateRef, watch } from 'vue';
+import { computed, nextTick, onScopeDispose, ref, useTemplateRef, watch } from 'vue';
 import TransitionDialog from '@/components/transition/dialog.vue';
 import VOverlay from '@/components/v-overlay.vue';
 import { useDialogRouteLeave } from '@/composables/use-dialog-route';
-import { useFocusTrapManager } from '@/composables/use-focus-trap-manager';
+import {
+	type DialogTrapHandle,
+	registerDialogTrap,
+	unregisterDialogTrap,
+	useFocusTrapManager,
+} from '@/composables/use-focus-trap-manager';
 
 export type ApplyShortcut = 'meta+enter' | 'meta+s';
 
@@ -95,6 +100,22 @@ function useOverlayFocusTrap() {
 
 	addFocusTrap(focusTrap);
 
+	const trapHandle: DialogTrapHandle = {
+		// mirrors the z-index stacking of the dialog placements in the styles below
+		get zRank() {
+			if (props.placement === 'center') return props.keepBehind ? 500 : 600;
+			return props.keepBehind ? 490 : 500;
+		},
+		reassert() {
+			const focused = document.activeElement;
+
+			focusTrap.deactivate({ returnFocus: false });
+			focusTrap.activate();
+
+			if (focused instanceof HTMLElement && overlayEl.value?.contains(focused)) focused.focus();
+		},
+	};
+
 	watch(
 		internalActive,
 		(newActive) => {
@@ -110,11 +131,18 @@ function useOverlayFocusTrap() {
 		async (newActive) => {
 			await nextTick();
 
-			if (newActive) focusTrap.activate();
-			else focusTrap.deactivate();
+			if (newActive) {
+				focusTrap.activate();
+				registerDialogTrap(trapHandle);
+			} else {
+				unregisterDialogTrap(trapHandle);
+				focusTrap.deactivate();
+			}
 		},
 		{ immediate: true },
 	);
+
+	onScopeDispose(() => unregisterDialogTrap(trapHandle));
 }
 </script>
 

--- a/app/src/composables/use-focus-trap-manager.test.ts
+++ b/app/src/composables/use-focus-trap-manager.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import { type DialogTrapHandle, registerDialogTrap, unregisterDialogTrap } from './use-focus-trap-manager';
+
+function makeHandle(zRank: number): DialogTrapHandle & { reassert: ReturnType<typeof vi.fn> } {
+	return { zRank, reassert: vi.fn() };
+}
+
+describe('registerDialogTrap', () => {
+	it('does not reassert when the new trap has the highest rank', () => {
+		const drawer = makeHandle(500);
+		const modal = makeHandle(600);
+
+		registerDialogTrap(drawer);
+		registerDialogTrap(modal);
+
+		expect(drawer.reassert).not.toHaveBeenCalled();
+		expect(modal.reassert).not.toHaveBeenCalled();
+
+		unregisterDialogTrap(drawer);
+		unregisterDialogTrap(modal);
+	});
+
+	it('reasserts an active center modal when a drawer activates after it', () => {
+		// customer scenario: license modal already open, route drawer (field detail) mounts after
+		const modal = makeHandle(600);
+		const drawer = makeHandle(500);
+
+		registerDialogTrap(modal);
+		registerDialogTrap(drawer);
+
+		expect(modal.reassert).toHaveBeenCalledOnce();
+		expect(drawer.reassert).not.toHaveBeenCalled();
+
+		unregisterDialogTrap(modal);
+		unregisterDialogTrap(drawer);
+	});
+
+	it('lets the most recently activated trap win ties', () => {
+		const drawerOne = makeHandle(500);
+		const drawerTwo = makeHandle(500);
+
+		registerDialogTrap(drawerOne);
+		registerDialogTrap(drawerTwo);
+
+		expect(drawerOne.reassert).not.toHaveBeenCalled();
+		expect(drawerTwo.reassert).not.toHaveBeenCalled();
+
+		unregisterDialogTrap(drawerOne);
+		unregisterDialogTrap(drawerTwo);
+	});
+
+	it('reasserts the most recently activated of multiple higher-ranked traps', () => {
+		const modalOne = makeHandle(600);
+		const modalTwo = makeHandle(600);
+		const drawer = makeHandle(500);
+
+		registerDialogTrap(modalOne);
+		registerDialogTrap(modalTwo);
+		registerDialogTrap(drawer);
+
+		expect(modalOne.reassert).not.toHaveBeenCalled();
+		expect(modalTwo.reassert).toHaveBeenCalledOnce();
+
+		unregisterDialogTrap(modalOne);
+		unregisterDialogTrap(modalTwo);
+		unregisterDialogTrap(drawer);
+	});
+
+	it('keeps keep-behind center dialogs below regular drawers', () => {
+		const keepBehindModal = makeHandle(500);
+		const drawer = makeHandle(500);
+
+		registerDialogTrap(keepBehindModal);
+		registerDialogTrap(drawer);
+
+		// equal rank: drawer activated later, stays on top
+		expect(keepBehindModal.reassert).not.toHaveBeenCalled();
+
+		unregisterDialogTrap(keepBehindModal);
+		unregisterDialogTrap(drawer);
+	});
+
+	it('does not reassert unregistered traps', () => {
+		const modal = makeHandle(600);
+		const drawer = makeHandle(500);
+
+		registerDialogTrap(modal);
+		unregisterDialogTrap(modal);
+		registerDialogTrap(drawer);
+
+		expect(modal.reassert).not.toHaveBeenCalled();
+
+		unregisterDialogTrap(drawer);
+	});
+});

--- a/app/src/composables/use-focus-trap-manager.ts
+++ b/app/src/composables/use-focus-trap-manager.ts
@@ -29,3 +29,35 @@ export function useInjectFocusTrapManager() {
 		unpauseFocusTrap: () => {},
 	});
 }
+
+export interface DialogTrapHandle {
+	/** Mirrors the visual z-index stacking of the dialog placements */
+	readonly zRank: number;
+	reassert: () => void;
+}
+
+const activeDialogTraps: DialogTrapHandle[] = [];
+
+/**
+ * Dialog focus traps activate in mount order, which may not match their visual stacking:
+ * a route drawer mounting after an already-open center modal would put its trap on top of
+ * the focus-trap stack and block all interaction with the modal rendered above it.
+ * Whenever a dialog trap activates, re-assert the highest-ranked active dialog trap
+ * (most recently activated wins ties) so the trap order matches the visual order.
+ */
+export function registerDialogTrap(handle: DialogTrapHandle) {
+	activeDialogTraps.push(handle);
+
+	let top = handle;
+
+	for (const trap of activeDialogTraps) {
+		if (trap.zRank >= top.zRank) top = trap;
+	}
+
+	if (top !== handle) top.reassert();
+}
+
+export function unregisterDialogTrap(handle: DialogTrapHandle) {
+	const index = activeDialogTraps.indexOf(handle);
+	if (index !== -1) activeDialogTraps.splice(index, 1);
+}

--- a/app/src/views/private/components/license-banner.vue
+++ b/app/src/views/private/components/license-banner.vue
@@ -49,7 +49,11 @@ async function setOwner() {
 
 function remindLater() {
 	// 30 days, will be deleted on logout / session end
-	cookies.set('license-banner-dismissed', 'true', { expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30) });
+	cookies.set('license-banner-dismissed', 'true', {
+		path: '/',
+		expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30),
+	});
+
 	notify({ title: t('license_banner.remind_next_login'), type: 'info' });
 	model.value = false;
 }

--- a/app/src/views/private/components/license-onboarding.vue
+++ b/app/src/views/private/components/license-onboarding.vue
@@ -93,6 +93,7 @@ async function save() {
 
 function dismiss() {
 	cookies.set('license-onboarding-dismissed', 'true', {
+		path: '/',
 		expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365 * 10),
 	});
 

--- a/app/src/views/private/components/license/license-login-modal.vue
+++ b/app/src/views/private/components/license/license-login-modal.vue
@@ -52,6 +52,7 @@ async function save() {
 
 function dismiss() {
 	cookies.set('license-login-modal-dismissed', 'true', {
+		path: '/',
 		expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30),
 	});
 


### PR DESCRIPTION
## Problem

In the Core grace period, the license modal's "Remind Later" button does nothing. The modal stays up and can't be dismissed, which blocks work. Happens on deep links like `/admin/settings/data-model/<collection>/<field>`.

## Cause

Those settings pages open a field-detail `VDrawer` after the license modal is already showing. Both use `focus-trap`, which keeps one global "last activated wins" stack. The drawer's trap ends up on top and blocks every click outside the drawer, including the modal sitting above it. So the button click never lands. ESC is dead for the same reason.

## Fix

Track active dialog focus traps. When one activates, re-assert the trap with the highest visual stacking (z-rank matches the CSS z-index). Trap order now matches what's painted on top. The modal works again, and the drawer underneath still works after dismiss.

Also: the three license dismissal cookies were set without a `path`, so they only applied to the current URL folder and didn't survive navigation. Set `path: '/'` on them and the matching `auth.ts` removals.

## Changes

- `use-focus-trap-manager.ts`: `registerDialogTrap` / `unregisterDialogTrap` z-rank logic + unit tests
- `v-dialog.vue`: register each trap with a rank mirroring its z-index; `reassert()` re-activates and restores focus
- `license-login-modal.vue`, `license-banner.vue`, `license-onboarding.vue`, `auth.ts`: `path: '/'` on dismissal cookies

## Testing

- 6 unit tests covering the drawer-under-modal case
- Manual Playwright run (mocked `/license` as core-grace + over-limit) on a field-detail URL:
  - Before: click does nothing, no cookie, modal persists after navigation
  - After: click dismisses, cookie set with `path=/`, drawer clicks work, dismissal sticks
- eslint + vue-tsc clean on changed files
- Reviewer check: confirm menus/dropdowns opened inside a dialog still work (they use the existing pause/unpause path, not touched here)

---
Fixes CMS-2631