### PR TITLE
Fix geometry fields losing their subtype on schema changes

### DIFF
--- a/.changeset/blue-beds-love.md
+++ b/.changeset/blue-beds-love.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed geometry fields losing their subtype on schema changes

--- a/.changeset/preserve-geometry-subtype-special.md
+++ b/.changeset/preserve-geometry-subtype-special.md
@@ -1,0 +1,5 @@
+---
+"@directus/app": patch
+---
+
+Fixed geometry fields losing their subtype (e.g. `Point` becoming `Geometry (Any)`) when changing an unrelated schema option such as Allow NULL

--- a/.changeset/preserve-geometry-subtype-special.md
+++ b/.changeset/preserve-geometry-subtype-special.md
@@ -1,5 +1,0 @@
----
-"@directus/app": patch
----
-
-Fixed geometry fields losing their subtype (e.g. `Point` becoming `Geometry (Any)`) when changing an unrelated schema option such as Allow NULL

--- a/app/src/utils/get-special-for-type.test.ts
+++ b/app/src/utils/get-special-for-type.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from 'vitest';
 import { getSpecialForType } from './get-special-for-type';
 
 const castPrefixedSpecials = ['json', 'csv', 'boolean'];
-const nonPrefixedSpecials = ['uuid', 'hash', 'geometry'];
+const nonPrefixedSpecials = ['uuid', 'hash'];
 
 test('Returns cast-prefixed special array for json, csv, and boolean field types', () => {
 	const types = TYPES.filter((type) => castPrefixedSpecials.includes(type));
@@ -13,7 +13,7 @@ test('Returns cast-prefixed special array for json, csv, and boolean field types
 	}
 });
 
-test('Returns special array for uuid, hash, and geometry field types', () => {
+test('Returns special array for uuid and hash field types', () => {
 	const types = TYPES.filter((type) => nonPrefixedSpecials.includes(type));
 
 	for (const type of types) {
@@ -21,9 +21,18 @@ test('Returns special array for uuid, hash, and geometry field types', () => {
 	}
 });
 
+test('Returns the type as special for geometry, keeping any subtype', () => {
+	const types = TYPES.filter((type) => type.startsWith('geometry'));
+
+	// covers bare `geometry` as well as subtypes like `geometry.Point`
+	for (const type of types) {
+		expect(getSpecialForType(type)).toStrictEqual([type]);
+	}
+});
+
 test('Returns null for other field types', () => {
 	const specials = [...castPrefixedSpecials, ...nonPrefixedSpecials];
-	const types = TYPES.filter((type) => !specials.includes(type));
+	const types = TYPES.filter((type) => !specials.includes(type) && !type.startsWith('geometry'));
 
 	for (const type of types) {
 		expect(getSpecialForType(type)).toStrictEqual(null);

--- a/app/src/utils/get-special-for-type.ts
+++ b/app/src/utils/get-special-for-type.ts
@@ -1,6 +1,10 @@
 import { Type } from '@directus/types';
 
 export function getSpecialForType(type: Type): string[] | null {
+	// Geometry types encode their subtype in `type` (e.g. `geometry.Point`)
+	// Preserve it in `special` to avoid collapsing back to the generic `geometry` type after schema updates
+	if (type.startsWith('geometry')) return [type];
+
 	switch (type) {
 		case 'json':
 		case 'csv':
@@ -10,9 +14,6 @@ export function getSpecialForType(type: Type): string[] | null {
 		case 'hash':
 			return [type];
 		default:
-			// geometry types carry their subtype in the type (e.g. `geometry.Point`); keep it in
-			// `special` so the column doesn't collapse to a generic `geometry` on the next schema change
-			if (type.startsWith('geometry')) return [type];
 			return null;
 	}
 }

--- a/app/src/utils/get-special-for-type.ts
+++ b/app/src/utils/get-special-for-type.ts
@@ -8,9 +8,11 @@ export function getSpecialForType(type: Type): string[] | null {
 			return ['cast-' + type];
 		case 'uuid':
 		case 'hash':
-		case 'geometry':
 			return [type];
 		default:
+			// geometry types carry their subtype in the type (e.g. `geometry.Point`); keep it in
+			// `special` so the column doesn't collapse to a generic `geometry` on the next schema change
+			if (type.startsWith('geometry')) return [type];
 			return null;
 	}
 }

--- a/contributors.yml
+++ b/contributors.yml
@@ -285,3 +285,4 @@
 - levgiorg
 - MahinAnowar
 - joeltco
+- rajkumar0932


### PR DESCRIPTION
## Scope

What's changed:

- `getSpecialForType()` now preserves the geometry **subtype**. Previously it only handled the base `geometry` type — `geometry.Point` fell through to `null` and `geometry` returned `['geometry']`, so neither kept the subtype.
- As a result, save paths that recompute `special` (`FieldSelect.openFieldDetail()`, `standard.setSpecialForType`) could persist a generic `['geometry']`, collapsing the field's resolved type to `geometry`. A later, unrelated schema change (e.g. toggling **Allow NULL**) then rebuilt the column as `geometry(Geometry)`, silently dropping the subtype (`Point` → `Geometry (Any)`).
- The helper now returns the full type as the special for any geometry type (`geometry.Point` → `['geometry.Point']`), which matches how `getLocalType` and existing data (see migration `20211103B`) already expect it.

## Potential Risks / Drawbacks

- Low risk — this is a pure helper change. Bare `geometry` fields behave exactly as before (`geometry` → `['geometry']`); only the subtype cases change (previously `null`), and `['geometry.Point']` is the value the rest of the codebase already treats as canonical.

## Tested Scenarios

- Updated the `getSpecialForType` unit test to cover geometry subtypes (bare `geometry` and each `geometry.*` now return the type as the special).
- Reproduced the original bug on a local PostGIS + Directus instance: once `special` drifts to `['geometry']`, a schema-only `PATCH /fields/:c/:f { schema: { is_nullable: false } }` (no `type` sent) rebuilds the column as `geometry(geometry, 4326)` — confirmed via Postgres statement logging. Keeping `special` subtype-bearing prevents the type from collapsing, so the downgrade no longer happens.

## Review Notes / Questions

- Full root-cause write-up is in the issue thread (#27804). This is the **Studio-side** fix that stops the metadata drift at its source.
- There's also an **API-side** angle: the actual data loss happens in `services/fields.ts`, where a non-incremental column `.alter()` re-specifies the geometry column from the (now generic) type. Happy to add a defense-in-depth guard there as well if you'd prefer — just let me know.

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #27804
