### PR TITLE
tw ← Tiptap WYSIWYG: preserve non-schema semantic HTML tags (CMS-2839)

### DIFF
--- a/.changeset/wysiwyg-tiptap-semantic-html.md
+++ b/.changeset/wysiwyg-tiptap-semantic-html.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Preserved non-schema semantic HTML tags (section, article, figure, details, dl, mark, abbr) in the Tiptap rich text editor

--- a/app/src/interfaces/input-rich-text-html/extensions/index.ts
+++ b/app/src/interfaces/input-rich-text-html/extensions/index.ts
@@ -6,6 +6,7 @@ import { CustomImage } from './image';
 import { Media } from './media';
 import { PageBreak } from './page-break';
 import { PreKeymap } from './pre-keymap';
+import { semanticHtml } from './semantic-html';
 import { CustomSubscript, CustomSuperscript } from './subscript-superscript';
 import { Table } from './table';
 import { TextAlignment } from './text-alignment';
@@ -38,4 +39,5 @@ export const editorExtensions = [
 	Table,
 	PreKeymap,
 	CharacterCount,
+	...semanticHtml,
 ];

--- a/app/src/interfaces/input-rich-text-html/extensions/semantic-html.ts
+++ b/app/src/interfaces/input-rich-text-html/extensions/semantic-html.ts
@@ -1,0 +1,145 @@
+import { type AnyExtension, Mark, Node } from '@tiptap/vue-3';
+
+/**
+ * Parse/serialize fidelity extensions for semantic HTML tags the base schema doesn't model.
+ * Without these, the tags are unwrapped or dropped on the first edit + save. No toolbar UI or
+ * commands; only allowlisted attributes round-trip (`details[open]`, `abbr[title]`).
+ */
+
+/** Block container that wraps other block content (`<section>`, `<article>`, …). */
+function blockContainer(name: string, tag: string, content = 'block+') {
+	return Node.create({
+		name,
+		group: 'block',
+		content,
+		defining: true,
+
+		parseHTML() {
+			return [{ tag }];
+		},
+
+		renderHTML({ HTMLAttributes }) {
+			return [tag, HTMLAttributes, 0];
+		},
+	});
+}
+
+/** Inline-content child node only valid inside its parent container (`<figcaption>`, `<dt>`, …). */
+function inlineChild(name: string, tag: string) {
+	return Node.create({
+		name,
+		content: 'inline*',
+		defining: true,
+
+		parseHTML() {
+			return [{ tag }];
+		},
+
+		renderHTML({ HTMLAttributes }) {
+			return [tag, HTMLAttributes, 0];
+		},
+	});
+}
+
+export const Section = blockContainer('section', 'section');
+
+export const Article = blockContainer('article', 'article');
+
+// `(block | figcaption)+` instead of the spec's caption-first-or-last so any authored order survives
+export const Figure = blockContainer('figure', 'figure', '(block | figcaption)+');
+
+export const Figcaption = inlineChild('figcaption', 'figcaption');
+
+export const Details = Node.create({
+	name: 'details',
+	group: 'block',
+	content: '(detailsSummary | block)+',
+	defining: true,
+
+	addAttributes() {
+		return {
+			open: {
+				default: false,
+				parseHTML: (element) => element.hasAttribute('open'),
+				renderHTML: (attributes) => (attributes.open ? { open: '' } : {}),
+			},
+		};
+	},
+
+	parseHTML() {
+		return [{ tag: 'details' }];
+	},
+
+	renderHTML({ HTMLAttributes }) {
+		return ['details', HTMLAttributes, 0];
+	},
+});
+
+export const DetailsSummary = inlineChild('detailsSummary', 'summary');
+
+export const DescriptionList = blockContainer('descriptionList', 'dl', '(descriptionTerm | descriptionDetails)+');
+
+export const DescriptionTerm = inlineChild('descriptionTerm', 'dt');
+
+// block content (unlike `<dt>`) so multi-paragraph definitions keep their structure
+export const DescriptionDetails = Node.create({
+	name: 'descriptionDetails',
+	content: 'block+',
+	defining: true,
+
+	parseHTML() {
+		return [{ tag: 'dd' }];
+	},
+
+	renderHTML({ HTMLAttributes }) {
+		return ['dd', HTMLAttributes, 0];
+	},
+});
+
+export const Highlight = Mark.create({
+	name: 'highlight',
+
+	parseHTML() {
+		return [{ tag: 'mark' }];
+	},
+
+	renderHTML({ HTMLAttributes }) {
+		return ['mark', HTMLAttributes, 0];
+	},
+});
+
+export const Abbreviation = Mark.create({
+	name: 'abbreviation',
+
+	addAttributes() {
+		return {
+			title: {
+				default: null,
+				parseHTML: (element) => element.getAttribute('title'),
+				renderHTML: (attributes) => (attributes.title ? { title: attributes.title } : {}),
+			},
+		};
+	},
+
+	parseHTML() {
+		return [{ tag: 'abbr' }];
+	},
+
+	renderHTML({ HTMLAttributes }) {
+		return ['abbr', HTMLAttributes, 0];
+	},
+});
+
+export const semanticHtml: AnyExtension[] = [
+	Section,
+	Article,
+	Figure,
+	Figcaption,
+	Details,
+	DetailsSummary,
+	DescriptionList,
+	DescriptionTerm,
+	DescriptionDetails,
+	Highlight,
+	Abbreviation,
+];

