### PR TITLE
Show collection title with display template

### DIFF
--- a/.changeset/metal-comics-chew.md
+++ b/.changeset/metal-comics-chew.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added collection title to always display beside collection display template on item view

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -1032,7 +1032,8 @@ function useAutoSwitchToDraft() {
 		<template v-else-if="isNew === false && collectionInfo.meta && collectionInfo.meta.display_template" #title>
 			<VSkeletonLoader v-if="loading" class="title-loader" type="text" />
 
-			<h1 v-else class="type-title">
+			<h1 v-else class="type-title type-title-template">
+				{{ collectionInfo.name }}:
 				<RenderTemplate
 					:collection="collectionInfo.collection"
 					:item="templateData"
@@ -1405,6 +1406,18 @@ function useAutoSwitchToDraft() {
 
 :deep(.type-title) {
 	min-inline-size: 0;
+}
+
+.type-title-template {
+	display: flex;
+	gap: 0.25rem;
+
+	:deep(.render-template) {
+		.vertical-aligner,
+		> * {
+			vertical-align: bottom;
+		}
+	}
 }
 
 .content-split {


### PR DESCRIPTION
## What's Changed

- The collection name will now always display beside a rendered display template

Before
<img width="302" height="94" alt="CleanShot 2026-07-14 at 17 54 04" src="https://github.com/user-attachments/assets/51f8f533-e4a9-4377-be8d-0ccd8ef8ba1a" />

After
<img width="417" height="127" alt="CleanShot 2026-07-14 at 17 53 46" src="https://github.com/user-attachments/assets/986fbae0-a027-4af9-b2f9-5cad4d8040df" />


## Tested Scenarios

- Tested with and without display template set
- Tested with creating new item (display template not shown)

## Review Notes / Questions / Concerns

- It was tricky getting them to line up correctly, please check my thinking on the CSS

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes CMS-2598
