### PR TITLE
Fix schema apply ignoring configured license

### DIFF
--- a/.changeset/quick-melons-camp.md
+++ b/.changeset/quick-melons-camp.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed the `schema apply` CLI command ignoring the configured license
+Fix schema apply ignoring configured license

--- a/.changeset/quick-melons-camp.md
+++ b/.changeset/quick-melons-camp.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed the `schema apply` CLI command ignoring the configured license

--- a/.changeset/quick-melons-camp.md
+++ b/.changeset/quick-melons-camp.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fix schema apply ignoring configured license
+Fixed schema apply ignoring configured license

--- a/api/src/cli/commands/schema/apply.test.ts
+++ b/api/src/cli/commands/schema/apply.test.ts
@@ -10,6 +10,7 @@ import { createTracker, MockClient, Tracker } from 'knex-mock-client';
 import type { MockedFunction } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import getDatabase, { isInstalled, validateDatabaseConnection } from '../../../database/index.js';
+import { getLicenseManager } from '../../../license/index.js';
 import { useLogger } from '../../../logger/index.js';
 import { applySnapshot } from '../../../utils/apply-snapshot.js';
 import { getSnapshotDiff } from '../../../utils/get-snapshot-diff.js';
@@ -18,6 +19,7 @@ import { apply, filterSnapshotDiff, formatPath, formatRelatedCollection } from '
 
 vi.mock('inquirer');
 vi.mock('../../../database/index.js');
+vi.mock('../../../license/index.js');
 vi.mock('../../../logger/index.js');
 vi.mock('../../../utils/apply-snapshot.js');
 vi.mock('../../../utils/get-snapshot-diff.js');
@@ -263,6 +265,7 @@ describe('apply command', () => {
 	describe('apply function', () => {
 		let mockLogger: any;
 		let mockDatabase: any;
+		let mockLicenseManager: any;
 
 		beforeEach(() => {
 			// Setup mocks
@@ -275,8 +278,13 @@ describe('apply command', () => {
 				destroy: vi.fn(),
 			};
 
+			mockLicenseManager = {
+				initialize: vi.fn().mockResolvedValue(undefined),
+			};
+
 			// Setup default mock implementations
 			vi.mocked(getDatabase).mockReturnValue(mockDatabase as Knex);
+			vi.mocked(getLicenseManager).mockReturnValue(mockLicenseManager);
 			vi.mocked(useLogger).mockReturnValue(mockLogger);
 			vi.mocked(validateDatabaseConnection).mockResolvedValue(undefined);
 			vi.mocked(isInstalled).mockResolvedValue(true);

--- a/api/src/cli/commands/schema/apply.ts
+++ b/api/src/cli/commands/schema/apply.ts
@@ -7,6 +7,7 @@ import chalk from 'chalk';
 import inquirer from 'inquirer';
 import { load as loadYaml } from 'js-yaml';
 import getDatabase, { isInstalled, validateDatabaseConnection } from '../../../database/index.js';
+import { getLicenseManager } from '../../../license/index.js';
 import { useLogger } from '../../../logger/index.js';
 import { isNestedMetaUpdate } from '../../../utils/apply-diff.js';
 import { applySnapshot } from '../../../utils/apply-snapshot.js';
@@ -211,6 +212,9 @@ export async function apply(
 				process.exit(0);
 			}
 		}
+
+		// Load the license so schema changes are checked against the active limits
+		await getLicenseManager().initialize();
 
 		await applySnapshot(snapshot, { current: currentSnapshot, diff: snapshotDiff, database });
 


### PR DESCRIPTION
## What's Changed

- Load license before applying cli snapshot

## Tested Scenarios

- [x] No license key limits and throws limit exceeded
- [x] Snapshot allows above core tier when within set license limits

## Review Notes / Questions / Concerns

- N/A

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes #27833
