### PR TITLE
ci: add manual Docker dry-run workflow

### DIFF
--- a/.github/workflows/docker-dryrun.yml
+++ b/.github/workflows/docker-dryrun.yml
@@ -1,10 +1,10 @@
 name: Docker Dry-Run
 
 # Manual, live dry-run of the Docker build + multi-arch publish path from
-# release.yml, WITHOUT publishing to NPM, creating a GitHub release, or touching
-# the real image. Images are pushed to a SEPARATE GHCR package
-# (ghcr.io/<repo>-dryrun) with an experimental tag, so nothing public on Docker
-# Hub is affected and cleanup is just deleting that package.
+# release.yml, WITHOUT publishing to NPM, creating a GitHub release, or signing
+# with cosign. Images are pushed to a SEPARATE Docker Hub repository
+# (docker.io/<repo>-dryrun) with an experimental tag, so the real
+# docker.io/<repo> image is never touched and cleanup is just deleting that repo.
 
 on:
   workflow_dispatch:
@@ -25,14 +25,14 @@ on:
 
 permissions:
   contents: read
-  packages: write
   id-token: write # OIDC token used to sign build provenance attestations
   attestations: write # write the provenance attestation back to the registry
 
 env:
-  # Separate package name: new GHCR packages are private by default and the real
-  # ghcr.io/<repo> image is never touched.
-  GHCR_IMAGE: ghcr.io/${{ github.repository }}-dryrun
+  # Separate repository so the real docker.io/<repo> image is never touched.
+  # NOTE: Docker Hub repos default to PUBLIC; pre-create and set this repo to
+  # private on Docker Hub if the dry-run images should not be publicly visible.
+  DOCKERHUB_IMAGE: docker.io/${{ github.repository }}-dryrun
 
 jobs:
   setup:
@@ -67,7 +67,7 @@ jobs:
             tag="dryrun-${GITHUB_SHA::12}"
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "ℹ️ Dry-run images will be tagged '$tag' on ${GHCR_IMAGE}"
+          echo "ℹ️ Dry-run images will be tagged '$tag' on ${DOCKERHUB_IMAGE}"
 
   build-images:
     name: Build Images
@@ -87,7 +87,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
-      packages: write
       id-token: write
       attestations: write
     steps:
@@ -117,16 +116,16 @@ jobs:
           flavor: |
             suffix=${{ matrix.variant.suffix }}
           images: |
-            ${{ env.GHCR_IMAGE }}
+            ${{ env.DOCKERHUB_IMAGE }}
           tags: |
             type=raw,value=${{ needs.setup.outputs.tag }}
 
-      - name: Login to GHCR
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       # DHI base image lives behind an entitled registry; reuse the Docker Hub
       # publishing credentials (that account must hold the DHI entitlement).
