### PR TITLE
Fix WebSocket handlers not validating query parameters

### DIFF
--- a/.changeset/websocket-validate-query.md
+++ b/.changeset/websocket-validate-query.md
@@ -2,4 +2,4 @@
 "@directus/api": patch
 ---
 
-Validate query parameters in WebSocket `item` read and `subscribe` handlers to reject invalid values (e.g. `limit < -1`) that the REST API already rejects.
+Fixed WebSocket handlers not validating query parameters

--- a/.changeset/websocket-validate-query.md
+++ b/.changeset/websocket-validate-query.md
@@ -1,0 +1,5 @@
+---
+"@directus/api": patch
+---
+
+Validate query parameters in WebSocket `item` read and `subscribe` handlers to reject invalid values (e.g. `limit < -1`) that the REST API already rejects.

--- a/api/src/websocket/handlers/items.ts
+++ b/api/src/websocket/handlers/items.ts
@@ -3,6 +3,7 @@ import emitter from '../../emitter.js';
 import { ItemsService, MetaService } from '../../services/index.js';
 import { getSchema } from '../../utils/get-schema.js';
 import { sanitizeQuery } from '../../utils/sanitize-query.js';
+import { validateQuery } from '../../utils/validate-query.js';
 import { handleWebSocketError, WebSocketError } from '../errors.js';
 import { WebSocketItemsMessage } from '../messages.js';
 import type { WebSocketClient } from '../types.js';
@@ -47,6 +48,7 @@ export class ItemsHandler {
 
 		if (message.action === 'create') {
 			const query = await sanitizeQuery(message?.query ?? {}, schema, accountability);
+			validateQuery(query);
 
 			if (Array.isArray(message.data)) {
 				const keys = await service.createMany(message.data);
@@ -59,6 +61,7 @@ export class ItemsHandler {
 
 		if (message.action === 'read') {
 			const query = await sanitizeQuery(message.query ?? {}, schema, accountability);
+			validateQuery(query);
 
 			if (message.id) {
 				result = await service.readOne(message.id, query);
@@ -75,6 +78,7 @@ export class ItemsHandler {
 
 		if (message.action === 'update') {
 			const query = await sanitizeQuery(message.query ?? {}, schema, accountability);
+			validateQuery(query);
 
 			if (message.id) {
 				const key = await service.updateOne(message.id, message.data);
@@ -106,6 +110,7 @@ export class ItemsHandler {
 				result = message.ids;
 			} else if (message.query) {
 				const query = await sanitizeQuery(message.query, schema, accountability);
+				validateQuery(query);
 				result = await service.deleteByQuery(query);
 			} else {
 				throw new WebSocketError(

--- a/api/src/websocket/handlers/subscribe.ts
+++ b/api/src/websocket/handlers/subscribe.ts
@@ -4,6 +4,7 @@ import { useBus } from '../../bus/index.js';
 import emitter from '../../emitter.js';
 import { getSchema } from '../../utils/get-schema.js';
 import { sanitizeQuery } from '../../utils/sanitize-query.js';
+import { validateQuery } from '../../utils/validate-query.js';
 import { handleWebSocketError, WebSocketError } from '../errors.js';
 import type { WebSocketEvent } from '../messages.js';
 import { WebSocketSubscribeMessage } from '../messages.js';
@@ -164,6 +165,7 @@ export class SubscribeHandler {
 
 				if (message.query) {
 					subscription.query = await sanitizeQuery(message.query, schema, accountability);
+					validateQuery(subscription.query);
 				}
 
 				if ('item' in message) subscription.item = String(message.item);

--- a/contributors.yml
+++ b/contributors.yml
@@ -285,3 +285,4 @@
 - levgiorg
 - MahinAnowar
 - joeltco
+- tsushanth


### PR DESCRIPTION
## Problem

The WebSocket handlers run `sanitizeQuery(...)` but never call `validateQuery(...)`, unlike the REST `sanitize-query` middleware which does both. As a result, invalid query params (e.g. `limit < -1`) that REST rejects are silently accepted over WebSocket. This affects both the items handler (create / read / update / delete-by-query paths) and the subscribe handler.

## Fix

Add `validateQuery(...)` immediately after each `sanitizeQuery(...)` in both `api/src/websocket/handlers/items.ts` and `api/src/websocket/handlers/subscribe.ts`, mirroring the REST middleware.

## Before / after

- **Before:** a WebSocket message with `{ query: { limit: -5 } }` silently returned all rows.
- **After:** the same message is rejected with `INVALID_QUERY` — for both the read/items path and the subscribe path. A valid `{ limit: 2 }` still returns data as expected.
- REST behavior is unchanged.

Closes #27844
