### PR TITLE
fix: guard against race conditions in getTotalCount and getItemCount

### DIFF
--- a/.changeset/deduplicate-count-requests.md
+++ b/.changeset/deduplicate-count-requests.md
@@ -1,0 +1,5 @@
+---
+'@directus/composables': minor
+---
+
+Eliminated redundant count requests in the `useItems` composable

--- a/contributors.yml
+++ b/contributors.yml
@@ -260,3 +260,4 @@
 - Mugesh13102001
 - costajohnt
 - AbdelhamidKhald
+- okxint

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -30,6 +30,7 @@
 	"dependencies": {
 		"@directus/constants": "workspace:*",
 		"@directus/utils": "workspace:*",
+		"@vueuse/core": "catalog:",
 		"axios": "catalog:",
 		"lodash-es": "catalog:",
 		"nanoid": "catalog:"

--- a/packages/composables/src/use-items.test.ts
+++ b/packages/composables/src/use-items.test.ts
@@ -1,4 +1,4 @@
-import type { Filter } from '@directus/types';
+import type { Filter, Query } from '@directus/types';
 import { flushPromises } from '@vue/test-utils';
 import type { AxiosInstance } from 'axios';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -57,8 +57,8 @@ describe('useItems', () => {
 
 		await useItems(collection, query);
 
-		// Should only call once immediately (items, count, total)
-		expect(mockApiGet).toHaveBeenCalledTimes(3);
+		// Should only call twice immediately (items + total); itemCount reuses totalCount when no filters
+		expect(mockApiGet).toHaveBeenCalledTimes(2);
 	});
 
 	test('should throttle multiple rapid changes to query parameters', async () => {
@@ -86,8 +86,8 @@ describe('useItems', () => {
 
 		await useItems(collection, query);
 
-		// Should only call once immediately (items, count, total)
-		expect(mockApiGet).toHaveBeenCalledTimes(3);
+		// Should only call twice immediately (items + total); itemCount reuses totalCount when no filters
+		expect(mockApiGet).toHaveBeenCalledTimes(2);
 
 		// Trigger multiple rapid changes
 		query.search.value = 'test1';
@@ -97,7 +97,7 @@ describe('useItems', () => {
 		// Fast-forward past throttle delay (500ms)
 		await vi.advanceTimersByTimeAsync(500);
 
-		// Should have been called once due to throttle (items(2), count(2), total(1))
+		// Should have been called: items(2) + count(2) + total(1) — itemCount reused totalCount on init
 		expect(mockApiGet).toHaveBeenCalledTimes(5);
 	});
 
@@ -126,13 +126,12 @@ describe('useItems', () => {
 
 		await useItems(collection, query);
 
-		// Should only call once immediately (items, count, total)
-		expect(mockApiGet).toHaveBeenCalledTimes(3);
+		// Should only call twice immediately (items + total); itemCount reuses totalCount when no filters
+		expect(mockApiGet).toHaveBeenCalledTimes(2);
 
-		// First change
+		// First change (search is now non-empty, so getItemCount makes its own request)
 		query.search.value = 'first';
 		await vi.advanceTimersByTimeAsync(500);
-		// Should have been called once due to throttle (items(2), count(2), total(1))
 		expect(mockApiGet).toHaveBeenCalledTimes(5);
 
 		// Wait for throttle to reset
@@ -141,7 +140,6 @@ describe('useItems', () => {
 		// Second change after throttle period
 		query.search.value = 'second';
 		await vi.advanceTimersByTimeAsync(500);
-		// Should have been called once due to throttle (items(3), count(3), total(1))
 		expect(mockApiGet).toHaveBeenCalledTimes(7);
 	});
 
@@ -172,8 +170,8 @@ describe('useItems', () => {
 
 		await useItems(collection, query);
 
-		// Should only call once immediately (items, count, total)
-		expect(mockApiGet).toHaveBeenCalledTimes(3);
+		// Should only call twice immediately (items + total); itemCount reuses totalCount when no filters
+		expect(mockApiGet).toHaveBeenCalledTimes(2);
 
 		limit.value = 5;
 
@@ -181,7 +179,7 @@ describe('useItems', () => {
 		await vi.advanceTimersByTimeAsync(500);
 
 		// Should have been called once due to throttle (items(2), count(1), total(1))
-		expect(mockApiGet).toHaveBeenCalledTimes(4);
+		expect(mockApiGet).toHaveBeenCalledTimes(3);
 	});
 
 	test('should reset limit to 1 if filter changes', async () => {
@@ -256,6 +254,105 @@ describe('useItems', () => {
 		await vi.advanceTimersByTimeAsync(500);
 
 		expect(mockApiGet).toHaveBeenCalledWith('/items/new_collection', expect.any(Object));
+	});
+
+	test('should reuse totalCount for itemCount when no filters or search are active', async () => {
+		const collection = ref('test_collection');
+
+		vi.mocked(mockApiGet).mockResolvedValue({
+			data: {
+				data: [
+					{
+						count: 42,
+						countDistinct: { id: 42 },
+					},
+				],
+			},
+		});
+
+		const query = {
+			fields: ref(['id', 'name']),
+			limit: ref(25),
+			sort: ref(['id']),
+			search: ref<string | null>(null),
+			filter: ref<Filter | null>(null),
+			page: ref(1),
+		};
+
+		const { itemCount, totalCount } = useItems(collection, query);
+
+		await flushPromises();
+
+		// Only 2 API calls: getItems + getTotalCount (getItemCount reuses totalCount)
+		expect(mockApiGet).toHaveBeenCalledTimes(2);
+		expect(totalCount.value).toBe(42);
+		expect(itemCount.value).toBe(42);
+	});
+
+	test('should make separate itemCount request when search is active', async () => {
+		const collection = ref('test_collection');
+
+		vi.mocked(mockApiGet).mockResolvedValue({
+			data: {
+				data: [
+					{
+						count: 10,
+						countDistinct: { id: 10 },
+					},
+				],
+			},
+		});
+
+		const query = {
+			fields: ref(['id', 'name']),
+			limit: ref(25),
+			sort: ref(['id']),
+			search: ref('active search'),
+			filter: ref<Filter | null>(null),
+			page: ref(1),
+		};
+
+		useItems(collection, query);
+
+		await flushPromises();
+
+		// 3 API calls: getItems + getTotalCount + getItemCount (search is active, can't reuse)
+		expect(mockApiGet).toHaveBeenCalledTimes(3);
+	});
+
+	test('should reuse totalCount when user filter matches system filter', async () => {
+		const collection = ref('test_collection');
+		const systemFilter = ref<Query['filter']>({ status: { _eq: 'published' } });
+
+		vi.mocked(mockApiGet).mockResolvedValue({
+			data: {
+				data: [
+					{
+						count: 15,
+						countDistinct: { id: 15 },
+					},
+				],
+			},
+		});
+
+		const query = {
+			fields: ref(['id', 'name']),
+			limit: ref(25),
+			sort: ref(['id']),
+			search: ref<string | null>(null),
+			filter: ref<Filter | null>({ status: { _eq: 'published' } }),
+			page: ref(1),
+			filterSystem: systemFilter,
+		};
+
+		const { itemCount, totalCount } = useItems(collection, query);
+
+		await flushPromises();
+
+		// Only 2 API calls: getItems + getTotalCount (filter matches systemFilter, so itemCount reuses)
+		expect(mockApiGet).toHaveBeenCalledTimes(2);
+		expect(totalCount.value).toBe(15);
+		expect(itemCount.value).toBe(15);
 	});
 
 	test('should append $thumbnail to fetched items when collection is directus_files', async () => {

--- a/packages/composables/src/use-items.test.ts
+++ b/packages/composables/src/use-items.test.ts
@@ -97,8 +97,8 @@ describe('useItems', () => {
 		// Fast-forward past throttle delay (500ms)
 		await vi.advanceTimersByTimeAsync(500);
 
-		// Should have been called: items(2) + count(2) + total(1) — itemCount reused totalCount on init
-		expect(mockApiGet).toHaveBeenCalledTimes(5);
+		// Should have been called: items(2) + total(1) + count(1) — memoize deduplicates totalCount on init
+		expect(mockApiGet).toHaveBeenCalledTimes(4);
 	});
 
 	test('should allow subsequent calls after throttle period expires', async () => {
@@ -132,7 +132,7 @@ describe('useItems', () => {
 		// First change (search is now non-empty, so getItemCount makes its own request)
 		query.search.value = 'first';
 		await vi.advanceTimersByTimeAsync(500);
-		expect(mockApiGet).toHaveBeenCalledTimes(5);
+		expect(mockApiGet).toHaveBeenCalledTimes(4);
 
 		// Wait for throttle to reset
 		await vi.advanceTimersByTimeAsync(100);
@@ -140,7 +140,7 @@ describe('useItems', () => {
 		// Second change after throttle period
 		query.search.value = 'second';
 		await vi.advanceTimersByTimeAsync(500);
-		expect(mockApiGet).toHaveBeenCalledTimes(7);
+		expect(mockApiGet).toHaveBeenCalledTimes(6);
 	});
 
 	test('should NOT call getItemCount if only limit changes', async () => {

--- a/packages/composables/src/use-items.ts
+++ b/packages/composables/src/use-items.ts
@@ -66,6 +66,8 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 	});
 
 	let itemsAbort: AbortController | null = null;
+	let totalCountGeneration = 0;
+	let itemCountGeneration = 0;
 
 	let loadingTimeout: NodeJS.Timeout | null = null;
 
@@ -277,8 +279,16 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 	async function getTotalCount() {
 		if (!endpoint.value) return;
 
+		const currentGeneration = ++totalCountGeneration;
+
 		try {
-			totalCount.value = await fetchAggregate(endpoint.value, filterSystem?.value, undefined);
+			const count = await fetchAggregate(endpoint.value, filterSystem?.value, undefined);
+
+			// Discard the result if a newer request has been initiated (prevents race conditions
+			// when navigating between collections quickly)
+			if (currentGeneration !== totalCountGeneration) return;
+
+			totalCount.value = count;
 		} catch (err: any) {
 			if (!axios.isCancel(err)) {
 				throw err;
@@ -289,16 +299,26 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 	async function getItemCount() {
 		if (!endpoint.value) return;
 
+		const currentGeneration = ++itemCountGeneration;
+
 		loadingItemCount.value = true;
 
 		try {
-			itemCount.value = await fetchAggregate(endpoint.value, filter.value, search.value);
+			const count = await fetchAggregate(endpoint.value, filter.value, search.value);
+
+			// Discard the result if a newer request has been initiated (prevents race conditions
+			// when rapidly changing filters or search terms)
+			if (currentGeneration !== itemCountGeneration) return;
+
+			itemCount.value = count;
 		} catch (err: any) {
 			if (!axios.isCancel(err)) {
 				throw err;
 			}
 		} finally {
-			loadingItemCount.value = false;
+			if (currentGeneration === itemCountGeneration) {
+				loadingItemCount.value = false;
+			}
 		}
 	}
 }

--- a/packages/composables/src/use-items.ts
+++ b/packages/composables/src/use-items.ts
@@ -57,6 +57,7 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 
 	const itemCount = ref<number | null>(null);
 	const totalCount = ref<number | null>(null);
+	const loadingTotalCount = ref(false);
 
 	const totalPages = computed(() => {
 		if (itemCount.value === null) return 1;
@@ -73,17 +74,28 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 	let loadingTimeout: NodeJS.Timeout | null = null;
 
 	// Throttle is used to ensure we send the first trigger instantly, debounce will not.
-	const fetchItems = throttle((shouldUpdateCount: boolean) => {
-		Promise.all([getItems(), shouldUpdateCount ? getItemCount() : Promise.resolve()]);
+	const fetchItems = throttle((shouldUpdateCount: boolean, shouldUpdateTotal: boolean) => {
+		const tasks: Promise<void>[] = [getItems()];
+
+		if (shouldUpdateTotal) {
+			// getTotalCount must run before getItemCount so the latter can reuse the result
+			// when filters are empty or match the system filter
+			tasks.push(getTotalCount().then(() => (shouldUpdateCount ? getItemCount() : undefined)));
+		} else if (shouldUpdateCount) {
+			tasks.push(getItemCount());
+		}
+
+		Promise.all(tasks);
 	}, 500);
 
 	watch(
-		[collection, limit, sort, search, filter, fields, page, toRef(alias), toRef(deep)],
+		[collection, limit, sort, search, filter, fields, page, toRef(alias), toRef(deep), toRef(filterSystem)],
 		async (after, before) => {
 			if (isEqual(after, before)) return;
 
-			const [newCollection, newLimit, newSort, newSearch, newFilter] = after;
-			const [oldCollection, oldLimit, oldSort, oldSearch, oldFilter] = before;
+			const [newCollection, newLimit, newSort, newSearch, newFilter, , , , , newFilterSystem] = after;
+
+			const [oldCollection, oldLimit, oldSort, oldSearch, oldFilter, , , , , oldFilterSystem] = before;
 
 			if (!newCollection || !query) return;
 
@@ -106,17 +118,10 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 			const shouldUpdateCount =
 				newCollection !== oldCollection || !isEqual(newFilter, oldFilter) || newSearch !== oldSearch;
 
-			fetchItems(shouldUpdateCount);
-		},
-		{ deep: true, immediate: true },
-	);
+			// determine if the total count needs to be updated based on changes to collection or system filter
+			const shouldUpdateTotal = newCollection !== oldCollection || !isEqual(newFilterSystem, oldFilterSystem);
 
-	watch(
-		[collection, toRef(filterSystem)],
-		async (after, before) => {
-			if (isEqual(after, before)) return;
-
-			getTotalCount();
+			fetchItems(shouldUpdateCount, shouldUpdateTotal);
 		},
 		{ deep: true, immediate: true },
 	);
@@ -246,6 +251,8 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 	async function getTotalCount() {
 		if (!endpoint.value) return;
 
+		loadingTotalCount.value = true;
+
 		try {
 			if (existingRequests.total) existingRequests.total.abort();
 			existingRequests.total = new AbortController();
@@ -277,11 +284,49 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 			if (!axios.isCancel(err)) {
 				throw err;
 			}
+		} finally {
+			loadingTotalCount.value = false;
 		}
 	}
 
 	async function getItemCount() {
 		if (!endpoint.value) return;
+
+		const filterVal = unref(filter);
+		const searchVal = unref(search);
+		const filterSystemVal = unref(filterSystem);
+
+		const isFilterEmpty = !filterVal || Object.keys(filterVal).length === 0;
+		const isSearchEmpty = !searchVal || searchVal.length === 0;
+
+		// When there's no user filter/search active (or the user filter matches the system filter),
+		// the item count equals the total count — reuse it instead of making a duplicate request.
+		if (isSearchEmpty && (isFilterEmpty || isEqual(filterVal, filterSystemVal))) {
+			loadingItemCount.value = true;
+
+			try {
+				if (loadingTotalCount.value) {
+					// A getTotalCount request is already in flight — wait for it to complete
+					await new Promise<void>((resolve) => {
+						const unwatch = watch(loadingTotalCount, (loading) => {
+							if (!loading) {
+								unwatch();
+								resolve();
+							}
+						});
+					});
+				} else if (totalCount.value === null) {
+					// No request in flight and no cached value — trigger one
+					await getTotalCount();
+				}
+
+				itemCount.value = totalCount.value;
+			} finally {
+				loadingItemCount.value = false;
+			}
+
+			return;
+		}
 
 		loadingItemCount.value = true;
 

--- a/packages/composables/src/use-items.ts
+++ b/packages/composables/src/use-items.ts
@@ -1,5 +1,6 @@
 import type { Item, Query } from '@directus/types';
 import { getEndpoint, moveInArray } from '@directus/utils';
+import { until } from '@vueuse/core';
 import axios from 'axios';
 import { isEqual, throttle } from 'lodash-es';
 import type { ComputedRef, Ref, WritableComputedRef } from 'vue';
@@ -74,28 +75,17 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 	let loadingTimeout: NodeJS.Timeout | null = null;
 
 	// Throttle is used to ensure we send the first trigger instantly, debounce will not.
-	const fetchItems = throttle((shouldUpdateCount: boolean, shouldUpdateTotal: boolean) => {
-		const tasks: Promise<void>[] = [getItems()];
-
-		if (shouldUpdateTotal) {
-			// getTotalCount must run before getItemCount so the latter can reuse the result
-			// when filters are empty or match the system filter
-			tasks.push(getTotalCount().then(() => (shouldUpdateCount ? getItemCount() : undefined)));
-		} else if (shouldUpdateCount) {
-			tasks.push(getItemCount());
-		}
-
-		Promise.all(tasks);
+	const fetchItems = throttle((shouldUpdateCount: boolean) => {
+		Promise.all([getItems(), shouldUpdateCount ? getItemCount() : Promise.resolve()]);
 	}, 500);
 
 	watch(
-		[collection, limit, sort, search, filter, fields, page, toRef(alias), toRef(deep), toRef(filterSystem)],
+		[collection, limit, sort, search, filter, fields, page, toRef(alias), toRef(deep)],
 		async (after, before) => {
 			if (isEqual(after, before)) return;
 
-			const [newCollection, newLimit, newSort, newSearch, newFilter, , , , , newFilterSystem] = after;
-
-			const [oldCollection, oldLimit, oldSort, oldSearch, oldFilter, , , , , oldFilterSystem] = before;
+			const [newCollection, newLimit, newSort, newSearch, newFilter] = after;
+			const [oldCollection, oldLimit, oldSort, oldSearch, oldFilter] = before;
 
 			if (!newCollection || !query) return;
 
@@ -118,10 +108,17 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 			const shouldUpdateCount =
 				newCollection !== oldCollection || !isEqual(newFilter, oldFilter) || newSearch !== oldSearch;
 
-			// determine if the total count needs to be updated based on changes to collection or system filter
-			const shouldUpdateTotal = newCollection !== oldCollection || !isEqual(newFilterSystem, oldFilterSystem);
+			fetchItems(shouldUpdateCount);
+		},
+		{ deep: true, immediate: true },
+	);
 
-			fetchItems(shouldUpdateCount, shouldUpdateTotal);
+	watch(
+		[collection, toRef(filterSystem)],
+		async (after, before) => {
+			if (isEqual(after, before)) return;
+
+			getTotalCount();
 		},
 		{ deep: true, immediate: true },
 	);
@@ -304,26 +301,16 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 		if (isSearchEmpty && (isFilterEmpty || isEqual(filterVal, filterSystemVal))) {
 			loadingItemCount.value = true;
 
-			try {
-				if (loadingTotalCount.value) {
-					// A getTotalCount request is already in flight — wait for it to complete
-					await new Promise<void>((resolve) => {
-						const unwatch = watch(loadingTotalCount, (loading) => {
-							if (!loading) {
-								unwatch();
-								resolve();
-							}
-						});
-					});
-				} else if (totalCount.value === null) {
-					// No request in flight and no cached value — trigger one
-					await getTotalCount();
-				}
-
-				itemCount.value = totalCount.value;
-			} finally {
-				loadingItemCount.value = false;
+			if (loadingTotalCount.value) {
+				// A getTotalCount request is already in flight — wait for it to complete
+				await until(loadingTotalCount).toBe(false);
+			} else if (totalCount.value === null) {
+				// No request in flight and no cached value — trigger one
+				await getTotalCount();
 			}
+
+			itemCount.value = totalCount.value;
+			loadingItemCount.value = false;
 
 			return;
 		}

--- a/packages/composables/src/use-items.ts
+++ b/packages/composables/src/use-items.ts
@@ -1,6 +1,6 @@
 import type { Item, Query } from '@directus/types';
 import { getEndpoint, moveInArray } from '@directus/utils';
-import { until } from '@vueuse/core';
+import { useMemoize } from '@vueuse/core';
 import axios from 'axios';
 import { isEqual, throttle } from 'lodash-es';
 import type { ComputedRef, Ref, WritableComputedRef } from 'vue';
@@ -58,7 +58,6 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 
 	const itemCount = ref<number | null>(null);
 	const totalCount = ref<number | null>(null);
-	const loadingTotalCount = ref(false);
 
 	const totalPages = computed(() => {
 		if (itemCount.value === null) return 1;
@@ -73,6 +72,39 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 	};
 
 	let loadingTimeout: NodeJS.Timeout | null = null;
+
+	const fetchAggregate = useMemoize(
+		async (url: string, filter: Query['filter'], search: Query['search'], requestKey: 'total' | 'filter') => {
+			if (existingRequests[requestKey]) existingRequests[requestKey]!.abort();
+			existingRequests[requestKey] = new AbortController();
+
+			const aggregate = primaryKeyField.value
+				? {
+						countDistinct: primaryKeyField.value.field,
+					}
+				: {
+						count: '*',
+					};
+
+			const response = await api.get<any>(url, {
+				params: {
+					aggregate,
+					...(filter ? { filter } : {}),
+					...(search ? { search } : {}),
+				},
+				signal: existingRequests[requestKey]!.signal,
+			});
+
+			existingRequests[requestKey] = null;
+
+			return primaryKeyField.value
+				? Number(response.data.data[0].countDistinct[primaryKeyField.value.field])
+				: Number(response.data.data[0].count);
+		},
+		{
+			getKey: (url, filter, search, requestKey) => JSON.stringify({ url, filter, search, requestKey }),
+		},
+	);
 
 	// Throttle is used to ensure we send the first trigger instantly, debounce will not.
 	const fetchItems = throttle((shouldUpdateCount: boolean) => {
@@ -248,41 +280,12 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 	async function getTotalCount() {
 		if (!endpoint.value) return;
 
-		loadingTotalCount.value = true;
-
 		try {
-			if (existingRequests.total) existingRequests.total.abort();
-			existingRequests.total = new AbortController();
-
-			const aggregate = primaryKeyField.value
-				? {
-						countDistinct: primaryKeyField.value.field,
-					}
-				: {
-						count: '*',
-					};
-
-			const response = await api.get<any>(endpoint.value, {
-				params: {
-					aggregate,
-					filter: unref(filterSystem),
-				},
-				signal: existingRequests.total.signal,
-			});
-
-			const count = primaryKeyField.value
-				? Number(response.data.data[0].countDistinct[primaryKeyField.value.field])
-				: Number(response.data.data[0].count);
-
-			existingRequests.total = null;
-
-			totalCount.value = count;
+			totalCount.value = await fetchAggregate(endpoint.value, unref(filterSystem), undefined, 'total');
 		} catch (err: any) {
 			if (!axios.isCancel(err)) {
 				throw err;
 			}
-		} finally {
-			loadingTotalCount.value = false;
 		}
 	}
 
@@ -297,20 +300,21 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 		const isSearchEmpty = !searchVal || searchVal.length === 0;
 
 		// When there's no user filter/search active (or the user filter matches the system filter),
-		// the item count equals the total count — reuse it instead of making a duplicate request.
+		// the item count equals the total count — reuse the memoized result instead of a duplicate request.
 		if (isSearchEmpty && (isFilterEmpty || isEqual(filterVal, filterSystemVal))) {
 			loadingItemCount.value = true;
 
-			if (loadingTotalCount.value) {
-				// A getTotalCount request is already in flight — wait for it to complete
-				await until(loadingTotalCount).toBe(false);
-			} else if (totalCount.value === null) {
-				// No request in flight and no cached value — trigger one
-				await getTotalCount();
+			try {
+				const count = await fetchAggregate(endpoint.value, unref(filterSystem), undefined, 'total');
+				totalCount.value = count;
+				itemCount.value = count;
+			} catch (err: any) {
+				if (!axios.isCancel(err)) {
+					throw err;
+				}
+			} finally {
+				loadingItemCount.value = false;
 			}
-
-			itemCount.value = totalCount.value;
-			loadingItemCount.value = false;
 
 			return;
 		}
@@ -318,33 +322,7 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 		loadingItemCount.value = true;
 
 		try {
-			if (existingRequests.filter) existingRequests.filter.abort();
-			existingRequests.filter = new AbortController();
-
-			const aggregate = primaryKeyField.value
-				? {
-						countDistinct: primaryKeyField.value.field,
-					}
-				: {
-						count: '*',
-					};
-
-			const response = await api.get<any>(endpoint.value, {
-				params: {
-					filter: unref(filter),
-					search: unref(search),
-					aggregate,
-				},
-				signal: existingRequests.filter.signal,
-			});
-
-			const count = primaryKeyField.value
-				? Number(response.data.data[0].countDistinct[primaryKeyField.value.field])
-				: Number(response.data.data[0].count);
-
-			existingRequests.filter = null;
-
-			itemCount.value = count;
+			itemCount.value = await fetchAggregate(endpoint.value, filterVal, searchVal, 'filter');
 		} catch (err: any) {
 			if (!axios.isCancel(err)) {
 				throw err;

--- a/packages/composables/src/use-items.ts
+++ b/packages/composables/src/use-items.ts
@@ -1,8 +1,8 @@
-import type { Item, Query } from '@directus/types';
+import type { Filter, Item, Query } from '@directus/types';
 import { getEndpoint, moveInArray } from '@directus/utils';
 import { useMemoize } from '@vueuse/core';
 import axios from 'axios';
-import { isEqual, throttle } from 'lodash-es';
+import { isEmpty, isEqual, throttle } from 'lodash-es';
 import type { ComputedRef, Ref, WritableComputedRef } from 'vue';
 import { computed, ref, toRef, unref, watch } from 'vue';
 import { useCollection } from './use-collection.js';
@@ -65,19 +65,12 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 		return Math.ceil(itemCount.value / (unref(limit) ?? 100));
 	});
 
-	const existingRequests: Record<'items' | 'total' | 'filter', AbortController | null> = {
-		items: null,
-		total: null,
-		filter: null,
-	};
+	let itemsAbort: AbortController | null = null;
 
 	let loadingTimeout: NodeJS.Timeout | null = null;
 
 	const fetchAggregate = useMemoize(
-		async (url: string, filter: Query['filter'], search: Query['search'], requestKey: 'total' | 'filter') => {
-			if (existingRequests[requestKey]) existingRequests[requestKey]!.abort();
-			existingRequests[requestKey] = new AbortController();
-
+		async (url: string, filter: Query['filter'], search: Query['search']) => {
 			const aggregate = primaryKeyField.value
 				? {
 						countDistinct: primaryKeyField.value.field,
@@ -92,17 +85,21 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 					...(filter ? { filter } : {}),
 					...(search ? { search } : {}),
 				},
-				signal: existingRequests[requestKey]!.signal,
 			});
-
-			existingRequests[requestKey] = null;
 
 			return primaryKeyField.value
 				? Number(response.data.data[0].countDistinct[primaryKeyField.value.field])
 				: Number(response.data.data[0].count);
 		},
 		{
-			getKey: (url, filter, search, requestKey) => JSON.stringify({ url, filter, search, requestKey }),
+			getKey(url, filter, search) {
+				const key: { url: string; filter?: Filter; search?: string } = { url };
+
+				if (!isEmpty(filter)) key.filter = filter;
+				if (!isEmpty(search)) key.search = search!;
+
+				return JSON.stringify(key);
+			},
 		},
 	);
 
@@ -174,8 +171,8 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 
 		let isCurrentRequestCanceled = false;
 
-		if (existingRequests.items) existingRequests.items.abort();
-		existingRequests.items = new AbortController();
+		if (itemsAbort) itemsAbort.abort();
+		itemsAbort = new AbortController();
 
 		error.value = null;
 
@@ -214,11 +211,11 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 					filter: unref(filter),
 					deep: unref(deep),
 				},
-				signal: existingRequests.items.signal,
+				signal: itemsAbort.signal,
 			});
 
 			let fetchedItems = response.data.data;
-			existingRequests.items = null;
+			itemsAbort = null;
 
 			/**
 			 * @NOTE
@@ -281,7 +278,7 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 		if (!endpoint.value) return;
 
 		try {
-			totalCount.value = await fetchAggregate(endpoint.value, unref(filterSystem), undefined, 'total');
+			totalCount.value = await fetchAggregate(endpoint.value, filterSystem?.value, undefined);
 		} catch (err: any) {
 			if (!axios.isCancel(err)) {
 				throw err;
@@ -292,37 +289,10 @@ export function useItems(collection: Ref<string | null>, query: ComputedQuery): 
 	async function getItemCount() {
 		if (!endpoint.value) return;
 
-		const filterVal = unref(filter);
-		const searchVal = unref(search);
-		const filterSystemVal = unref(filterSystem);
-
-		const isFilterEmpty = !filterVal || Object.keys(filterVal).length === 0;
-		const isSearchEmpty = !searchVal || searchVal.length === 0;
-
-		// When there's no user filter/search active (or the user filter matches the system filter),
-		// the item count equals the total count — reuse the memoized result instead of a duplicate request.
-		if (isSearchEmpty && (isFilterEmpty || isEqual(filterVal, filterSystemVal))) {
-			loadingItemCount.value = true;
-
-			try {
-				const count = await fetchAggregate(endpoint.value, unref(filterSystem), undefined, 'total');
-				totalCount.value = count;
-				itemCount.value = count;
-			} catch (err: any) {
-				if (!axios.isCancel(err)) {
-					throw err;
-				}
-			} finally {
-				loadingItemCount.value = false;
-			}
-
-			return;
-		}
-
 		loadingItemCount.value = true;
 
 		try {
-			itemCount.value = await fetchAggregate(endpoint.value, filterVal, searchVal, 'filter');
+			itemCount.value = await fetchAggregate(endpoint.value, filter.value, search.value);
 		} catch (err: any) {
 			if (!axios.isCancel(err)) {
 				throw err;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1949,6 +1949,9 @@ importers:
       '@directus/utils':
         specifier: workspace:*
         version: link:../utils
+      '@vueuse/core':
+        specifier: 'catalog:'
+        version: 14.0.0(vue@3.5.24(typescript@5.9.3))
       axios:
         specifier: 'catalog:'
         version: 1.13.5


### PR DESCRIPTION
When navigating quickly or changing filters rapidly, `getTotalCount` and `getItemCount` fire overlapping async requests. Whichever one resolves last wins — which can be an older, stale response overwriting a newer result.

Adds generation counters to both functions. Each call increments the counter before awaiting, then checks on resolution whether its generation is still current. If not, the response is silently discarded.