### PR TITLE
 prevent conditions value disappearing while editing

### DIFF
--- a/.changeset/gentle-windows-try.md
+++ b/.changeset/gentle-windows-try.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+fix: prevent conditions value disappearing while editing

--- a/app/src/components/v-form/components/form-field.vue
+++ b/app/src/components/v-form/components/form-field.vue
@@ -117,7 +117,9 @@ const showCustomValidationMessage = computed(() => {
 });
 
 function emitValue(value: any) {
-	if (
+	if (props.field.field === 'conditions' && isEqual(value, props.initialValue)) {
+		return;
+	} else if (
 		(isEqual(value, props.initialValue) || (props.initialValue === undefined && isEqual(value, defaultValue.value))) &&
 		props.batchMode === false
 	) {


### PR DESCRIPTION
## What's Changed

When the **conditions** value remains unchanged, `field.meta.conditions` value is removed from the update state. As a result, when the form re-renders, it can no longer find the conditions value, causing the conditions editor to disappear.

This change preserves the conditions state when the value is unchanged

## Tested Scenarios

N/A

## Review Notes / Questions / Concerns

This change is currently scoped to the **conditions** field, as it relies on the field remaining in the update state during editing.

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](<https://github.com/directus/openapi>)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes directus/directus#27896