### PR TITLE
Add support for partial schema snapshots

### DIFF
--- a/.changeset/soft-goats-fly.md
+++ b/.changeset/soft-goats-fly.md
@@ -4,4 +4,4 @@
 '@directus/sdk': minor
 ---
 
-Added support for collection scoping on schema snapshot via new `includeCollections`/`excludeCollections` parameters
+Added support for partial schema snapshot via new `includeCollections`/`excludeCollections` parameters

--- a/.changeset/soft-goats-fly.md
+++ b/.changeset/soft-goats-fly.md
@@ -1,0 +1,7 @@
+---
+'@directus/specs': minor
+'@directus/api': minor
+'@directus/sdk': minor
+---
+
+Added support for collection scoping on schema snapshot via new `includeCollections`/`excludeCollections` parameters

--- a/api/src/constants.ts
+++ b/api/src/constants.ts
@@ -57,6 +57,11 @@ export const FILTER_VARIABLES = ['$NOW', '$CURRENT_USER', '$CURRENT_ROLE'];
 
 export const ALIAS_TYPES = ['alias', 'o2m', 'm2m', 'm2a', 'o2a', 'files', 'translations'];
 
+export const SNAPSHOT_VERSION = {
+	FULL: 1,
+	PARTIAL: 2,
+} as const;
+
 export const DEFAULT_AUTH_PROVIDER = 'default';
 
 export const COLUMN_TRANSFORMS = ['year', 'month', 'day', 'weekday', 'hour', 'minute', 'second'];

--- a/api/src/controllers/schema.ts
+++ b/api/src/controllers/schema.ts
@@ -1,23 +1,46 @@
 import { InvalidPayloadError, UnsupportedMediaTypeError } from '@directus/errors';
 import type { Snapshot, SnapshotDiffWithHash } from '@directus/types';
-import { parseJSON, toBoolean } from '@directus/utils';
+import { parseJSON, toArray, toBoolean } from '@directus/utils';
 import Busboy from 'busboy';
 import type { RequestHandler } from 'express';
 import express from 'express';
 import { load as loadYaml } from 'js-yaml';
+import { z } from 'zod';
+import { fromZodError } from 'zod-validation-error';
 import { useLogger } from '../logger/index.js';
+import checkIsAdmin from '../middleware/is-admin.js';
 import { respond } from '../middleware/respond.js';
 import { SchemaService } from '../services/schema.js';
 import asyncHandler from '../utils/async-handler.js';
 import { getVersionedHash } from '../utils/get-versioned-hash.js';
+import { resolveScopedCollections } from './schema/resolve-scoped-collections.js';
 
 const router = express.Router();
 
