### PR TITLE
Add missing `id` path parameter to the `/comments/{id}` OpenAPI spec

### DIFF
--- a/.changeset/fix-comments-path-parameter.md
+++ b/.changeset/fix-comments-path-parameter.md
@@ -1,0 +1,5 @@
+---
+'@directus/specs': patch
+---
+
+Fix missing `id` path parameter declaration on `/comments/{id}` (Fixes #24155)

--- a/.changeset/fix-comments-path-parameter.md
+++ b/.changeset/fix-comments-path-parameter.md
@@ -2,4 +2,4 @@
 '@directus/specs': patch
 ---
 
-Fixed missing `id` path parameter to the `/comments/{id}` OpenAPI spec
+Added missing `id` path parameter to the `/comments/{id}` OpenAPI spec

--- a/.changeset/fix-comments-path-parameter.md
+++ b/.changeset/fix-comments-path-parameter.md
@@ -2,4 +2,4 @@
 '@directus/specs': patch
 ---
 
-Fix missing `id` path parameter declaration on `/comments/{id}` (Fixes #24155)
+Fixed missing `id` path parameter to the `/comments/{id}` OpenAPI spec

--- a/packages/specs/src/paths/comments/comment.yaml
+++ b/packages/specs/src/paths/comments/comment.yaml
@@ -76,3 +76,6 @@ delete:
       description: Successful request
     '401':
       $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
+
+parameters:
+  - $ref: '../../openapi.yaml#/components/parameters/UUId'


### PR DESCRIPTION
## What's Changed

- Added the missing `id` path parameter declaration to `packages/specs/src/paths/comments/comment.yaml`. All operations on `/comments/{id}` were failing OAS validation because the `{id}` path variable was referenced in the path template but never declared as a parameter.

## Tested Scenarios

- `pnpm --filter @directus/specs validate` shows zero new swagger-cli errors relative to `main` (this specific path-template error is eliminated; remaining pre-existing errors on `items.yaml` are unrelated and untouched by this change).

## Review Notes / Questions / Concerns

- Extracted from #27316 as the first, smallest, most isolated piece of that PR's split into scoped follow-ups (see #27700 for the tracking issue covering the rest).
- Also resolves `directus/openapi#23` ("OpenApi spec is broken"), which was filed against the same underlying bug: its body reports the exact same missing `{id}` path parameter on `/comments/{id}`. No separate PR needed in `directus/openapi` but I'm unsure if the `Fixes directus/openapi#23` at the bottom of this message auto-closes that issue or not. If not, it should be manually closed as resolved.

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [x] OpenAPI updated
  - [x] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes #24155
Fixes directus/openapi#23
