### PR TITLE
Add clearable indicator to input hash field

### DIFF
--- a/.changeset/common-plums-sneeze.md
+++ b/.changeset/common-plums-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added clearable indicator to input hash field

--- a/app/src/interfaces/input-hash/input-hash.test.ts
+++ b/app/src/interfaces/input-hash/input-hash.test.ts
@@ -94,4 +94,21 @@ describe('Interface', () => {
 
 		expect(wrapper.find('[name="close"]').exists()).toBe(false);
 	});
+
+	it('should reflect the hashed state once an entered value is persisted', async () => {
+		const wrapper = mount(InputHash, {
+			props: {
+				value: null,
+			},
+			global,
+		});
+
+		// User types a value; the plaintext is held locally, so the field is not yet hashed.
+		await wrapper.find('input').setValue('plaintext');
+		expect(wrapper.find('.v-input').classes()).not.toContain('hashed');
+
+		// Saving persists the value, so props.value becomes the stored hash.
+		await wrapper.setProps({ value: 'stored-hash' });
+		expect(wrapper.find('.v-input').classes()).toContain('hashed');
+	});
 });

--- a/app/src/interfaces/input-hash/input-hash.test.ts
+++ b/app/src/interfaces/input-hash/input-hash.test.ts
@@ -55,4 +55,43 @@ describe('Interface', () => {
 		expect(wrapper.find('input').attributes('type')).toBe('password');
 		expect(wrapper.find('input').attributes('autocomplete')).toBe('off');
 	});
+
+	it('should not show the clear icon when there is no value', () => {
+		const wrapper = mount(InputHash, {
+			props: {
+				value: null,
+			},
+			global,
+		});
+
+		expect(wrapper.find('[name="close"]').exists()).toBe(false);
+	});
+
+	it('should show the clear icon and emit null when a stored value is cleared', async () => {
+		const wrapper = mount(InputHash, {
+			props: {
+				value: 'stored-secret',
+			},
+			global,
+		});
+
+		const clearIcon = wrapper.find('[name="close"]');
+		expect(clearIcon.exists()).toBe(true);
+
+		await clearIcon.trigger('click');
+
+		expect(wrapper.emitted('input')).toEqual([[null]]);
+	});
+
+	it('should not show the clear icon when disabled', () => {
+		const wrapper = mount(InputHash, {
+			props: {
+				value: 'stored-secret',
+				disabled: true,
+			},
+			global,
+		});
+
+		expect(wrapper.find('[name="close"]').exists()).toBe(false);
+	});
 });

--- a/app/src/interfaces/input-hash/input-hash.vue
+++ b/app/src/interfaces/input-hash/input-hash.vue
@@ -67,6 +67,7 @@ function clearValue() {
 		@update:model-value="emitValue"
 	>
 		<template #append>
+			<VIcon class="lock" :class="{ disabled }" :name="isHashed && !localValue ? 'lock' : 'lock_open'" />
 			<VIcon
 				v-if="(isHashed || localValue) && !disabled && !nonEditable"
 				v-tooltip="t('clear_value')"
@@ -75,7 +76,6 @@ function clearValue() {
 				clickable
 				@click.stop="clearValue"
 			/>
-			<VIcon class="lock" :class="{ disabled }" :name="isHashed && !localValue ? 'lock' : 'lock_open'" />
 		</template>
 	</VInput>
 </template>
@@ -92,12 +92,12 @@ function clearValue() {
 
 .clear {
 	--v-icon-color: var(--theme--form--field--input--foreground-subdued);
-
-	margin-inline-end: var(--theme--form--field--input--padding);
 }
 
 .lock {
 	--v-icon-color: var(--theme--warning);
+
+	margin-inline-end: 0.25rem;
 
 	&.disabled {
 		--v-icon-color: var(--theme--form--field--input--foreground-subdued);

--- a/app/src/interfaces/input-hash/input-hash.vue
+++ b/app/src/interfaces/input-hash/input-hash.vue
@@ -38,8 +38,14 @@ const internalPlaceholder = computed(() => {
 
 watch(
 	() => props.value,
-	() => {
-		isHashed.value = !!(props.value && props.value.length > 0);
+	(newValue) => {
+		isHashed.value = !!(newValue && newValue.length > 0);
+
+		// Once an entered value is persisted, props.value becomes the stored hash,
+		// Reset localValue so the field reflects the securely-stored (hashed) state.
+		if (newValue !== localValue.value) {
+			localValue.value = null;
+		}
 	},
 	{ immediate: true },
 );

--- a/app/src/interfaces/input-hash/input-hash.vue
+++ b/app/src/interfaces/input-hash/input-hash.vue
@@ -48,6 +48,11 @@ function emitValue(newValue: string) {
 	emit('input', newValue);
 	localValue.value = newValue;
 }
+
+function clearValue() {
+	localValue.value = null;
+	emit('input', null);
+}
 </script>
 
 <template>
@@ -57,11 +62,19 @@ function emitValue(newValue: string) {
 		:non-editable
 		:type="masked ? 'password' : 'text'"
 		:autocomplete
-		:model-value="localValue"
+		:model-value="localValue ?? ''"
 		:class="{ hashed: isHashed && !localValue, 'non-editable': nonEditable }"
 		@update:model-value="emitValue"
 	>
 		<template #append>
+			<VIcon
+				v-if="(isHashed || localValue) && !disabled && !nonEditable"
+				v-tooltip="t('clear_value')"
+				class="clear"
+				name="close"
+				clickable
+				@click.stop="clearValue"
+			/>
 			<VIcon class="lock" :class="{ disabled }" :name="isHashed && !localValue ? 'lock' : 'lock_open'" />
 		</template>
 	</VInput>
@@ -75,6 +88,12 @@ function emitValue(newValue: string) {
 	&.hashed {
 		--v-icon-color: var(--theme--primary);
 	}
+}
+
+.clear {
+	--v-icon-color: var(--theme--form--field--input--foreground-subdued);
+
+	margin-inline-end: var(--theme--form--field--input--padding);
 }
 
 .lock {


### PR DESCRIPTION
## Scope

What's changed:

  - Added an inline clear (✕) control to the `input-hash` interface
  - Clicking it empties the input and emits `null` — the same clearing signal as
  the existing field-label "Clear value" menu
  - Fixed pre-existing bug that prevented the secure state from rendering when using save and stay

  ## Potential Risks / Drawbacks

  - None I can think of — change is isolated to the `input-hash` interface and
  reuses the existing emit-`null` clear convention

  ## Tested Scenarios

  - Stored (hashed) value: clear icon appears, clicking it emits `null` and
  reverts the placeholder/lock state
  - Typed-but-unsaved value: clear icon appears and empties the field
  - Clear icon is hidden when the field is empty, `disabled`, or `nonEditable`
  - Added unit tests covering icon visibility and the `null` emit (all passing)

  ## Review Notes / Questions

  ## Checklist

  - [x] Added or updated tests
  - [x] Documentation PR created [here](https://github.com/directus/docs) or not
  required
  - [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or
  not required

Fixes [CMS-2262](https://linear.app/directus/issue/CMS-2262/add-inline-option-to-clear-ai-api-key)