+/** Accepts a single collection name or a list, always normalizing to a string array. */
+const collectionList = z.union([z.string(), z.array(z.string())]).transform((value) => toArray(value));
+
+const snapshotQuerySchema = z
+	.object({
+		includeCollections: collectionList.optional(),
+		excludeCollections: collectionList.optional(),
+	})
+	.refine((value) => !(value.includeCollections && value.excludeCollections), {
+		message: `"includeCollections" and "excludeCollections" parameters cannot be used together`,
+	});
+
 router.get(
 	'/snapshot',
+	checkIsAdmin,
 	asyncHandler(async (req, res, next) => {
+		const parsed = snapshotQuerySchema.safeParse(req.query);
+		if (!parsed.success) throw new InvalidPayloadError({ reason: fromZodError(parsed.error).message });
+
+		// `null` (no scope) is full snapshot.
+		const collections = resolveScopedCollections(req.schema, parsed.data) ?? undefined;
+
 		const service = new SchemaService({ accountability: req.accountability });
-		const currentSnapshot = await service.snapshot();
+		const currentSnapshot = await service.snapshot({ collections });
 		res.locals['payload'] = { data: currentSnapshot };
 		return next();
 	}),

--- a/api/src/controllers/schema/resolve-scoped-collections.test.ts
+++ b/api/src/controllers/schema/resolve-scoped-collections.test.ts
@@ -1,0 +1,60 @@
+import { SchemaBuilder } from '@directus/schema-builder';
+import { describe, expect, test } from 'vitest';
+import { resolveScopedCollections } from './resolve-scoped-collections.js';
+
+const schema = new SchemaBuilder()
+	.collection('articles', (c) => c.field('id').id())
+	.collection('authors', (c) => c.field('id').id())
+	.collection('tags', (c) => c.field('id').id())
+	.collection('articles_tags', (c) => c.field('id').id())
+	.collection('categories', (c) => c.field('id').id())
+	.collection('directus_users', (c) => c.field('id').id())
+	.build();
+
+const asSet = (collections: string[] | null) => new Set(collections);
+
+describe('resolveScopedCollections', () => {
+	test('returns null when no scope is given', () => {
+		const result = resolveScopedCollections(schema, {});
+
+		expect(result).toBeNull();
+	});
+
+	test('returns exactly the included collections', () => {
+		const result = resolveScopedCollections(schema, { includeCollections: ['articles', 'authors'] });
+
+		expect(asSet(result)).toEqual(new Set(['articles', 'authors']));
+	});
+
+	test('returns every collection except the excluded ones', () => {
+		const result = resolveScopedCollections(schema, { excludeCollections: ['articles'] });
+
+		expect(asSet(result)).toEqual(new Set(['articles_tags', 'authors', 'categories', 'directus_users', 'tags']));
+	});
+
+	test('ignores included names that do not exist in the schema', () => {
+		const result = resolveScopedCollections(schema, { includeCollections: ['nope', 'articles'] });
+
+		expect(asSet(result)).toEqual(new Set(['articles']));
+	});
+
+	test('returns an empty list when none of the included names exist', () => {
+		const result = resolveScopedCollections(schema, { includeCollections: ['nope'] });
+
+		expect(result).toEqual([]);
+	});
+
+	test('ignores excluded names that do not exist in the schema', () => {
+		const result = resolveScopedCollections(schema, { excludeCollections: ['nope'] });
+
+		expect(asSet(result)).toEqual(
+			new Set(['articles', 'articles_tags', 'authors', 'categories', 'directus_users', 'tags']),
+		);
+	});
+
+	test('keeps a system collection that is explicitly included', () => {
+		const result = resolveScopedCollections(schema, { includeCollections: ['directus_users', 'articles'] });
+
+		expect(asSet(result)).toEqual(new Set(['articles', 'directus_users']));
+	});
+});

--- a/api/src/controllers/schema/resolve-scoped-collections.test.ts
+++ b/api/src/controllers/schema/resolve-scoped-collections.test.ts
@@ -57,4 +57,10 @@ describe('resolveScopedCollections', () => {
 
 		expect(asSet(result)).toEqual(new Set(['articles', 'directus_users']));
 	});
+
+	test('throws when both includeCollections and excludeCollections are given', () => {
+		expect(() =>
+			resolveScopedCollections(schema, { includeCollections: ['articles'], excludeCollections: ['authors'] }),
+		).toThrow('"includeCollections" and "excludeCollections" parameters cannot be used together');
+	});
 });

--- a/api/src/controllers/schema/resolve-scoped-collections.ts
+++ b/api/src/controllers/schema/resolve-scoped-collections.ts
@@ -1,0 +1,33 @@
+import type { SchemaOverview } from '@directus/types';
+
+/**
+ * Resolves a collection scope into a list of collections a partial snapshot should contain. Names not present in the
+ * schema are ignored.
+ *
+ * @param schema - Overview of the current schema, used to validate names and to build the exclude complement.
+ * @param scope - The requested scope; `includeCollections` and `excludeCollections` are mutually exclusive.
+ * @param scope.includeCollections - Restrict the snapshot to exactly these collections.
+ * @param scope.excludeCollections - Include every collection except these.
+ * @returns The collections to snapshot, or `null` for a full snapshot
+ */
+export function resolveScopedCollections(
+	schema: SchemaOverview,
+	scope: {
+		includeCollections?: string[] | undefined;
+		excludeCollections?: string[] | undefined;
+	},
+): string[] | null {
+	const { includeCollections, excludeCollections } = scope;
+
+	if (!includeCollections && !excludeCollections) return null;
+
+	const allCollections = Object.keys(schema.collections);
+
+	if (includeCollections) {
+		const knownCollections = new Set(allCollections);
+		return includeCollections.filter((collection) => knownCollections.has(collection));
+	}
+
+	const excludedCollections = new Set(excludeCollections);
+	return allCollections.filter((collection) => !excludedCollections.has(collection));
+}

