### PR TITLE
Release 12.1.0

### DIFF
--- a/.changeset/back-button-relational-traversal.md
+++ b/.changeset/back-button-relational-traversal.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Restored pre-v12 back button behavior: returns to the previously visited item/page when navigating via a relation, and to the collection listing when landing on an item directly

--- a/.changeset/cms-2720-foreground-overlay-shader.md
+++ b/.changeset/cms-2720-foreground-overlay-shader.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Fixed the public page foreground image rendering side-by-side with the shader background instead of overlaying it

--- a/.changeset/common-plums-sneeze.md
+++ b/.changeset/common-plums-sneeze.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Added clearable indicator to input hash field

--- a/.changeset/curly-jokes-strive.md
+++ b/.changeset/curly-jokes-strive.md
@@ -1,7 +1,0 @@
----
-'@directus/env': minor
-'@directus/api': minor
-'@directus/app': minor
----
-
-Added `PROJECT_OWNER_ENABLED` env var to allow disabling owner info collection and sync

--- a/.changeset/curvy-mammals-strive.md
+++ b/.changeset/curvy-mammals-strive.md
@@ -1,7 +1,0 @@
----
-'@directus/specs': major
-'@directus/api': major
-'@directus/sdk': major
----
-
-Removed `/utils/hash/generate` and `/utils/hash/verify` endpoints

--- a/.changeset/dry-pillows-hope.md
+++ b/.changeset/dry-pillows-hope.md
@@ -1,5 +1,0 @@
----
-'@directus/app': minor
----
-
-Replaced tooltip with Reka UI one

--- a/.changeset/famous-boats-relate.md
+++ b/.changeset/famous-boats-relate.md
@@ -1,5 +1,0 @@
----
-'@directus/api': major
----
-
-Fixed failed TUS file replacements leaving orphaned file records. Hardened upload path validation to prevent writes to extension and temporary storage directories

--- a/.changeset/fix-lfi-path-traversal.md
+++ b/.changeset/fix-lfi-path-traversal.md
@@ -1,5 +1,0 @@
----
-'@directus/api': patch
----
-
-Fixed a Local File Inclusion vulnerability in `MailService.renderTemplate`

--- a/.changeset/fix-pg-value-too-long-field.md
+++ b/.changeset/fix-pg-value-too-long-field.md
@@ -1,5 +1,0 @@
----
-'@directus/api': patch
----
-
-Fixed Postgres value too long errors being misattributed to an unrelated field

--- a/.changeset/floppy-keys-relax.md
+++ b/.changeset/floppy-keys-relax.md
@@ -1,5 +1,0 @@
----
-'@directus/app': minor
----
-
-Added `v-kbd` component and support `{ text, kbd }` syntax in tooltip

--- a/.changeset/full-trees-type.md
+++ b/.changeset/full-trees-type.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Added lazy loading of social icons on v-button

--- a/.changeset/funny-ends-sleep.md
+++ b/.changeset/funny-ends-sleep.md
@@ -1,5 +1,0 @@
----
-'@directus/api': patch
----
-
-Added validation to restrict geometry types to known types

--- a/.changeset/fuzzy-aliases-guard.md
+++ b/.changeset/fuzzy-aliases-guard.md
@@ -1,6 +1,0 @@
----
-'@directus/api': major
-'@directus/env': patch
----
-
-Limited sensitive system mutations defined by GRAPHQL_SINGLE_USE_MUTATIONS to single use

--- a/.changeset/hardened-docker-images.md
+++ b/.changeset/hardened-docker-images.md
@@ -1,5 +1,0 @@
----
-'directus': major
----
-
-Hardened the published Docker image and added a distroless Docker Hardened Image (DHI) variant alongside it. The standard image now applies outstanding OS-level patches at build time and drops `npm`/`npx` from the runtime; the new DHI variant is published under a `-dhi` tag suffix.

--- a/.changeset/many-papers-decide.md
+++ b/.changeset/many-papers-decide.md
@@ -1,6 +1,0 @@
----
-'@directus/api': patch
-'@directus/app': patch
----
-
-Bumped version of @directus/license package

