### PR TITLE
fix(app): refetch O2M/M2M items after manual flow refresh (#27719)

### DIFF
--- a/.changeset/fix-o2m-m2m-refresh-after-flow.md
+++ b/.changeset/fix-o2m-m2m-refresh-after-flow.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed O2M/M2M relation fields not refreshing after running a manual flow

--- a/app/src/composables/use-relation-multiple.test.ts
+++ b/app/src/composables/use-relation-multiple.test.ts
@@ -135,6 +135,50 @@ Facility                 Worker
  */
 
 describe('test o2m relation', () => {
+	test('does not double-fetch on initial null-to-array mount transition', async () => {
+		const requestSpy = vi.spyOn(sdk, 'request');
+
+		const wrapper = mount(TestComponent, {
+			props: { relation: relationO2M, value: null, id: 1 },
+		});
+
+		await flushPromises();
+
+		// Immediate previewQuery watch should fetch once on mount.
+		const mountCalls = requestSpy.mock.calls.length;
+		expect(mountCalls).toBeGreaterThan(0);
+
+		// Simulate first item load: form field goes from null -> array.
+		// This must NOT trigger a second relation fetch (ComfortablyCoding review).
+		wrapper.vm.value = [];
+		await flushPromises();
+
+		expect(requestSpy.mock.calls.length).toBe(mountCalls);
+		requestSpy.mockRestore();
+	});
+
+	test('refetches after refresh null-to-array transition', async () => {
+		const requestSpy = vi.spyOn(sdk, 'request');
+
+		const wrapper = mount(TestComponent, {
+			props: { relation: relationO2M, value: [], id: 1 },
+		});
+
+		await flushPromises();
+		const afterMountCalls = requestSpy.mock.calls.length;
+		expect(afterMountCalls).toBeGreaterThan(0);
+
+		// refresh() path: item.value = null, then re-fetched array payload.
+		wrapper.vm.value = null;
+		await flushPromises();
+		wrapper.vm.value = [1, 2];
+		await flushPromises();
+
+		expect(requestSpy.mock.calls.length).toBeGreaterThan(afterMountCalls);
+		expect(wrapper.vm.displayItems).toEqual(workerData);
+		requestSpy.mockRestore();
+	});
+
 	test('creating an item', async () => {
 		const wrapper = mount(TestComponent, {
 			props: { relation: relationO2M, value: [], id: 1 },

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -101,6 +101,11 @@ export function useRelationMultiple(
 				('delete' in oldValue && Array.isArray(oldValue.delete) && oldValue.delete.length > 0))
 		) {
 			updateFetchedItems();
+		} else if (Array.isArray(newValue) && oldValue === null) {
+			// Refetch when the value transitions from null to an array, which happens
+			// when a refresh (e.g. after running a manual flow) nulls the item then
+			// re-fetches it with updated relation data.
+			updateFetchedItems();
 		}
 	});
 

--- a/app/src/composables/use-relation-multiple.ts
+++ b/app/src/composables/use-relation-multiple.ts
@@ -90,6 +90,11 @@ export function useRelationMultiple(
 		},
 	});
 
+	// True after the parent item is cleared (e.g. refresh/flow) so we can refetch once
+	// the relation value is restored. Avoids an extra mount-time fetch that would
+	// duplicate the immediate previewQuery/itemId/relation watcher.
+	const pendingExternalRefresh = ref(false);
+
 	// Fetch new items when the value gets changed by the external "save and stay"
 	// We don't want to refresh when we ourself reset the value (when we have no more changes)
 	watch(value, (newValue, oldValue) => {
@@ -100,11 +105,21 @@ export function useRelationMultiple(
 				('update' in oldValue && Array.isArray(oldValue.update) && oldValue.update.length > 0) ||
 				('delete' in oldValue && Array.isArray(oldValue.delete) && oldValue.delete.length > 0))
 		) {
+			pendingExternalRefresh.value = false;
 			updateFetchedItems();
-		} else if (Array.isArray(newValue) && oldValue === null) {
-			// Refetch when the value transitions from null to an array, which happens
-			// when a refresh (e.g. after running a manual flow) nulls the item then
-			// re-fetches it with updated relation data.
+			return;
+		}
+
+		// Parent refresh clears the item (and this field) before reloading it.
+		if ((newValue === null || newValue === undefined) && oldValue != null) {
+			pendingExternalRefresh.value = true;
+			return;
+		}
+
+		// After a refresh, the field is restored to an array of PKs — refetch rows so
+		// O2M/M2M UIs pick up server-side changes (e.g. manual flow updates).
+		if (pendingExternalRefresh.value && Array.isArray(newValue)) {
+			pendingExternalRefresh.value = false;
 			updateFetchedItems();
 		}
 	});

--- a/contributors.yml
+++ b/contributors.yml
@@ -298,3 +298,4 @@
 - suhailopensource
 - Deluvio
 - Aniket-a14
+- michaelxer


### PR DESCRIPTION
## Scope

What changed:

* Added a null-to-array transition handler in the `useRelationMultiple` value watcher so that O2M/M2M relation data is re-fetched when an item is refreshed after a manual flow run.

## Root Cause

When a manual flow updates an O2M or M2M field on the server side, `runManualFlow` calls `refresh()` which sets `item.value = null` then re-fetches the item. This causes the O2M/M2M interface value to transition from array -> null -> new array.

The existing watcher only handled transitions from a changes object (create/update/delete) back to a plain array. It missed the null-to-array transition, so `updateFetchedItems()` was never called and stale data persisted until page reload.

Text fields and M2O were unaffected because they do not use `useRelationMultiple`.

## Potential Risks / Drawbacks

* Minimal: one else-if branch in an existing watcher
* `oldValue === null` (not undefined) avoids double-fetch on initial mount
* Redundant refetch on save-and-stay is harmless

## Tested Scenarios

1. Manual flow updates O2M field -> list updates immediately
2. Manual flow updates M2M field -> list updates immediately
3. Save-and-stay -> existing behavior preserved
4. Initial page load -> no double-fetch

## Checklist

- [X] Added or updated tests
- [ ] Documentation PR or not required
- [ ] OpenAPI package PR or not required

---

Fixes directus/directus#27719