--- a/api/src/controllers/schema/resolve-scoped-collections.ts
+++ b/api/src/controllers/schema/resolve-scoped-collections.ts
@@ -1,3 +1,4 @@
+import { InvalidPayloadError } from '@directus/errors';
 import type { SchemaOverview } from '@directus/types';
 
 /**
@@ -9,6 +10,7 @@ import type { SchemaOverview } from '@directus/types';
  * @param scope.includeCollections - Restrict the snapshot to exactly these collections.
  * @param scope.excludeCollections - Include every collection except these.
  * @returns The collections to snapshot, or `null` for a full snapshot
+ * @throws {InvalidPayloadError} If both `includeCollections` and `excludeCollections` are provided.
  */
 export function resolveScopedCollections(
 	schema: SchemaOverview,
@@ -18,6 +20,12 @@ export function resolveScopedCollections(
 	},
 ): string[] | null {
 	const { includeCollections, excludeCollections } = scope;
+
+	if (includeCollections && excludeCollections) {
+		throw new InvalidPayloadError({
+			reason: `"includeCollections" and "excludeCollections" parameters cannot be used together`,
+		});
+	}
 
 	if (!includeCollections && !excludeCollections) return null;
 

--- a/api/src/services/schema.ts
+++ b/api/src/services/schema.ts
@@ -25,10 +25,11 @@ export class SchemaService {
 		this.accountability = options.accountability ?? null;
 	}
 
-	async snapshot(): Promise<Snapshot> {
+	/** Snapshot the schema, optionally scoped to a subset of `collections` (a partial snapshot). Admin only. */
+	async snapshot(options?: { collections?: string[] | undefined }): Promise<Snapshot> {
 		if (this.accountability?.admin !== true) throw new ForbiddenError();
 
-		const currentSnapshot = await getSnapshot({ database: this.knex });
+		const currentSnapshot = await getSnapshot({ database: this.knex, collections: options?.collections });
 
 		return currentSnapshot;
 	}

--- a/api/src/utils/get-snapshot.test.ts
+++ b/api/src/utils/get-snapshot.test.ts
@@ -387,6 +387,77 @@ describe('getSnapshot', () => {
 		});
 	});
 
