### PR TITLE
Add interface for status field in collections

### DIFF
--- a/.changeset/yellow-cougars-laugh.md
+++ b/.changeset/yellow-cougars-laugh.md
@@ -1,0 +1,6 @@
+---
+'@directus/system-data': patch
+'@directus/app': patch
+---
+
+Added interface settings for collection status field

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2056,8 +2056,6 @@ field_options:
     only_track_activity: Only Track Activity
     do_not_track_anything: Do Not Track Anything
     collection_setup: Collection Setup
-    status_active: Active
-    status_inactive: Inactive
     collection_naming_translations_note:
       "Override the collection's display name in the app based on the user's language."
     note_placeholder: A description of this collection...

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1759,6 +1759,7 @@ fields:
     collection: Collection
     icon: Icon
     note: Note
+    status: Status
     color: Color
     display_template: Display Template
     hidden: Hidden
@@ -2055,6 +2056,8 @@ field_options:
     only_track_activity: Only Track Activity
     do_not_track_anything: Do Not Track Anything
     collection_setup: Collection Setup
+    status_active: Active
+    status_inactive: Inactive
     collection_naming_translations_note:
       "Override the collection's display name in the app based on the user's language."
     note_placeholder: A description of this collection...

--- a/packages/system-data/src/fields/collections.yaml
+++ b/packages/system-data/src/fields/collections.yaml
@@ -28,9 +28,9 @@ fields:
     interface: select-dropdown
     options:
       choices:
-        - text: $t:field_options.directus_collections.status_active
+        - text: $t:active
           value: active
-        - text: $t:field_options.directus_collections.status_inactive
+        - text: $t:inactive
           value: inactive
     width: half
 

--- a/packages/system-data/src/fields/collections.yaml
+++ b/packages/system-data/src/fields/collections.yaml
@@ -24,6 +24,16 @@ fields:
       placeholder: $t:field_options.directus_collections.note_placeholder
     width: half
 
+  - field: status
+    interface: select-dropdown
+    options:
+      choices:
+        - text: $t:field_options.directus_collections.status_active
+          value: active
+        - text: $t:field_options.directus_collections.status_inactive
+          value: inactive
+    width: half
+
   - field: icon
     interface: select-icon
     options:


### PR DESCRIPTION
## Scope

  What's changed:

  - Adds a `status` interface field to the `directus_collections` system fields (`select-dropdown` with `active`/`inactive` choices) in
  `packages/system-data/src/fields/collections.yaml`

  ## Potential Risks / Drawbacks

  - None I can think of — this only adds interface configuration for an existing field; no schema or migration changes

  ## Tested Scenarios

  - Collection settings shows the new Status dropdown with Active/Inactive options

  ## Review Notes / Questions

  ## Checklist

  - [ ] Added or updated tests
  - [x] Documentation PR created [here](https://github.com/directus/docs) or not required
  - [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

Fixes [CMS-2730](https://linear.app/directus/issue/CMS-2730/a-wild-status-field-has-appeared)