### PR TITLE
Fix contributing link in readme

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,4 +1,3 @@
 # Contributing
 
-Please see our contributing guidelines on
-[https://directus.com/docs/community/contribution/translations](https://directus.com/docs/community/contribution/translations)
+Please see [our contributing guidelines](https://directus.com/docs/community/contribution/pull-requests)

--- a/directus/readme.md
+++ b/directus/readme.md
@@ -84,8 +84,8 @@ One click. Fully provisioned with PostgreSQL, Redis, and S3-compatible storage, 
 
 ## ❤️ Contributing
 
-Read our [Contributing Guide](https://github.com/directus/directus/blob/main/.github/CONTRIBUTING.md) before submitting
-pull requests.
+Read our [Contributing Guide](https://github.com/directus/directus/blob/main/contributing.md) before submitting pull
+requests.
 
 Report security vulnerabilities per our [Security Policy](https://github.com/directus/directus/security/policy).
 


### PR DESCRIPTION
## Scope

What's changed:

- Fixes the incorrect link to `contributing.md` in our readme.
- Updates the contribution entry point to direct users to pull requests, as this is the primary contribution workflow rather than translations.

## Potential Risks / Drawbacks

- N/A

## Tested Scenarios

- N/A

## Review Notes / Questions

- N/A

## Checklist

- [x] Added or updated tests or **not required**
- [x] Documentation PR created [here](https://github.com/directus/docs) or **not required**
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or **not required**

---

Fixes #27786 
