### PR TITLE
ci: pin tj-actions/changed-files to a commit SHA

### DIFF
--- a/.changeset/pin-changed-files-sha.md
+++ b/.changeset/pin-changed-files-sha.md
@@ -1,0 +1,4 @@
+---
+---
+
+Pin `tj-actions/changed-files` to a commit SHA in the CI workflows. Ref-only hardening (the SHA is the exact commit the `v47` tag points to), no runtime or release impact.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Fetch Changesets
         if: ${{ ! contains(github.event.pull_request.labels.*.name, 'No Changeset') }}
         id: cs
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62  # v47
         with:
           files_yaml: |
             changeset:

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Fetch Changesets
         if: ${{ ! contains(github.event.pull_request.labels.*.name, 'No Changeset') }}
         id: cs
-        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62  # v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           files_yaml: |
             changeset:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62  # v47
 
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -53,7 +53,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62  # v47
 
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -72,7 +72,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62  # v47
 
       - name: Prepare
         uses: ./.github/actions/prepare

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62  # v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
 
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -53,7 +53,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62  # v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
 
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -72,7 +72,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62  # v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
 
       - name: Prepare
         uses: ./.github/actions/prepare

--- a/contributors.yml
+++ b/contributors.yml
@@ -283,3 +283,4 @@
 - valerkahere
 - levgiorg
 - MahinAnowar
+- eliottreich


### PR DESCRIPTION
## Scope

Pins `tj-actions/changed-files` from the mutable `v47` tag to the exact commit that tag points to today (`24d32ffd4924...`), keeping a `# v47` comment so the version stays legible. 4 usages across .github/workflows/changeset-check.yml (1), .github/workflows/check.yml (3).

A mutable tag can be re-pointed by the upstream maintainer; pinning to an immutable commit SHA is the [GitHub-recommended hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) for third-party actions. `tj-actions/changed-files` is also the action that was compromised in the March 2025 supply-chain incident, where a re-pointed tag leaked secrets from many workflows; SHA-pinning is the recommended mitigation.

## Potential Risks / Drawbacks

- None expected. Ref-only change: the pinned SHA is the exact commit `v47` resolves to today, so the step runs identically.
- Future updates: the `# v47` comment keeps the version readable, and an updater (Dependabot / Renovate) can bump the pin as new releases ship.

## Tested Scenarios

- No application code is touched; this is a CI configuration reference change only. The resolved commit is unchanged from what `v47` points to now.

## Review Notes / Questions

Happy to split per-file, add a Dependabot entry for `github-actions`, or close if this isn't useful.

A repository-specific security report with the other categories reviewed (public files only): https://www.task-bounty.com/fix-more?repo=directus/directus

<sub>Prepared by TaskBounty. The pinned SHA was verified against the upstream `v47` tag.</sub>