### PR TITLE
fix: remove native tooltip showing field path in O2M/M2M tables (fixes #27568)

### DIFF
--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -569,7 +569,6 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 			>
 				<template v-for="header in headers" :key="header.value" #[`item.${header.value}`]="{ item }">
 					<RenderTemplate
-						:title="header.value"
 						:collection="relationInfo.junctionCollection.collection"
 						:item="item"
 						:template="`{{${header.value}}}`"

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -531,7 +531,6 @@ const menuActive = computed(() => Boolean(currentlyEditing.value) || selectModal
 			>
 				<template v-for="header in headers" :key="header.value" #[`item.${header.value}`]="{ item }">
 					<RenderTemplate
-						:title="header.value"
 						:collection="relationInfo.relatedCollection.collection"
 						:item="item"
 						:template="`{{${header.value}}}`"


### PR DESCRIPTION
Removes the native title attribute from RenderTemplate in list-o2m and list-m2m. The title attribute was inherited by the root div, causing native tooltips to show the internal field path (e.g. hardware_item.asset_tag) instead of the rendered display value.

Fixes #27568