### PR TITLE
fix(sdk): add local type defs for RequestCredentials and CloseEvent (fixes #26850)

### DIFF
--- a/sdk/src/auth/types.ts
+++ b/sdk/src/auth/types.ts
@@ -1,3 +1,5 @@
+type RequestCredentials = 'omit' | 'same-origin' | 'include';
+
 export type AuthenticationMode = 'json' | 'cookie' | 'session';
 
 export type LocalLoginPayload = { email: string; password: string };

--- a/sdk/src/graphql/types.ts
+++ b/sdk/src/graphql/types.ts
@@ -1,3 +1,5 @@
+type RequestCredentials = 'omit' | 'same-origin' | 'include';
+
 export interface GraphqlClient<_Schema> {
 	query<Output extends object = Record<string, any>>(
 		query: string,

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -5,6 +5,7 @@ import { queryToParams } from '../utils/query-to-params.js';
 import { auth } from './commands/auth.js';
 import { pong } from './commands/pong.js';
 import type {
+	CloseEvent,
 	ConnectionState,
 	ReconnectState,
 	SubscribeOptions,

--- a/sdk/src/realtime/types.ts
+++ b/sdk/src/realtime/types.ts
@@ -27,6 +27,12 @@ export interface SubscribeOptions<Schema, Collection extends keyof Schema> {
 	uid?: string;
 }
 
+export interface CloseEvent extends Event {
+	readonly code: number;
+	readonly reason: string;
+	readonly wasClean: boolean;
+}
+
 export type WebSocketEvents = 'open' | 'close' | 'error' | 'message';
 export type RemoveEventHandler = () => void;
 export type WebSocketEventHandler = (this: WebSocketInterface, ev: Event | CloseEvent | any) => any;

--- a/sdk/src/rest/types.ts
+++ b/sdk/src/rest/types.ts
@@ -4,6 +4,8 @@ export interface RestCommand<_Output extends object | unknown, _Schema> {
 	(): RequestOptions;
 }
 
+type RequestCredentials = 'omit' | 'same-origin' | 'include';
+
 export interface RestClient<Schema> {
 	request<Output>(options: RestCommand<Output, Schema>): Promise<Output>;
 }


### PR DESCRIPTION
The SDK types reference DOM-only types \RequestCredentials\ and \CloseEvent\ without defining or importing them, causing type errors for consumers who don't include 'DOM' in their tsconfig \lib\. This adds local type definitions so the published .d.ts files are self-contained.\n\nFixes #26850