### PR TITLE
Fix updates failing on PostgreSQL when a permission rule compiles to an empty condition

### DIFF
--- a/.changeset/gentle-cases-agree.md
+++ b/.changeset/gentle-cases-agree.md
@@ -2,5 +2,5 @@
 '@directus/api': patch
 ---
 
-Fixed updates failing on PostgreSQL when a permission rule compiles to an empty condition by using a boolean-valid
-always-true CASE/WHEN fallback
+Fixed updates failing on PostgreSQL when an invalid permission rule compiles to an empty condition. Such rules now deny
+access via a boolean-valid CASE/WHEN fallback instead of erroring the request

--- a/.changeset/gentle-cases-agree.md
+++ b/.changeset/gentle-cases-agree.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+---
+
+Fixed updates failing on PostgreSQL when a permission rule compiles to an empty condition by using a boolean-valid
+always-true CASE/WHEN fallback

--- a/.changeset/gentle-cases-agree.md
+++ b/.changeset/gentle-cases-agree.md
@@ -2,5 +2,6 @@
 '@directus/api': patch
 ---
 
-Fixed updates failing on PostgreSQL when an invalid permission rule compiles to an empty condition. Such rules now deny
-access via a boolean-valid CASE/WHEN fallback instead of erroring the request
+Fixed PostgreSQL queries failing when a permission rule compiles to an empty condition (for example a rule referencing
+fields or relations that no longer exist). The CASE/WHEN fallback now uses a boolean-valid expression, matching the
+behaviour MySQL and SQLite already had.

--- a/api/src/database/run-ast/utils/apply-case-when.test.ts
+++ b/api/src/database/run-ast/utils/apply-case-when.test.ts
@@ -1,0 +1,69 @@
+import { SchemaBuilder } from '@directus/schema-builder';
+import type { Filter } from '@directus/types';
+import knex from 'knex';
+import { expect, test, vi } from 'vitest';
+import { Client_SQLite3 } from '../lib/apply-query/mock.js';
+import { applyCaseWhen } from './apply-case-when.js';
+
+const schema = new SchemaBuilder()
+	.collection('articles', (c) => {
+		c.field('id').id();
+		c.field('title').string();
+	})
+	.build();
+
+const clients: { dialect: string; client: knex.Knex.Config['client'] }[] = [
+	{ dialect: 'sqlite', client: Client_SQLite3 },
+	{ dialect: 'postgres', client: 'pg' },
+];
+
+test.each(clients)(
+	'Uses a boolean-valid always-true condition when the case filter compiles to no SQL ($dialect)',
+	({ client }) => {
+		const db = vi.mocked(knex.default({ client }));
+
+		// Permission rule traversing a relational path that no longer exists in the schema, for example
+		// a rule created before a relation was renamed. applyFilter silently skips relational paths that
+		// match no relation (unknown scalar fields throw instead), so the compiled condition ends up
+		// empty and the case must fall back to an always-true condition. That fallback has to be a valid
+		// boolean expression: PostgreSQL rejects `CASE WHEN 1 THEN ... END` with "argument of CASE/WHEN
+		// must be type boolean", which breaks updates on items gated by such permission rules (CMS-2151).
+		const cases: Filter[] = [{ _and: [{ country: { code: { _in: ['NL'] } } }] } as unknown as Filter];
+
+		const result = applyCaseWhen(
+			{
+				column: db.raw(1),
+				columnCases: cases,
+				aliasMap: {},
+				cases,
+				table: 'articles',
+				alias: 'title',
+				permissions: [],
+			},
+			{ knex: db, schema },
+		);
+
+		expect(result.toQuery()).toBe('(CASE WHEN 1 = 1 THEN 1 END) AS "title"');
+	},
+);
+
+test.each(clients)('Keeps the compiled filter condition when the case filter produces SQL ($dialect)', ({ client }) => {
+	const db = vi.mocked(knex.default({ client }));
+
+	const cases: Filter[] = [{ title: { _eq: 'allowed' } } as unknown as Filter];
+
+	const result = applyCaseWhen(
+		{
+			column: db.raw(1),
+			columnCases: cases,
+			aliasMap: {},
+			cases,
+			table: 'articles',
+			alias: 'title',
+			permissions: [],
+		},
+		{ knex: db, schema },
+	);
+
+	expect(result.toQuery()).toBe('(CASE WHEN ("articles"."title" = \'allowed\') THEN 1 END) AS "title"');
+});

