### PR TITLE
fix: lower translations split view breakpoint from 960px to 720px (fixes #27678)

### DIFF
--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -114,7 +114,7 @@ function useSplitView() {
 	});
 
 	const { width } = useWindowSize();
-	const splitViewAvailable = computed(() => width.value > 960 && languageOptions.value.length > 1);
+	const splitViewAvailable = computed(() => width.value > 720 && languageOptions.value.length > 1);
 	const splitViewEnabled = computed(() => splitViewAvailable.value && splitView.value);
 
 	return {


### PR DESCRIPTION
The split view translations used a JavaScript hard breakpoint at 960px (via useWindowSize), while the CSS form-grid container queries support two-column layout down to 712px. This mismatch caused the second translation column to disappear when snapping the browser window.\n\nLowering the JS threshold to 720px aligns it with the CSS breakpoints so the split view works consistently.\n\nFixes #27678