### PR TITLE
fix: deduplicate primaryKeys before count comparison in validateItemAccess

### DIFF
--- a/api/src/permissions/modules/validate-access/lib/validate-item-access.ts
+++ b/api/src/permissions/modules/validate-access/lib/validate-item-access.ts
@@ -131,7 +131,7 @@ export async function validateItemAccess(
 		action: options.action,
 	});
 
-	const expectedCount = isSingleton && !hasPrimaryKeys ? 1 : options.primaryKeys!.length;
+	const expectedCount = isSingleton && !hasPrimaryKeys ? 1 : new Set(options.primaryKeys!).size;
 	const hasAccess = items && items.length === expectedCount;
 
 	if (!hasAccess) {


### PR DESCRIPTION
## Description

When a non-admin user sends a request with duplicate primary keys (e.g. the same item ID appearing multiple times in a batch), the access validation calculates `expectedCount = primaryKeys.length` which counts duplicates. However, the database query returns distinct rows, so the counts never match and access is incorrectly denied.

This manifests as non-admin users getting permission denied errors when performing operations that include duplicate primary keys.

## Fix

Changed to deduplicate primaryKeys before calculating the expected count:

```typescript
// Before (buggy)
const expectedCount = isSingleton && !hasPrimaryKeys ? 1 : options.primaryKeys!.length;

// After (fixed)
const expectedCount = isSingleton && !hasPrimaryKeys ? 1 : new Set(options.primaryKeys!).size;
```

`new Set()` deduplicates the array, so the expected count matches what the database actually returns.

Fixes directus/directus#27863