### PR TITLE
fix(api): mark conceal/encrypt fields writeOnly in generated OAS

### DIFF
--- a/.changeset/soft-masks-writeonly.md
+++ b/.changeset/soft-masks-writeonly.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Mark conceal/encrypt fields as writeOnly in the generated OpenAPI schema

--- a/api/src/services/specifications.test.ts
+++ b/api/src/services/specifications.test.ts
@@ -254,6 +254,53 @@ describe('Integration Tests', () => {
 							}
 						`);
 					});
+
+					it('marks conceal/encrypt fields writeOnly, not hash-only', async () => {
+						const maskedSchema = new SchemaBuilder()
+							.collection('test_secrets', (c) => {
+								c.field('id').integer().primary().options({ nullable: false });
+								c.field('api_key').string().options({ special: ['conceal'] });
+								c.field('blob').string().options({ special: ['encrypt'] });
+								c.field('password_hash').hash();
+							})
+							.build();
+
+						const service = new SpecificationService({
+							knex: db,
+							schema: maskedSchema,
+							accountability: { role: 'admin', admin: true } as Accountability,
+						});
+
+						const spec = await service.oas.generate();
+						const properties = (spec.components?.schemas?.['ItemsTestSecrets'] as any)?.properties;
+
+						expect(properties?.api_key?.writeOnly).toBe(true);
+						expect(properties?.blob?.writeOnly).toBe(true);
+						expect(properties?.password_hash?.writeOnly).toBeUndefined();
+						expect(properties?.id?.writeOnly).toBeUndefined();
+					});
+
+					it('marks system Users password writeOnly from the live schema special flags', async () => {
+						const usersSchema = new SchemaBuilder()
+							.collection('directus_users', (c) => {
+								c.field('id').uuid().primary().options({ nullable: false });
+								c.field('password').hash().options({ special: ['hash', 'conceal'] });
+								c.field('email').string();
+							})
+							.build();
+
+						const service = new SpecificationService({
+							knex: db,
+							schema: usersSchema,
+							accountability: { role: 'admin', admin: true } as Accountability,
+						});
+
+						const spec = await service.oas.generate();
+						const properties = (spec.components?.schemas?.['Users'] as any)?.properties;
+
+						expect(properties?.password?.writeOnly).toBe(true);
+						expect(properties?.email?.writeOnly).toBeUndefined();
+					});
 				});
 
 				describe('path', () => {

--- a/api/src/services/specifications.test.ts
+++ b/api/src/services/specifications.test.ts
@@ -259,8 +259,12 @@ describe('Integration Tests', () => {
 						const maskedSchema = new SchemaBuilder()
 							.collection('test_secrets', (c) => {
 								c.field('id').integer().primary().options({ nullable: false });
-								c.field('api_key').string().options({ special: ['conceal'] });
-								c.field('blob').string().options({ special: ['encrypt'] });
+								c.field('api_key')
+									.string()
+									.options({ special: ['conceal'] });
+								c.field('blob')
+									.string()
+									.options({ special: ['encrypt'] });
 								c.field('password_hash').hash();
 							})
 							.build();
@@ -284,7 +288,9 @@ describe('Integration Tests', () => {
 						const usersSchema = new SchemaBuilder()
 							.collection('directus_users', (c) => {
 								c.field('id').uuid().primary().options({ nullable: false });
-								c.field('password').hash().options({ special: ['hash', 'conceal'] });
+								c.field('password')
+									.hash()
+									.options({ special: ['hash', 'conceal'] });
 								c.field('email').string();
 							})
 							.build();

--- a/api/src/services/specifications.test.ts
+++ b/api/src/services/specifications.test.ts
@@ -259,12 +259,15 @@ describe('Integration Tests', () => {
 						const maskedSchema = new SchemaBuilder()
 							.collection('test_secrets', (c) => {
 								c.field('id').integer().primary().options({ nullable: false });
+
 								c.field('api_key')
 									.string()
 									.options({ special: ['conceal'] });
+
 								c.field('blob')
 									.string()
 									.options({ special: ['encrypt'] });
+
 								c.field('password_hash').hash();
 							})
 							.build();
@@ -288,9 +291,11 @@ describe('Integration Tests', () => {
 						const usersSchema = new SchemaBuilder()
 							.collection('directus_users', (c) => {
 								c.field('id').uuid().primary().options({ nullable: false });
+
 								c.field('password')
 									.hash()
 									.options({ special: ['hash', 'conceal'] });
+
 								c.field('email').string();
 							})
 							.build();

--- a/api/src/services/specifications.ts
+++ b/api/src/services/specifications.ts
@@ -394,10 +394,12 @@ class OASSpecsService implements SpecificationSubService {
 				schemaComponent['x-collection'] = collection.collection;
 
 				for (const field of fieldsInCollection) {
-					schemaComponent.properties[field.field] =
+					const property =
 						(cloneDeep(
 							(spec.components!.schemas![tag.name] as SchemaObject).properties![field.field],
 						) as SchemaObject) || this.generateField(schema, collection.collection, field, tags);
+
+					schemaComponent.properties[field.field] = this.applyWriteOnly(property, field);
 				}
 
 				components.schemas[tag.name] = schemaComponent;
@@ -413,7 +415,7 @@ class OASSpecsService implements SpecificationSubService {
 
 				for (const field of fieldsInCollection) {
 					const fieldSchema = this.generateField(schema, collection.collection, field, tags);
-					schemaComponent.properties![field.field] = fieldSchema;
+					schemaComponent.properties![field.field] = this.applyWriteOnly(fieldSchema, field);
 
 					// Check if field is required
 					if (field.nullable === false && field.defaultValue === null && field.generated === false) {
@@ -451,6 +453,15 @@ class OASSpecsService implements SpecificationSubService {
 			default:
 				return 'read';
 		}
+	}
+
+	/** conceal/encrypt fields are masked on every read — mark writeOnly in OAS */
+	private applyWriteOnly(property: SchemaObject, field: FieldOverview): SchemaObject {
+		if (field.special?.includes('conceal') || field.special?.includes('encrypt')) {
+			property.writeOnly = true;
+		}
+
+		return property;
 	}
 
 	private generateField(

--- a/contributors.yml
+++ b/contributors.yml
@@ -291,3 +291,4 @@
 - itsabhay1
 - tsushanth
 - apoorva-01
+- thribhuvan003


### PR DESCRIPTION
fixes directus/directus#27890

conceal/encrypt fields get masked on every read (`**********` / null), but the generated openapi schema still looked like normal readable properties. that confuses codegen.

when `special` includes conceal or encrypt, set `writeOnly: true` — both on system collections (cloned static components) and custom ones. hash-only is left alone since those still come back on read.

tests cover conceal/encrypt/hash-only custom fields plus Users.password on the system path.