--- a/api/src/database/run-ast/utils/apply-case-when.test.ts
+++ b/api/src/database/run-ast/utils/apply-case-when.test.ts
@@ -12,59 +12,42 @@ const schema = new SchemaBuilder()
 	})
 	.build();
 
+// pg is included because it rejects a bare integer as a CASE/WHEN condition ("argument of CASE/WHEN
+// must be type boolean"), which was the original CMS-2151 failure; the fallback must be a real boolean.
 const clients: { dialect: string; client: knex.Knex.Config['client'] }[] = [
 	{ dialect: 'sqlite', client: Client_SQLite3 },
 	{ dialect: 'postgres', client: 'pg' },
 ];
 
-test.each(clients)(
-	'Denies with a boolean-valid always-false condition when the case filter compiles to no SQL ($dialect)',
-	({ client }) => {
-		const db = vi.mocked(knex.default({ client }));
-
-		// Permission rule traversing a relational path that no longer exists in the schema, for example
-		// a rule created before a relation was renamed. applyFilter silently skips relational paths that
-		// match no relation (unknown scalar fields throw instead), so the compiled condition ends up
-		// empty. An invalid rule must not grant unconditional access, so the case falls back to an
-		// always-false condition (the field is hidden). That fallback has to be a valid boolean
-		// expression: PostgreSQL rejects `CASE WHEN 1 THEN ... END` with "argument of CASE/WHEN must be
-		// type boolean", which was breaking updates on items gated by such permission rules (CMS-2151).
-		const cases: Filter[] = [{ _and: [{ country: { code: { _in: ['NL'] } } }] } as unknown as Filter];
-
-		const result = applyCaseWhen(
-			{
-				column: db.raw(1),
-				columnCases: cases,
-				aliasMap: {},
-				cases,
-				table: 'articles',
-				alias: 'title',
-				permissions: [],
-			},
-			{ knex: db, schema },
-		);
-
-		expect(result.toQuery()).toBe('(CASE WHEN 1 = 0 THEN 1 END) AS "title"');
-	},
-);
-
-test.each(clients)('Keeps the compiled filter condition when the case filter produces SQL ($dialect)', ({ client }) => {
+function run(cases: Filter[], client: knex.Knex.Config['client']) {
 	const db = vi.mocked(knex.default({ client }));
 
+	return applyCaseWhen(
+		{ column: db.raw(1), columnCases: cases, aliasMap: {}, cases, table: 'articles', alias: 'title', permissions: [] },
+		{ knex: db, schema },
+	).toQuery();
+}
+
+test.each(clients)('Keeps the compiled filter condition when the case filter produces SQL ($dialect)', ({ client }) => {
 	const cases: Filter[] = [{ title: { _eq: 'allowed' } } as unknown as Filter];
 
-	const result = applyCaseWhen(
-		{
-			column: db.raw(1),
-			columnCases: cases,
-			aliasMap: {},
-			cases,
-			table: 'articles',
-			alias: 'title',
-			permissions: [],
-		},
-		{ knex: db, schema },
-	);
-
-	expect(result.toQuery()).toBe('(CASE WHEN ("articles"."title" = \'allowed\') THEN 1 END) AS "title"');
+	expect(run(cases, client)).toBe('(CASE WHEN ("articles"."title" = \'allowed\') THEN 1 END) AS "title"');
 });
+
+test.each(clients)(
+	'Falls back to an always-true boolean when the case filter compiles to no SQL ($dialect)',
+	({ client }) => {
+		// A rule whose conditions reference fields/relations that no longer exist (applyFilter silently
+		// drops them), and a genuinely empty rule, both compile to no SQL. Both keep granting access, as
+		// MySQL/SQLite already did with the bare `1`; the fallback just has to be a valid boolean for pg.
+		const noSqlCases: Filter[] = [
+			{ _and: [{ country: { code: { _in: ['NL'] } } }] } as unknown as Filter,
+			{ _and: [] } as unknown as Filter,
+			{ _or: [] } as unknown as Filter,
+		];
+
+		for (const rule of noSqlCases) {
+			expect(run([rule], client)).toBe('(CASE WHEN 1 = 1 THEN 1 END) AS "title"');
+		}
+	},
+);

--- a/api/src/database/run-ast/utils/apply-case-when.test.ts
+++ b/api/src/database/run-ast/utils/apply-case-when.test.ts
@@ -18,16 +18,17 @@ const clients: { dialect: string; client: knex.Knex.Config['client'] }[] = [
 ];
 
 test.each(clients)(
-	'Uses a boolean-valid always-true condition when the case filter compiles to no SQL ($dialect)',
+	'Denies with a boolean-valid always-false condition when the case filter compiles to no SQL ($dialect)',
 	({ client }) => {
 		const db = vi.mocked(knex.default({ client }));
 
 		// Permission rule traversing a relational path that no longer exists in the schema, for example
 		// a rule created before a relation was renamed. applyFilter silently skips relational paths that
 		// match no relation (unknown scalar fields throw instead), so the compiled condition ends up
-		// empty and the case must fall back to an always-true condition. That fallback has to be a valid
-		// boolean expression: PostgreSQL rejects `CASE WHEN 1 THEN ... END` with "argument of CASE/WHEN
-		// must be type boolean", which breaks updates on items gated by such permission rules (CMS-2151).
+		// empty. An invalid rule must not grant unconditional access, so the case falls back to an
+		// always-false condition (the field is hidden). That fallback has to be a valid boolean
+		// expression: PostgreSQL rejects `CASE WHEN 1 THEN ... END` with "argument of CASE/WHEN must be
+		// type boolean", which was breaking updates on items gated by such permission rules (CMS-2151).
 		const cases: Filter[] = [{ _and: [{ country: { code: { _in: ['NL'] } } }] } as unknown as Filter];
 
 		const result = applyCaseWhen(
@@ -43,7 +44,7 @@ test.each(clients)(
 			{ knex: db, schema },
 		);
 
-		expect(result.toQuery()).toBe('(CASE WHEN 1 = 1 THEN 1 END) AS "title"');
+		expect(result.toQuery()).toBe('(CASE WHEN 1 = 0 THEN 1 END) AS "title"');
 	},
 );
 

--- a/api/src/database/run-ast/utils/apply-case-when.ts
+++ b/api/src/database/run-ast/utils/apply-case-when.ts
@@ -45,11 +45,10 @@ export function applyCaseWhen(
 		}
 	}
 
-	// The filter had conditions but none compiled to SQL, so the rule is invalid (eg. it references
-	// fields or relations that no longer exist). Deny rather than grant unconditional access: gate the
-	// column behind an always-false condition so the field is hidden. Must be a real boolean expression,
-	// since eg. PostgreSQL rejects a plain integer as a CASE/WHEN condition.
-	const sql = sqlParts.length > 0 ? sqlParts.join(' ') : '1 = 0';
+	// Fall back to an always-true condition when nothing compiled (eg. a rule referencing fields that no
+	// longer exist). This matches how MySQL/SQLite already treated the bare `1`; it must be a real
+	// boolean since PostgreSQL rejects a plain integer as a CASE/WHEN condition.
+	const sql = sqlParts.length > 0 ? sqlParts.join(' ') : '1 = 1';
 	const bindings = [...caseQuery.toSQL().bindings, column];
 
 	let rawCase = `(CASE WHEN ${sql} THEN ?? END)`;

--- a/api/src/database/run-ast/utils/apply-case-when.ts
+++ b/api/src/database/run-ast/utils/apply-case-when.ts
@@ -45,10 +45,11 @@ export function applyCaseWhen(
 		}
 	}
 
-	// Fall back to an always-true condition when the filter compiled to no SQL (eg. a rule that only
-	// references unknown fields). Needs to be an actual boolean expression, since eg. PostgreSQL
-	// rejects a plain `1` as a CASE/WHEN condition.
-	const sql = sqlParts.length > 0 ? sqlParts.join(' ') : '1 = 1';
+	// The filter had conditions but none compiled to SQL, so the rule is invalid (eg. it references
+	// fields or relations that no longer exist). Deny rather than grant unconditional access: gate the
+	// column behind an always-false condition so the field is hidden. Must be a real boolean expression,
+	// since eg. PostgreSQL rejects a plain integer as a CASE/WHEN condition.
+	const sql = sqlParts.length > 0 ? sqlParts.join(' ') : '1 = 0';
 	const bindings = [...caseQuery.toSQL().bindings, column];
 
 	let rawCase = `(CASE WHEN ${sql} THEN ?? END)`;

--- a/api/src/database/run-ast/utils/apply-case-when.ts
+++ b/api/src/database/run-ast/utils/apply-case-when.ts
@@ -45,7 +45,10 @@ export function applyCaseWhen(
 		}
 	}
 
