### PR TITLE
fix: hide required/readonly for presentation fields (fixes #26961)

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-field.vue
@@ -35,12 +35,12 @@ const isSearchableType = computed(() => {
 
 <template>
 	<div class="form">
-		<div v-if="!isGenerated" class="field half-left">
+		<div v-if="!isGenerated && localType !== 'presentation'" class="field half-left">
 			<div class="label type-label">{{ $t('readonly') }}</div>
 			<VCheckbox v-model="readonly" :label="$t('readonly_field_label')" block />
 		</div>
 
-		<div v-if="!isGenerated" class="field half-right">
+		<div v-if="!isGenerated && localType !== 'presentation'" class="field half-right">
 			<div class="label type-label">{{ $t('required') }}</div>
 			<VCheckbox v-model="required" :label="$t('require_value_to_be_set')" block />
 		</div>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-configuration.vue
@@ -120,7 +120,7 @@ const options = computed({
 						<VInput v-else v-model="defaultValue" class="monospace" placeholder="NULL" />
 					</div>
 
-					<div class="field half-right">
+					<div v-if="localType !== 'presentation'" class="field half-right">
 						<div class="label type-label">
 							{{ $t('required') }}
 						</div>

--- a/app/src/modules/settings/routes/data-model/field-detail/store/alterations/presentation.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store/alterations/presentation.ts
@@ -8,7 +8,13 @@ export function applyChanges(updates: StateUpdates, state: State, helperFn: Help
 		removeSchema(updates);
 		setTypeToAlias(updates);
 		setSpecialToNoData(updates);
+		removeRequiredAndReadonly(updates);
 	}
+}
+
+export function removeRequiredAndReadonly(updates: StateUpdates) {
+	set(updates, 'field.meta.required', false);
+	set(updates, 'field.meta.readonly', false);
 }
 
 export function removeSchema(updates: StateUpdates) {


### PR DESCRIPTION
Presentation fields (divider, notice, header, links) are display-only and have no input, but the field settings UI still shows the 'required' and 'readonly' checkboxes. This PR hides them for presentation types and strips the values when switching to a presentation local type.\n\nFixes #26961