### PR TITLE
Lazy-load social icons to slim shared app bundle

### DIFF
--- a/.changeset/full-trees-type.md
+++ b/.changeset/full-trees-type.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Lazy loaded social icons on v-button

--- a/.changeset/full-trees-type.md
+++ b/.changeset/full-trees-type.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Lazy loaded social icons on v-button
+Added lazy loading of social icons on v-button

--- a/app/src/components/v-icon/v-icon.test.ts
+++ b/app/src/components/v-icon/v-icon.test.ts
@@ -1,6 +1,6 @@
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { createTestingPinia } from '@pinia/testing';
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import { expect, test, vi } from 'vitest';
 import VIcon from './v-icon.vue';
 
@@ -62,7 +62,7 @@ test('custom icon', () => {
 	expect(wrapper.find('svg').exists()).toBeTruthy();
 });
 
-test('social icon', () => {
+test('social icon', async () => {
 	const wrapper = mount(VIcon, {
 		props: {
 			name: 'docker',
@@ -76,10 +76,14 @@ test('social icon', () => {
 		},
 	});
 
+	// SocialIcon is loaded asynchronously via defineAsyncComponent
+	await vi.dynamicImportSettled();
+	await flushPromises();
+
 	expect(wrapper.find('svg').exists()).toBeTruthy();
 });
 
-test('should only load fontawesome brand icons when using social icon', () => {
+test('should only load fontawesome brand icons when using social icon', async () => {
 	const libraryAddSpy = vi.spyOn(library, 'add');
 
 	mount(VIcon, {
@@ -95,6 +99,9 @@ test('should only load fontawesome brand icons when using social icon', () => {
 		},
 	});
 
+	await vi.dynamicImportSettled();
+	await flushPromises();
+
 	expect(libraryAddSpy).not.toHaveBeenCalled();
 
 	mount(VIcon, {
@@ -109,6 +116,10 @@ test('should only load fontawesome brand icons when using social icon', () => {
 			],
 		},
 	});
+
+	// SocialIcon is loaded asynchronously via defineAsyncComponent
+	await vi.dynamicImportSettled();
+	await flushPromises();
 
 	expect(libraryAddSpy).toHaveBeenCalledOnce();
 });

--- a/app/src/components/v-icon/v-icon.vue
+++ b/app/src/components/v-icon/v-icon.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
 import { useSizeClass } from '@directus/composables';
 import { isIn } from '@directus/utils';
-import { IconName } from '@fortawesome/fontawesome-svg-core';
+import type { IconName } from '@fortawesome/fontawesome-svg-core';
 import { camelCase, upperFirst } from 'lodash';
-import { computed } from 'vue';
+import { computed, defineAsyncComponent } from 'vue';
 import { RTL_REVERSE_ICONS } from '../../constants/text-direction';
 import { components } from './custom-icons';
-import SocialIcon from './social-icon.vue';
 import { socialIcons } from './social-icons';
 import { useUserStore } from '@/stores/user';
+
+const SocialIcon = defineAsyncComponent(() => import('./social-icon.vue'));
 
 const props = withDefaults(
 	defineProps<{


### PR DESCRIPTION
## Scope

What's changed:

- `v-icon.vue` now imports `SocialIcon` via `defineAsyncComponent(() => import('./social-icon.vue'))` instead of statically.
- Switched `IconName` to a `import type` (type-only, never reaches runtime).

Why: `social-icon.vue` does `library.add(fab)`, eagerly registering the **entire** Font Awesome free-brands set (~557 KB). Because `v-icon`/`v-button` are imported on nearly every screen, Rollup hoisted that whole icon pack into the shared common chunk that loads on every page (it was the bulk of the misleadingly-named ~1 MB `v-button` chunk). Social icons only ever render in SSO login buttons, so eager loading was pure waste.

Result after the change:

- The Font Awesome `fab` pack (~571 KB) is now isolated in its own `social-icon-*.js` chunk, lazy-loaded only when a social icon actually renders.
- The eager common chunk no longer contains any brand icons (verified: `iconName` references appear only in the split `social-icon` chunk).

## Potential Risks / Drawbacks

- `SocialIcon` now resolves asynchronously, so an SSO provider button using a brand icon renders its icon one tick later (after the chunk loads). Negligible in practice and only on the login screen.
- No explicit loading/error fallback on the async component — acceptable given the tiny, non-critical icon.

## Tested Scenarios

- `pnpm --filter app build` — confirmed the 1 MB `v-button` common chunk is gone and `fab` moved to `social-icon-*.js` (571 KB).
- Verified `iconName` (Font Awesome) no longer appears in any eager chunk, only in the lazy `social-icon` chunk.
- `story:dev` — `v-icon` renders both Material and social (e.g. `github`) icons correctly; `v-button` with icons unaffected.

## Review Notes / Questions

- The old chunk was named `v-button` only because Rollup names auto-split shared chunks after a representative module — the size was never v-button's own code.
- Follow-up opportunity (out of scope): `library.add(fab)` registers every brand icon; importing only the icons in the `socialIcons` list would shrink the 571 KB chunk to a few KB.

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required