### PR TITLE
Fix MCP OAuth role resolution to use the users role instead of the root role

### DIFF
--- a/.changeset/slick-colts-work.md
+++ b/.changeset/slick-colts-work.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed MCP OAuth role resolution to use the users role instead of the root role

--- a/api/src/services/mcp-oauth/index.test.ts
+++ b/api/src/services/mcp-oauth/index.test.ts
@@ -1953,6 +1953,24 @@ describe('McpOAuthService', () => {
 			expect(decoded['iss']).toBe('directus');
 		});
 
+		it("JWT role claim is the user's own role, not the roles tree root", async () => {
+			mockClientLookup(clientId);
+			mockCodeLookup();
+			tracker.on.update('directus_oauth_codes').response(1);
+
+			mockUserLookup({ role: 'own-role' });
+			tracker.on.select('directus_oauth_tokens').response([]);
+			tracker.on.insert('directus_sessions').response([]);
+			tracker.on.insert('directus_oauth_tokens').response([]);
+
+			mockFetchRolesTree.mockResolvedValue(['root-role', 'parent-role', 'own-role']);
+
+			const result = await service.exchangeCode(validParams(), context);
+			const decoded = decodeAccessToken(result.access_token);
+
+			expect(decoded['role']).toBe('own-role');
+		});
+
 		it('refresh_token omitted if client did not register refresh_token grant type', async () => {
 			mockCodeLookup();
 			tracker.on.update('directus_oauth_codes').response(1);

--- a/api/src/services/mcp-oauth/index.ts
+++ b/api/src/services/mcp-oauth/index.ts
@@ -1920,7 +1920,7 @@ export class McpOAuthService {
 		return jwt.sign(
 			{
 				id: opts.userId,
-				role: rolesTree[0] ?? null,
+				role: opts.role,
 				app_access: globalAccess.app,
 				admin_access: globalAccess.admin,
 				session: opts.sessionHash,


### PR DESCRIPTION
## Scope

What's changed:

- jwt assigned role now set to users role instead of root role

## Potential Risks / Drawbacks

- None

## Tested Scenarios

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #27787
