### PR TITLE
fix: GraphQL non-null fields with default value should not be nullable (fixes #25888)

### DIFF
--- a/api/src/services/graphql/schema/get-types.ts
+++ b/api/src/services/graphql/schema/get-types.ts
@@ -97,12 +97,15 @@ export function getTypes(
 					// submitted on updates
 					if (
 						field.nullable === false &&
-						!field.defaultValue &&
 						!GENERATE_SPECIAL.some((flag) => field.special.includes(flag)) &&
 						fieldIsInconsistent === false &&
 						action !== 'update'
 					) {
-						type = new GraphQLNonNull(type);
+						if (action === 'create' && field.defaultValue) {
+							// Fields with a default value are optional during create but non-null in read
+						} else {
+							type = new GraphQLNonNull(type);
+						}
 					}
 
 					if (collection.primary === field.field && fieldIsInconsistent === false) {


### PR DESCRIPTION
When a field has <br>ullable: false\\ but also has a default value, the GraphQL schema incorrectly marks it as nullable. This is because the !field.defaultValue\\ check prevented the \\GraphQLNonNull\\ wrapper. A field with a default value is optional during create but will always have a value in the database, so it should be non-null in the read schema.\\n\\nFixes directus/directus#25888