### PR TITLE
Fix an unhandled rejection in the sdk realtime client when the connection closed during a heartbeat ping

### DIFF
--- a/.changeset/tall-clouds-cheer.md
+++ b/.changeset/tall-clouds-cheer.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Fixed an unhandled promise rejection in the realtime client when the connection closed while a heartbeat ping was being handled

--- a/.changeset/tall-clouds-cheer.md
+++ b/.changeset/tall-clouds-cheer.md
@@ -2,4 +2,4 @@
 '@directus/sdk': patch
 ---
 
-Fixed an unhandled promise rejection in the realtime client when the connection closed while a heartbeat ping was being handled
+Fixed an unhandled rejection in the sdk realtime client when the connection closed during a heartbeat ping

--- a/contributors.yml
+++ b/contributors.yml
@@ -285,3 +285,4 @@
 - levgiorg
 - MahinAnowar
 - joeltco
+- apoorva-01

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -213,6 +213,7 @@ export function realtime(config: WebSocketConfig = {}) {
 				}
 
 				if (config.heartbeat && message['type'] === 'ping') {
+					if (state.code !== 'open') continue;
 					state.connection.send(pong());
 					state.firstMessage = false;
 					continue;

--- a/sdk/tests/realtime/heartbeat.test.ts
+++ b/sdk/tests/realtime/heartbeat.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test, vi } from 'vitest';
+import type { WebSocketInterface } from '../../src/index.js';
+import { createDirectus } from '../../src/index.js';
+import { pong } from '../../src/realtime/commands/pong.js';
+import { realtime } from '../../src/realtime/composable.js';
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+class FakeWebSocket implements WebSocketInterface {
+	static instances: FakeWebSocket[] = [];
+
+	readonly readyState = 1;
+	send = vi.fn((_data: string): void => {});
+	close = vi.fn((_code?: number, _reason?: string): void => {
+		this.emit('close', { code: 1006 });
+	});
+
+	private listeners: Record<string, Set<(ev: any) => void>> = {
+		open: new Set(),
+		message: new Set(),
+		error: new Set(),
+		close: new Set(),
+	};
+
+	constructor(public url: string) {
+		FakeWebSocket.instances.push(this);
+	}
+
+	addEventListener(type: string, listener: (ev: any) => void): void {
+		this.listeners[type]?.add(listener);
+	}
+
+	removeEventListener(type: string, listener: (ev: any) => void): void {
+		this.listeners[type]?.delete(listener);
+	}
+
+	emit(type: string, event: unknown): void {
+		this.listeners[type]?.forEach((listener) => listener.call(this, event));
+	}
+}
+
+async function openConnection() {
+	FakeWebSocket.instances = [];
+
+	const client = createDirectus('http://localhost:8055', {
+		globals: { WebSocket: FakeWebSocket },
+	}).with(realtime({ reconnect: false }));
+
+	const connecting = client.connect();
+
+	await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+	const socket = FakeWebSocket.instances[0]!;
+	socket.emit('open', {});
+	await connecting;
+
+	return { client, socket };
+}
+
+function sendPing(socket: FakeWebSocket) {
+	socket.emit('message', { data: JSON.stringify({ type: 'ping' }) });
+}
+
+describe('realtime heartbeat', () => {
+	test('replies to a ping with a pong while the connection is open', async () => {
+		const { client, socket } = await openConnection();
+
+		sendPing(socket);
+		await flush();
+
+		expect(socket.send).toHaveBeenCalledWith(pong());
+
+		client.disconnect();
+	});
+
+	test('does not raise an unhandled rejection when the connection closes during a ping (#25078)', async () => {
+		const { socket } = await openConnection();
+
+		const rejections: unknown[] = [];
+		const onRejection = (reason: unknown) => rejections.push(reason);
+		process.on('unhandledRejection', onRejection);
+
+		try {
+			// The ping resolves, but the socket closes before the awaited handler resumes,
+			// so `state.connection` is already gone by the time the pong would be sent.
+			sendPing(socket);
+			socket.emit('close', { code: 1006 });
+			await flush();
+			await flush();
+		} finally {
+			process.off('unhandledRejection', onRejection);
+		}
+
+		expect(rejections).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Scope

- The realtime loop `await`s the next message before handling a `ping`. If the socket closes during that `await`, `state.connection` is gone and `state.connection.send(pong())` blows up with `Cannot read properties of undefined (reading 'send')` as an unhandled rejection (#25078). Added a `state.code !== 'open'` guard before the send, same as the branch right below already does.

## Potential Risks / Drawbacks

- None really. Connection's already closed, so there's nothing to pong back anyway.

## Tested Scenarios

- Added a test that reproduces the race (ping resolves, socket closes before the handler resumes). Fails on `main` with the reported `TypeError`, passes with the guard. Plus one that checks a normal ping still gets a pong.

## Review Notes / Questions

- Kept this to the reported heartbeat path. `handleAuthError` has the same await-then-send shape (`getToken()` then `send(auth(...))`), so it can hit this too. Want me to guard that here or leave it for a follow-up?

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Fixes #25078
