### PR TITLE
fix(app): normalize decimal separator in v-input display value

### DIFF
--- a/.changeset/fix-decimal-separator.md
+++ b/.changeset/fix-decimal-separator.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed decimal input field displaying wrong separator (comma instead of dot) for locales that use comma as decimal separator

--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -350,7 +350,7 @@ function useInlineWarning() {
 					:max="max"
 					:step="step"
 					:disabled="disabled"
-					:value="modelValue === undefined || modelValue === null ? '' : String(modelValue)"
+					:value="modelValue == null ? '' : props.float ? String(modelValue).replace(',', '.') : String(modelValue)"
 					v-on="listeners"
 					@keydown.space="$emit('keydown:space', $event)"
 					@keydown.enter="$emit('keydown:enter', $event)"


### PR DESCRIPTION
On systems where the OS locale uses commas as decimal separators (e.g. nl-BE), the float input field shows values with commas (`300,44`) instead of dots (`300.44`).

The emit path already normalizes commas to dots (line 248 in `v-input.vue`), but the display/render binding didn't apply the same normalization. This adds the same replace to the value binding when float mode is active.

Fixes #24803