### PR TITLE
Skip IP custom header warning for /server/ping and /server/info

### DIFF
--- a/.changeset/ip-custom-header-warning-endpoints.md
+++ b/.changeset/ip-custom-header-warning-endpoints.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Stopped logging the "Custom IP header didn't return valid IP address" warning for requests to the no-auth `/server/ping` and `/server/info` endpoints, which are commonly hit directly (health checks, uptime pings) rather than through the proxy that sets `IP_CUSTOM_HEADER`

--- a/.changeset/ip-custom-header-warning-endpoints.md
+++ b/.changeset/ip-custom-header-warning-endpoints.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Stopped logging the "Custom IP header didn't return valid IP address" warning for requests to the no-auth `/server/ping` and `/server/info` endpoints, which are commonly hit directly (health checks, uptime pings) rather than through the proxy that sets `IP_CUSTOM_HEADER`
+Stopped logging the missing custom IP header warning on `/server/ping` and `/server/info`, which are commonly hit directly (health checks)

--- a/api/src/utils/get-ip-from-req.test.ts
+++ b/api/src/utils/get-ip-from-req.test.ts
@@ -1,9 +1,19 @@
 import type { IncomingMessage } from 'http';
 import { useEnv } from '@directus/env';
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { getIPFromReq } from './get-ip-from-req.js';
 
+const warn = vi.fn();
+
 vi.mock('@directus/env');
