### PR TITLE
Add missing param def for `/users/{id}/tfa/disable`

### DIFF
--- a/packages/specs/src/paths/users/pk-tfa-disable.yaml
+++ b/packages/specs/src/paths/users/pk-tfa-disable.yaml
@@ -11,3 +11,5 @@ post:
       $ref: '../../openapi.yaml#/components/responses/ForbiddenError'
   tags:
     - Users
+parameters:
+  - $ref: '../../openapi.yaml#/components/parameters/UUId'


### PR DESCRIPTION
## What's Changed

- Added a missing param def/ref for `/users/{id}/tfa/disable` added in #27857

## Tested Scenarios

- N/A

## Review Notes / Questions / Concerns

- N/A

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [x] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes N/A
