### PR TITLE
Emphasize minimal inline comments in AGENTS.md

### DIFF
--- a/.changeset/reduce-comment-verbosity-guidance.md
+++ b/.changeset/reduce-comment-verbosity-guidance.md
@@ -1,0 +1,4 @@
+---
+---
+
+Added inline comment guidelines to AGENTS.md, docs only, no release

--- a/.changeset/reduce-comment-verbosity-guidance.md
+++ b/.changeset/reduce-comment-verbosity-guidance.md
@@ -1,4 +1,0 @@
----
----
-
-Added inline comment guidelines to AGENTS.md, docs only, no release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,9 @@ TEST_DB=postgres pnpm test:blackbox  # Against specific database
 - Prefer `const` over `let`, avoid `var`
 - Follow existing ESLint and Prettier configurations
 - Test files named `*.test.ts`, placed next to source files
+- Keep inline comments minimal and concise; add them only when strictly needed (non-obvious logic, gotchas, why not
+  what)
+- Don't comment what the code already says; delete redundant or narrating comments
 
 ## Testing Conventions
 


### PR DESCRIPTION
## Scope

What's changed:

- Added two inline comment rules to the Code Style section of `AGENTS.md`: keep comments minimal and only when strictly needed (non-obvious logic, gotchas, why not what), and don't comment what the code already says

## Potential Risks / Drawbacks

- None, guidance-only change for AI coding assistants

## Tested Scenarios

- `prettier --check AGENTS.md` passes

## Review Notes / Questions

- Aimed at reducing redundant/narrating comments in AI-generated PRs
- Docs only, labeled `No Changeset`

## Checklist

- [x] Added or updated tests (not required)
- [x] Documentation PR created [here](https://github.com/directus/docs) or not required
- [x] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required