+
+vi.mock('../logger/index.js', () => ({
+	useLogger: vi.fn(() => ({ warn })),
+}));
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
 
 describe('getIPFromReq', () => {
 	test('Removes null if ip is undefined', () => {
@@ -57,6 +67,84 @@ describe('getIPFromReq', () => {
 		} as unknown as IncomingMessage);
 
 		expect(result).toBe('127.0.0.2');
+	});
+
+	describe('Custom IP header warning', () => {
+		test('Warns when custom header does not return a valid IP', () => {
+			vi.mocked(useEnv).mockReturnValue({
+				IP_TRUST_PROXY: true,
+				IP_CUSTOM_HEADER: 'X-CUSTOM-IP',
+			});
+
+			getIPFromReq({
+				socket: { remoteAddress: '127.0.0.1' },
+				headers: {},
+				url: '/items/articles',
+			} as unknown as IncomingMessage);
+
+			expect(warn).toHaveBeenCalledOnce();
+		});
+
+		test('Does not warn when the custom header returns a valid IP', () => {
+			vi.mocked(useEnv).mockReturnValue({
+				IP_TRUST_PROXY: true,
+				IP_CUSTOM_HEADER: 'X-CUSTOM-IP',
+			});
+
+			getIPFromReq({
+				socket: { remoteAddress: '127.0.0.1' },
+				headers: { 'x-custom-ip': '127.0.0.2' },
+			} as unknown as IncomingMessage);
+
+			expect(warn).not.toHaveBeenCalled();
+		});
+
+		test.each(['/server/ping', '/server/info'])('Suppresses the warning on the no-auth endpoint %s', (path) => {
+			vi.mocked(useEnv).mockReturnValue({
+				IP_TRUST_PROXY: true,
+				IP_CUSTOM_HEADER: 'X-CUSTOM-IP',
+			});
+
+			const result = getIPFromReq({
+				socket: { remoteAddress: '127.0.0.1' },
+				headers: {},
+				originalUrl: path,
+			} as unknown as IncomingMessage);
+
+			expect(warn).not.toHaveBeenCalled();
+			// Falls back to the resolved socket IP
+			expect(result).toBe('127.0.0.1');
+		});
+
+		test('Suppresses the warning on excluded endpoints even with a query string', () => {
+			vi.mocked(useEnv).mockReturnValue({
+				IP_TRUST_PROXY: true,
+				IP_CUSTOM_HEADER: 'X-CUSTOM-IP',
+			});
+
+			getIPFromReq({
+				socket: { remoteAddress: '127.0.0.1' },
+				headers: {},
+				url: '/server/info?foo=bar',
+			} as unknown as IncomingMessage);
+
+			expect(warn).not.toHaveBeenCalled();
+		});
+
+		test('Still warns on other /server endpoints', () => {
+			vi.mocked(useEnv).mockReturnValue({
+				IP_TRUST_PROXY: true,
+				IP_CUSTOM_HEADER: 'X-CUSTOM-IP',
+			});
+
+			getIPFromReq({
+				socket: { remoteAddress: '127.0.0.1' },
+				headers: {},
+				url: '/server/health',
+			} as unknown as IncomingMessage);
+
+			expect(warn).toHaveBeenCalledOnce();
+		});
 	});
 
 	describe('IP_TRUST_PROXY', () => {

--- a/api/src/utils/get-ip-from-req.test.ts
+++ b/api/src/utils/get-ip-from-req.test.ts
@@ -131,6 +131,36 @@ describe('getIPFromReq', () => {
 			expect(warn).not.toHaveBeenCalled();
 		});
 
+		test('Suppresses the warning regardless of path casing', () => {
+			vi.mocked(useEnv).mockReturnValue({
+				IP_TRUST_PROXY: true,
+				IP_CUSTOM_HEADER: 'X-CUSTOM-IP',
+			});
+
+			getIPFromReq({
+				socket: { remoteAddress: '127.0.0.1' },
+				headers: {},
+				url: '/server/PING',
+			} as unknown as IncomingMessage);
+
+			expect(warn).not.toHaveBeenCalled();
+		});
+
+		test('Does not throw and still warns on a malformed request target', () => {
+			vi.mocked(useEnv).mockReturnValue({
+				IP_TRUST_PROXY: true,
+				IP_CUSTOM_HEADER: 'X-CUSTOM-IP',
+			});
+
+			getIPFromReq({
+				socket: { remoteAddress: '127.0.0.1' },
+				headers: {},
+				url: '//bad url',
+			} as unknown as IncomingMessage);
+
+			expect(warn).toHaveBeenCalledOnce();
+		});
+
 		test('Still warns on other /server endpoints', () => {
 			vi.mocked(useEnv).mockReturnValue({
 				IP_TRUST_PROXY: true,

--- a/api/src/utils/get-ip-from-req.ts
+++ b/api/src/utils/get-ip-from-req.ts
@@ -5,11 +5,7 @@ import type { Request } from 'express';
 import proxyAddr from 'proxy-addr';
 import { useLogger } from '../logger/index.js';
 
-/**
- * No-auth endpoints that are commonly hit directly (health checks, uptime pings) rather than
- * through the proxy that sets IP_CUSTOM_HEADER. The missing-header warning is expected noise on
- * these, so it's suppressed. Auth'd requests still warn, since IP-based permissions may apply.
- */
+// No-auth endpoints often hit directly (health checks/pings), bypassing the IP_CUSTOM_HEADER proxy, so the missing-header warning is just noise.
 const IP_HEADER_WARNING_EXCLUDED_PATHS = new Set(['/server/ping', '/server/info']);
 
 function getReqPathname(req: IncomingMessage | Request): string {

--- a/api/src/utils/get-ip-from-req.ts
+++ b/api/src/utils/get-ip-from-req.ts
@@ -6,6 +6,19 @@ import proxyAddr from 'proxy-addr';
 import { useLogger } from '../logger/index.js';
 
 /**
+ * No-auth endpoints that are commonly hit directly (health checks, uptime pings) rather than
+ * through the proxy that sets IP_CUSTOM_HEADER. The missing-header warning is expected noise on
+ * these, so it's suppressed. Auth'd requests still warn, since IP-based permissions may apply.
+ */
+const IP_HEADER_WARNING_EXCLUDED_PATHS = new Set(['/server/ping', '/server/info']);
+
+function getReqPathname(req: IncomingMessage | Request): string {
+	const rawUrl = ('originalUrl' in req && req.originalUrl) || req.url || '';
+	const end = rawUrl.search(/[?#]/);
+	return end === -1 ? rawUrl : rawUrl.slice(0, end);
+}
+
+/**
  * Generate the trusted ip list
  *
  * Adapted to have feature parity with the express equivalent https://github.com/expressjs/express/blob/9f4dbe3a1332cd883069ba9b73a9eed99234cfc7/lib/utils.js#L192
@@ -44,7 +57,7 @@ export function getIPFromReq(req: IncomingMessage | Request): string | null {
 
 		if (typeof customIPHeaderValue === 'string' && isIP(customIPHeaderValue) !== 0) {
 			ip = customIPHeaderValue;
-		} else {
+		} else if (!IP_HEADER_WARNING_EXCLUDED_PATHS.has(getReqPathname(req))) {
 			logger.warn(`Custom IP header didn't return valid IP address: ${JSON.stringify(customIPHeaderValue)}`);
 		}
 	}

--- a/api/src/utils/get-ip-from-req.ts
+++ b/api/src/utils/get-ip-from-req.ts
@@ -5,17 +5,15 @@ import type { Request } from 'express';
 import proxyAddr from 'proxy-addr';
 import { useLogger } from '../logger/index.js';
 
-// No-auth endpoints often hit directly (health checks/pings), bypassing the IP_CUSTOM_HEADER proxy, so the missing-header warning is just noise.
 const IP_HEADER_WARNING_EXCLUDED_PATHS = new Set(['/server/ping', '/server/info']);
 
 function getReqPathname(req: IncomingMessage | Request): string {
 	const rawUrl = ('originalUrl' in req && req.originalUrl) || req.url || '';
 
 	try {
-		// Lower-cased since express routing is case-insensitive by default (/server/PING hits the same endpoint)
+		// Express routing is case-insensitive, so normalize before matching
 		return new URL(rawUrl, 'http://localhost').pathname.toLowerCase();
 	} catch {
-		// Malformed request target (never a valid excluded health-check path); don't throw, just don't suppress
 		return '';
 	}
 }

--- a/api/src/utils/get-ip-from-req.ts
+++ b/api/src/utils/get-ip-from-req.ts
@@ -10,8 +10,14 @@ const IP_HEADER_WARNING_EXCLUDED_PATHS = new Set(['/server/ping', '/server/info'
 
 function getReqPathname(req: IncomingMessage | Request): string {
 	const rawUrl = ('originalUrl' in req && req.originalUrl) || req.url || '';
-	const end = rawUrl.search(/[?#]/);
-	return end === -1 ? rawUrl : rawUrl.slice(0, end);
+
+	try {
+		// Lower-cased since express routing is case-insensitive by default (/server/PING hits the same endpoint)
+		return new URL(rawUrl, 'http://localhost').pathname.toLowerCase();
+	} catch {
+		// Malformed request target (never a valid excluded health-check path); don't throw, just don't suppress
+		return '';
+	}
 }
 
 /**


### PR DESCRIPTION
## What's Changed

When `IP_CUSTOM_HEADER` is set (e.g. Cloudflare / a WAF), `getIPFromReq` logs `Custom IP header didn't return valid IP address` on every request that arrives without a valid value in that header. Behind a proxy that also receives direct traffic (platform health checks, uptime pings) this fires constantly and floods the logs (observed on Northflank).

- Skip that warning for the no-auth endpoints that legitimately get hit directly, bypassing the proxy: `/server/ping` and `/server/info`.
- Single path-based exclusion in `getIPFromReq`, so it covers all call sites (rate limiters, authenticate middleware, response logger).
- Everything else keeps warning. For auth'd requests IP-based permissions may apply, so the signal stays useful there.

This is the outcome of the RFR discussion on #27901 (which proposed a blanket `IP_CUSTOM_HEADER_WARNINGS` env var). That approach was rejected as too specific; this endpoint-scoped fix supersedes it. Thread: https://directus-team.slack.com/archives/C08R1EJD89Y/p1783953280381289?thread_ts=1783939354.754399&cid=C08R1EJD89Y

## Tested Scenarios

- Unit tests in `get-ip-from-req.test.ts`: warns on a normal path (`/items/articles`); suppressed on `/server/ping` and `/server/info` (incl. with a query string); still warns on other `/server` paths (`/server/health`); no warning when the header returns a valid IP.
- Full file suite: 15 passed.

## Review Notes / Questions / Concerns

- Path is read from `req.originalUrl || req.url` (query/hash stripped) so it works for both the express `Request` and the raw `IncomingMessage` passed by the response logger.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] Environment variables documented for new/changed config

---

Closes [CMS-2829](https://linear.app/directus/issue/CMS-2829/skip-ip-custom-header-warning-for-serverping-and-serverinfo)
