### PR TITLE
fix: align disabled action cells in permissions row (fixes #27445)

### DIFF
--- a/app/src/interfaces/_system/system-permissions/permissions-row.vue
+++ b/app/src/interfaces/_system/system-permissions/permissions-row.vue
@@ -125,6 +125,11 @@ const emit = defineEmits<{
 	}
 
 	.null {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		inline-size: 1.125rem;
+		block-size: 1.125rem;
 		cursor: not-allowed;
 	}
 


### PR DESCRIPTION
When directus_extensions is the only collection in the permissions interface, the disabled 'create' and 'delete' action cells display -- without proper centering, causing a visual glitch. This adds flexbox centering to the .null class for consistent alignment with toggle chips.\n\nFixes #27445