+	describe('partial snapshots (collection scoping)', () => {
+		const collections = [
+			{ collection: 'articles', meta: {} },
+			{ collection: 'authors', meta: {} },
+			{ collection: 'tags', meta: {} },
+		];
+
+		const fields = [
+			{ field: 'id', collection: 'articles', meta: {} },
+			{ field: 'title', collection: 'articles', meta: {} },
+			{ field: 'author', collection: 'articles', meta: {} },
+			{ field: 'owner', collection: 'articles', meta: {} },
+			{ field: 'id', collection: 'authors', meta: {} },
+			{ field: 'name', collection: 'authors', meta: {} },
+			{ field: 'articles', collection: 'authors', type: 'alias', meta: {} },
+			{ field: 'id', collection: 'tags', meta: {} },
+			{
+				field: 'external_identifier',
+				collection: 'directus_users',
+				meta: { system: true },
+				schema: { is_indexed: true },
+			},
+		];
+
+		const relations = [
+			{ collection: 'articles', field: 'author', related_collection: 'authors', meta: { one_field: 'articles' } },
+			{ collection: 'articles', field: 'owner', related_collection: 'directus_users', meta: {} },
+		];
+
+		beforeEach(() => {
+			mockCollectionsService.readByQuery.mockResolvedValue(collections);
+			mockFieldsService.readAll.mockResolvedValue(fields);
+			mockRelationsService.readAll.mockResolvedValue(relations);
+		});
+
+		const collectionNames = (snapshot: any) => snapshot.collections.map((c: any) => c.collection);
+		const fieldKeys = (snapshot: any) => snapshot.fields.map((f: any) => `${f.collection}.${f.field}`);
+		const relationKeys = (snapshot: any) => snapshot.relations.map((r: any) => `${r.collection}.${r.field}`);
+		const systemFieldKeys = (snapshot: any) => snapshot.systemFields.map((f: any) => `${f.collection}.${f.field}`);
+
+		test('includes only the scoped collections and its fields, relations, and system fields', async () => {
+			const snapshot = await getSnapshot({ collections: ['articles', 'authors'] });
+
+			expect(snapshot.version).toBe(2);
+			expect(collectionNames(snapshot)).toEqual(['articles', 'authors']);
+
+			expect(fieldKeys(snapshot)).toEqual([
+				'articles.id',
+				'articles.title',
+				'articles.author',
+				'articles.owner',
+				'authors.id',
+				'authors.name',
+				'authors.articles',
+			]);
+
+			expect(relationKeys(snapshot)).toEqual(['articles.author', 'articles.owner']);
+			expect(systemFieldKeys(snapshot)).toEqual([]);
+		});
+
+		test('captures the indexed system fields of a scoped system collection', async () => {
+			const snapshot = await getSnapshot({ collections: ['directus_users'] });
+
+			expect(snapshot.version).toBe(2);
+			expect(collectionNames(snapshot)).toEqual([]);
+			expect(fieldKeys(snapshot)).toEqual([]);
+			expect(relationKeys(snapshot)).toEqual([]);
+			expect(systemFieldKeys(snapshot)).toEqual(['directus_users.external_identifier']);
+		});
+	});
+
 	describe('integration scenarios', () => {
 		test('should handle complex mixed data correctly', async () => {
 			const collections = [

--- a/api/src/utils/get-snapshot.test.ts
+++ b/api/src/utils/get-snapshot.test.ts
@@ -447,6 +447,14 @@ describe('getSnapshot', () => {
 			expect(systemFieldKeys(snapshot)).toEqual([]);
 		});
 
+		test('drops a relation owned by an out-of-scope collection while keeping the scoped fields', async () => {
+			const snapshot = await getSnapshot({ collections: ['authors'] });
+
+			expect(collectionNames(snapshot)).toEqual(['authors']);
+			expect(fieldKeys(snapshot)).toEqual(['authors.id', 'authors.name', 'authors.articles']);
+			expect(relationKeys(snapshot)).toEqual([]);
+		});
+
 		test('captures the indexed system fields of a scoped system collection', async () => {
 			const snapshot = await getSnapshot({ collections: ['directus_users'] });
 

--- a/api/src/utils/get-snapshot.ts
+++ b/api/src/utils/get-snapshot.ts
@@ -2,6 +2,7 @@ import type { Field, Relation, SchemaOverview, Snapshot } from '@directus/types'
 import { version } from 'directus/version';
 import type { Knex } from 'knex';
 import { fromPairs, isArray, isPlainObject, mapValues, omit, sortBy, toPairs } from 'lodash-es';
+import { SNAPSHOT_VERSION } from '../constants.js';
 import getDatabase, { getDatabaseClient } from '../database/index.js';
 import { CollectionsService } from '../services/collections.js';
 import { FieldsService } from '../services/fields.js';
@@ -9,7 +10,25 @@ import { RelationsService } from '../services/relations.js';
 import { getSchema } from './get-schema.js';
 import { sanitizeCollection, sanitizeField, sanitizeRelation, sanitizeSystemField } from './sanitize-schema.js';
 
-export async function getSnapshot(options?: { database?: Knex; schema?: SchemaOverview }): Promise<Snapshot> {
+export interface GetSnapshotOptions {
+	database?: Knex;
+	schema?: SchemaOverview;
+	/**
+	 * Scope the snapshot to exactly these collections
+	 */
+	collections?: string[] | undefined;
+}
+
+/**
+ * Build a snapshot of the current schema.
+ *
+ * @param options - Optional connection overrides and collection scoping.
+ * @param options.database - Knex instance to read from; defaults to the shared connection.
+ * @param options.schema - Pre-fetched schema overview; fetched fresh (cache bypassed) when omitted.
+ * @param options.collections - Restrict the snapshot to these collections, producing a partial snapshot (version 2)
+ * @returns The schema snapshot.
+ */
+export async function getSnapshot(options?: GetSnapshotOptions): Promise<Snapshot> {
 	const database = options?.database ?? getDatabase();
 	const vendor = getDatabaseClient(database);
 	const schema = options?.schema ?? (await getSchema({ database, bypassCache: true }));
@@ -24,10 +43,21 @@ export async function getSnapshot(options?: { database?: Knex; schema?: SchemaOv
 		relationsService.readAll(),
 	]);
 
-	const collectionsFiltered = collectionsRaw.filter((item) => excludeSystem(item) && excludeUntracked(item));
-	const fieldsFiltered = fieldsRaw.filter((item) => excludeSystem(item) && excludeUntracked(item));
-	const relationsFiltered = relationsRaw.filter((item) => excludeSystem(item) && excludeUntracked(item));
-	const systemFieldsFiltered = fieldsRaw.filter((item) => systemFieldWithIndex(item));
+	const scope = options?.collections !== undefined ? new Set(options.collections) : null;
+
+	const collectionsFiltered = collectionsRaw.filter(
+		(item) => excludeSystem(item) && excludeUntracked(item) && excludeOutOfScope(item, scope),
+	);
+
+	const fieldsFiltered = fieldsRaw.filter(
+		(item) => excludeSystem(item) && excludeUntracked(item) && excludeOutOfScope(item, scope),
+	);
+
+	const relationsFiltered = relationsRaw.filter(
+		(item) => excludeSystem(item) && excludeUntracked(item) && excludeOutOfScope(item, scope),
+	);
+
+	const systemFieldsFiltered = fieldsRaw.filter((item) => systemFieldWithIndex(item) && excludeOutOfScope(item, scope));
 
 	const collectionsSorted = sortBy(mapValues(collectionsFiltered, sortDeep), ['collection']).map((collection) =>
 		sanitizeCollection(collection),
@@ -46,7 +76,7 @@ export async function getSnapshot(options?: { database?: Knex; schema?: SchemaOv
 	);
 
 	return {
-		version: 1,
+		version: scope !== null ? SNAPSHOT_VERSION.PARTIAL : SNAPSHOT_VERSION.FULL,
 		directus: version,
 		vendor,
 		collections: collectionsSorted,
@@ -66,6 +96,11 @@ function systemFieldWithIndex(item: {
 	schema: { is_indexed: boolean } | null;
 }) {
 	return item.meta?.system === true && item.schema?.is_indexed;
+}
+
+function excludeOutOfScope(item: { collection: string }, scope: Set<string> | null) {
+	if (scope === null) return true;
+	return scope.has(item.collection);
 }
 
 function excludeUntracked(item: { meta: unknown | null } | null) {

--- a/packages/specs/src/paths/schema/snapshot.yaml
+++ b/packages/specs/src/paths/schema/snapshot.yaml
@@ -4,6 +4,26 @@ get:
   operationId: schemaSnapshot
   parameters:
     - $ref: '../../openapi.yaml#/components/parameters/Export'
+    - name: includeCollections
+      description: >-
+        Restrict the snapshot to these collections (produces a partial snapshot, version 2). Mutually exclusive with
+        `excludeCollections`.
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+    - name: excludeCollections
+      description: >-
+        Exclude these collections from the snapshot (produces a partial snapshot, version 2). Mutually exclusive with
+        `includeCollections`.
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
   responses:
     '200':
       description: Successful request

--- a/sdk/src/rest/commands/schema/snapshot.ts
+++ b/sdk/src/rest/commands/schema/snapshot.ts
@@ -1,22 +1,64 @@
+import type { AllCollections } from '../../../types/index.js';
 import type { RestCommand } from '../../types.js';
 
 // TODO improve typing
 export type SchemaSnapshotOutput = {
+	/** `1` for a full snapshot, `2` for a partial (collection-scoped) snapshot. */
 	version: number;
 	directus: string;
 	vendor: string;
 	collections: Record<string, any>[];
 	fields: Record<string, any>[];
+	systemFields: Record<string, any>[];
 	relations: Record<string, any>[];
 };
 
 /**
+ * Optional collection scoping for {@link schemaSnapshot}. Omit for a full snapshot, or provide exactly one of
+ * `includeCollections` / `excludeCollections` for a partial snapshot.
+ */
+export type SchemaSnapshotOptions<Schema> =
+	| {
+			/**
+			 * Restrict the snapshot to these collections (partial snapshot). Mutually exclusive with `excludeCollections`.
+			 */
+			includeCollections: AllCollections<Schema>[];
+	  }
+	| {
+			/**
+			 * Exclude these collections from the snapshot (partial snapshot). Mutually exclusive with `includeCollections`.
+			 */
+			excludeCollections: AllCollections<Schema>[];
+	  };
+
+/**
  * Retrieve the current schema. This endpoint is only available to admin users.
+ *
+ * @param options Optional collection scoping (partial). Omit for a full snapshot.
+ * @param options.includeCollections Restrict the snapshot to these collections.
+ * @param options.excludeCollections Exclude these collections from the snapshot.
+ *
  * @returns Returns the JSON object containing schema details.
+ * @throws Will throw if both `includeCollections` and `excludeCollections` are provided.
  */
 export const schemaSnapshot =
-	<Schema>(): RestCommand<SchemaSnapshotOutput, Schema> =>
-	() => ({
-		method: 'GET',
-		path: '/schema/snapshot',
-	});
+	<Schema>(options?: SchemaSnapshotOptions<Schema>): RestCommand<SchemaSnapshotOutput, Schema> =>
+	() => {
+		const includeCollections = options && 'includeCollections' in options;
+		const excludeCollections = options && 'excludeCollections' in options;
+
+		if (includeCollections && excludeCollections) {
+			throw new Error(`"includeCollections" and "excludeCollections" parameters cannot be used together`);
+		}
+
+		const params: Record<string, string> = {};
+
+		if (includeCollections) params['includeCollections'] = options.includeCollections.join(',');
+		if (excludeCollections) params['excludeCollections'] = options.excludeCollections.join(',');
+
+		return {
+			method: 'GET',
+			path: '/schema/snapshot',
+			params,
+		};
+	};

--- a/sdk/tests/rest/schema-snapshot.test.ts
+++ b/sdk/tests/rest/schema-snapshot.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest';
+import { schemaSnapshot } from '../../src/index.js';
+import type { TestSchema } from '../schema.js';
+
+describe('schemaSnapshot', () => {
+	test('requests a full snapshot with no params when no options are given', () => {
+		const request = schemaSnapshot<TestSchema>()();
+
+		expect(request).toEqual({
+			method: 'GET',
+			path: '/schema/snapshot',
+			params: {},
+		});
+	});
+
+	test('sends the included collections as a comma-separated param', () => {
+		const request = schemaSnapshot<TestSchema>({ includeCollections: ['collection_a', 'collection_b'] })();
+
+		expect(request.params).toEqual({ includeCollections: 'collection_a,collection_b' });
+	});
+
+	test('sends the excluded collections as a comma-separated param', () => {
+		const request = schemaSnapshot<TestSchema>({ excludeCollections: ['collection_a', 'collection_b'] })();
+
+		expect(request.params).toEqual({ excludeCollections: 'collection_a,collection_b' });
+	});
+
+	test('throws when both includeCollections and excludeCollections are given', () => {
+		expect(() =>
+			schemaSnapshot<TestSchema>({
+				includeCollections: ['collection_a'],
+				excludeCollections: ['collection_b'],
+			})(),
+		).toThrow('"includeCollections" and "excludeCollections" parameters cannot be used together');
+	});
+});

--- a/tests/e2e/tests/schema/partial-snapshot.test.ts
+++ b/tests/e2e/tests/schema/partial-snapshot.test.ts
@@ -1,25 +1,22 @@
-import { randomUUID } from 'node:crypto';
 import { createCollection, createDirectus, deleteCollection, rest, schemaSnapshot, staticToken } from '@directus/sdk';
 import { port } from '@utils/constants.js';
-import { afterAll, describe, expect, test } from 'vitest';
+import { getUID } from '@utils/getUID.js';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 const api = createDirectus(`http://localhost:${port}`).with(rest()).with(staticToken('admin'));
 
-const suffix = randomUUID().replace(/-/g, '');
+const suffix = getUID();
 const authors = `authors_${suffix}`;
 const articles = `articles_${suffix}`;
 const tags = `tags_${suffix}`;
 
-const intPrimaryKey = () => ({
-	field: 'id',
-	type: 'integer' as const,
-	meta: { hidden: true },
-	schema: { is_primary_key: true, has_auto_increment: true },
-});
+const createTable = (collection: string) => api.request(createCollection({ collection, schema: {}, meta: {} }));
 
-await api.request(createCollection({ collection: authors, fields: [intPrimaryKey()], schema: {}, meta: {} }));
-await api.request(createCollection({ collection: articles, fields: [intPrimaryKey()], schema: {}, meta: {} }));
-await api.request(createCollection({ collection: tags, fields: [intPrimaryKey()], schema: {}, meta: {} }));
+beforeAll(async () => {
+	await createTable(authors);
+	await createTable(articles);
+	await createTable(tags);
+});
 
 afterAll(async () => {
 	await api.request(deleteCollection(articles)).catch(() => {});

--- a/tests/e2e/tests/schema/partial-snapshot.test.ts
+++ b/tests/e2e/tests/schema/partial-snapshot.test.ts
@@ -1,0 +1,55 @@
+import { randomUUID } from 'node:crypto';
+import { createCollection, createDirectus, deleteCollection, rest, schemaSnapshot, staticToken } from '@directus/sdk';
+import { port } from '@utils/constants.js';
+import { afterAll, describe, expect, test } from 'vitest';
+
+const api = createDirectus(`http://localhost:${port}`).with(rest()).with(staticToken('admin'));
+
+const suffix = randomUUID().replace(/-/g, '');
+const authors = `authors_${suffix}`;
+const articles = `articles_${suffix}`;
+const tags = `tags_${suffix}`;
+
+const intPrimaryKey = () => ({
+	field: 'id',
+	type: 'integer' as const,
+	meta: { hidden: true },
+	schema: { is_primary_key: true, has_auto_increment: true },
+});
+
+await api.request(createCollection({ collection: authors, fields: [intPrimaryKey()], schema: {}, meta: {} }));
+await api.request(createCollection({ collection: articles, fields: [intPrimaryKey()], schema: {}, meta: {} }));
+await api.request(createCollection({ collection: tags, fields: [intPrimaryKey()], schema: {}, meta: {} }));
+
+afterAll(async () => {
+	await api.request(deleteCollection(articles)).catch(() => {});
+	await api.request(deleteCollection(authors)).catch(() => {});
+	await api.request(deleteCollection(tags)).catch(() => {});
+});
+
+const owners = (rows: Record<string, any>[]) => rows.map((row) => row['collection']);
+
+describe('GET /schema/snapshot — partial (collection scoping)', () => {
+	test('scopes the snapshot to the included collections', async () => {
+		const snapshot = await api.request(schemaSnapshot({ includeCollections: [articles, authors] }));
+
+		expect(snapshot.version).toBe(2);
+		expect(owners(snapshot.collections).sort()).toEqual([articles, authors].sort());
+		expect(owners(snapshot.fields)).not.toContain(tags);
+	});
+
+	test('excludes the named collections from the snapshot', async () => {
+		const snapshot = await api.request(schemaSnapshot({ excludeCollections: [tags] }));
+
+		expect(snapshot.version).toBe(2);
+		expect(owners(snapshot.collections)).toContain(articles);
+		expect(owners(snapshot.collections)).not.toContain(tags);
+	});
+
+	test('silently skips an unknown collection name', async () => {
+		const snapshot = await api.request(schemaSnapshot({ includeCollections: [articles, `missing_${suffix}`] }));
+
+		expect(snapshot.version).toBe(2);
+		expect(owners(snapshot.collections)).toEqual([articles]);
+	});
+});


### PR DESCRIPTION
## Scope

What's changed:

- Added support for collection scoping on schema snapshot via new `includeCollections`/`excludeCollections` parameters
- Partial snapshots are indicated by `version: 2`, full remain as `version: 1`
- Relations to out-of-scope collections are not returned in the snapshot, the indicated collections are assumed to be the full picture.

## Potential Risks / Drawbacks

- CA partial snapshot can reference relations/targets not contained within it, if the expected collections are not existing on the target will result in an error.

## Tested Scenarios

- [x] No include/exclude collections returns full schema
- [x] Include collections returns only specified collection(s)
- [x] Exclude collection returns all collection(s) aside from specified
- [x] Unknown collections are ignored 

## Review Notes / Questions

- Unknown/system names are silently skipped by design

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or **not required** - Done as part of CMS-2792
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or **not required** - Done as part of CMS-2792

---

Fixes CMS-2781
