### PR TITLE
Fix issue causing singleton primary key mismatch

### DIFF
--- a/.changeset/proud-schools-attend.md
+++ b/.changeset/proud-schools-attend.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed issue causing singleton primary key mismatch

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -746,6 +746,12 @@ function useResolvePrimaryKey() {
 	const resolvedPrimaryKey = ref<PrimaryKey | null>(primaryKeyParam.value);
 	const existingPrimaryKey = computed(() => (resolvedPrimaryKey.value === '+' ? null : resolvedPrimaryKey.value));
 
+	// Reset on collection change to avoid previous singleton’s primary key leaking into the next
+	// collection’s queries.
+	watch(collection, () => {
+		resolvedPrimaryKey.value = primaryKeyParam.value;
+	});
+
 	return {
 		primaryKeyParam,
 		resolvedPrimaryKey,


### PR DESCRIPTION
## What's Changed

- Resets `resolvedPrimaryKey` in `useResolvePrimaryKey` (`app/src/modules/content/routes/item.vue`) when the collection
  changes, so a previously resolved singleton primary key no longer leaks into the next collection's queries

## Tested Scenarios

- Navigating between a singleton with an integer primary key and one with a UUID primary key (each with M2M relations)
  no longer produces errors, and network requests filter by the correct key

## Review Notes / Questions / Concerns

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes
[CMS-2842](https://linear.app/directus/issue/CMS-2842/bug-navigating-between-two-singletons-will-result-in-error-when)