### PR TITLE
fix: keep fullscreen open when adding hyperlink in WYSIWYG editor (fixes #26300)

### DIFF
--- a/app/src/interfaces/input-rich-text-html/useLink.ts
+++ b/app/src/interfaces/input-rich-text-html/useLink.ts
@@ -43,10 +43,6 @@ export default function useLink(editor: Ref<any>): UsableLink {
 		icon: 'link',
 		tooltip: i18n.global.t('wysiwyg_options.link'),
 		onAction: () => {
-			if (editor.value.plugins.fullscreen.isFullscreen()) {
-				editor.value.execCommand('mceFullScreen');
-			}
-
 			linkDrawerOpen.value = true;
 
 			if (linkNode.value) {


### PR DESCRIPTION
The WYSIWYG link tool button was explicitly toggling fullscreen off before opening the link drawer. This was a leftover from an older approach that was already fixed for image and media dialogs (PR #12045), but the link button was missed.\n\nRemoves the mceFullScreen execCommand call so the link drawer opens while keeping fullscreen mode active, consistent with the image and media dialogs.\n\nFixes #26300