### PR TITLE
fix(api): apply FILES_MIME_TYPE_ALLOW_LIST to TUS uploads

### DIFF
--- a/api/src/services/tus/data-store.ts
+++ b/api/src/services/tus/data-store.ts
@@ -8,6 +8,10 @@ import { omit } from 'lodash-es';
 import { extension } from 'mime-types';
 import getDatabase from '../../database/index.js';
 import { useLogger } from '../../logger/index.js';
+import { useEnv } from '@directus/env';
+import { toArray } from '@directus/utils';
+import { minimatch } from 'minimatch';
+import { InvalidPayloadError } from '@directus/errors';
 import { assertUniqueFilename } from '../files/lib/assert-unique-filename.js';
 import { assertValidStoragePath } from '../files/lib/assert-valid-storage-path.js';
 import { sanitizeFilepath } from '../files/lib/sanitize-filepath.js';
@@ -64,11 +68,20 @@ export class TusDataStore extends DataStore {
 			throw ERRORS.INVALID_METADATA;
 		}
 
-		if (!upload.metadata['type']) {
-			upload.metadata['type'] = 'application/octet-stream';
-		}
+	if (!upload.metadata['type']) {
+		upload.metadata['type'] = 'application/octet-stream';
+	}
 
-		if (!upload.metadata['title']) {
+	const env = useEnv();
+	const allowedPatterns = toArray(env['FILES_MIME_TYPE_ALLOW_LIST'] as string | string[]);
+	if (allowedPatterns.length > 0) {
+		const mimeTypeAllowed = allowedPatterns.some((pattern) => minimatch(upload.metadata['type'], pattern));
+		if (mimeTypeAllowed === false) {
+			throw new InvalidPayloadError({ reason: 'Uploaded file mime type is not allowed' });
+		}
+	}
+
+	if (!upload.metadata['title']) {
 			upload.metadata['title'] = formatTitle(upload.metadata['filename_download']);
 		}
 


### PR DESCRIPTION
## Summary

Mirrors the existing multipart upload MIME type allow-list check in the TUS upload path. Without this, the TUS resumable upload endpoint bypasses FILES_MIME_TYPE_ALLOW_LIST configuration.

## Changes

- **api/src/services/tus/data-store.ts**: Added FILES_MIME_TYPE_ALLOW_LIST check in TusDataStore.create() mirroring the logic from api/src/controllers/files.ts

## Testing

1. Set FILES_MIME_TYPE_ALLOW_LIST=image/jpeg,image/png and TUS_ENABLED=true
2. Upload via TUS with type=application/pdf ? should now be rejected
3. Upload via TUS with type=image/png ? should be accepted

## Review Notes

- The fix follows the exact same pattern already used in the multipart upload path
- No new dependencies introduced

Closes #27784