### PR TITLE
Fix live preview forbidden error when opening an unsaved draft version

### DIFF
--- a/.changeset/proud-otters-wait.md
+++ b/.changeset/proud-otters-wait.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed live preview requesting a draft version before it exists, which caused a forbidden error

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { translateShortcut, useCollection, useShortcut } from '@directus/composables';
-import { VERSION_KEY_DRAFT, VERSION_KEY_PUBLISHED } from '@directus/constants';
+import { VERSION_KEY_DRAFT } from '@directus/constants';
 import type { AppCollection, Item, PrimaryKey } from '@directus/types';
 import { sameOrigin } from '@directus/utils/browser';
 import { SplitPanel } from '@directus/vue-split-panel';
@@ -53,6 +53,7 @@ import { useNotificationsStore } from '@/stores/notifications';
 import { useUserStore } from '@/stores/user';
 import type { ContentVersionMaybeNew, ContentVersionWithType } from '@/types/versions';
 import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fields';
+import { getPreviewVersionKey } from '@/utils/get-preview-version-key';
 import { getCollectionRoute, getItemRoute } from '@/utils/get-route';
 import { mergeItemData } from '@/utils/merge-item-data';
 import { pushGroupOptionsDown } from '@/utils/push-group-options-down';
@@ -418,7 +419,7 @@ const previewTemplate = computed(() => collectionInfo.value?.meta?.preview_url ?
 
 const { templateData: previewData, fetchTemplateValues } = useTemplateData(collectionInfo, primaryKeyParam, {
 	template: previewTemplate,
-	injectData: computed(() => ({ $version: currentVersion.value?.key ?? VERSION_KEY_PUBLISHED })),
+	injectData: computed(() => ({ $version: getPreviewVersionKey(currentVersion.value) })),
 });
 
 const previewUrl = computed(() => {

--- a/app/src/modules/content/routes/preview.vue
+++ b/app/src/modules/content/routes/preview.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { useCollection } from '@directus/composables';
-import { VERSION_KEY_PUBLISHED } from '@directus/constants';
 import { computed, toRefs } from 'vue';
 import { useTemplateData } from '@/composables/use-template-data';
 import { useVersions } from '@/composables/use-versions';
 import { useVisualEditing } from '@/composables/use-visual-editing';
+import { getPreviewVersionKey } from '@/utils/get-preview-version-key';
 import { renderStringTemplate } from '@/utils/render-string-template';
 import LivePreview from '@/views/private/components/live-preview.vue';
 
@@ -23,7 +23,7 @@ const previewTemplate = computed(() => collectionInfo.value?.meta?.preview_url ?
 
 const { templateData: previewData } = useTemplateData(collectionInfo, primaryKey, {
 	template: previewTemplate,
-	injectData: computed(() => ({ $version: currentVersion.value?.key ?? VERSION_KEY_PUBLISHED })),
+	injectData: computed(() => ({ $version: getPreviewVersionKey(currentVersion.value) })),
 });
 
 const previewUrl = computed(() => {

--- a/app/src/utils/get-preview-version-key.test.ts
+++ b/app/src/utils/get-preview-version-key.test.ts
@@ -1,0 +1,59 @@
+import { VERSION_KEY_DRAFT, VERSION_KEY_PUBLISHED } from '@directus/constants';
+import { describe, expect, test } from 'vitest';
+import type { ContentVersionMaybeNew, NewContentVersion } from '@/types/versions';
+import { getPreviewVersionKey } from '@/utils/get-preview-version-key';
+
+describe('getPreviewVersionKey', () => {
+	test('resolves to the published key when no version is selected', () => {
+		expect(getPreviewVersionKey(null)).toBe(VERSION_KEY_PUBLISHED);
+	});
+
+	test('resolves to the published key when the selected version is not persisted yet', () => {
+		const unsavedDraft: NewContentVersion = {
+			id: '+',
+			key: VERSION_KEY_DRAFT,
+			name: null,
+			type: 'global',
+		};
+
+		expect(getPreviewVersionKey(unsavedDraft)).toBe(VERSION_KEY_PUBLISHED);
+	});
+
+	test('resolves to the version key once the selected version is persisted', () => {
+		const persistedDraft: ContentVersionMaybeNew = {
+			id: 'existing-draft-id',
+			key: VERSION_KEY_DRAFT,
+			name: null,
+			collection: 'test_collection',
+			item: '1',
+			hash: 'abc123',
+			date_created: '2024-01-01',
+			date_updated: null,
+			user_created: 'user-1',
+			user_updated: null,
+			delta: {},
+			type: 'global',
+		};
+
+		expect(getPreviewVersionKey(persistedDraft)).toBe(VERSION_KEY_DRAFT);
+	});
+
+	test('resolves to the version key for a persisted named version', () => {
+		const namedVersion: ContentVersionMaybeNew = {
+			id: 'existing-version-id',
+			key: 'my-version',
+			name: 'My Version',
+			collection: 'test_collection',
+			item: '1',
+			hash: 'abc123',
+			date_created: '2024-01-01',
+			date_updated: null,
+			user_created: 'user-1',
+			user_updated: null,
+			delta: {},
+			type: 'local',
+		};
+
+		expect(getPreviewVersionKey(namedVersion)).toBe('my-version');
+	});
+});

--- a/app/src/utils/get-preview-version-key.ts
+++ b/app/src/utils/get-preview-version-key.ts
@@ -1,0 +1,7 @@
+import { VERSION_KEY_PUBLISHED } from '@directus/constants';
+import type { ContentVersionMaybeNew } from '@/types/versions';
+
+export function getPreviewVersionKey(version: ContentVersionMaybeNew | null): string {
+	if (!version || version.id === '+') return VERSION_KEY_PUBLISHED;
+	return version.key;
+}


### PR DESCRIPTION
## Scope

- Live preview injected `version=draft` into the preview URL while the draft only existed as the unsaved pseudo version, so frontends requesting `?version=draft` got a 403 until the first autosave created the record
- Added a `getPreviewVersionKey` util: returns the published key when nothing is selected or the selected version is not persisted yet, otherwise the version key
- Used it for the preview URL data in split view (`item.vue`) and the popup preview route (`preview.vue`)
- An unsaved draft has no delta, so published content is identical. Once autosave creates the record, the URL switches to the draft key reactively

## Potential Risks / Drawbacks

- Frontends that branch on the version param see `published` while the draft is still unsaved. Content is identical at that point, so this should be invisible
- App only, no API behavior changes

## Tested Scenarios

- Unit tests: no version selected, unsaved pseudo draft, persisted draft, persisted named version
- Full `@directus/app` suite green (275 files, 110730 tests)
- vue-tsc reports no new errors compared to the base commit

## Review Notes / Questions

- The popup preview route had the identical bug, so both call sites are covered here
- Context: the API returns Forbidden for a version key that has no `directus_versions` record yet (`handle-version.ts`). Adapting live preview was the agreed direction, so the API is untouched

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Linear: CMS-2751
