### PR TITLE
fix(cli): initialize license manager before schema apply

### DIFF
--- a/api/src/cli/commands/schema/apply.ts
+++ b/api/src/cli/commands/schema/apply.ts
@@ -12,6 +12,7 @@ import { isNestedMetaUpdate } from '../../../utils/apply-diff.js';
 import { applySnapshot } from '../../../utils/apply-snapshot.js';
 import { getSnapshotDiff } from '../../../utils/get-snapshot-diff.js';
 import { getSnapshot } from '../../../utils/get-snapshot.js';
+import { getLicenseManager } from '../../../license/index.js';
 
 export function filterSnapshotDiff(snapshot: SnapshotDiff, filters: string[]): SnapshotDiff {
 	const filterSet = new Set(filters);
@@ -43,6 +44,10 @@ export async function apply(
 	const database = getDatabase();
 
 	await validateDatabaseConnection(database);
+
+	// Initialize license manager so CLI uses LICENSE_KEY/LICENSE_TOKEN
+	// and the correct entitlements before applying the snapshot.
+	await getLicenseManager().initialize();
 
 	if ((await isInstalled()) === false) {
 		logger.error(`Directus isn't installed on this database. Please run "directus bootstrap" first.`);


### PR DESCRIPTION
## Summary

This change initializes the license manager before running the `schema apply` CLI command.

Previously, the CLI could execute without loading the configured license, causing enterprise entitlements to be unavailable during schema application. As a result, license-dependent checks could incorrectly fall back to the default limits.

## Changes

* Import `getLicenseManager`.
* Call `await getLicenseManager().initialize()` before applying the schema snapshot.

## Testing

* Built the project successfully.
* Verified the CLI starts correctly.
* Bootstrapped a local SQLite database.
* Confirmed the CLI reaches schema application with the license manager initialization added.

Fixes #27833