### PR TITLE
dp ← Fix public page foreground image overlaying shader background

### DIFF
--- a/.changeset/cms-2720-foreground-overlay-shader.md
+++ b/.changeset/cms-2720-foreground-overlay-shader.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the public page foreground image rendering side-by-side with the shader background instead of overlaying it

--- a/app/src/views/public/components/shader-background.vue
+++ b/app/src/views/public/components/shader-background.vue
@@ -17,20 +17,26 @@ const CLEAR_COLOR = '#000000';
 function createRenderer({ canvas }: TresRendererSetupContext) {
 	return new WebGPURenderer({ canvas: toValue(canvas), antialias: true });
 }
+
+// TresCanvas forces `position: relative` as an inline style; merge our own inline style so it
+// wins and the canvas drops out of flow, letting the foreground image overlay it.
+const canvasStyle = {
+	position: 'absolute',
+	inset: 0,
+	zIndex: -1,
+} as const;
 </script>
 
 <template>
-	<TresCanvas :renderer="createRenderer" :clear-color="CLEAR_COLOR" :dpr="[1, 2]" class="public-shader-background">
+	<TresCanvas
+		:renderer="createRenderer"
+		:clear-color="CLEAR_COLOR"
+		:dpr="[1, 2]"
+		class="public-shader-background"
+		:style="canvasStyle"
+	>
 		<TresPerspectiveCamera :position="[0, 0, 10]" :look-at="[0, 0, 0]" />
 		<!-- Shader scene goes here -->
 		<DotGridShader :project-color="projectColor" />
 	</TresCanvas>
 </template>
-
-<style lang="scss" scoped>
-.public-shader-background {
-	position: absolute;
-	inset: 0;
-	z-index: -1;
-}
-</style>


### PR DESCRIPTION
## Scope

What's changed:

- Fixed the public/login page foreground image rendering side-by-side with the shader background instead of overlaying it
- Moved the shader canvas positioning from a scoped CSS rule into an inline `:style` binding on `<TresCanvas>`
- Removed the now-redundant scoped `<style>` block in `shader-background.vue`

**Root cause:** `TresCanvas` (`@tresjs/core`) renders its `<canvas>` with a hard-coded inline `position: relative` (when `windowSize` is false, the default). Inline styles override scoped CSS, so the previous `.public-shader-background { position: absolute }` rule never applied — the canvas stayed in flex flow as a sibling of `.foreground` inside the `display:flex` `.art` container, so they rendered next to each other. The old `.fallback` `<div>` was positioned `absolute` directly by the parent, so it never hit this. `TresCanvas` merges `$attrs.style` last in its style object, so an inline `:style` binding wins and takes the canvas back out of flow.

## Potential Risks / Drawbacks

- Relies on `TresCanvas` continuing to spread `$attrs.style` last in its inline style (current behavior in `@tresjs/core` v5.8.1). A future upstream change to that merge order could regress this.
- Low blast radius: change is isolated to the public-page shader background component.

## Tested Scenarios

- Lint (`eslint`) and Volar/TS diagnostics pass on the changed component
- Visual verification on the login page with a foreground image set is still recommended before merge (requires full stack + WebGPU)

## Review Notes / Questions

- Kept the `public-shader-background` class on the canvas as a DOM hook even though its scoped styles are gone — can drop it if preferred.

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Closes CMS-2720
