### PR TITLE
fix: preserve trailing zeros in float input while editing (fixes #25961)

### DIFF
--- a/app/src/components/v-input.vue
+++ b/app/src/components/v-input.vue
@@ -227,6 +227,16 @@ function emitValue(event: InputEvent) {
 	}
 
 	if (props.type === 'number') {
+		// Keep float values as strings to preserve trailing zeros during editing
+		if (props.float === true) {
+			value = value.replace(',', '.');
+			if (props.modelValue !== value) {
+				emit('update:modelValue', value);
+			}
+
+			return;
+		}
+
 		const parsedNumber = Number(value);
 
 		if (props.integer === true && !Number.isInteger(parsedNumber) && Number.isNaN(parsedNumber) === false) {


### PR DESCRIPTION
When editing a float field, deleting digits after the decimal point causes trailing zeros to be stripped. For example, typing 1.004 and deleting the 4 results in 1 instead of 1.00.

Root cause: emitValue converts the input string via Number(), which strips trailing zeros. This fix keeps the raw string value for float inputs so that intermediate editing states preserve trailing zeros.

Fixes #25961