### PR TITLE
fix: support W (week of month) token in datetime custom format (fixes #27315)

### DIFF
--- a/app/src/utils/localized-format.ts
+++ b/app/src/utils/localized-format.ts
@@ -3,8 +3,21 @@ import { getDateFNSLocale } from '@/utils/get-date-fns-locale';
 
 type LocalizedFormat = (...a: Parameters<typeof formatOriginal>) => string;
 
+function resolveCustomTokens(date: Date, formatStr: string): string {
+	const placeholders: string[] = [];
+	const withoutQuoted = formatStr.replace(/'([^']*)'/g, (match) => {
+		placeholders.push(match);
+		return `\x00${placeholders.length - 1}\x00`;
+	});
+	const resolved = withoutQuoted.replace(/(W+)/g, (match) => {
+		const weekOfMonth = Math.ceil(date.getDate() / 7);
+		return match.length > 1 ? String(weekOfMonth).padStart(match.length, '0') : String(weekOfMonth);
+	});
+	return resolved.replace(/\x00(\d+)\x00/g, (_match, index) => placeholders[Number(index)]);
+}
+
 export const localizedFormat: LocalizedFormat = (date, format, options): string => {
-	return formatOriginal(date, format, {
+	return formatOriginal(date, resolveCustomTokens(date, format), {
 		...options,
 		locale: getDateFNSLocale(),
 	});


### PR DESCRIPTION
The 'W' token (week of month) from the Unicode TR35 spec is not supported by date-fns, causing an error when used in custom datetime format strings. This adds preprocessing to resolve the W token before passing the format string to date-fns.\n\nQuoted literal sections in the format string are preserved correctly.\n\nFixes #27315