### PR TITLE
Fix a memory leak where the WebSocket heartbeat handler left a `websocket.message` listener registered after each heartbeat timeout

### DIFF
--- a/.changeset/wacky-stars-cheat.md
+++ b/.changeset/wacky-stars-cheat.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+---
+
+Fixed a memory leak where the WebSocket heartbeat handler left a `websocket.message` listener registered after each
+heartbeat timeout

--- a/api/src/websocket/handlers/heartbeat.test.ts
+++ b/api/src/websocket/handlers/heartbeat.test.ts
@@ -98,23 +98,25 @@ describe('WebSocket heartbeat handler', () => {
 		expect(mockClient.send).toBeCalled();
 	});
 
-	test('should clean up websocket.message listener after heartbeat timeout', () => {
-		const onSpy = vi.spyOn(emitter, 'onAction');
-		const offSpy = vi.spyOn(emitter, 'offAction');
+	// regression (#27831): idle clients used to leak a websocket.message listener on every heartbeat cycle
+	test('should not accumulate websocket.message listeners across idle heartbeat cycles', () => {
+		const actionEmitter = (emitter as unknown as { actionEmitter: { listenerCount(e: string): number } }).actionEmitter;
+
+		const messageListenerCount = () => actionEmitter.listenerCount('websocket.message');
 
 		new HeartbeatHandler(controller);
 
 		controller.clients.add(mockClient);
-
 		emitter.emitAction('websocket.connect', {}, {} as EventContext);
 
-		// First heartbeat starts
-		vi.advanceTimersByTime(1000);
+		const baseline = messageListenerCount();
 
-		// Timeout expires
-		vi.advanceTimersByTime(1000);
+		for (let cycle = 0; cycle < 10; cycle++) {
+			vi.advanceTimersByTime(1000);
+		}
 
-		expect(onSpy).toHaveBeenCalledWith('websocket.message', expect.any(Function));
-		expect(offSpy).toHaveBeenCalledWith('websocket.message', expect.any(Function));
+		// a leak would leave baseline + 10 listeners; only the current cycle's watcher should still be attached
+		expect(messageListenerCount()).toBeLessThanOrEqual(baseline + 1);
+		expect(mockClient.close).toBeCalled();
 	});
 });

--- a/api/src/websocket/handlers/heartbeat.test.ts
+++ b/api/src/websocket/handlers/heartbeat.test.ts
@@ -97,4 +97,24 @@ describe('WebSocket heartbeat handler', () => {
 		emitter.emitAction('websocket.message', { client: mockClient, message: { type: 'ping' } }, {} as EventContext);
 		expect(mockClient.send).toBeCalled();
 	});
+
+	test('should clean up websocket.message listener after heartbeat timeout', () => {
+		const onSpy = vi.spyOn(emitter, 'onAction');
+		const offSpy = vi.spyOn(emitter, 'offAction');
+
+		new HeartbeatHandler(controller);
+
+		controller.clients.add(mockClient);
+
+		emitter.emitAction('websocket.connect', {}, {} as EventContext);
+
+		// First heartbeat starts
+		vi.advanceTimersByTime(1000);
+
+		// Timeout expires
+		vi.advanceTimersByTime(1000);
+
+		expect(onSpy).toHaveBeenCalledWith('websocket.message', expect.any(Function));
+		expect(offSpy).toHaveBeenCalledWith('websocket.message', expect.any(Function));
+	});
 });