--- a/.changeset/mcp-files-update-data-schema.md
+++ b/.changeset/mcp-files-update-data-schema.md
@@ -1,5 +1,0 @@
----
-"@directus/api": patch
----
-
-Fixed batch update failures in the MCP files tool

--- a/.changeset/plain-turtles-rest.md
+++ b/.changeset/plain-turtles-rest.md
@@ -1,5 +1,0 @@
----
-'@directus/api': patch
----
-
-Updated dependencies to resolve security advisories and removed obsolete override pins

--- a/.changeset/preview-url-array-indexing.md
+++ b/.changeset/preview-url-array-indexing.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Fixed array indexing (e.g. `field[0]` or `field.0`) in display and preview URL templates, so a template like `{{ categories[0].name }}` now resolves to the indexed value instead of rendering empty

--- a/.changeset/proud-ducks-march.md
+++ b/.changeset/proud-ducks-march.md
@@ -1,8 +1,0 @@
----
-'@directus/extensions-sdk': patch
-'@directus/system-data': patch
-'@directus/app': minor
-'@directus/composables': patch
----
-
-Updated bundled `esbuild` to `0.28.1` (resolves GHSA-gv7w-rqvm-qjhr)

--- a/.changeset/public-areas-pay.md
+++ b/.changeset/public-areas-pay.md
@@ -1,5 +1,0 @@
----
-'@directus/api': major
----
-
-Updated GraphQL WebSocket restrictions to match the HTTP endpoint and hid validation hints when introspection is disabled

--- a/.changeset/quick-foxes-shine.md
+++ b/.changeset/quick-foxes-shine.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Fixed a stored XSS vulnerability where the project color could break out of the generated favicon's SVG markup and inject arbitrary HTML

--- a/.changeset/ready-feet-try.md
+++ b/.changeset/ready-feet-try.md
@@ -1,5 +1,0 @@
----
-'@directus/api': patch
----
-
-Fixed accountability overrides in the graphql websocket

--- a/.changeset/red-suns-reply.md
+++ b/.changeset/red-suns-reply.md
@@ -1,6 +1,0 @@
----
-'@directus/validation': patch
-'@directus/app': patch
----
-
-Fixed an internal server error when validating out-of-range integer values

--- a/.changeset/slick-colts-work.md
+++ b/.changeset/slick-colts-work.md
@@ -1,5 +1,0 @@
----
-'@directus/api': patch
----
-
-Fixed MCP OAuth role resolution to use the users role instead of the root role

--- a/.changeset/ssrf-embedded-ipv4-blocklist.md
+++ b/.changeset/ssrf-embedded-ipv4-blocklist.md
@@ -1,5 +1,0 @@
----
-'@directus/utils': patch
----
-
-Classified the embedded IPv4 of IPv6 transition forms (IPv4-compatible, NAT64, 6to4) in `IpBlocklist.checkAddress` so they cannot bypass an IPv4 deny rule

--- a/.changeset/tame-clowns-say.md
+++ b/.changeset/tame-clowns-say.md
@@ -1,5 +1,0 @@
----
-'@directus/api': patch
----
-
-Bumped hono and vite dependencies

--- a/.changeset/thick-bees-juggle.md
+++ b/.changeset/thick-bees-juggle.md
@@ -1,5 +1,0 @@
----
-'@directus/api': patch
----
-
-Fixed pre-validation side effects in services

--- a/.changeset/three-dragons-flow.md
+++ b/.changeset/three-dragons-flow.md
@@ -1,5 +1,0 @@
----
-'@directus/api': patch
----
-
-Fixed public websocket accountability handling

--- a/.changeset/vast-cases-fetch.md
+++ b/.changeset/vast-cases-fetch.md
@@ -1,5 +1,0 @@
----
-'@directus/api': major
----
-
-Added CORS_ORIGIN checks for websocket connections

