### PR TITLE
fix: auto-focus dialog to prevent keyboard shortcuts bypassing error overlay (fixes #25882)

### DIFF
--- a/app/src/components/v-dialog.vue
+++ b/app/src/components/v-dialog.vue
@@ -94,7 +94,7 @@ function useOverlayFocusTrap() {
 
 	const focusTrap = useFocusTrap(overlayEl, {
 		escapeDeactivates: false,
-		initialFocus: false,
+		initialFocus: true,
 		setReturnFocus: () => (returnFocusTarget && document.contains(returnFocusTarget) ? returnFocusTarget : false),
 	});
 


### PR DESCRIPTION
When a Forbidden error dialog appears, keyboard shortcuts (e.g. Cmd+S, Cmd+Shift+S) still fire on the underlying form. Root cause: the focus trap has initialFocus: false, so focus remains in the form underneath the dialog, and the form's useShortcut handlers still fire.

Setting initialFocus: true moves focus to the first focusable element in the dialog (e.g. the Dismiss button), so keyboard shortcuts no longer reach the form underneath.

Fixes #25882