### PR TITLE
Fix required M2M validation bypass when clearing all relations

### DIFF
--- a/.changeset/m2m-required-validation-clear.md
+++ b/.changeset/m2m-required-validation-clear.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed required Many-to-Many (and other relational) field validation being bypassed when all existing relations are cleared while editing an item

--- a/app/src/composables/use-item/index.ts
+++ b/app/src/composables/use-item/index.ts
@@ -175,7 +175,7 @@ export function useItem<T extends Item>(
 
 		const payloadToValidate = mergeItemData(defaultValues.value, item.value ?? {}, editsWithClearedValues);
 
-		const errors = validateItem(payloadToValidate, fields, isNew.value);
+		const errors = validateItem(payloadToValidate, fields, isNew.value, false, null, item.value);
 		if (nestedValidationErrors.value?.length) errors.push(...nestedValidationErrors.value);
 
 		if (errors.length > 0) {

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -910,7 +910,16 @@ function usePublishActions() {
 		const defaultValues = getDefaultValuesFromFields(fields);
 		const payloadToValidate = mergeItemData(defaultValues.value, item.value ?? {}, edits.value);
 		const fieldsToValidate = pushGroupOptionsDown(fields.value);
-		const clientErrors = validateItem(payloadToValidate, fieldsToValidate, false, false, currentVersion.value);
+
+		const clientErrors = validateItem(
+			payloadToValidate,
+			fieldsToValidate,
+			false,
+			false,
+			currentVersion.value,
+			item.value,
+		);
+
 		versionValidationErrors.value = clientErrors;
 		return clientErrors.length === 0;
 	}

--- a/app/src/utils/validate-item.test.ts
+++ b/app/src/utils/validate-item.test.ts
@@ -98,6 +98,82 @@ test('Required fields', () => {
 	expect(result.length).toEqual(1);
 });
 
+test('Required relational field cleared on update via staged changes', () => {
+	// When editing an existing item and removing all related items, the relational
+	// interface stages the change as a `{ create, update, delete }` object rather
+	// than an empty array. This must still be treated as an empty value so the
+	// required validation fires (see directus/directus#27695).
+	let result = validateItem(
+		{
+			id: 1,
+			name: 'test',
+			email: 'test@test.com',
+			role: { create: [], update: [], delete: [1, 2] },
+		},
+		fields as Field[],
+		false,
+		false,
+		null,
+		// Two related items existed and both are being deleted -> nets to empty.
+		{ role: [1, 2] },
+	);
+
+	expect(result.length).toEqual(1);
+
+	// A staged change that still results in related items (a create) must pass.
+	result = validateItem(
+		{
+			id: 1,
+			name: 'test',
+			email: 'test@test.com',
+			role: { create: [{ some: 'value' }], update: [], delete: [1] },
+		},
+		fields as Field[],
+		false,
+		false,
+		null,
+		{ role: [1] },
+	);
+
+	expect(result.length).toEqual(0);
+
+	// A partial removal that leaves related items behind must not be flagged.
+	result = validateItem(
+		{
+			id: 1,
+			name: 'test',
+			email: 'test@test.com',
+			role: { create: [], update: [], delete: [1] },
+		},
+		fields as Field[],
+		false,
+		false,
+		null,
+		// Three related items existed, only one is being deleted -> two remain.
+		{ role: [1, 2, 3] },
+	);
+
+	expect(result.length).toEqual(0);
+
+	// A staged update with no creates/deletes (e.g. editing an existing relation)
+	// must not be treated as empty.
+	result = validateItem(
+		{
+			id: 1,
+			name: 'test',
+			email: 'test@test.com',
+			role: { create: [], update: [{ id: 1, some: 'value' }], delete: [] },
+		},
+		fields as Field[],
+		false,
+		false,
+		null,
+		{ role: [1] },
+	);
+
+	expect(result.length).toEqual(0);
+});
+
 test('Custom validation with $NOW dynamic variable does not throw', () => {
 	const fieldsWithValidation: DeepPartial<Field>[] = [
 		{

--- a/app/src/utils/validate-item.ts
+++ b/app/src/utils/validate-item.ts
@@ -5,7 +5,7 @@ import {
 	FailedValidationErrorExtensions,
 	joiValidationErrorItemToErrorExtensions,
 } from '@directus/validation';
-import { cloneDeep, flatten, isEmpty, isNil } from 'lodash';
+import { cloneDeep, flatten, isEmpty, isNil, isPlainObject } from 'lodash';
 import { applyConditions } from './apply-conditions';
 import { parseFilter } from './parse-filter';
 import { useRelationsStore } from '@/stores/relations';
@@ -17,6 +17,7 @@ export function validateItem(
 	isNew: boolean,
 	includeCustomValidations = false,
 	currentVersion: ContentVersionMaybeNew | null = null,
+	originalItem: Record<string, any> | null = null,
 ): FailedValidationErrorExtensions[] {
 	const relationsStore = useRelationsStore();
 	const validationRules: LogicalFilterAND = { _and: [] };
@@ -36,7 +37,22 @@ export function validateItem(
 		const relation = relationsStore.getRelationsForField(field.collection, field.field);
 		if (!relation.length) return;
 
-		const isEmptyArray = Array.isArray(updatedItem[field.field]) && isEmpty(updatedItem[field.field]);
+		const value = updatedItem[field.field];
+
+		// On update, relational interfaces stage their changes as a
+		// `{ create, update, delete }` object rather than a plain array. When every
+		// existing related item is removed (and nothing new is created) the field is
+		// effectively empty, so normalize it to `null` to trigger required validation
+		// (see directus/directus#27695).
+		if (isStagedRelationalChanges(value)) {
+			const existingCount = Array.isArray(originalItem?.[field.field]) ? originalItem![field.field].length : 0;
+			const netCount = Math.max(existingCount - value.delete.length, 0) + value.create.length;
+
+			if (netCount === 0) updatedItem[field.field] = null;
+			return;
+		}
+
+		const isEmptyArray = Array.isArray(value) && isEmpty(value);
 		if (isEmptyArray) updatedItem[field.field] = null;
 	});
 
@@ -76,4 +92,23 @@ export function validateItem(
 			validationRules._and.push(parseFilter(validation));
 		});
 	}
+}
+
+type StagedRelationalChanges = {
+	create: unknown[];
+	update: unknown[];
+	delete: unknown[];
+};
+
+/**
+ * Relational interfaces (o2m/m2m/m2a) stage their edits as a
+ * `{ create, update, delete }` object instead of a plain array of related items.
+ */
+function isStagedRelationalChanges(value: unknown): value is StagedRelationalChanges {
+	return (
+		isPlainObject(value) &&
+		Array.isArray((value as Record<string, unknown>)['create']) &&
+		Array.isArray((value as Record<string, unknown>)['update']) &&
+		Array.isArray((value as Record<string, unknown>)['delete'])
+	);
 }

--- a/contributors.yml
+++ b/contributors.yml
@@ -283,3 +283,4 @@
 - valerkahere
 - levgiorg
 - MahinAnowar
+- Shevilll


### PR DESCRIPTION
## Scope

Fixes directus/directus#27695 — required Many-to-Many field validation was bypassed when clearing all existing relations while editing an item.

## Cause

The client-side required-field check in `app/src/utils/validate-item.ts` only normalized an empty **array** to `null` so the `_nnull` rule could fail it. On edit, the relational interfaces stage changes as a `{ create, update, delete }` object rather than an array, so removing all relations produced `{ create: [], update: [], delete: [...] }` — not an array — and the check was skipped, allowing the save. The required error then only surfaced on the next edit, once the value reloaded as an empty array.

## Fix

* In `validate-item.ts`, detect staged relational-change objects and compute the net related count (`max(existing − delete, 0) + create`). When it nets to zero, normalize the value to `null` so required validation fires immediately. The computation uses the original (pre-merge) item, so partial removals that still leave relations behind are not falsely flagged.
* Thread the original item through the two save/validation call sites.
* Unit tests covering: all relations removed (error), create still present (pass), partial delete (pass), update-only (pass).
* Changeset for `@directus/app`.