### PR TITLE
Fix maildev test

### DIFF
--- a/tests/sandbox/src/docker/maildev.yml
+++ b/tests/sandbox/src/docker/maildev.yml
@@ -1,6 +1,6 @@
 services:
   maildev:
-    image: maildev/maildev:latest
+    image: maildev/maildev:2.2.1
     platform: linux/amd64
     ports:
       - '${MAILDEV_WEBUI}:1080' # Web interface


### PR DESCRIPTION
## Scope

What's changed:

- We were using `maildev:latest` for our e2e tests and maildev recently released `v3.0.0-rc.1` as their latest version breaking our tests
