### PR TITLE
Fix save-as-copy creating empty M2M children after reordering

### DIFF
--- a/.changeset/clever-feet-ring.md
+++ b/.changeset/clever-feet-ring.md
@@ -1,5 +1,5 @@
 ---
-'@directus/app': minor
+'@directus/app': patch
 ---
 
 Amended app's save-as-copy logic to not create new items when only adjusting order on relationals

--- a/.changeset/clever-feet-ring.md
+++ b/.changeset/clever-feet-ring.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Amended app's save-as-copy logic to not create new items when only adjusting order on relationals

--- a/app/src/composables/use-item/index.test.ts
+++ b/app/src/composables/use-item/index.test.ts
@@ -898,3 +898,121 @@ describe('findExistingRelatedItems SEARCH fallback', () => {
 		);
 	});
 });
+
+describe('Save As Copy with M2M relation', () => {
+	const mockCollection = {
+		collection: 'test',
+		meta: {
+			item_duplication_fields: ['children'],
+		},
+	} as unknown as AppCollection;
+
+	const mockPrimaryKeyField = {
+		field: 'id',
+		schema: { has_auto_increment: true },
+	} as Field;
+
+	/**
+	 * Sets up an M2M relation: parent (`test`) -> junction (`test_junction`) -> child (`test_child`),
+	 * all with auto-increment primary keys.
+	 */
+	function setupM2MMocks() {
+		const sdkSpy = vi.spyOn(sdk, 'request');
+
+		vi.mocked(useCollection).mockReturnValue({
+			info: computed(() => mockCollection),
+			primaryKeyField: computed(() => mockPrimaryKeyField),
+			fields: computed(() => [mockPrimaryKeyField] as Field[]),
+		} as any);
+
+		const fieldsStore = useFieldsStore();
+		const relationsStore = useRelationsStore();
+
+		const autoIncrementPk = { field: 'id', schema: { has_auto_increment: true } } as Field;
+		vi.mocked(fieldsStore.getPrimaryKeyFieldForCollection).mockReturnValue(autoIncrementPk);
+
+		vi.mocked(relationsStore.getRelationsForCollection).mockReturnValue([
+			{
+				collection: 'test_junction',
+				field: 'test_id',
+				related_collection: 'test',
+				meta: { one_field: 'children', junction_field: 'child_id' },
+			} as unknown as Relation,
+		]);
+
+		vi.mocked(relationsStore).relations = [
+			{
+				collection: 'test_junction',
+				field: 'child_id',
+				related_collection: 'test_child',
+				meta: { many_field: 'child_id', junction_field: null },
+			} as unknown as Relation,
+		];
+
+		return sdkSpy;
+	}
+
+	test('should keep the existing child link when reordering (link-only update)', async () => {
+		const sdkSpy = setupM2MMocks();
+
+		sdkSpy
+			.mockResolvedValueOnce({}) // initial getItem
+			.mockResolvedValueOnce({ item: { id: 1 } }) // graphql duplication fetch
+			.mockResolvedValueOnce({ id: 2 }); // save
+
+		const { saveAsCopy, edits } = useItem(ref('test'), ref(1));
+
+		// Reordering stages an `update` per row whose junction field carries only the related PK
+		edits.value = {
+			children: {
+				create: [],
+				update: [
+					{ id: 100, sort: 1, child_id: { id: 10 } },
+					{ id: 101, sort: 2, child_id: { id: 11 } },
+				],
+				delete: [],
+			},
+		};
+
+		await saveAsCopy();
+
+		const saveBody = (sdkSpy.mock.lastCall?.[0]() as any).body;
+
+		// The junction PK is dropped (new junction rows) but the child PK is preserved so the copy
+		// re-links to the existing children instead of creating new, empty ones.
+		expect(saveBody.children.create).toEqual([
+			{ sort: 1, child_id: { id: 10 } },
+			{ sort: 2, child_id: { id: 11 } },
+		]);
+
+		expect(saveBody.children.update).toEqual([]);
+	});
+
+	test('should deep-duplicate the child when its content was edited', async () => {
+		const sdkSpy = setupM2MMocks();
+
+		sdkSpy
+			.mockResolvedValueOnce({}) // initial getItem
+			.mockResolvedValueOnce({ item: { id: 1 } }) // graphql duplication fetch
+			.mockResolvedValueOnce({ id: 2 }); // save
+
+		const { saveAsCopy, edits } = useItem(ref('test'), ref(1));
+
+		// The junction field carries more than the related PK, i.e. the child was edited inline
+		edits.value = {
+			children: {
+				create: [],
+				update: [{ id: 100, sort: 1, child_id: { id: 10, name: 'edited' } }],
+				delete: [],
+			},
+		};
+
+		await saveAsCopy();
+
+		const saveBody = (sdkSpy.mock.lastCall?.[0]() as any).body;
+
+		// Both the junction PK and the child PK are dropped so a brand-new child is created
+		expect(saveBody.children.create).toEqual([{ sort: 1, child_id: { name: 'edited' } }]);
+		expect(saveBody.children.update).toEqual([]);
+	});
+});