--- a/.changeset/yellow-cougars-laugh.md
+++ b/.changeset/yellow-cougars-laugh.md
@@ -1,6 +1,0 @@
----
-'@directus/system-data': patch
-'@directus/app': patch
----
-
-Added interface settings for collection status field

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/api",
-	"version": "36.0.2",
+	"version": "37.0.0",
 	"description": "Directus is a real-time API and App dashboard for managing SQL database content",
 	"keywords": [
 		"directus",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/app",
-	"version": "16.1.1",
+	"version": "16.2.0",
 	"description": "App dashboard for Directus",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/directus/package.json
+++ b/directus/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "directus",
-	"version": "12.0.2",
+	"version": "12.1.0",
 	"description": "Directus is a real-time API and App dashboard for managing SQL database content",
 	"keywords": [
 		"directus",

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/composables",
-	"version": "11.5.0",
+	"version": "11.5.1",
 	"description": "Shared Vue composables for Directus use",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/create-directus-extension/package.json
+++ b/packages/create-directus-extension/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "create-directus-extension",
-	"version": "12.1.0",
+	"version": "12.1.1",
 	"description": "A small util that will scaffold a Directus extension",
 	"keywords": [
 		"directus",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/env",
-	"version": "6.0.0",
+	"version": "6.1.0",
 	"description": "Utilities around using global env configuration",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/extensions-registry/package.json
+++ b/packages/extensions-registry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/extensions-registry",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"description": "Abstraction for exploring Directus extensions on a package registry",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/extensions-sdk/package.json
+++ b/packages/extensions-sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/extensions-sdk",
-	"version": "18.0.0",
+	"version": "18.0.1",
 	"description": "A toolkit to develop extensions to extend Directus",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/extensions",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"description": "Utilities and types for Directus extensions",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/memory",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"description": "Memory / Redis abstraction for Directus",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/pressure/package.json
+++ b/packages/pressure/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/pressure",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"description": "Pressure based rate limiter",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/specs/package.json
+++ b/packages/specs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/specs",
-	"version": "14.0.0",
+	"version": "15.0.0",
 	"description": "OpenAPI Specification of the Directus API",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/storage-driver-azure/package.json
+++ b/packages/storage-driver-azure/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-azure",
-	"version": "13.0.0",
+	"version": "13.0.1",
 	"description": "Azure file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/storage-driver-cloudinary/package.json
+++ b/packages/storage-driver-cloudinary/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-cloudinary",
-	"version": "13.0.0",
+	"version": "13.0.1",
 	"description": "Cloudinary file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/storage-driver-gcs/package.json
+++ b/packages/storage-driver-gcs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-gcs",
-	"version": "13.0.0",
+	"version": "13.0.1",
 	"description": "GCS file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/storage-driver-s3/package.json
+++ b/packages/storage-driver-s3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-s3",
-	"version": "13.0.0",
+	"version": "13.0.1",
 	"description": "S3 file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/storage-driver-supabase/package.json
+++ b/packages/storage-driver-supabase/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-supabase",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"description": "Supabase file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/system-data/package.json
+++ b/packages/system-data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/system-data",
-	"version": "4.5.0",
+	"version": "4.5.1",
 	"description": "Definitions and types for Directus system collections",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/themes",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "Themes for Directus",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/utils",
-	"version": "13.5.0",
+	"version": "13.5.1",
 	"description": "Utilities shared between the Directus packages",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/validation",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"type": "module",
 	"sideEffects": false,
 	"scripts": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/sdk",
-	"version": "22.0.0",
+	"version": "23.0.0",
 	"description": "Directus JavaScript SDK",
 	"homepage": "https://directus.com",
 	"repository": {


### PR DESCRIPTION
### ✅ Release Checklist
- [x] Changesets processed
- [x] Package versions updated
- [x] Release notes generated
- [x] Merge Crowdin PR: https://github.com/directus/directus/pull/27321
- [x] PR reviewed and approved
- [x] Blackbox tests passed
- [x] E2E tests passed

### 🚀 Release Notes
```md
### ⚠️ Potential Breaking Changes

- **@directus/api**
  - Limited sensitive system mutations defined by GRAPHQL_SINGLE_USE_MUTATIONS to single use ([#27801](https://github.com/directus/directus/pull/27801) by @br41nslug)
  - Removed `/utils/hash/generate` and `/utils/hash/verify` endpoints ([#27774](https://github.com/directus/directus/pull/27774) by @br41nslug)
  - Fixed failed TUS file replacements leaving orphaned file records. Hardened upload path validation to prevent writes to extension and temporary storage directories ([#27803](https://github.com/directus/directus/pull/27803) by @br41nslug)
  - Updated GraphQL WebSocket restrictions to match the HTTP endpoint and hid validation hints when introspection is disabled ([#27801](https://github.com/directus/directus/pull/27801) by @br41nslug)
  - Added CORS_ORIGIN checks for websocket connections ([#27812](https://github.com/directus/directus/pull/27812) by @br41nslug)
- **@directus/specs**
  - Removed `/utils/hash/generate` and `/utils/hash/verify` endpoints ([#27774](https://github.com/directus/directus/pull/27774) by @br41nslug)
- **@directus/sdk**
  - Removed `/utils/hash/generate` and `/utils/hash/verify` endpoints ([#27774](https://github.com/directus/directus/pull/27774) by @br41nslug)

### ✨ New Features & Improvements

- **@directus/app**
  - Added `PROJECT_OWNER_ENABLED` env var to allow disabling owner info collection and sync ([#27802](https://github.com/directus/directus/pull/27802) by @ComfortablyCoding)
  - Replaced tooltip with Reka UI one ([#27029](https://github.com/directus/directus/pull/27029) by @HZooly)
  - Added `v-kbd` component and support `{ text, kbd }` syntax in tooltip ([#27029](https://github.com/directus/directus/pull/27029) by @HZooly)
  - Updated bundled `esbuild` to `0.28.1` (resolves GHSA-gv7w-rqvm-qjhr) ([#27738](https://github.com/directus/directus/pull/27738) by @br41nslug)
- **@directus/api**
  - Added `PROJECT_OWNER_ENABLED` env var to allow disabling owner info collection and sync ([#27802](https://github.com/directus/directus/pull/27802) by @ComfortablyCoding)
- **@directus/env**
  - Added `PROJECT_OWNER_ENABLED` env var to allow disabling owner info collection and sync ([#27802](https://github.com/directus/directus/pull/27802) by @ComfortablyCoding)

### 🐛 Bug Fixes & Optimizations

- **@directus/app**
  - Restored pre-v12 back button behavior: returns to the previously visited item/page when navigating via a relation, and to the collection listing when landing on an item directly ([#27799](https://github.com/directus/directus/pull/27799) by @robluton)
  - Fixed the public page foreground image rendering side-by-side with the shader background instead of overlaying it ([#27782](https://github.com/directus/directus/pull/27782) by @alvarosabu)
  - Added clearable indicator to input hash field ([#27729](https://github.com/directus/directus/pull/27729) by @robluton)
  - Added lazy loading of social icons on v-button ([#27724](https://github.com/directus/directus/pull/27724) by @alvarosabu)
  - Bumped version of @directus/license package ([#27785](https://github.com/directus/directus/pull/27785) by @AlexGaillard)
  - Fixed array indexing (e.g. `field[0]` or `field.0`) in display and preview URL templates, so a template like `{{ categories[0].name }}` now resolves to the indexed value instead of rendering empty ([#27773](https://github.com/directus/directus/pull/27773) by @dstockton)
  - Fixed a stored XSS vulnerability where the project color could break out of the generated favicon's SVG markup and inject arbitrary HTML ([#27810](https://github.com/directus/directus/pull/27810) by @br41nslug)
  - Fixed an internal server error when validating out-of-range integer values ([#27321](https://github.com/directus/directus/pull/27321) by @sourav-18)
  - Added interface settings for collection status field ([#27781](https://github.com/directus/directus/pull/27781) by @robluton)
- **@directus/api**
  - Bumped version of @directus/license package ([#27785](https://github.com/directus/directus/pull/27785) by @AlexGaillard)
  - Fixed a Local File Inclusion vulnerability in `MailService.renderTemplate` ([#27811](https://github.com/directus/directus/pull/27811) by @br41nslug)
  - Fixed Postgres value too long errors being misattributed to an unrelated field ([#27768](https://github.com/directus/directus/pull/27768) by @MahinAnowar)
  - Added validation to restrict geometry types to known types ([#27809](https://github.com/directus/directus/pull/27809) by @br41nslug)
  - Fixed batch update failures in the MCP files tool ([#27121](https://github.com/directus/directus/pull/27121) by @aayushbaluni)
  - Updated dependencies to resolve security advisories and removed obsolete override pins ([#27814](https://github.com/directus/directus/pull/27814) by @br41nslug)
  - Fixed accountability overrides in the graphql websocket ([#27813](https://github.com/directus/directus/pull/27813) by @br41nslug)
  - Fixed MCP OAuth role resolution to use the users role instead of the root role ([#27790](https://github.com/directus/directus/pull/27790) by @ComfortablyCoding)
  - Bumped hono and vite dependencies ([#27820](https://github.com/directus/directus/pull/27820) by @br41nslug)
  - Fixed pre-validation side effects in services ([#27800](https://github.com/directus/directus/pull/27800) by @br41nslug)
  - Fixed public websocket accountability handling ([#27808](https://github.com/directus/directus/pull/27808) by @br41nslug)
- **@directus/extensions-sdk**
  - Updated bundled `esbuild` to `0.28.1` (resolves GHSA-gv7w-rqvm-qjhr) ([#27738](https://github.com/directus/directus/pull/27738) by @br41nslug)
- **@directus/system-data**
  - Updated bundled `esbuild` to `0.28.1` (resolves GHSA-gv7w-rqvm-qjhr) ([#27738](https://github.com/directus/directus/pull/27738) by @br41nslug)
  - Added interface settings for collection status field ([#27781](https://github.com/directus/directus/pull/27781) by @robluton)
- **@directus/composables**
  - Updated bundled `esbuild` to `0.28.1` (resolves GHSA-gv7w-rqvm-qjhr) ([#27738](https://github.com/directus/directus/pull/27738) by @br41nslug)
- **@directus/validation**
  - Fixed an internal server error when validating out-of-range integer values ([#27321](https://github.com/directus/directus/pull/27321) by @sourav-18)
- **@directus/env**
  - Limited sensitive system mutations defined by GRAPHQL_SINGLE_USE_MUTATIONS to single use ([#27801](https://github.com/directus/directus/pull/27801) by @br41nslug)
- **@directus/utils**
  - Classified the embedded IPv4 of IPv6 transition forms (IPv4-compatible, NAT64, 6to4) in `IpBlocklist.checkAddress` so they cannot bypass an IPv4 deny rule ([#27698](https://github.com/directus/directus/pull/27698) by @joeltco)

### 📦 Published Versions

- `@directus/app@16.2.0`
- `@directus/api@37.0.0`
- `@directus/composables@11.5.1`
- `create-directus-extension@12.1.1`
- `@directus/env@6.1.0`
- `@directus/extensions@4.0.1`
- `@directus/extensions-registry@4.0.1`
- `@directus/extensions-sdk@18.0.1`
- `@directus/memory@4.0.1`
- `@directus/pressure@4.0.1`
- `@directus/specs@15.0.0`
- `@directus/storage-driver-azure@13.0.1`
- `@directus/storage-driver-cloudinary@13.0.1`
- `@directus/storage-driver-gcs@13.0.1`
- `@directus/storage-driver-s3@13.0.1`
- `@directus/storage-driver-supabase@4.0.1`
- `@directus/system-data@4.5.1`
- `@directus/themes@2.0.1`
- `@directus/utils@13.5.1`
- `@directus/validation@3.0.1`
- `@directus/sdk@23.0.0`
```