-	const sql = sqlParts.length > 0 ? sqlParts.join(' ') : '1';
+	// Fall back to an always-true condition when the filter compiled to no SQL (eg. a rule that only
+	// references unknown fields). Needs to be an actual boolean expression, since eg. PostgreSQL
+	// rejects a plain `1` as a CASE/WHEN condition.
+	const sql = sqlParts.length > 0 ? sqlParts.join(' ') : '1 = 1';
 	const bindings = [...caseQuery.toSQL().bindings, column];
 
 	let rawCase = `(CASE WHEN ${sql} THEN ?? END)`;


### PR DESCRIPTION
## Scope

- `applyCaseWhen` fell back to the literal `1` as the CASE WHEN condition whenever a permission rule filter compiles to no SQL (for example a rule whose relational path no longer exists after a field rename; such paths are silently skipped)
- PostgreSQL rejects a bare integer there (`argument of CASE/WHEN must be type boolean`), so every update on an item gated by such a rule returned a 500, including o2m deselects which save through the parent item
- The fallback is now `1 = 1`, a valid boolean everywhere. MySQL and SQLite already treated the bare `1` as truthy, so behavior there is unchanged
- Unit tests cover the empty-condition fallback and the normal compiled path, on both the sqlite and pg dialects

## Potential Risks / Drawbacks

- A rule that compiles to nothing now evaluates always-true in the CASE path instead of erroring the whole request on Postgres. That matches the existing lenient WHERE behavior for the same rule, but it is fail-open rather than fail-closed. Validating rules at save time would be the stricter follow-up

## Tested Scenarios

- Loaded the reporter's SQL dumps into Postgres 13: the PATCH on the gated item 500s with the CASE/WHEN boolean error on 11.15.2, 11.15.3 and 11.17.3 alike, while `/permissions/me/...` returns update access true
- Ran the failing generated SQL and the fixed variant directly against that database: the old form errors, the fixed form returns the row
- New tests were red before the fix and green after; full `@directus/api` suite passes (354 files, 4530 tests)

## Review Notes / Questions

- The reported worked-in-11.15.3, broken-in-11.15.4 window did not reproduce with the attached dumps; this save path has been broken on Postgres for this rule shape the whole time. Most likely the customer schema drifted (field renames), so the rule stopped matching real fields
- Should stale rules fail closed instead? This keeps the lenient semantics to match the WHERE path; tightening that feels like its own issue

## Checklist

- [x] Added or updated tests
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required

---

Linear: CMS-2151
