### PR TITLE
Fix MSSQL schema introspection reporting the byte size as `max_length` for non-character types

### DIFF
--- a/.changeset/mssql-max-length-bytes.md
+++ b/.changeset/mssql-max-length-bytes.md
@@ -2,4 +2,4 @@
 '@directus/schema': patch
 ---
 
-Fixed MSSQL schema introspection reporting the storage size in bytes as `max_length` for non-character types (e.g. `decimal(12,2)` reported `max_length: 9`), which incorrectly capped the input length for decimal, bigint, and uuid fields in the Data Studio
+Fixed MSSQL schema introspection reporting the byte size as `max_length` for non-character types

--- a/.changeset/mssql-max-length-bytes.md
+++ b/.changeset/mssql-max-length-bytes.md
@@ -1,0 +1,5 @@
+---
+'@directus/schema': patch
+---
+
+Fixed MSSQL schema introspection reporting the storage size in bytes as `max_length` for non-character types (e.g. `decimal(12,2)` reported `max_length: 9`), which incorrectly capped the input length for decimal, bigint, and uuid fields in the Data Studio

--- a/contributors.yml
+++ b/contributors.yml
@@ -285,3 +285,4 @@
 - levgiorg
 - MahinAnowar
 - joeltco
+- BIGSUS24

--- a/packages/schema/src/dialects/mssql.test.ts
+++ b/packages/schema/src/dialects/mssql.test.ts
@@ -72,6 +72,45 @@ describe('MSSQL dialect', () => {
 				const result = rawColumnToColumn({ ...baseRawColumn, data_type: 'nvarchar', max_length: null });
 				expect(result.max_length).toBeNull();
 			});
+
+			it('returns null for decimal (storage size in bytes, not a character count)', () => {
+				const result = rawColumnToColumn({
+					...baseRawColumn,
+					data_type: 'decimal',
+					max_length: 9,
+					numeric_precision: 12,
+					numeric_scale: 2,
+				});
+
+				expect(result.max_length).toBeNull();
+			});
+
+			it('returns null for numeric (storage size in bytes, not a character count)', () => {
+				const result = rawColumnToColumn({
+					...baseRawColumn,
+					data_type: 'numeric',
+					max_length: 9,
+					numeric_precision: 12,
+					numeric_scale: 2,
+				});
+
+				expect(result.max_length).toBeNull();
+			});
+
+			it('returns null for bigint (storage size in bytes, not a character count)', () => {
+				const result = rawColumnToColumn({ ...baseRawColumn, data_type: 'bigint', max_length: 8 });
+				expect(result.max_length).toBeNull();
+			});
+
+			it('returns null for uniqueidentifier (storage size in bytes, not a character count)', () => {
+				const result = rawColumnToColumn({ ...baseRawColumn, data_type: 'uniqueidentifier', max_length: 16 });
+				expect(result.max_length).toBeNull();
+			});
+
+			it('keeps max_length for varbinary', () => {
+				const result = rawColumnToColumn({ ...baseRawColumn, data_type: 'varbinary', max_length: 100 });
+				expect(result.max_length).toBe(100);
+			});
 		});
 	});
 

--- a/packages/schema/src/dialects/mssql.ts
+++ b/packages/schema/src/dialects/mssql.ts
@@ -58,6 +58,18 @@ export function rawColumnToColumn(rawColumn: RawColumn): Column {
 			return null;
 		}
 
+		// sys.columns reports max_length as the storage size in bytes for every data type, which is only
+		// meaningful as a character count for character/binary types. For all other types (decimal,
+		// numeric, bigint, uniqueidentifier, datetime, ...) it reflects the internal storage size
+		// (e.g. decimal(12,2) => max_length == 9) and must not be reported as a character limit.
+		// This mirrors INFORMATION_SCHEMA.COLUMNS.CHARACTER_MAXIMUM_LENGTH, which is NULL for all
+		// other types.
+		const characterTypes = ['char', 'varchar', 'text', 'nchar', 'nvarchar', 'ntext', 'binary', 'varbinary', 'image'];
+
+		if (characterTypes.includes(rawColumn.data_type) === false) {
+			return null;
+		}
+
 		// n-* columns save every character as 2 bytes, which causes the max_length column to return the
 		// max length in bytes instead of characters. For example:
 		// varchar(100) => max_length == 100