--- a/api/src/websocket/handlers/heartbeat.ts
+++ b/api/src/websocket/handlers/heartbeat.ts
@@ -66,15 +66,7 @@ export class HeartbeatHandler {
 		const pendingClients = new Set<WebSocketClient>(this.controller.clients);
 		const activeClients = new Set<WebSocketClient>();
 
-		let timeout: NodeJS.Timeout;
-		let messageWatcher: ActionHandler;
-
-		const cleanup = () => {
-			clearTimeout(timeout);
-			emitter.offAction('websocket.message', messageWatcher);
-		};
-
-		messageWatcher = ({ client }) => {
+		const messageWatcher: ActionHandler = ({ client }) => {
 			// any message means this connection is still open
 			if (!activeClients.has(client)) {
 				pendingClients.delete(client);
@@ -82,21 +74,22 @@ export class HeartbeatHandler {
 			}
 
 			if (pendingClients.size === 0) {
-				cleanup();
+				clearTimeout(timeout);
+				emitter.offAction('websocket.message', messageWatcher);
 			}
 		};
 
-		timeout = setTimeout(() => {
-			// Remove the listener before closing idle clients
-			cleanup();
+		emitter.onAction('websocket.message', messageWatcher);
+
+		const timeout = setTimeout(() => {
+			// Remove listener before closing idle clients
+			emitter.offAction('websocket.message', messageWatcher);
 
 			// close connections that haven't responded
 			for (const client of pendingClients) {
 				client.close();
 			}
 		}, HEARTBEAT_FREQUENCY);
-
-		emitter.onAction('websocket.message', messageWatcher);
 
 		// ping all the clients
 		for (const client of pendingClients) {

--- a/api/src/websocket/handlers/heartbeat.ts
+++ b/api/src/websocket/handlers/heartbeat.ts
@@ -66,14 +66,15 @@ export class HeartbeatHandler {
 		const pendingClients = new Set<WebSocketClient>(this.controller.clients);
 		const activeClients = new Set<WebSocketClient>();
 
-		const timeout = setTimeout(() => {
-			// close connections that haven't responded
-			for (const client of pendingClients) {
-				client.close();
-			}
-		}, HEARTBEAT_FREQUENCY);
+		let timeout: NodeJS.Timeout;
+		let messageWatcher: ActionHandler;
 
-		const messageWatcher: ActionHandler = ({ client }) => {
+		const cleanup = () => {
+			clearTimeout(timeout);
+			emitter.offAction('websocket.message', messageWatcher);
+		};
+
+		messageWatcher = ({ client }) => {
 			// any message means this connection is still open
 			if (!activeClients.has(client)) {
 				pendingClients.delete(client);
@@ -81,10 +82,19 @@ export class HeartbeatHandler {
 			}
 
 			if (pendingClients.size === 0) {
-				clearTimeout(timeout);
-				emitter.offAction('websocket.message', messageWatcher);
+				cleanup();
 			}
 		};
+
+		timeout = setTimeout(() => {
+			// Remove the listener before closing idle clients
+			cleanup();
+
+			// close connections that haven't responded
+			for (const client of pendingClients) {
+				client.close();
+			}
+		}, HEARTBEAT_FREQUENCY);
 
 		emitter.onAction('websocket.message', messageWatcher);
 

--- a/api/src/websocket/handlers/heartbeat.ts
+++ b/api/src/websocket/handlers/heartbeat.ts
@@ -82,10 +82,10 @@ export class HeartbeatHandler {
 		emitter.onAction('websocket.message', messageWatcher);
 
 		const timeout = setTimeout(() => {
-			// Remove listener before closing idle clients
+			// detach the watcher before closing so a close wont trigger the watcher
 			emitter.offAction('websocket.message', messageWatcher);
 
-			// close connections that haven't responded
+			// close any connections that did not respond in time
 			for (const client of pendingClients) {
 				client.close();
 			}


### PR DESCRIPTION
## Scope

What's changed:

* Fixed a WebSocket heartbeat listener leak by ensuring temporary `websocket.message` listeners are removed when the heartbeat timeout expires.
* Added a regression test that reproduces the missing cleanup and verifies the listener is removed after the timeout.
* Preserved the existing heartbeat behavior for active and idle clients.

## Potential Risks / Drawbacks

* The change only affects the cleanup path for heartbeat timeout.
* No changes were made to the heartbeat protocol or client communication flow.

## Tested Scenarios

* Verified active clients continue responding to heartbeat pings without being disconnected.
* Verified idle clients are still closed after the heartbeat timeout.
* Added and ran a regression test to confirm the temporary `websocket.message` listener is cleaned up after timeout.
* Ran the existing heartbeat test suite successfully.

## Review Notes / Questions

* This change addresses the reported listener leak by ensuring the temporary listener is removed regardless of whether clients respond or the heartbeat times out.
* Please let me know if you'd prefer the cleanup logic to be extracted into a helper for reuse.

## Checklist

- [X] Added or updated tests
- [ ] Documentation PR created \[[here](<https://github.com/directus/docs>)\]([https://github.com/directus/docs](<https://github.com/directus/docs>)) or not required
- [ ] OpenAPI package PR created \[[here](<https://github.com/directus/openapi>)\]([https://github.com/directus/openapi](<https://github.com/directus/openapi>)) or not required

---

Fixes directus/directus#27830