### PR TITLE
Fix milestone workflow PR write permission

### DIFF
--- a/.github/workflows/assign-next-release-milestone.yml
+++ b/.github/workflows/assign-next-release-milestone.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   assign:


### PR DESCRIPTION
## Summary

The **Assign Next Release Milestone** workflow is failing on every run with:

```
RequestError [HttpError]: Resource not accessible by integration
  status: 403
  PATCH https://api.github.com/repos/directus/directus/issues/<n>
  x-accepted-github-permissions: issues=write; pull_requests=write
```

The failing step is the `github.rest.issues.update(...)` call that assigns the milestone to the merged PR. Although milestones are part of the issues API, updating the milestone field on a **pull request** requires both `issues: write` **and** `pull-requests: write` — exactly what GitHub reports in the `x-accepted-github-permissions` header. The workflow only granted `pull-requests: read`.

## Fix

Restore `pull-requests: write`:

```diff
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
```

## Why this is safe

This does **not** reintroduce the security concern that #27558 addressed. That PR's goal was dropping `pull_request_target` — which ran the write-scoped token in the context of (potentially untrusted) fork PRs. The trigger here remains `on: push: branches: [main]`, which only fires on already-merged, trusted code. The `pull-requests: read` was an incidental under-permission introduced during that refactor; granting write under the trusted `push` trigger is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)