### PR TITLE
fix(permissions): deduplicate primaryKeys in validateItemAccess count check

### DIFF
--- a/api/src/permissions/modules/validate-access/lib/validate-item-access.ts
+++ b/api/src/permissions/modules/validate-access/lib/validate-item-access.ts
@@ -66,7 +66,7 @@ export async function validateItemAccess(
 	const ast: AST = {
 		type: 'root',
 		name: options.collection,
-		query: { limit: isSingleton && !hasPrimaryKeys ? 1 : options.primaryKeys!.length },
+		query: { limit: isSingleton && !hasPrimaryKeys ? 1 : [...new Set(options.primaryKeys!)].length },
 		// Act as if every field was a "normal" field
 		children:
 			options.fields?.map((field) => ({ type: 'field', name: field, fieldKey: field, whenCase: [], alias: false })) ??
@@ -131,7 +131,7 @@ export async function validateItemAccess(
 		action: options.action,
 	});
 
-	const expectedCount = isSingleton && !hasPrimaryKeys ? 1 : options.primaryKeys!.length;
+	const expectedCount = isSingleton && !hasPrimaryKeys ? 1 : [...new Set(options.primaryKeys!)].length;
 	const hasAccess = items && items.length === expectedCount;
 
 	if (!hasAccess) {


### PR DESCRIPTION
## The Bug

`validateItemAccess` counts expected rows using `primaryKeys.length`, but the internal query `{ pk: { _in: primaryKeys } }` always returns **distinct** rows from the database. When `primaryKeys` contains duplicates (e.g. `["1","1","2"]`), only 2 distinct rows are returned while `expectedCount` is 3, causing the check to fail even when all referenced rows exist.

The error is reported as a misleading *field-permission FORBIDDEN* because `validateAccess` throws the field-permission error whenever `validateItemAccess` returns false and `options.fields` is set. Admins skip the check entirely, so the same payload succeeds for an administrator, making the bug look like a configuration issue.

## The Fix

Deduplicate `primaryKeys` before computing `expectedCount`:

```
- isSingleton && !hasPrimaryKeys ? 1 : options.primaryKeys!.length
+ isSingleton && !hasPrimaryKeys ? 1 : [...new Set(options.primaryKeys!)].length
```

Closes #27863
