### PR TITLE
fix: show collection name alongside display template in item header (fixes #27680)

### DIFF
--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -1026,13 +1026,16 @@ function useAutoSwitchToDraft() {
 		<template v-else-if="isNew === false && collectionInfo.meta && collectionInfo.meta.display_template" #title>
 			<VSkeletonLoader v-if="loading" class="title-loader" type="text" />
 
-			<h1 v-else class="type-title">
-				<RenderTemplate
-					:collection="collectionInfo.collection"
-					:item="templateData"
-					:template="collectionInfo.meta!.display_template"
-				/>
-			</h1>
+			<div v-else class="display-template-header">
+				<span class="collection-label">{{ collectionInfo.name }}</span>
+				<h1 class="type-title">
+					<RenderTemplate
+						:collection="collectionInfo.collection"
+						:item="templateData"
+						:template="collectionInfo.meta!.display_template"
+					/>
+				</h1>
+			</div>
 		</template>
 
 		<template v-if="shouldShowVersioning" #title-outer:append>
@@ -1399,6 +1402,18 @@ function useAutoSwitchToDraft() {
 
 :deep(.type-title) {
 	min-inline-size: 0;
+}
+
+.display-template-header {
+	.collection-label {
+		display: block;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: var(--theme--foreground-subdued);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		margin-block-end: 0.25rem;
+	}
 }
 
 .content-split {


### PR DESCRIPTION
When a Display Template is set for a collection, the item page header only shows the rendered template value but no longer shows the collection name. This was regressed in the v12 Studio Design Updates. This fix adds the collection name as a label above the display template value. Fixes #27680