### PR TITLE
tw ← Tiptap WYSIWYG: dropdown caret on color + style menus (CMS-2764)

### DIFF
--- a/app/src/interfaces/input-rich-text-html/toolbar/buttons.ts
+++ b/app/src/interfaces/input-rich-text-html/toolbar/buttons.ts
@@ -80,6 +80,10 @@ const FONT_SIZES: { label: string; value: string | null }[] = [12, 14, 16, 18, 2
 const FONT_FAMILY_WIDTH = 132;
 const FONT_SIZE_WIDTH = 80;
 
+// Icon + caret dropdowns (color pickers) are wider than a plain icon button; keep in sync with the
+// `2.5rem` activator width in color-menu.vue and `popoverWidth` in toolbar.vue.
+const CARET_BUTTON_WIDTH = 40;
+
 // text-align directions; `alignnone` (unset) is registered separately below
 const align: Record<string, ToolbarButton> = Object.fromEntries(
 	(['left', 'center', 'right', 'justify'] as const).map((value) => [
@@ -140,12 +144,14 @@ export const toolbarButtons: Record<string, ToolbarButton> = {
 		icon: 'format_color_text',
 		label: 'wysiwyg_options.forecolor',
 		component: ColorMenu,
+		width: CARET_BUTTON_WIDTH,
 		componentProps: { icon: 'format_color_text', label: 'wysiwyg_options.forecolor', mode: 'text' },
 	},
 	backcolor: {
 		icon: 'format_color_fill',
 		label: 'wysiwyg_options.backcolor',
 		component: ColorMenu,
+		width: CARET_BUTTON_WIDTH,
 		componentProps: { icon: 'format_color_fill', label: 'wysiwyg_options.backcolor', mode: 'background' },
 	},
 	bold: {

--- a/app/src/interfaces/input-rich-text-html/toolbar/menus/color-menu.vue
+++ b/app/src/interfaces/input-rich-text-html/toolbar/menus/color-menu.vue
@@ -2,6 +2,7 @@
 import type { Editor } from '@tiptap/vue-3';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
+import ToolbarCaret from '../toolbar-caret.vue';
 import { applyStyle, readStyle, type StyleAttr } from './text-style';
 import VButton from '@/components/v-button.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
@@ -46,6 +47,7 @@ defineExpose({ apply });
 				@click="toggle"
 			>
 				<VIcon :name="icon" :style="current() ? { color: current()! } : undefined" />
+				<ToolbarCaret class="color-menu-caret" />
 			</VButton>
 		</template>
 		<div class="color-menu">
@@ -60,6 +62,17 @@ defineExpose({ apply });
 .toolbar-button.ghost.active {
 	--v-button-background-color: var(--theme--form--field--input--border-color);
 	--v-button-color: var(--theme--foreground);
+}
+
+// `icon` makes VButton a tight square with no padding; icon + caret need more room. Widen to fit both
+// (keep in sync with `CARET_BUTTON_WIDTH` in buttons.ts, `2.5rem` = 40px) and center the content.
+.toolbar-button :deep(.button.icon) {
+	inline-size: 2.5rem;
+	justify-content: center;
+}
+
+.color-menu-caret {
+	margin-inline-start: -0.125rem;
 }
 
 .color-menu {

--- a/app/src/interfaces/input-rich-text-html/toolbar/menus/style-list-menu.vue
+++ b/app/src/interfaces/input-rich-text-html/toolbar/menus/style-list-menu.vue
@@ -2,9 +2,9 @@
 import type { Editor } from '@tiptap/vue-3';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
+import ToolbarCaret from '../toolbar-caret.vue';
 import { applyStyle, readStyle, type StyleAttr } from './text-style';
 import VButton from '@/components/v-button.vue';
-import VIcon from '@/components/v-icon/v-icon.vue';
 import VListItemContent from '@/components/v-list-item-content.vue';
 import VListItem from '@/components/v-list-item.vue';
 import VList from '@/components/v-list.vue';
@@ -95,7 +95,7 @@ defineExpose({ select, currentLabel });
 				<span class="style-list-label" :style="currentFont ? { fontFamily: currentFont } : undefined">
 					{{ currentLabel }}
 				</span>
-				<VIcon class="style-list-caret" name="expand_more" small />
+				<ToolbarCaret class="style-list-caret" />
 			</VButton>
 		</template>
 		<VList class="style-list">

--- a/app/src/interfaces/input-rich-text-html/toolbar/toolbar-caret.vue
+++ b/app/src/interfaces/input-rich-text-html/toolbar/toolbar-caret.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import VIcon from '@/components/v-icon/v-icon.vue';
+</script>
+
+<template>
+	<VIcon class="toolbar-caret" name="expand_more" small />
+</template>
+
+<style lang="scss" scoped>
+// Shared dropdown-caret glyph; consumers position it (margin/flex) via their own class on the root.
+.toolbar-caret {
+	--v-icon-size: 1rem;
+}
+</style>

--- a/app/src/interfaces/input-rich-text-html/toolbar/toolbar-popover.vue
+++ b/app/src/interfaces/input-rich-text-html/toolbar/toolbar-popover.vue
@@ -5,6 +5,7 @@ import { useI18n } from 'vue-i18n';
 import { toolbarButtons, type ToolbarContext } from './buttons';
 import type { RenderGroup } from './compute-toolbar-layout';
 import ToolbarButtonComp from './toolbar-button.vue';
+import ToolbarCaret from './toolbar-caret.vue';
 import VButton from '@/components/v-button.vue';
 import VIcon from '@/components/v-icon/v-icon.vue';
 import VMenu from '@/components/v-menu.vue';
@@ -55,7 +56,7 @@ const triggerLabel = computed(() => {
 				@click.stop="toggle"
 			>
 				<VIcon :name="triggerIcon" />
-				<VIcon class="toolbar-popover-caret" name="expand_more" small />
+				<ToolbarCaret class="toolbar-popover-caret" />
 			</VButton>
 		</template>
 		<div class="toolbar-popover-items">
@@ -73,10 +74,15 @@ const triggerLabel = computed(() => {
 </template>
 
 <style lang="scss" scoped>
+// `icon` makes VButton a tight square with no padding; icon + caret need more room. Widen to fit both
+// (matches `popoverWidth` in toolbar.vue) and center the content.
+.toolbar-popover :deep(.button.icon) {
+	inline-size: 2.5rem;
+	justify-content: center;
+}
+
 .toolbar-popover-caret {
 	margin-inline-start: -0.125rem;
-
-	--v-icon-size: 1rem;
 }
 
 .toolbar-popover-items {

--- a/app/src/interfaces/input-rich-text-html/toolbar/toolbar.vue
+++ b/app/src/interfaces/input-rich-text-html/toolbar/toolbar.vue
@@ -64,7 +64,7 @@ const MEASUREMENTS: LayoutMeasurements = {
 	moreWidth: 32,
 	separatorWidth: 9,
 	minItems: 5,
-	popoverWidth: 44,
+	popoverWidth: 40,
 	keyWidths,
 };
 


### PR DESCRIPTION
## Scope

What's changed:

- Add a shared `toolbar-caret.vue` (the `expand_more` glyph at `1rem`) and use it in the align popover, color, and style-list menus — removes the inline caret duplicated across components.
- Add the dropdown caret to the `forecolor` / `backcolor` color buttons, which had none. (`fontfamily` / `fontsize` already rendered one.)
- Fix the cramped activators: VButton's `icon` prop forces a tight `2rem` square with `padding: 0`, so the icon + caret overflowed and were clipped. Widen those dropdown buttons to `2.5rem` (40px) and center their content.
- Reserve the matching footprint in the overflow layout so the wider buttons don't clip early — `CARET_BUTTON_WIDTH` for `forecolor`/`backcolor` (were defaulting to the 32px icon width) and `popoverWidth: 40` for the popover.

## Potential Risks / Drawbacks

- The `40px` width lives in three coordinated spots (CSS `2.5rem`, `CARET_BUTTON_WIDTH` in `buttons.ts`, `popoverWidth` in `toolbar.vue`); cross-referenced in comments but must stay in sync.
- The shared caret positioning relies on Vue's scoped-style behavior where a child component's root element also receives the parent's scope id (each consumer applies its own margin/flex class).

## Tested Scenarios

- toolbar unit suite passes (9 files / 56 tests), incl. `compute-toolbar-layout`.
- forecolor / backcolor / align / font dropdowns all show the caret with consistent spacing; no overflow clipping.

## Review Notes / Questions

- `menus/table-menu.vue` (the `table` button) would share this single-button-with-dropdown pattern but isn't built yet and is out of scope per design feedback (color + style only). The shared caret is ready to drop in when it lands.
- No new unit tests — this is a presentational change covered by the existing suite.

## Checklist

- [ ] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Closes [CMS-2764](https://linear.app/directus/issue/CMS-2764/tiptap-wysiwyg-add-dropdown-caret-to-color-style-menus)