--- a/app/src/interfaces/input-rich-text-html/round-trip.test.ts
+++ b/app/src/interfaces/input-rich-text-html/round-trip.test.ts
@@ -89,6 +89,45 @@ describe('round-trip: faithful (StarterKit + TextStyleKit schema)', () => {
 	});
 });
 
+/**
+ * Non-schema semantic tags preserved by the semantic-html extensions. Exact-equality assertions
+ * (not snapshots) so the preserved form, including which attributes survive, is explicit:
+ * `details[open]`, `abbr[title]`. Other attributes (class/id/data-/aria-) are not yet preserved.
+ */
+const SEMANTIC: Record<string, string> = {
+	section: '<section><p>text</p></section>',
+	article: '<article><p>text</p></article>',
+	'nested section in article': '<article><section><p>text</p></section></article>',
+	'figure with figcaption': '<figure><img src="/assets/abc" alt="photo"><figcaption>A caption</figcaption></figure>',
+	'figure with figcaption first':
+		'<figure><figcaption>A caption</figcaption><img src="/assets/abc" alt="photo"></figure>',
+	'details with summary': '<details><summary>More info</summary><p>Hidden content</p></details>',
+	'details open': '<details open=""><summary>More info</summary><p>Visible content</p></details>',
+	'description list':
+		'<dl><dt>Term</dt><dd><p>Definition</p></dd><dt>Other term</dt><dd><p>Other definition</p></dd></dl>',
+	mark: '<p>text with <mark>highlight</mark></p>',
+	abbr: '<p><abbr title="HyperText Markup Language">HTML</abbr> is a language</p>',
+	'abbr without title': '<p><abbr>HTML</abbr> is a language</p>',
+};
+
+describe('round-trip: semantic tags (preservation extensions)', () => {
+	test.each(Object.entries(SEMANTIC))('%s survives round-trip unchanged', (_name, html) => {
+		expect(roundTrip(html)).toBe(html);
+	});
+
+	test('details bare open attribute normalizes to open=""', () => {
+		expect(roundTrip('<details open><summary>t</summary><p>c</p></details>')).toBe(
+			'<details open=""><summary>t</summary><p>c</p></details>',
+		);
+	});
+
+	test('dd plain text is wrapped in a paragraph', () => {
+		expect(roundTrip('<dl><dt>Term</dt><dd>Definition</dd></dl>')).toBe(
+			'<dl><dt>Term</dt><dd><p>Definition</p></dd></dl>',
+		);
+	});
+});
+
 describe('round-trip: image', () => {
 	test('preserves src with query params, alt, and loading="lazy"', () => {
 		const out = roundTrip('<img src="/assets/abc?width=100&access_token=x" loading="lazy" alt="alt">');


### PR DESCRIPTION
## What's Changed

- Added parse/serialize fidelity extensions for semantic HTML tags the base Tiptap schema doesn't model: `<section>`, `<article>`, `<figure>`/`<figcaption>`, `<details>`/`<summary>`, `<dl>`/`<dt>`/`<dd>`, `<mark>`, `<abbr>`
- Without these, such tags were unwrapped or dropped on the first edit + save; now they round-trip unchanged
- No toolbar UI or editor commands, these are preservation-only extensions
- Only allowlisted attributes survive: `details[open]` and `abbr[title]`; other attributes (class/id/data-/aria-) are not yet preserved

## Tested Scenarios

- Round-trip unit tests for every preserved tag with exact-equality assertions (62 tests pass), including nested containers, figcaption in any position, `details open` normalization, and `<dd>` plain-text wrapping

## Review Notes / Questions / Concerns

- `<figure>` content is `(block | figcaption)+` instead of the spec's caption-first-or-last so any authored order survives
- `<dd>` accepts block content (unlike `<dt>`) so multi-paragraph definitions keep their structure
- Attribute preservation beyond the allowlist (class/id/data-) is intentionally out of scope here

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes CMS-2839
