### PR TITLE
fix(specs): add missing OpenAPI specs for /server/health, /files/import, /flows/trigger/{id}

### DIFF
--- a/.changeset/tough-dingos-clean.md
+++ b/.changeset/tough-dingos-clean.md
@@ -1,0 +1,5 @@
+---
+'@directus/specs': patch
+---
+
+Added missing OpenAPI specs for /server/health, /files/import, and /flows/trigger/{id}

--- a/packages/specs/src/openapi.yaml
+++ b/packages/specs/src/openapi.yaml
@@ -178,10 +178,14 @@ paths:
     $ref: './paths/files/files.yaml'
   /files/{id}:
     $ref: './paths/files/file.yaml'
+  /files/import:
+    $ref: './paths/files/import.yaml'
 
   # Flows
   /flows:
     $ref: './paths/flows/flows.yaml'
+  /flows/trigger/{id}:
+    $ref: './paths/flows/trigger.yaml'
   /flows/{id}:
     $ref: './paths/flows/flow.yaml'
 
@@ -236,6 +240,8 @@ paths:
     $ref: './paths/server/info.yaml'
   /server/ping:
     $ref: './paths/server/ping.yaml'
+  /server/health:
+    $ref: './paths/server/health.yaml'
 
   # Settings
   /settings:

--- a/packages/specs/src/paths/files/import.yaml
+++ b/packages/specs/src/paths/files/import.yaml
@@ -1,0 +1,34 @@
+post:
+  summary: Import File from URL
+  description: Import a file from a remote URL.
+  operationId: importFile
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - url
+          properties:
+            url:
+              type: string
+              format: uri
+              description: The URL to import the file from
+            data:
+              type: object
+              description: Any additional data to pass along with the file
+            filterMimeType:
+              type: string
+              description: Optional MIME type filter
+  responses:
+    '200':
+      description: Successful request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '../../openapi.yaml#/components/schemas/Files'
+  tags:
+    - Files

--- a/packages/specs/src/paths/flows/trigger.yaml
+++ b/packages/specs/src/paths/flows/trigger.yaml
@@ -1,0 +1,36 @@
+get:
+  summary: Trigger a Flow via GET
+  description: Trigger a flow via a GET webhook request.
+  operationId: triggerFlow
+  parameters:
+    - $ref: '../../openapi.yaml#/components/parameters/UUId'
+  responses:
+    '200':
+      description: Successful request
+      content:
+        application/json:
+          schema:
+            type: object
+  tags:
+    - Flows
+
+post:
+  summary: Trigger a Flow via POST
+  description: Trigger a flow via a POST webhook request.
+  operationId: triggerFlowPost
+  parameters:
+    - $ref: '../../openapi.yaml#/components/parameters/UUId'
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+  responses:
+    '200':
+      description: Successful request
+      content:
+        application/json:
+          schema:
+            type: object
+  tags:
+    - Flows

--- a/packages/specs/src/paths/server/health.yaml
+++ b/packages/specs/src/paths/server/health.yaml
@@ -1,0 +1,56 @@
+get:
+  summary: Health Check
+  description: |-
+    Checks if the server is healthy and can be used.
+    Returns 200 when healthy, 503 when degraded.
+    Only available when HEALTHCHECK_ENABLED is not false.
+  operationId: health
+  responses:
+    '200':
+      description: Healthy
+      content:
+        application/health+json:
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                example: ok
+              releaseId:
+                type: string
+              serviceId:
+                type: string
+              checks:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    type:
+                      type: string
+                    status:
+                      type: string
+                    threshold:
+                      type: integer
+                      nullable: true
+    '503':
+      description: Service Unavailable
+      content:
+        application/health+json:
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                example: error
+              releaseId:
+                type: string
+              serviceId:
+                type: string
+              checks:
+                type: array
+                items:
+                  type: object
+  tags:
+    - Server


### PR DESCRIPTION
Part of the spec drift audit tracked in #27700.

Adds OpenAPI specs for three undocumented endpoint groups:

**`/server/health`** — new file `paths/server/health.yaml`
- `GET /server/health`: returns `200` when healthy or `503` when degraded
- Content-Type: `application/health+json`
- Gated by `HEALTHCHECK_ENABLED` (not available when env var is `false`)

**`/files/import`** — new file `paths/files/import.yaml`
- `POST /files/import`: imports a file from a remote URL
- Accepts `url` (required), optional `data` and `filterMimeType`
- Response schema mirrors the existing Files schema

**`/flows/trigger/{id}`** — new file `paths/flows/trigger.yaml`
- `GET /flows/trigger/{id}`: trigger a flow via GET webhook
- `POST /flows/trigger/{id}`: trigger a flow via POST webhook
- Both accept arbitrary payload and return whatever the flow returns

**`packages/specs/src/openapi.yaml`** — updated with path references for the three new entries

Closes #27765