--- a/packages/schema/src/dialects/mssql.ts
+++ b/packages/schema/src/dialects/mssql.ts
@@ -58,12 +58,9 @@ export function rawColumnToColumn(rawColumn: RawColumn): Column {
 			return null;
 		}
 
-		// sys.columns reports max_length as the storage size in bytes for every data type, which is only
-		// meaningful as a character count for character/binary types. For all other types (decimal,
-		// numeric, bigint, uniqueidentifier, datetime, ...) it reflects the internal storage size
-		// (e.g. decimal(12,2) => max_length == 9) and must not be reported as a character limit.
-		// This mirrors INFORMATION_SCHEMA.COLUMNS.CHARACTER_MAXIMUM_LENGTH, which is NULL for all
-		// other types.
+		// sys.columns.max_length is a byte size for every data type, so it's only a meaningful length
+		// for character/binary types (e.g. varchar(100) => 100). For other types it's just the storage
+		// size (int => 4, decimal(12,2) => 9), which isn't a length, so report null.
 		const characterTypes = ['char', 'varchar', 'text', 'nchar', 'nvarchar', 'ntext', 'binary', 'varbinary', 'image'];
 
 		if (characterTypes.includes(rawColumn.data_type) === false) {


### PR DESCRIPTION
## Summary

On MSSQL, a `DECIMAL(12,2)` field cannot be filled to its configured precision in the Data Studio: the input is capped at 9 characters (including the decimal point). The same hidden cap affects `bigint` fields (capped at 8 characters, though bigint holds up to 19 digits) and `uniqueidentifier` fields rendered as string inputs (capped at 16 characters, though a UUID literal is 36 characters).

Fixes #26137

## Root Cause

`columnInfo()` in `packages/schema/src/dialects/mssql.ts` reads `[c].[max_length]` from `[sys].[columns]`. SQL Server documents this column as the **storage size in bytes** for every data type — it is only a character count for character/binary types. `parseMaxLength` special-cases the `n*` types (halving bytes to characters) but passes the raw byte size through for everything else, so a `decimal(12,2)` column (stored in 9 bytes) is introspected as `max_length: 9`.

The app then forwards `field.schema.max_length` to the input interface (`form-field-interface.vue` → `:length` → `input.vue` → `:max-length`), where it becomes the HTML `maxlength` attribute. Because `decimal` and `bigInteger` are rendered as `type="text"` inputs (see `APP_NUMERIC_STRING_TYPES`, used to avoid rounding errors), the browser enforces this bogus limit — exactly the behavior confirmed by @br41nslug in the issue ("The dot `.` is counted towards the limit preventing you from setting the configured precision").

This also made `columnInfo()` inconsistent with:

- the MSSQL dialect's own `overview()` method, which uses `INFORMATION_SCHEMA.COLUMNS.CHARACTER_MAXIMUM_LENGTH` (NULL for non character/binary types),
- the Postgres and MySQL dialects, which report `max_length: null` for these types, and
- the repo's own e2e snapshot fixtures, which record `max_length: null` for decimal/bigint/uuid columns — so applying a cross-vendor snapshot to MSSQL produced spurious `max_length` diffs.

## Fix

Per the maintainer guidance on the issue ("we likely shouldn't be relying on this max_length value for the decimal input length with MSSQL"), `parseMaxLength` now returns `null` unless the column's data type is one of `char`, `varchar`, `text`, `nchar`, `nvarchar`, `ntext`, `binary`, `varbinary`, `image` — exactly the set of types for which SQL Server's `CHARACTER_MAXIMUM_LENGTH` is non-NULL. Behavior for all character/binary types (including the existing `n*` byte-halving and `MAX` → `null` handling) is unchanged.

Regression tests are added to the existing `parseMaxLength` block in `mssql.test.ts` covering `decimal`, `numeric`, `bigint`, and `uniqueidentifier` (now `null`) plus `varbinary` (byte length preserved).

## Scope

- `packages/schema/src/dialects/mssql.ts` — one guard added in `parseMaxLength`; no changes to queries or any other dialect.
- `packages/schema/src/dialects/mssql.test.ts` — regression tests only.
- `.changeset/mssql-max-length-bytes.md` — patch changeset for `@directus/schema`.

Consumers were audited for regressions: `getLocalType` reads `max_length` only for `varchar`/`nvarchar` (still whitelisted, so `(n)varchar(MAX)` → `text` mapping is unaffected), `FieldsService` uses it only for `field.type === 'string'` columns, and the GraphQL field resolver and translation utils are pass-throughs.