--- a/app/src/composables/use-item/index.ts
+++ b/app/src/composables/use-item/index.ts
@@ -443,7 +443,16 @@ export function useItem<T extends Item>(
 
 			const relatedItem = item[relation.meta.junction_field];
 
-			if (isObject(relatedItem)) clearPrimaryKey(junctionRelatedPrimaryKeyField, relatedItem);
+			if (!isObject(relatedItem)) return;
+
+			// Only deep-duplicate the related item when it carries edited content. If it's just a PK
+			// reference (e.g. a link-only reorder update), keep the key so the copy re-links to it.
+			const relatedPkField = junctionRelatedPrimaryKeyField?.field;
+			const carriesEditedContent = Object.keys(relatedItem).some((key) => key !== relatedPkField);
+
+			if (!carriesEditedContent) return;
+
+			clearPrimaryKey(junctionRelatedPrimaryKeyField, relatedItem);
 		}
 	}
 

--- a/app/src/composables/use-item/index.ts
+++ b/app/src/composables/use-item/index.ts
@@ -443,8 +443,6 @@ export function useItem<T extends Item>(
 
 			const relatedItem = item[relation.meta.junction_field];
 
-			if (!isObject(relatedItem)) return;
-
 			// Only deep-duplicate the related item when it carries edited content. If it's just a PK
 			// reference (e.g. a link-only reorder update), keep the key so the copy re-links to it.
 			const relatedPkField = junctionRelatedPrimaryKeyField?.field;


### PR DESCRIPTION
## What's Changed

- Fixed **Save as Copy** creating brand-new, empty Many-to-Many children instead of re-linking to the existing ones, when the M2M items had been reordered before copying.
- `clearJunctionRelatedKey` in `use-item` now only strips the related item's primary key when the junction field carries edited content. A bare PK reference (as staged by a link-only reorder update) keeps its key, so the copy re-links to the existing item. Inline-edited related items are still deep-duplicated as before.

## Tested Scenarios

- Item with an M2M relation, **Save as Copy** without changes → copy links to the same children (`parent → child1, child2, child3` ⇒ `parent2 → child1, child2, child3`).
- Reorder the children in the M2M interface, then **Save as Copy** → copy re-links to the same existing children instead of creating new empty ones (previously produced `parent2 → child4, child5, child6`).
- Edit a child's content inline, then **Save as Copy** → child is still deep-duplicated with the edited content.
- Added regression tests in `use-item/index.test.ts` for the link-only reorder and inline-edited cases; confirmed the reorder test fails without the fix.

## Review Notes / Questions / Concerns

- Root cause: reordering stages a link-only `update` alteration per row (via `sortItems` in `list-m2m.vue`) whose junction field holds only the related PK, e.g. `{ child_id: { id: 10 } }`. In `saveAsCopy` these updates are converted to `create` entries, and `clearJunctionRelatedKey` previously stripped the related PK unconditionally — turning each "link to existing child" into "create a new empty child".
- The guard distinguishes a re-link from an edit by the shape of the staged junction payload (PK-only vs. additional fields). Based on how `sortItems` and the M2M drawer stage changes today, a re-link only ever carries the PK, so behavior for genuine inline edits is unchanged.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes cms-2803