@@ -151,7 +150,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           # prettier-ignore
-          outputs: type=image,"name=${{ env.GHCR_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,"name=${{ env.DOCKERHUB_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
         run: |
@@ -185,9 +184,6 @@ jobs:
       fail-fast: false
       matrix:
         variant: ${{ fromJSON(needs.setup.outputs.variants) }}
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: Download digests
         uses: actions/download-artifact@v6
@@ -206,24 +202,24 @@ jobs:
           flavor: |
             suffix=${{ matrix.variant.suffix }}
           images: |
-            ${{ env.GHCR_IMAGE }}
+            ${{ env.DOCKERHUB_IMAGE }}
           tags: |
             type=raw,value=${{ needs.setup.outputs.tag }}
 
-      - name: Login to GHCR
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Create manifest list and push to GHCR
+      - name: Create manifest list and push to Docker Hub
         working-directory: ${{ runner.temp }}/digests
         run: |
           docker buildx imagetools create \
-            $(jq -cr '.tags | map(select(startswith("ghcr.io"))) | map("-t " + .) | join(" ")' <<< '${{ steps.meta.outputs.json }}') \
-            $(printf '${{ env.GHCR_IMAGE }}@sha256:%s ' *)
+            $(jq -cr '.tags | map(select(startswith("docker.io"))) | map("-t " + .) | join(" ")' <<< '${{ steps.meta.outputs.json }}') \
+            $(printf '${{ env.DOCKERHUB_IMAGE }}@sha256:%s ' *)
 
-      - name: Inspect GHCR image
+      - name: Inspect Docker Hub image
         run: |
-          docker buildx imagetools inspect ${{ env.GHCR_IMAGE }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.DOCKERHUB_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-dryrun.yml
+++ b/.github/workflows/docker-dryrun.yml
@@ -1,0 +1,229 @@
+name: Docker Dry-Run
+
+# Manual, live dry-run of the Docker build + multi-arch publish path from
+# release.yml, WITHOUT publishing to NPM, creating a GitHub release, or touching
+# the real image. Images are pushed to a SEPARATE GHCR package
+# (ghcr.io/<repo>-dryrun) with an experimental tag, so nothing public on Docker
+# Hub is affected and cleanup is just deleting that package.
+
+on:
+  workflow_dispatch:
+    inputs:
+      variant:
+        description: 'Which image variant(s) to build'
+        type: choice
+        options:
+          - both
+          - standard
+          - dhi
+        default: both
+      tag:
+        description: 'Experimental image tag (default: dryrun-<short-sha>)'
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write # OIDC token used to sign build provenance attestations
+  attestations: write # write the provenance attestation back to the registry
+
+env:
+  # Separate package name: new GHCR packages are private by default and the real
+  # ghcr.io/<repo> image is never touched.
+  GHCR_IMAGE: ghcr.io/${{ github.repository }}-dryrun
+
+jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    outputs:
+      variants: ${{ steps.variants.outputs.variants }}
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: Resolve variant matrix
+        id: variants
+        env:
+          VARIANT: ${{ inputs.variant }}
+        run: |
+          standard='{"name":"standard","suffix":"","file":"./Dockerfile"}'
+          dhi='{"name":"dhi","suffix":"-dhi","file":"./Dockerfile.dhi"}'
+          case "$VARIANT" in
+            standard) variants="[$standard]" ;;
+            dhi)      variants="[$dhi]" ;;
+            *)        variants="[$standard,$dhi]" ;;
+          esac
+          echo "variants=$variants" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve experimental tag
+        id: tag
+        env:
+          TAG_INPUT: ${{ inputs.tag }}
+        run: |
+          if [ -n "$TAG_INPUT" ]; then
+            tag="$TAG_INPUT"
+          else
+            tag="dryrun-${GITHUB_SHA::12}"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "ℹ️ Dry-run images will be tagged '$tag' on ${GHCR_IMAGE}"
+
+  build-images:
+    name: Build Images
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ${{ fromJSON(needs.setup.outputs.variants) }}
+        platform:
+          - linux/amd64
+          - linux/arm64
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_SLUG=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v5
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-${{ env.PLATFORM_SLUG }}-${{ matrix.variant.name }}-dryrun-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.PLATFORM_SLUG }}-${{ matrix.variant.name }}-dryrun-buildx-
+
+      - name: Extract metadata for Docker image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          flavor: |
+            suffix=${{ matrix.variant.suffix }}
+          images: |
+            ${{ env.GHCR_IMAGE }}
+          tags: |
+            type=raw,value=${{ needs.setup.outputs.tag }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # DHI base image lives behind an entitled registry; reuse the Docker Hub
+      # publishing credentials (that account must hold the DHI entitlement).
+      # Gated to the dhi variant so the standard build never attempts this login.
+      - name: Login to DHI registry
+        uses: docker/login-action@v3
+        if: matrix.variant.name == 'dhi'
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and push by digest
+        uses: docker/build-push-action@v6
+        id: build
+        with:
+          context: .
+          file: ${{ matrix.variant.file }}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          # prettier-ignore
+          outputs: type=image,"name=${{ env.GHCR_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v6
+        with:
+          name: digests-${{ matrix.variant.name }}-${{ env.PLATFORM_SLUG }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+      # Temp fix for cache growth:
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  publish-docker-images:
+    name: Publish Docker Images
+    runs-on: ubuntu-latest
+    needs:
+      - setup
+      - build-images
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ${{ fromJSON(needs.setup.outputs.variants) }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v6
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-${{ matrix.variant.name }}-*
+          merge-multiple: true
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata for Docker image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          flavor: |
+            suffix=${{ matrix.variant.suffix }}
+          images: |
+            ${{ env.GHCR_IMAGE }}
+          tags: |
+            type=raw,value=${{ needs.setup.outputs.tag }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push to GHCR
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map(select(startswith("ghcr.io"))) | map("-t " + .) | join(" ")' <<< '${{ steps.meta.outputs.json }}') \
+            $(printf '${{ env.GHCR_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect GHCR image
+        run: |
+          docker buildx imagetools inspect ${{ env.GHCR_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-dryrun.yml
+++ b/.github/workflows/docker-dryrun.yml
@@ -7,6 +7,7 @@ name: Docker Dry-Run
 # docker.io/<repo> image is never touched and cleanup is just deleting that repo.
 
 on:
+  # Manual button (only available once this file is on the default branch).
   workflow_dispatch:
     inputs:
       variant:
@@ -22,6 +23,12 @@ on:
         type: string
         required: false
         default: ''
+  # Label gate: add the "dryrun" label to a PR to trigger a run from that PR's
+  # branch (no merge to the default branch required). Uses default settings
+  # (variant=both, tag=dryrun-<short-sha>) since label events carry no inputs.
+  # Same-repo PRs only have access to the required secrets; fork PRs do not.
+  pull_request:
+    types: [labeled]
 
 permissions:
   contents: read
@@ -37,6 +44,9 @@ env:
 jobs:
   setup:
     name: Setup
+    # Run for the manual button, or when a PR is labeled exactly "dryrun".
+    # Downstream jobs depend on this one, so gating here gates the whole run.
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'dryrun'
     runs-on: ubuntu-latest
     outputs:
       variants: ${{ steps.variants.outputs.variants }}
@@ -45,7 +55,7 @@ jobs:
       - name: Resolve variant matrix
         id: variants
         env:
-          VARIANT: ${{ inputs.variant }}
+          VARIANT: ${{ inputs.variant || 'both' }}
         run: |
           standard='{"name":"standard","suffix":"","file":"./Dockerfile"}'
           dhi='{"name":"dhi","suffix":"-dhi","file":"./Dockerfile.dhi"}'
@@ -60,11 +70,14 @@ jobs:
         id: tag
         env:
           TAG_INPUT: ${{ inputs.tag }}
+          # Empty on workflow_dispatch; the PR head sha on a label event.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [ -n "$TAG_INPUT" ]; then
             tag="$TAG_INPUT"
           else
-            tag="dryrun-${GITHUB_SHA::12}"
+            sha="${HEAD_SHA:-$GITHUB_SHA}"
+            tag="dryrun-${sha::12}"
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "ℹ️ Dry-run images will be tagged '$tag' on ${DOCKERHUB_IMAGE}"


### PR DESCRIPTION
## What

Adds `.github/workflows/docker-dryrun.yml` — a **manually triggered, live dry-run** of the Docker portion of `release.yml`. It exercises the real build + multi-arch publish path **without** any of the release side effects.

It does **not**:

- publish packages to NPM
- create a GitHub release
- sign anything with cosign
- touch the real `docker.io/directus/directus` image

## Why

`release.yml` only runs on a pushed `v*` tag, and bundles NPM publish, Docker build/publish, and release creation together. There was no way to validate Docker changes (e.g. the new `Dockerfile.dhi` on `harden-docker`) end-to-end against a real registry without cutting a release. This workflow fills that gap so the build → push-by-digest → multi-arch manifest path can be smoke-tested on demand.

## How it works

Triggers:

- **`workflow_dispatch`** (Actions tab → "Docker Dry-Run" → Run workflow) — only available once this file is on the **default branch**. Exposes the `variant` and `tag` inputs below.
- **`pull_request` `labeled`** — add the **`dryrun`** label to a PR to run it from that PR's branch **without merging to the default branch**. Label events carry no inputs, so it uses defaults: `variant=both`, `tag=dryrun-<short-sha>`. ⚠️ Only **same-repo** PRs have access to the required secrets; fork PRs do not.

Inputs (dispatch only):

- `variant` — `both` (default), `standard`, or `dhi`
- `tag` — optional experimental tag (defaults to `dryrun-<short-sha>`)

Jobs:

1. **setup** — resolves the variant matrix from the input and computes the experimental tag.
2. **build-images** — builds the selected variant(s) across `linux/amd64` + `linux/arm64`, pushes **by digest**, keeps `provenance: true`. Retains the entitled `dhi.io` login (gated to the `dhi` variant) for the DHI base image.
3. **publish-docker-images** — assembles the multi-arch manifest, tags it, and inspects it.

## Target & isolation

- Pushes to **Docker Hub**, to a **separate repository**: `docker.io/directus/directus-dryrun`. The real `docker.io/directus/directus` image is never touched.
- Only experimental tags (`dryrun-<sha>`) are written — never `latest`, `canary`, or version tags.
- Cleanup is just deleting the `directus-dryrun` repo.
- ⚠️ **Docker Hub repos default to public.** Pre-create `directus/directus-dryrun` and set it to private on Docker Hub if the dry-run images should not be publicly visible.

## Secrets used

- `DOCKERHUB_USERNAME` / `DOCKERHUB_PASSWORD` — push to Docker Hub, and pull the entitled DHI base image (same credentials `release.yml` already uses)

## Notes

- Base is `harden-docker` because the `dhi` variant depends on `Dockerfile.dhi`, which lives on that branch.
- Opened as a **draft** for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
