### PR TITLE
Surface changeset version output in prepare-release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -139,9 +139,20 @@ jobs:
 
           echo "is_prerelease=$IS_PRERELEASE" >> $GITHUB_OUTPUT
 
-          # Capture the changeset version output
+          # Capture the changeset version output without letting `set -e`
+          # abort before we've printed it (default shell runs with -eo pipefail)
+          set +e
           OUTPUT=$(pnpm changeset version 2>&1)
+          STATUS=$?
+          set -e
+
+          # Always surface the output so failures are visible in the logs
           echo "$OUTPUT"
+
+          if [ "$STATUS" -ne 0 ]; then
+            echo "❌ 'pnpm changeset version' failed with exit code $STATUS"
+            exit 1
+          fi
 
           # Extract release notes from the output
           # The release notes generator outputs between the divider lines


### PR DESCRIPTION
### Problem

The `Generate release notes and update versions` step in `prepare-release.yml` fails with a bare `Process completed with exit code 1` and no diagnostic output.

The cause is that the changeset output is captured into a variable:

```bash
OUTPUT=$(pnpm changeset version 2>&1)
echo "$OUTPUT"
```

GitHub Actions runs `run:` blocks with `bash --noprofile --norc -eo pipefail`. When `pnpm changeset version` exits non-zero, the command-substitution assignment fails and `set -e` aborts the step **before** `echo "$OUTPUT"` ever runs — so the real error (captured via `2>&1`) is swallowed.

### Fix

Decouple the capture from the abort so the output is always printed before the step decides to fail:

```bash
set +e
OUTPUT=$(pnpm changeset version 2>&1)
STATUS=$?
set -e
echo "$OUTPUT"
if [ "$STATUS" -ne 0 ]; then
  echo "❌ 'pnpm changeset version' failed with exit code $STATUS"
  exit 1
fi
```

The underlying `changeset version` error now shows up in the workflow logs, and the step still fails as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)