### PR TITLE
tw ← Tiptap WYSIWYG: normalization warning + raw HTML mode (CMS-2844)

### DIFF
--- a/.changeset/cms-2844-normalization-warning.md
+++ b/.changeset/cms-2844-normalization-warning.md
@@ -2,4 +2,4 @@
 '@directus/app': minor
 ---
 
-Added a warning dialog on first focus of a Tiptap rich text field when the stored HTML contains markup the editor would normalize on save
+Kept Tiptap rich text fields read-only, with a warning dialog on click, when the stored HTML contains markup the editor would normalize on save, so no edit (or autosave) can rewrite the content before the change is confirmed; the dialog also offers a raw HTML editing mode that swaps in the code interface and preserves the markup verbatim

--- a/.changeset/cms-2844-normalization-warning.md
+++ b/.changeset/cms-2844-normalization-warning.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Added a warning dialog on first focus of a Tiptap rich text field when the stored HTML contains markup the editor would normalize on save

--- a/.changeset/cms-2859-wysiwyg-bubble-menu-crash.md
+++ b/.changeset/cms-2859-wysiwyg-bubble-menu-crash.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the Tiptap rich text editor body disappearing (only the toolbar left visible) when the table bubble menu was removed mid-session, e.g. when the normalization warning locked the field after pasting unsupported markup via Edit Raw Value

--- a/app/src/interfaces/input-rich-text-html/comparison-diff.test.ts
+++ b/app/src/interfaces/input-rich-text-html/comparison-diff.test.ts
@@ -88,7 +88,8 @@ describe('interface wiring', () => {
 	test('normal mode keeps chrome and strips diff spans', async () => {
 		const { wrapper, editor } = await mountInterface({});
 
-		expect(editor.isEditable).toBe(true);
+		// the stripped spans register as normalization loss, so the guard mounts the editor read-only
+		expect(editor.isEditable).toBe(false);
 		expect(wrapper.find('toolbar-stub').exists()).toBe(true);
 		expect(editor.getHTML()).toBe('<p>Hello world</p>');
 	});

--- a/app/src/interfaces/input-rich-text-html/comparison-diff.test.ts
+++ b/app/src/interfaces/input-rich-text-html/comparison-diff.test.ts
@@ -81,7 +81,7 @@ describe('interface wiring', () => {
 		expect(wrapper.find('table-bubble-menu-stub').exists()).toBe(false);
 		// the diff-marked value inflates the count, so the counter must not render either
 		expect(wrapper.find('.remaining').exists()).toBe(false);
-		expect(wrapper.classes()).toContain('non-editable');
+		expect(wrapper.find('.wysiwyg').classes()).toContain('non-editable');
 		expect(editor.getHTML()).toBe(DIFF_HTML);
 	});
 

--- a/app/src/interfaces/input-rich-text-html/components/diff-lines.vue
+++ b/app/src/interfaces/input-rich-text-html/components/diff-lines.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import type { Change } from 'diff';
+import { computed } from 'vue';
+
+const props = defineProps<{ diff: Change[] }>();
+
+type DiffLine = { type: 'added' | 'removed' | 'context'; text: string };
+
+const lines = computed<DiffLine[]>(() => {
+	const result: DiffLine[] = [];
+
+	for (const change of props.diff) {
+		let type: DiffLine['type'] = 'context';
+		if (change.added) type = 'added';
+		else if (change.removed) type = 'removed';
+
+		const parts = change.value.split('\n');
+		// diffLines values end in a trailing newline → drop the empty tail it produces
+		if (parts.at(-1) === '') parts.pop();
+		for (const text of parts) result.push({ type, text });
+	}
+
+	return result;
+});
+</script>
+
+<template>
+	<div class="diff">
+		<span v-for="(line, index) in lines" :key="index" class="line" :class="`line--${line.type}`">
+			{{ line.text || ' ' }}
+		</span>
+	</div>
+</template>
+
+<style lang="scss" scoped>
+.diff {
+	overflow: auto;
+	max-block-size: 50vh;
+	padding: 0.5rem;
+	background-color: var(--theme--background-subdued);
+	border-radius: var(--theme--border-radius);
+	font-family: var(--theme--fonts--monospace--font-family);
+	font-size: 0.8125rem;
+	line-height: 1.6;
+}
+
+.line {
+	display: block;
+	white-space: pre-wrap;
+	padding-inline: 0.25rem;
+}
+
+.line--added {
+	color: var(--theme--success);
+	background-color: var(--theme--success-background);
+}
+
+.line--removed {
+	color: var(--theme--danger);
+	background-color: var(--theme--danger-background);
+}
+</style>

--- a/app/src/interfaces/input-rich-text-html/composables/normalization-diff.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/normalization-diff.ts
@@ -1,6 +1,7 @@
 import { Editor } from '@tiptap/vue-3';
 import { type Change, diffLines } from 'diff';
 import { editorExtensions } from '../extensions';
+import { decodePageBreaks, encodePageBreaks } from '../extensions/page-break';
 import { formatHtml } from './format-html';
 
 // Re-parse through the schema exactly as saveSourceCode will, so the diff compares against what
@@ -12,17 +13,31 @@ function roundTrip(html: string): string {
 	return out;
 }
 
-/**
- * Diffs the drawer's HTML against what saving it would actually store. Both sides run through
- * formatHtml so only semantic loss surfaces, never cosmetic reformatting. Returns null when the
- * document survives normalization unchanged.
- */
-export function computeNormalizationDiff(code: string): Change[] | null {
-	const before = formatHtml(code);
-	const after = formatHtml(roundTrip(code));
+// Both sides run through formatHtml so only semantic loss surfaces, never cosmetic reformatting.
+function diffFormatted(rawBefore: string, rawAfter: string): Change[] | null {
+	const before = formatHtml(rawBefore);
+	const after = formatHtml(rawAfter);
 	if (before === after) return null;
 
 	const changes = diffLines(before, after);
 	if (!changes.some((change) => change.added || change.removed)) return null;
 	return changes;
+}
+
+/**
+ * Diffs the source-code drawer's HTML against what saving it would actually store. Returns null
+ * when the document survives normalization unchanged.
+ */
+export function computeNormalizationDiff(code: string): Change[] | null {
+	return diffFormatted(code, roundTrip(code));
+}
+
+/**
+ * Same check for the stored field value: both sides are compared in the encoded (stored)
+ * representation so the page-break marker ↔ element boundary cancels out instead of reading
+ * as a change.
+ */
+export function computeValueNormalizationDiff(value: string): Change[] | null {
+	const decoded = decodePageBreaks(value);
+	return diffFormatted(encodePageBreaks(decoded), encodePageBreaks(roundTrip(decoded)));
 }

--- a/app/src/interfaces/input-rich-text-html/composables/use-normalization-warning.test.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/use-normalization-warning.test.ts
@@ -1,14 +1,6 @@
-import { afterEach, beforeEach, expect, test } from 'vitest';
-import { nextTick, ref } from 'vue';
-import { NORMALIZATION_WARNING_DISMISSED, useNormalizationWarning } from './use-normalization-warning';
-
-beforeEach(() => {
-	localStorage.removeItem(NORMALIZATION_WARNING_DISMISSED);
-});
-
-afterEach(() => {
-	localStorage.removeItem(NORMALIZATION_WARNING_DISMISSED);
-});
+import { expect, test } from 'vitest';
+import { ref } from 'vue';
+import { useNormalizationWarning } from './use-normalization-warning';
 
 function setup(initialValue: string | null) {
 	const value = ref<string | null>(initialValue);
@@ -100,40 +92,4 @@ test('a re-check after an external value change re-locks even after confirm', ()
 	checkValue();
 
 	expect(normalizationLocked.value).toBe(true);
-});
-
-test('confirm without the checkbox does not persist the opt-out', async () => {
-	const { onLockedClick, confirmNormalizationWarning } = setup(LOSSY);
-
-	onLockedClick();
-	confirmNormalizationWarning();
-	await nextTick();
-
-	expect(localStorage.getItem(NORMALIZATION_WARNING_DISMISSED)).not.toBe('true');
-});
-
-test('confirm with "don\'t show again" persists the opt-out and future instances never lock', async () => {
-	const first = setup(LOSSY);
-
-	first.onLockedClick();
-	first.dontShowAgain.value = true;
-	first.confirmNormalizationWarning();
-	await nextTick();
-
-	expect(localStorage.getItem(NORMALIZATION_WARNING_DISMISSED)).toBe('true');
-
-	const second = setup(LOSSY);
-	expect(second.normalizationLocked.value).toBe(false);
-});
-
-test('cancel with "don\'t show again" persists the opt-out and unlocks instead of bricking the field', async () => {
-	const { normalizationLocked, onLockedClick, dontShowAgain, cancelNormalizationWarning } = setup(LOSSY);
-
-	onLockedClick();
-	dontShowAgain.value = true;
-	cancelNormalizationWarning();
-	await nextTick();
-
-	expect(localStorage.getItem(NORMALIZATION_WARNING_DISMISSED)).toBe('true');
-	expect(normalizationLocked.value).toBe(false);
 });

--- a/app/src/interfaces/input-rich-text-html/composables/use-normalization-warning.test.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/use-normalization-warning.test.ts
@@ -1,90 +1,121 @@
-import { Editor } from '@tiptap/vue-3';
 import { afterEach, beforeEach, expect, test } from 'vitest';
-import { nextTick, ref, shallowRef } from 'vue';
-import { editorExtensions } from '../extensions';
+import { nextTick, ref } from 'vue';
 import { NORMALIZATION_WARNING_DISMISSED, useNormalizationWarning } from './use-normalization-warning';
-
-const editors: Editor[] = [];
 
 beforeEach(() => {
 	localStorage.removeItem(NORMALIZATION_WARNING_DISMISSED);
 });
 
 afterEach(() => {
-	while (editors.length) editors.pop()!.destroy();
+	localStorage.removeItem(NORMALIZATION_WARNING_DISMISSED);
 });
 
 function setup(initialValue: string | null) {
-	const editor = shallowRef(new Editor({ extensions: editorExtensions, content: '' }));
-	editors.push(editor.value);
 	const value = ref<string | null>(initialValue);
-	const usable = useNormalizationWarning(editor, value);
-	return { editor, value, ...usable };
+	const usable = useNormalizationWarning(value);
+	usable.checkValue();
+	return { value, ...usable };
 }
 
 const LOSSY = '<marquee>a</marquee>';
 
-test('focus with clean content shows no warning', () => {
-	const { normalizationWarningOpen, onEditorFocus } = setup('<p>hello <strong>world</strong></p>');
+test('clean content does not lock the editor', () => {
+	const { normalizationLocked } = setup('<p>hello <strong>world</strong></p>');
 
-	onEditorFocus();
-
-	expect(normalizationWarningOpen.value).toBe(false);
+	expect(normalizationLocked.value).toBe(false);
 });
 
-test('focus with unsupported markup opens the warning with a diff', () => {
-	const { normalizationWarningOpen, normalizationWarningDiff, onEditorFocus } = setup(LOSSY);
+test('unsupported markup locks the editor', () => {
+	const { normalizationLocked } = setup(LOSSY);
 
-	onEditorFocus();
+	expect(normalizationLocked.value).toBe(true);
+});
+
+test('clicking a locked editor opens the warning with a diff', () => {
+	const { normalizationWarningOpen, normalizationWarningDiff, onLockedClick } = setup(LOSSY);
+
+	onLockedClick();
 
 	expect(normalizationWarningOpen.value).toBe(true);
 	expect(normalizationWarningDiff.value.length).toBeGreaterThan(0);
 });
 
-test('the warning shows at most once per mount', () => {
-	const { normalizationWarningOpen, onEditorFocus, cancelNormalizationWarning } = setup(LOSSY);
+test('clicking an unlocked editor opens nothing', () => {
+	const { normalizationWarningOpen, onLockedClick } = setup('<p>hello</p>');
 
-	onEditorFocus();
-	cancelNormalizationWarning();
-	onEditorFocus();
+	onLockedClick();
 
 	expect(normalizationWarningOpen.value).toBe(false);
 });
 
-test('page-break storage markers do not trigger the warning', () => {
-	const { normalizationWarningOpen, onEditorFocus } = setup('<p>a</p><!-- pagebreak --><p>b</p>');
+test('page-break storage markers do not lock the editor', () => {
+	const { normalizationLocked } = setup('<p>a</p><!-- pagebreak --><p>b</p>');
 
-	onEditorFocus();
-
-	expect(normalizationWarningOpen.value).toBe(false);
+	expect(normalizationLocked.value).toBe(false);
 });
 
-test('an empty value does not consume the once-per-mount check', () => {
-	const { normalizationWarningOpen, value, onEditorFocus } = setup(null);
+test('an empty value does not lock; a re-check after async load does', () => {
+	const { normalizationLocked, value, checkValue } = setup(null);
 
-	onEditorFocus();
-	expect(normalizationWarningOpen.value).toBe(false);
+	expect(normalizationLocked.value).toBe(false);
 
 	value.value = LOSSY;
-	onEditorFocus();
+	checkValue();
+
+	expect(normalizationLocked.value).toBe(true);
+});
+
+test('confirm closes the warning and unlocks the editor', () => {
+	const { normalizationLocked, normalizationWarningOpen, onLockedClick, confirmNormalizationWarning } = setup(LOSSY);
+
+	onLockedClick();
+	confirmNormalizationWarning();
+
+	expect(normalizationWarningOpen.value).toBe(false);
+	expect(normalizationLocked.value).toBe(false);
+});
+
+test('cancel keeps the editor locked and the warning reopens on the next click', () => {
+	const { normalizationLocked, normalizationWarningOpen, onLockedClick, cancelNormalizationWarning } = setup(LOSSY);
+
+	onLockedClick();
+	cancelNormalizationWarning();
+
+	expect(normalizationWarningOpen.value).toBe(false);
+	expect(normalizationLocked.value).toBe(true);
+
+	onLockedClick();
+
 	expect(normalizationWarningOpen.value).toBe(true);
 });
 
-test('confirm closes the warning without persisting when the checkbox is unchecked', async () => {
-	const { normalizationWarningOpen, onEditorFocus, confirmNormalizationWarning } = setup(LOSSY);
+test('a re-check after an external value change re-locks even after confirm', () => {
+	const { normalizationLocked, value, checkValue, onLockedClick, confirmNormalizationWarning } = setup(LOSSY);
 
-	onEditorFocus();
+	onLockedClick();
+	confirmNormalizationWarning();
+	expect(normalizationLocked.value).toBe(false);
+
+	value.value = '<blink>b</blink>';
+	checkValue();
+
+	expect(normalizationLocked.value).toBe(true);
+});
+
+test('confirm without the checkbox does not persist the opt-out', async () => {
+	const { onLockedClick, confirmNormalizationWarning } = setup(LOSSY);
+
+	onLockedClick();
 	confirmNormalizationWarning();
 	await nextTick();
 
-	expect(normalizationWarningOpen.value).toBe(false);
 	expect(localStorage.getItem(NORMALIZATION_WARNING_DISMISSED)).not.toBe('true');
 });
 
-test('confirm with "don\'t show again" persists the opt-out and suppresses future instances', async () => {
+test('confirm with "don\'t show again" persists the opt-out and future instances never lock', async () => {
 	const first = setup(LOSSY);
 
-	first.onEditorFocus();
+	first.onLockedClick();
 	first.dontShowAgain.value = true;
 	first.confirmNormalizationWarning();
 	await nextTick();
@@ -92,17 +123,17 @@ test('confirm with "don\'t show again" persists the opt-out and suppresses futur
 	expect(localStorage.getItem(NORMALIZATION_WARNING_DISMISSED)).toBe('true');
 
 	const second = setup(LOSSY);
-	second.onEditorFocus();
-	expect(second.normalizationWarningOpen.value).toBe(false);
+	expect(second.normalizationLocked.value).toBe(false);
 });
 
-test('cancel with "don\'t show again" also persists the opt-out', async () => {
-	const { onEditorFocus, dontShowAgain, cancelNormalizationWarning } = setup(LOSSY);
+test('cancel with "don\'t show again" persists the opt-out and unlocks instead of bricking the field', async () => {
+	const { normalizationLocked, onLockedClick, dontShowAgain, cancelNormalizationWarning } = setup(LOSSY);
 
-	onEditorFocus();
+	onLockedClick();
 	dontShowAgain.value = true;
 	cancelNormalizationWarning();
 	await nextTick();
 
 	expect(localStorage.getItem(NORMALIZATION_WARNING_DISMISSED)).toBe('true');
+	expect(normalizationLocked.value).toBe(false);
 });

--- a/app/src/interfaces/input-rich-text-html/composables/use-normalization-warning.test.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/use-normalization-warning.test.ts
@@ -1,0 +1,108 @@
+import { Editor } from '@tiptap/vue-3';
+import { afterEach, beforeEach, expect, test } from 'vitest';
+import { nextTick, ref, shallowRef } from 'vue';
+import { editorExtensions } from '../extensions';
+import { NORMALIZATION_WARNING_DISMISSED, useNormalizationWarning } from './use-normalization-warning';
+
+const editors: Editor[] = [];
+
+beforeEach(() => {
+	localStorage.removeItem(NORMALIZATION_WARNING_DISMISSED);
+});
+
+afterEach(() => {
+	while (editors.length) editors.pop()!.destroy();
+});
+
+function setup(initialValue: string | null) {
+	const editor = shallowRef(new Editor({ extensions: editorExtensions, content: '' }));
+	editors.push(editor.value);
+	const value = ref<string | null>(initialValue);
+	const usable = useNormalizationWarning(editor, value);
+	return { editor, value, ...usable };
+}
+
+const LOSSY = '<marquee>a</marquee>';
+
+test('focus with clean content shows no warning', () => {
+	const { normalizationWarningOpen, onEditorFocus } = setup('<p>hello <strong>world</strong></p>');
+
+	onEditorFocus();
+
+	expect(normalizationWarningOpen.value).toBe(false);
+});
+
+test('focus with unsupported markup opens the warning with a diff', () => {
+	const { normalizationWarningOpen, normalizationWarningDiff, onEditorFocus } = setup(LOSSY);
+
+	onEditorFocus();
+
+	expect(normalizationWarningOpen.value).toBe(true);
+	expect(normalizationWarningDiff.value.length).toBeGreaterThan(0);
+});
+
+test('the warning shows at most once per mount', () => {
+	const { normalizationWarningOpen, onEditorFocus, cancelNormalizationWarning } = setup(LOSSY);
+
+	onEditorFocus();
+	cancelNormalizationWarning();
+	onEditorFocus();
+
+	expect(normalizationWarningOpen.value).toBe(false);
+});
+
+test('page-break storage markers do not trigger the warning', () => {
+	const { normalizationWarningOpen, onEditorFocus } = setup('<p>a</p><!-- pagebreak --><p>b</p>');
+
+	onEditorFocus();
+
+	expect(normalizationWarningOpen.value).toBe(false);
+});
+
+test('an empty value does not consume the once-per-mount check', () => {
+	const { normalizationWarningOpen, value, onEditorFocus } = setup(null);
+
+	onEditorFocus();
+	expect(normalizationWarningOpen.value).toBe(false);
+
+	value.value = LOSSY;
+	onEditorFocus();
+	expect(normalizationWarningOpen.value).toBe(true);
+});
+
+test('confirm closes the warning without persisting when the checkbox is unchecked', async () => {
+	const { normalizationWarningOpen, onEditorFocus, confirmNormalizationWarning } = setup(LOSSY);
+
+	onEditorFocus();
+	confirmNormalizationWarning();
+	await nextTick();
+
+	expect(normalizationWarningOpen.value).toBe(false);
+	expect(localStorage.getItem(NORMALIZATION_WARNING_DISMISSED)).not.toBe('true');
+});
+
+test('confirm with "don\'t show again" persists the opt-out and suppresses future instances', async () => {
+	const first = setup(LOSSY);
+
+	first.onEditorFocus();
+	first.dontShowAgain.value = true;
+	first.confirmNormalizationWarning();
+	await nextTick();
+
+	expect(localStorage.getItem(NORMALIZATION_WARNING_DISMISSED)).toBe('true');
+
+	const second = setup(LOSSY);
+	second.onEditorFocus();
+	expect(second.normalizationWarningOpen.value).toBe(false);
+});
+
+test('cancel with "don\'t show again" also persists the opt-out', async () => {
+	const { onEditorFocus, dontShowAgain, cancelNormalizationWarning } = setup(LOSSY);
+
+	onEditorFocus();
+	dontShowAgain.value = true;
+	cancelNormalizationWarning();
+	await nextTick();
+
+	expect(localStorage.getItem(NORMALIZATION_WARNING_DISMISSED)).toBe('true');
+});

--- a/app/src/interfaces/input-rich-text-html/composables/use-normalization-warning.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/use-normalization-warning.ts
@@ -1,15 +1,11 @@
-import { useLocalStorage } from '@vueuse/core';
 import type { Change } from 'diff';
 import { Ref, ref } from 'vue';
 import { computeValueNormalizationDiff } from './normalization-diff';
-
-export const NORMALIZATION_WARNING_DISMISSED = 'directus-wysiwyg_normalization_warning_dismissed';
 
 type UsableNormalizationWarning = {
 	normalizationLocked: Ref<boolean>;
 	normalizationWarningOpen: Ref<boolean>;
 	normalizationWarningDiff: Ref<Change[]>;
-	dontShowAgain: Ref<boolean>;
 	checkValue: () => void;
 	onLockedClick: () => void;
 	confirmNormalizationWarning: () => void;
@@ -20,21 +16,17 @@ type UsableNormalizationWarning = {
  * Guards stored HTML that contains markup the schema can't represent, i.e. content an edit + save
  * would rewrite (see round-trip.test.ts): the editor stays read-only (`normalizationLocked`) so no
  * edit can reach the value — and thus autosave — until the warning dialog is confirmed. Content
- * that survives normalization never locks. Opt-out persists per browser.
+ * that survives normalization never locks.
  */
 export function useNormalizationWarning(value: Ref<string | null>): UsableNormalizationWarning {
-	const dismissed = useLocalStorage(NORMALIZATION_WARNING_DISMISSED, false);
-
 	const normalizationLocked = ref(false);
 	const normalizationWarningOpen = ref(false);
 	const normalizationWarningDiff = ref<Change[]>([]);
-	const dontShowAgain = ref(false);
 
 	return {
 		normalizationLocked,
 		normalizationWarningOpen,
 		normalizationWarningDiff,
-		dontShowAgain,
 		checkValue,
 		onLockedClick,
 		confirmNormalizationWarning,
@@ -44,7 +36,7 @@ export function useNormalizationWarning(value: Ref<string | null>): UsableNormal
 	// runs on load and on external value changes (async load, revert, version switch) — never on
 	// the editor's own emits, so the round-trip stays off the typing path
 	function checkValue() {
-		if (dismissed.value || !value.value) {
+		if (!value.value) {
 			normalizationLocked.value = false;
 			normalizationWarningDiff.value = [];
 			return;
@@ -61,20 +53,11 @@ export function useNormalizationWarning(value: Ref<string | null>): UsableNormal
 	}
 
 	function confirmNormalizationWarning() {
-		persistOptOut();
 		normalizationWarningOpen.value = false;
 		normalizationLocked.value = false;
 	}
 
 	function cancelNormalizationWarning() {
-		persistOptOut();
 		normalizationWarningOpen.value = false;
-		// opting out on cancel must still unlock — otherwise the field is uneditable with no dialog left
-		if (dismissed.value) normalizationLocked.value = false;
-	}
-
-	// the opt-out is honored on both actions — either way the user explicitly declined future warnings
-	function persistOptOut() {
-		if (dontShowAgain.value) dismissed.value = true;
 	}
 }

--- a/app/src/interfaces/input-rich-text-html/composables/use-normalization-warning.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/use-normalization-warning.ts
@@ -1,4 +1,3 @@
-import type { Editor } from '@tiptap/vue-3';
 import { useLocalStorage } from '@vueuse/core';
 import type { Change } from 'diff';
 import { Ref, ref } from 'vue';
@@ -7,61 +6,71 @@ import { computeValueNormalizationDiff } from './normalization-diff';
 export const NORMALIZATION_WARNING_DISMISSED = 'directus-wysiwyg_normalization_warning_dismissed';
 
 type UsableNormalizationWarning = {
+	normalizationLocked: Ref<boolean>;
 	normalizationWarningOpen: Ref<boolean>;
 	normalizationWarningDiff: Ref<Change[]>;
 	dontShowAgain: Ref<boolean>;
-	onEditorFocus: () => void;
+	checkValue: () => void;
+	onLockedClick: () => void;
 	confirmNormalizationWarning: () => void;
 	cancelNormalizationWarning: () => void;
 };
 
 /**
- * Warns on first focus when the stored HTML contains markup the schema can't represent, i.e. when
- * an edit + save would rewrite it (see round-trip.test.ts). Content that survives normalization
- * never triggers the dialog. Opt-out persists per browser.
+ * Guards stored HTML that contains markup the schema can't represent, i.e. content an edit + save
+ * would rewrite (see round-trip.test.ts): the editor stays read-only (`normalizationLocked`) so no
+ * edit can reach the value — and thus autosave — until the warning dialog is confirmed. Content
+ * that survives normalization never locks. Opt-out persists per browser.
  */
-export function useNormalizationWarning(editor: Ref<Editor>, value: Ref<string | null>): UsableNormalizationWarning {
+export function useNormalizationWarning(value: Ref<string | null>): UsableNormalizationWarning {
 	const dismissed = useLocalStorage(NORMALIZATION_WARNING_DISMISSED, false);
 
+	const normalizationLocked = ref(false);
 	const normalizationWarningOpen = ref(false);
 	const normalizationWarningDiff = ref<Change[]>([]);
 	const dontShowAgain = ref(false);
 
-	// at most one check per mount: keeps the round-trip off every focus and swallows the refocus
-	// the closing dialog hands back to the editor
-	let checked = false;
-
 	return {
+		normalizationLocked,
 		normalizationWarningOpen,
 		normalizationWarningDiff,
 		dontShowAgain,
-		onEditorFocus,
+		checkValue,
+		onLockedClick,
 		confirmNormalizationWarning,
 		cancelNormalizationWarning,
 	};
 
-	function onEditorFocus() {
-		// an empty value doesn't consume the check — async-loaded content is still checked on a later focus
-		if (checked || dismissed.value || !value.value) return;
-		checked = true;
+	// runs on load and on external value changes (async load, revert, version switch) — never on
+	// the editor's own emits, so the round-trip stays off the typing path
+	function checkValue() {
+		if (dismissed.value || !value.value) {
+			normalizationLocked.value = false;
+			normalizationWarningDiff.value = [];
+			return;
+		}
 
 		const diff = computeValueNormalizationDiff(value.value);
-		if (diff === null) return;
+		normalizationLocked.value = diff !== null;
+		normalizationWarningDiff.value = diff ?? [];
+	}
 
-		normalizationWarningDiff.value = diff;
+	function onLockedClick() {
+		if (!normalizationLocked.value) return;
 		normalizationWarningOpen.value = true;
 	}
 
 	function confirmNormalizationWarning() {
 		persistOptOut();
 		normalizationWarningOpen.value = false;
-		editor.value.commands.focus();
+		normalizationLocked.value = false;
 	}
 
 	function cancelNormalizationWarning() {
 		persistOptOut();
 		normalizationWarningOpen.value = false;
-		editor.value.commands.blur();
+		// opting out on cancel must still unlock — otherwise the field is uneditable with no dialog left
+		if (dismissed.value) normalizationLocked.value = false;
 	}
 
 	// the opt-out is honored on both actions — either way the user explicitly declined future warnings

--- a/app/src/interfaces/input-rich-text-html/composables/use-normalization-warning.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/use-normalization-warning.ts
@@ -1,0 +1,71 @@
+import type { Editor } from '@tiptap/vue-3';
+import { useLocalStorage } from '@vueuse/core';
+import type { Change } from 'diff';
+import { Ref, ref } from 'vue';
+import { computeValueNormalizationDiff } from './normalization-diff';
+
+export const NORMALIZATION_WARNING_DISMISSED = 'directus-wysiwyg_normalization_warning_dismissed';
+
+type UsableNormalizationWarning = {
+	normalizationWarningOpen: Ref<boolean>;
+	normalizationWarningDiff: Ref<Change[]>;
+	dontShowAgain: Ref<boolean>;
+	onEditorFocus: () => void;
+	confirmNormalizationWarning: () => void;
+	cancelNormalizationWarning: () => void;
+};
+
+/**
+ * Warns on first focus when the stored HTML contains markup the schema can't represent, i.e. when
+ * an edit + save would rewrite it (see round-trip.test.ts). Content that survives normalization
+ * never triggers the dialog. Opt-out persists per browser.
+ */
+export function useNormalizationWarning(editor: Ref<Editor>, value: Ref<string | null>): UsableNormalizationWarning {
+	const dismissed = useLocalStorage(NORMALIZATION_WARNING_DISMISSED, false);
+
+	const normalizationWarningOpen = ref(false);
+	const normalizationWarningDiff = ref<Change[]>([]);
+	const dontShowAgain = ref(false);
+
+	// at most one check per mount: keeps the round-trip off every focus and swallows the refocus
+	// the closing dialog hands back to the editor
+	let checked = false;
+
+	return {
+		normalizationWarningOpen,
+		normalizationWarningDiff,
+		dontShowAgain,
+		onEditorFocus,
+		confirmNormalizationWarning,
+		cancelNormalizationWarning,
+	};
+
+	function onEditorFocus() {
+		// an empty value doesn't consume the check — async-loaded content is still checked on a later focus
+		if (checked || dismissed.value || !value.value) return;
+		checked = true;
+
+		const diff = computeValueNormalizationDiff(value.value);
+		if (diff === null) return;
+
+		normalizationWarningDiff.value = diff;
+		normalizationWarningOpen.value = true;
+	}
+
+	function confirmNormalizationWarning() {
+		persistOptOut();
+		normalizationWarningOpen.value = false;
+		editor.value.commands.focus();
+	}
+
+	function cancelNormalizationWarning() {
+		persistOptOut();
+		normalizationWarningOpen.value = false;
+		editor.value.commands.blur();
+	}
+
+	// the opt-out is honored on both actions — either way the user explicitly declined future warnings
+	function persistOptOut() {
+		if (dontShowAgain.value) dismissed.value = true;
+	}
+}

--- a/app/src/interfaces/input-rich-text-html/drawers/normalization-warning-dialog.vue
+++ b/app/src/interfaces/input-rich-text-html/drawers/normalization-warning-dialog.vue
@@ -5,7 +5,6 @@ import VButton from '@/components/v-button.vue';
 import VCardActions from '@/components/v-card-actions.vue';
 import VCardTitle from '@/components/v-card-title.vue';
 import VCard from '@/components/v-card.vue';
-import VCheckbox from '@/components/v-checkbox.vue';
 import VDetail from '@/components/v-detail.vue';
 import VDialog from '@/components/v-dialog.vue';
 import VNotice from '@/components/v-notice.vue';
@@ -14,7 +13,6 @@ defineProps<{ diff: Change[] }>();
 const emit = defineEmits<{ confirm: []; cancel: []; raw: [] }>();
 
 const open = defineModel<boolean>({ required: true });
-const dontShowAgain = defineModel<boolean>('dontShowAgain', { required: true });
 </script>
 
 <template>
@@ -28,8 +26,6 @@ const dontShowAgain = defineModel<boolean>('dontShowAgain', { required: true });
 				<VDetail class="detail" :label="$t('wysiwyg_options.normalization_warning_view_changes')">
 					<DiffLines :diff="diff" />
 				</VDetail>
-
-				<VCheckbox v-model="dontShowAgain" :label="$t('wysiwyg_options.normalization_warning_dont_show_again')" />
 			</div>
 
 			<VCardActions>

--- a/app/src/interfaces/input-rich-text-html/drawers/normalization-warning-dialog.vue
+++ b/app/src/interfaces/input-rich-text-html/drawers/normalization-warning-dialog.vue
@@ -11,14 +11,14 @@ import VDialog from '@/components/v-dialog.vue';
 import VNotice from '@/components/v-notice.vue';
 
 defineProps<{ diff: Change[] }>();
-const emit = defineEmits<{ confirm: []; cancel: [] }>();
+const emit = defineEmits<{ confirm: []; cancel: []; raw: [] }>();
 
 const open = defineModel<boolean>({ required: true });
 const dontShowAgain = defineModel<boolean>('dontShowAgain', { required: true });
 </script>
 
 <template>
-	<VDialog v-model="open" @esc="emit('cancel')" @apply="emit('confirm')">
+	<VDialog v-model="open" @esc="emit('cancel')" @apply="emit('raw')">
 		<VCard class="normalization-warning-dialog">
 			<VCardTitle>{{ $t('wysiwyg_options.normalization_warning_title') }}</VCardTitle>
 
@@ -33,8 +33,13 @@ const dontShowAgain = defineModel<boolean>('dontShowAgain', { required: true });
 			</div>
 
 			<VCardActions>
-				<VButton secondary @click="emit('cancel')">{{ $t('cancel') }}</VButton>
-				<VButton @click="emit('confirm')">{{ $t('continue') }}</VButton>
+				<VButton secondary @click="emit('cancel')">
+					{{ $t('wysiwyg_options.normalization_warning_keep_readonly') }}
+				</VButton>
+				<VButton secondary @click="emit('confirm')">
+					{{ $t('wysiwyg_options.normalization_warning_edit_anyway') }}
+				</VButton>
+				<VButton @click="emit('raw')">{{ $t('wysiwyg_options.normalization_warning_edit_raw') }}</VButton>
 			</VCardActions>
 		</VCard>
 	</VDialog>

--- a/app/src/interfaces/input-rich-text-html/drawers/normalization-warning-dialog.vue
+++ b/app/src/interfaces/input-rich-text-html/drawers/normalization-warning-dialog.vue
@@ -5,6 +5,8 @@ import VButton from '@/components/v-button.vue';
 import VCardActions from '@/components/v-card-actions.vue';
 import VCardTitle from '@/components/v-card-title.vue';
 import VCard from '@/components/v-card.vue';
+import VCheckbox from '@/components/v-checkbox.vue';
+import VDetail from '@/components/v-detail.vue';
 import VDialog from '@/components/v-dialog.vue';
 import VNotice from '@/components/v-notice.vue';
 
@@ -12,29 +14,34 @@ defineProps<{ diff: Change[] }>();
 const emit = defineEmits<{ confirm: []; cancel: [] }>();
 
 const open = defineModel<boolean>({ required: true });
+const dontShowAgain = defineModel<boolean>('dontShowAgain', { required: true });
 </script>
 
 <template>
 	<VDialog v-model="open" @esc="emit('cancel')" @apply="emit('confirm')">
-		<VCard class="normalize-dialog">
-			<VCardTitle>{{ $t('wysiwyg_options.source_code_normalize_title') }}</VCardTitle>
+		<VCard class="normalization-warning-dialog">
+			<VCardTitle>{{ $t('wysiwyg_options.normalization_warning_title') }}</VCardTitle>
 
 			<div class="content">
-				<VNotice type="warning" class="notice">{{ $t('wysiwyg_options.source_code_normalize_body') }}</VNotice>
+				<VNotice type="warning" class="notice">{{ $t('wysiwyg_options.normalization_warning_body') }}</VNotice>
 
-				<DiffLines :diff="diff" />
+				<VDetail class="detail" :label="$t('wysiwyg_options.normalization_warning_view_changes')">
+					<DiffLines :diff="diff" />
+				</VDetail>
+
+				<VCheckbox v-model="dontShowAgain" :label="$t('wysiwyg_options.normalization_warning_dont_show_again')" />
 			</div>
 
 			<VCardActions>
 				<VButton secondary @click="emit('cancel')">{{ $t('cancel') }}</VButton>
-				<VButton kind="warning" @click="emit('confirm')">{{ $t('wysiwyg_options.save_anyway') }}</VButton>
+				<VButton @click="emit('confirm')">{{ $t('continue') }}</VButton>
 			</VCardActions>
 		</VCard>
 	</VDialog>
 </template>
 
 <style lang="scss" scoped>
-.normalize-dialog {
+.normalization-warning-dialog {
 	--v-card-min-width: auto;
 
 	inline-size: min(52rem, calc(100vw - 7rem));
@@ -45,7 +52,8 @@ const open = defineModel<boolean>({ required: true });
 	padding: 0 var(--content-padding);
 }
 
-.notice {
+.notice,
+.detail {
 	margin-block-end: 1rem;
 }
 </style>

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -28,6 +28,7 @@ import { parseGlobalMimeTypeAllowList, useMimeTypeFilter } from '@/composables/u
 import InterfaceInputCode from '@/interfaces/input-code/input-code.vue';
 import { useServerStore } from '@/stores/server';
 import { useSettingsStore } from '@/stores/settings';
+import { getDirectusUrlWithUtm } from '@/utils/directus-url';
 import { percentage } from '@/utils/percentage';
 
 const props = withDefaults(
@@ -182,6 +183,15 @@ const { info } = useServerStore();
 
 const allowedMimeTypes = computed(() => parseGlobalMimeTypeAllowList(info.files?.mimeTypeAllowList)?.join(','));
 
+const normalizationDocsUrl = computed(
+	() =>
+		getDirectusUrlWithUtm(
+			'https://directus.com/docs/releases/breaking-changes/version-12',
+			info.version,
+			'wysiwyg_normalization_locked_learn_more_link',
+		) + '#wysiwyg-editor-rebuilt-on-tiptap',
+);
+
 // without this the picker/upload accept the global (usually image) list and the pick lands as a broken <video>
 const { mimeTypeFilter: mediaMimeTypeFilter, combinedAcceptString: mediaAllowedMimeTypes } = useMimeTypeFilter([
 	'video/*',
@@ -272,11 +282,7 @@ onKeyStroke('Escape', () => {
 <template>
 	<VNotice v-if="normalizationLocked && !rawMode" type="warning" multiline class="normalization-notice">
 		{{ t('wysiwyg_options.normalization_locked_notice') }}
-		<a
-			href="https://directus.com/docs/releases/breaking-changes/version-12#wysiwyg-editor-rebuilt-on-tiptap"
-			target="_blank"
-			rel="noopener noreferrer"
-		>
+		<a :href="normalizationDocsUrl" target="_blank" rel="noopener noreferrer">
 			{{ t('wysiwyg_options.normalization_locked_learn_more') }}
 		</a>
 	</VNotice>

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -22,7 +22,7 @@ import { decodePageBreaks, encodePageBreaks } from './extensions/page-break';
 import TableBubbleMenu from './toolbar/menus/table-bubble-menu.vue';
 import Toolbar from './toolbar/toolbar.vue';
 import toolbarDefault from './toolbar-default';
-import VButton from '@/components/v-button.vue';
+import VNotice from '@/components/v-notice.vue';
 import { useInjectFocusTrapManager } from '@/composables/use-focus-trap-manager';
 import { parseGlobalMimeTypeAllowList, useMimeTypeFilter } from '@/composables/use-mime-type-filter';
 import InterfaceInputCode from '@/interfaces/input-code/input-code.vue';
@@ -74,7 +74,6 @@ const {
 	normalizationLocked,
 	normalizationWarningOpen,
 	normalizationWarningDiff,
-	dontShowAgain,
 	checkValue,
 	onLockedClick,
 	confirmNormalizationWarning,
@@ -171,13 +170,6 @@ function enterRawMode() {
 	rawMode.value = true;
 }
 
-function exitRawMode() {
-	rawMode.value = false;
-	if (!editor.value) return;
-	if (encodePageBreaks(editor.value.getHTML()) !== props.value) syncValue(editor.value, props.value);
-	checkValue();
-}
-
 // the unlock flips `isEditable` on the next flush, so focus has to wait for it
 async function onWarningConfirm() {
 	confirmNormalizationWarning();
@@ -259,7 +251,7 @@ watch(isEditable, (editable) => editor.value?.setEditable(editable));
 watch(
 	() => props.value,
 	(value) => {
-		// raw mode edits flow straight through the code interface; the editor syncs on exit instead
+		// raw mode edits flow straight through the code interface, never through the editor
 		if (rawMode.value) return;
 		if (!editor.value) return;
 		// compare the encoded (stored) form so a re-emitted page-break marker doesn't look like a change
@@ -278,6 +270,16 @@ onKeyStroke('Escape', () => {
 </script>
 
 <template>
+	<VNotice v-if="normalizationLocked && !rawMode" type="warning" multiline class="normalization-notice">
+		{{ t('wysiwyg_options.normalization_locked_notice') }}
+		<a
+			href="https://directus.com/docs/releases/breaking-changes/version-12#wysiwyg-editor-rebuilt-on-tiptap"
+			target="_blank"
+			rel="noopener noreferrer"
+		>
+			{{ t('wysiwyg_options.normalization_locked_learn_more') }}
+		</a>
+	</VNotice>
 	<div
 		class="wysiwyg"
 		:class="{ disabled, 'non-editable': nonEditable || comparisonMode, fullscreen, visualaid }"
@@ -299,20 +301,14 @@ onKeyStroke('Escape', () => {
 			@open-link="openLinkDrawer"
 			@open-source-code="openSourceCodeDrawer"
 		/>
-		<div v-if="rawMode" class="raw-mode">
-			<div class="raw-mode-bar">
-				<VButton x-small secondary @click="exitRawMode">
-					{{ t('wysiwyg_options.back_to_visual_editor') }}
-				</VButton>
-			</div>
-			<InterfaceInputCode
-				:value="value"
-				language="htmlmixed"
-				:line-number="false"
-				:disabled="disabled"
-				@input="$emit('input', $event)"
-			/>
-		</div>
+		<InterfaceInputCode
+			v-if="rawMode"
+			:value="value"
+			language="htmlmixed"
+			:line-number="false"
+			:disabled="disabled"
+			@input="$emit('input', $event)"
+		/>
 
 		<EditorContent v-show="!rawMode" class="editor-content" :editor="editor" :dir="editorDir" @click="onEditorClick" />
 
@@ -378,7 +374,6 @@ onKeyStroke('Escape', () => {
 
 		<NormalizationWarningDialog
 			v-model="normalizationWarningOpen"
-			v-model:dont-show-again="dontShowAgain"
 			:diff="normalizationWarningDiff"
 			@confirm="onWarningConfirm"
 			@cancel="cancelNormalizationWarning"
@@ -434,11 +429,8 @@ onKeyStroke('Escape', () => {
 	}
 }
 
-.raw-mode-bar {
-	display: flex;
-	justify-content: flex-end;
-	padding: 0.5rem;
-	border-block-end: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
+.normalization-notice {
+	margin-block-end: 0.5rem;
 }
 
 .remaining {

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -2,7 +2,7 @@
 import type { SettingsStorageAssetPreset } from '@directus/types';
 import { type Editor, EditorContent, useEditor } from '@tiptap/vue-3';
 import { onKeyStroke } from '@vueuse/core';
-import { computed, ref, type Ref, toRefs, watch } from 'vue';
+import { computed, nextTick, ref, type Ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useImage } from './composables/use-image';
 import { useLink } from './composables/use-link';
@@ -22,8 +22,10 @@ import { decodePageBreaks, encodePageBreaks } from './extensions/page-break';
 import TableBubbleMenu from './toolbar/menus/table-bubble-menu.vue';
 import Toolbar from './toolbar/toolbar.vue';
 import toolbarDefault from './toolbar-default';
+import VButton from '@/components/v-button.vue';
 import { useInjectFocusTrapManager } from '@/composables/use-focus-trap-manager';
 import { parseGlobalMimeTypeAllowList, useMimeTypeFilter } from '@/composables/use-mime-type-filter';
+import InterfaceInputCode from '@/interfaces/input-code/input-code.vue';
 import { useServerStore } from '@/stores/server';
 import { useSettingsStore } from '@/stores/settings';
 import { percentage } from '@/utils/percentage';
@@ -68,8 +70,25 @@ const fontFamily = computed(() => {
 	return `var(--theme--fonts--${token}--font-family)`;
 });
 
-// all three states are read-only; `nonEditable`/`comparisonMode` keep the normal look, `disabled` dims (see styles)
-const isEditable = computed(() => !props.disabled && !props.nonEditable && !props.comparisonMode);
+const {
+	normalizationLocked,
+	normalizationWarningOpen,
+	normalizationWarningDiff,
+	dontShowAgain,
+	checkValue,
+	onLockedClick,
+	confirmNormalizationWarning,
+	cancelNormalizationWarning,
+} = useNormalizationWarning(value);
+
+// skipped for display-only modes; comparison values carry diff spans the base schema would flag as loss
+if (!props.comparisonMode && !props.nonEditable) checkValue();
+
+// read-only states: `nonEditable`/`comparisonMode` keep the normal look, `disabled` dims (see styles),
+// `normalizationLocked` guards lossy stored HTML until the warning dialog is confirmed
+const isEditable = computed(
+	() => !props.disabled && !props.nonEditable && !props.comparisonMode && !normalizationLocked.value,
+);
 
 const editorDir = computed(() => (props.direction === 'rtl' ? 'rtl' : 'ltr'));
 
@@ -136,10 +155,35 @@ const editor = useEditor({
 		updateCount(editor as Editor);
 		emit('input', editor.isEmpty ? null : encodePageBreaks(editor.getHTML()));
 	},
-	onFocus: () => {
-		if (isEditable.value) onEditorFocus();
-	},
 });
+
+function onEditorClick() {
+	if (props.disabled || props.nonEditable || props.comparisonMode) return;
+	onLockedClick();
+}
+
+// raw mode edits the stored HTML as text in the code interface — emits never round-trip through
+// the schema, so nothing is normalized away; the loss-free alternative the warning offers
+const rawMode = ref(false);
+
+function enterRawMode() {
+	normalizationWarningOpen.value = false;
+	rawMode.value = true;
+}
+
+function exitRawMode() {
+	rawMode.value = false;
+	if (!editor.value) return;
+	if (encodePageBreaks(editor.value.getHTML()) !== props.value) syncValue(editor.value, props.value);
+	checkValue();
+}
+
+// the unlock flips `isEditable` on the next flush, so focus has to wait for it
+async function onWarningConfirm() {
+	confirmNormalizationWarning();
+	await nextTick();
+	editor.value?.commands.focus();
+}
 
 const settingsStore = useSettingsStore();
 const { info } = useServerStore();
@@ -201,15 +245,6 @@ const {
 	cancelNormalize,
 } = useSourceCode(editor as Ref<Editor>);
 
-const {
-	normalizationWarningOpen,
-	normalizationWarningDiff,
-	dontShowAgain,
-	onEditorFocus,
-	confirmNormalizationWarning,
-	cancelNormalizationWarning,
-} = useNormalizationWarning(editor as Ref<Editor>, value);
-
 // pause the surrounding view's focus trap while a drawer is open so its inputs stay reachable
 const { pauseFocusTrap, unpauseFocusTrap } = useInjectFocusTrapManager();
 
@@ -224,10 +259,13 @@ watch(isEditable, (editable) => editor.value?.setEditable(editable));
 watch(
 	() => props.value,
 	(value) => {
+		// raw mode edits flow straight through the code interface; the editor syncs on exit instead
+		if (rawMode.value) return;
 		if (!editor.value) return;
 		// compare the encoded (stored) form so a re-emitted page-break marker doesn't look like a change
 		if (encodePageBreaks(editor.value.getHTML()) === value) return;
 		syncValue(editor.value, value);
+		if (!props.comparisonMode && !props.nonEditable) checkValue();
 	},
 );
 
@@ -246,12 +284,12 @@ onKeyStroke('Escape', () => {
 		:style="{ '--editor-font-family': fontFamily, '--page-break-label': pageBreakLabel }"
 	>
 		<Toolbar
-			v-if="!nonEditable && !comparisonMode"
+			v-if="!nonEditable && !comparisonMode && !rawMode"
 			:editor="editor"
 			:toolbar="toolbar"
 			:font="font"
 			:custom-formats="customFormatList"
-			:disabled="disabled"
+			:disabled="disabled || normalizationLocked"
 			:fullscreen="fullscreen"
 			:visualaid="visualaid"
 			@toggle-fullscreen="fullscreen = !fullscreen"
@@ -261,10 +299,25 @@ onKeyStroke('Escape', () => {
 			@open-link="openLinkDrawer"
 			@open-source-code="openSourceCodeDrawer"
 		/>
-		<EditorContent class="editor-content" :editor="editor" :dir="editorDir" />
+		<div v-if="rawMode" class="raw-mode">
+			<div class="raw-mode-bar">
+				<VButton x-small secondary @click="exitRawMode">
+					{{ t('wysiwyg_options.back_to_visual_editor') }}
+				</VButton>
+			</div>
+			<InterfaceInputCode
+				:value="value"
+				language="htmlmixed"
+				:line-number="false"
+				:disabled="disabled"
+				@input="$emit('input', $event)"
+			/>
+		</div>
+
+		<EditorContent v-show="!rawMode" class="editor-content" :editor="editor" :dir="editorDir" @click="onEditorClick" />
 
 		<span
-			v-if="softLength && !comparisonMode"
+			v-if="softLength && !comparisonMode && !rawMode"
 			class="remaining"
 			:class="{
 				warning: percRemaining < 10,
@@ -274,7 +327,7 @@ onKeyStroke('Escape', () => {
 			{{ softLength - count }}
 		</span>
 
-		<TableBubbleMenu v-if="!nonEditable && !comparisonMode" :editor="editor" />
+		<TableBubbleMenu v-if="!nonEditable && !comparisonMode && !normalizationLocked" :editor="editor" />
 
 		<ImageDrawer
 			v-model="imageDrawerOpen"
@@ -327,8 +380,9 @@ onKeyStroke('Escape', () => {
 			v-model="normalizationWarningOpen"
 			v-model:dont-show-again="dontShowAgain"
 			:diff="normalizationWarningDiff"
-			@confirm="confirmNormalizationWarning"
+			@confirm="onWarningConfirm"
 			@cancel="cancelNormalizationWarning"
+			@raw="enterRawMode"
 		/>
 	</div>
 </template>
@@ -378,6 +432,13 @@ onKeyStroke('Escape', () => {
 			overflow: auto;
 		}
 	}
+}
+
+.raw-mode-bar {
+	display: flex;
+	justify-content: flex-end;
+	padding: 0.5rem;
+	border-block-end: var(--theme--border-width) solid var(--theme--form--field--input--border-color);
 }
 
 .remaining {

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -7,10 +7,12 @@ import { useI18n } from 'vue-i18n';
 import { useImage } from './composables/use-image';
 import { useLink } from './composables/use-link';
 import { useMedia } from './composables/use-media';
+import { useNormalizationWarning } from './composables/use-normalization-warning';
 import { useSourceCode } from './composables/use-source-code';
 import ImageDrawer from './drawers/image-drawer.vue';
 import LinkDrawer from './drawers/link-drawer.vue';
 import MediaDrawer from './drawers/media-drawer.vue';
+import NormalizationWarningDialog from './drawers/normalization-warning-dialog.vue';
 import SourceCodeDrawer from './drawers/source-code-drawer.vue';
 import { editorExtensions } from './extensions';
 import { ComparisonDiff } from './extensions/comparison-diff';
@@ -53,7 +55,7 @@ const emit = defineEmits<{ input: [value: string | null] }>();
 
 const { t } = useI18n();
 
-const { imageToken, folder } = toRefs(props);
+const { imageToken, folder, value } = toRefs(props);
 
 // built once at init: `customFormats` is design-time config, not reactive
 const { extensions: customFormatExtensions, formats: customFormatList } = buildCustomFormats(props.customFormats);
@@ -134,6 +136,9 @@ const editor = useEditor({
 		updateCount(editor as Editor);
 		emit('input', editor.isEmpty ? null : encodePageBreaks(editor.getHTML()));
 	},
+	onFocus: () => {
+		if (isEditable.value) onEditorFocus();
+	},
 });
 
 const settingsStore = useSettingsStore();
@@ -195,6 +200,15 @@ const {
 	confirmSaveSourceCode,
 	cancelNormalize,
 } = useSourceCode(editor as Ref<Editor>);
+
+const {
+	normalizationWarningOpen,
+	normalizationWarningDiff,
+	dontShowAgain,
+	onEditorFocus,
+	confirmNormalizationWarning,
+	cancelNormalizationWarning,
+} = useNormalizationWarning(editor as Ref<Editor>, value);
 
 // pause the surrounding view's focus trap while a drawer is open so its inputs stay reachable
 const { pauseFocusTrap, unpauseFocusTrap } = useInjectFocusTrapManager();
@@ -307,6 +321,14 @@ onKeyStroke('Escape', () => {
 			@cancel="closeSourceCodeDrawer"
 			@confirm-save="confirmSaveSourceCode"
 			@cancel-normalize="cancelNormalize"
+		/>
+
+		<NormalizationWarningDialog
+			v-model="normalizationWarningOpen"
+			v-model:dont-show-again="dontShowAgain"
+			:diff="normalizationWarningDiff"
+			@confirm="confirmNormalizationWarning"
+			@cancel="cancelNormalizationWarning"
 		/>
 	</div>
 </template>

--- a/app/src/interfaces/input-rich-text-html/normalization-warning.test.ts
+++ b/app/src/interfaces/input-rich-text-html/normalization-warning.test.ts
@@ -5,14 +5,15 @@ import { afterEach, describe, expect, test } from 'vitest';
 import { nextTick } from 'vue';
 import { createI18n } from 'vue-i18n';
 import { NORMALIZATION_WARNING_DISMISSED } from './composables/use-normalization-warning';
+import NormalizationWarningDialog from './drawers/normalization-warning-dialog.vue';
 import Interface from './input-rich-text-html.vue';
 
 /**
- * Integration wiring for the first-focus normalization warning: focusing the editor over a stored
- * value the schema can't represent must open the dialog (see use-normalization-warning.test.ts for
- * the trigger logic itself).
+ * Integration wiring for the normalization guard: a stored value the schema can't represent keeps
+ * the editor read-only (so no edit can reach autosave) until the warning dialog is confirmed
+ * (see use-normalization-warning.test.ts for the state machine itself).
  */
-async function mountWithValue(value: string) {
+async function mountWithValue(value: string | null) {
 	const i18n = createI18n({ legacy: false, locale: 'en-US', messages: { 'en-US': {} } });
 
 	const wrapper = mount(Interface, {
@@ -37,12 +38,8 @@ async function mountWithValue(value: string) {
 	return { wrapper, editor };
 }
 
-function focus(editor: Editor) {
-	editor.emit('focus', { editor, event: new FocusEvent('focus'), transaction: editor.state.tr });
-}
-
 function findDialog(wrapper: Awaited<ReturnType<typeof mountWithValue>>['wrapper']) {
-	return wrapper.find('normalization-warning-dialog-stub');
+	return wrapper.findComponent(NormalizationWarningDialog);
 }
 
 afterEach(() => {
@@ -50,21 +47,79 @@ afterEach(() => {
 });
 
 describe('normalization warning wiring', () => {
-	test('focusing the editor over a lossy stored value opens the warning dialog', async () => {
-		const { wrapper, editor } = await mountWithValue('<marquee>legacy</marquee>');
+	test('a lossy stored value mounts the editor read-only', async () => {
+		const { editor } = await mountWithValue('<marquee>legacy</marquee>');
 
-		focus(editor);
-		await nextTick();
-
-		expect(findDialog(wrapper).attributes('modelvalue')).toBe('true');
+		expect(editor.isEditable).toBe(false);
 	});
 
-	test('focusing the editor over a clean stored value opens nothing', async () => {
+	test('a clean stored value mounts the editor editable and clicking opens nothing', async () => {
 		const { wrapper, editor } = await mountWithValue('<p>hello <strong>world</strong></p>');
 
-		focus(editor);
+		expect(editor.isEditable).toBe(true);
+
+		await wrapper.findComponent(EditorContent).trigger('click');
+
+		expect(findDialog(wrapper).props('modelValue')).toBe(false);
+	});
+
+	test('clicking a locked editor opens the warning dialog', async () => {
+		const { wrapper } = await mountWithValue('<marquee>legacy</marquee>');
+
+		await wrapper.findComponent(EditorContent).trigger('click');
+
+		expect(findDialog(wrapper).props('modelValue')).toBe(true);
+	});
+
+	test('confirming the warning unlocks the editor', async () => {
+		const { wrapper, editor } = await mountWithValue('<marquee>legacy</marquee>');
+
+		await wrapper.findComponent(EditorContent).trigger('click');
+		findDialog(wrapper).vm.$emit('confirm');
+		await flushPromises();
 		await nextTick();
 
-		expect(findDialog(wrapper).attributes('modelvalue')).toBe('false');
+		expect(editor.isEditable).toBe(true);
+	});
+
+	// setEditable(false) only blocks typing — commands still run programmatically, so the toolbar
+	// (bold, source-code drawer, …) must be disabled too or it can mutate the doc around the lock
+	test('the lock disables the toolbar and hides the table bubble menu until confirmed', async () => {
+		const { wrapper } = await mountWithValue('<marquee>legacy</marquee>');
+
+		expect(wrapper.find('toolbar-stub').attributes('disabled')).toBe('true');
+		expect(wrapper.find('table-bubble-menu-stub').exists()).toBe(false);
+
+		await wrapper.findComponent(EditorContent).trigger('click');
+		findDialog(wrapper).vm.$emit('confirm');
+		await flushPromises();
+		await nextTick();
+
+		expect(wrapper.find('toolbar-stub').attributes('disabled')).toBe('false');
+		expect(wrapper.find('table-bubble-menu-stub').exists()).toBe(true);
+	});
+
+	// versioned/draft items mount the form while loading, so the value arrives as a later prop change
+	test('a lossy value that arrives after mount locks the editor', async () => {
+		const { wrapper, editor } = await mountWithValue(null);
+
+		expect(editor.isEditable).toBe(true);
+
+		await wrapper.setProps({ value: '<marquee>legacy</marquee>' });
+		await flushPromises();
+		await nextTick();
+
+		expect(editor.isEditable).toBe(false);
+	});
+
+	test('cancelling the warning keeps the editor read-only', async () => {
+		const { wrapper, editor } = await mountWithValue('<marquee>legacy</marquee>');
+
+		await wrapper.findComponent(EditorContent).trigger('click');
+		findDialog(wrapper).vm.$emit('cancel');
+		await flushPromises();
+		await nextTick();
+
+		expect(editor.isEditable).toBe(false);
 	});
 });

--- a/app/src/interfaces/input-rich-text-html/normalization-warning.test.ts
+++ b/app/src/interfaces/input-rich-text-html/normalization-warning.test.ts
@@ -1,10 +1,9 @@
 import { type Editor, EditorContent } from '@tiptap/vue-3';
 import { flushPromises, mount } from '@vue/test-utils';
 import { createPinia } from 'pinia';
-import { afterEach, describe, expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { nextTick } from 'vue';
 import { createI18n } from 'vue-i18n';
-import { NORMALIZATION_WARNING_DISMISSED } from './composables/use-normalization-warning';
 import NormalizationWarningDialog from './drawers/normalization-warning-dialog.vue';
 import Interface from './input-rich-text-html.vue';
 
@@ -41,10 +40,6 @@ async function mountWithValue(value: string | null) {
 function findDialog(wrapper: Awaited<ReturnType<typeof mountWithValue>>['wrapper']) {
 	return wrapper.findComponent(NormalizationWarningDialog);
 }
-
-afterEach(() => {
-	localStorage.removeItem(NORMALIZATION_WARNING_DISMISSED);
-});
 
 describe('normalization warning wiring', () => {
 	test('a lossy stored value mounts the editor read-only', async () => {

--- a/app/src/interfaces/input-rich-text-html/normalization-warning.test.ts
+++ b/app/src/interfaces/input-rich-text-html/normalization-warning.test.ts
@@ -1,0 +1,70 @@
+import { type Editor, EditorContent } from '@tiptap/vue-3';
+import { flushPromises, mount } from '@vue/test-utils';
+import { createPinia } from 'pinia';
+import { afterEach, describe, expect, test } from 'vitest';
+import { nextTick } from 'vue';
+import { createI18n } from 'vue-i18n';
+import { NORMALIZATION_WARNING_DISMISSED } from './composables/use-normalization-warning';
+import Interface from './input-rich-text-html.vue';
+
+/**
+ * Integration wiring for the first-focus normalization warning: focusing the editor over a stored
+ * value the schema can't represent must open the dialog (see use-normalization-warning.test.ts for
+ * the trigger logic itself).
+ */
+async function mountWithValue(value: string) {
+	const i18n = createI18n({ legacy: false, locale: 'en-US', messages: { 'en-US': {} } });
+
+	const wrapper = mount(Interface, {
+		props: { value },
+		global: {
+			plugins: [createPinia(), i18n],
+			stubs: {
+				Toolbar: true,
+				TableBubbleMenu: true,
+				ImageDrawer: true,
+				LinkDrawer: true,
+				MediaDrawer: true,
+				SourceCodeDrawer: true,
+				NormalizationWarningDialog: true,
+			},
+		},
+	});
+
+	await flushPromises();
+	await nextTick();
+	const editor = wrapper.findComponent(EditorContent).props('editor') as Editor;
+	return { wrapper, editor };
+}
+
+function focus(editor: Editor) {
+	editor.emit('focus', { editor, event: new FocusEvent('focus'), transaction: editor.state.tr });
+}
+
+function findDialog(wrapper: Awaited<ReturnType<typeof mountWithValue>>['wrapper']) {
+	return wrapper.find('normalization-warning-dialog-stub');
+}
+
+afterEach(() => {
+	localStorage.removeItem(NORMALIZATION_WARNING_DISMISSED);
+});
+
+describe('normalization warning wiring', () => {
+	test('focusing the editor over a lossy stored value opens the warning dialog', async () => {
+		const { wrapper, editor } = await mountWithValue('<marquee>legacy</marquee>');
+
+		focus(editor);
+		await nextTick();
+
+		expect(findDialog(wrapper).attributes('modelvalue')).toBe('true');
+	});
+
+	test('focusing the editor over a clean stored value opens nothing', async () => {
+		const { wrapper, editor } = await mountWithValue('<p>hello <strong>world</strong></p>');
+
+		focus(editor);
+		await nextTick();
+
+		expect(findDialog(wrapper).attributes('modelvalue')).toBe('false');
+	});
+});

--- a/app/src/interfaces/input-rich-text-html/raw-mode.test.ts
+++ b/app/src/interfaces/input-rich-text-html/raw-mode.test.ts
@@ -1,0 +1,111 @@
+import { type Editor, EditorContent } from '@tiptap/vue-3';
+import { flushPromises, mount } from '@vue/test-utils';
+import { createPinia } from 'pinia';
+import { afterEach, describe, expect, test } from 'vitest';
+import { nextTick } from 'vue';
+import { createI18n } from 'vue-i18n';
+import { NORMALIZATION_WARNING_DISMISSED } from './composables/use-normalization-warning';
+import NormalizationWarningDialog from './drawers/normalization-warning-dialog.vue';
+import Interface from './input-rich-text-html.vue';
+import InterfaceInputCode from '@/interfaces/input-code/input-code.vue';
+
+/**
+ * Raw editing mode: the normalization warning offers editing the stored HTML as text in the code
+ * interface, which never round-trips through the Tiptap schema — the loss-free alternative to
+ * "Continue".
+ */
+const LOSSY = '<marquee>legacy</marquee>';
+
+async function mountWithValue(value: string) {
+	const i18n = createI18n({ legacy: false, locale: 'en-US', messages: { 'en-US': {} } });
+
+	const wrapper = mount(Interface, {
+		props: { value },
+		global: {
+			plugins: [createPinia(), i18n],
+			stubs: {
+				Toolbar: true,
+				TableBubbleMenu: true,
+				ImageDrawer: true,
+				LinkDrawer: true,
+				MediaDrawer: true,
+				SourceCodeDrawer: true,
+				NormalizationWarningDialog: true,
+				InterfaceInputCode: true,
+				VButton: true,
+			},
+		},
+	});
+
+	await flushPromises();
+	await nextTick();
+	const editor = wrapper.findComponent(EditorContent).props('editor') as Editor;
+	return { wrapper, editor };
+}
+
+async function enterRawMode(wrapper: Awaited<ReturnType<typeof mountWithValue>>['wrapper']) {
+	await wrapper.findComponent(EditorContent).trigger('click');
+	wrapper.findComponent(NormalizationWarningDialog).vm.$emit('raw');
+	await nextTick();
+}
+
+// isVisible() is unreliable for v-show under jsdom; assert on the inline style it toggles
+function editorContentHidden(wrapper: Awaited<ReturnType<typeof mountWithValue>>['wrapper']) {
+	return (wrapper.findComponent(EditorContent).attributes('style') ?? '').includes('display: none');
+}
+
+afterEach(() => {
+	localStorage.removeItem(NORMALIZATION_WARNING_DISMISSED);
+});
+
+describe('raw editing mode', () => {
+	test('choosing raw editing from the warning swaps the visual editor for the code interface', async () => {
+		const { wrapper } = await mountWithValue(LOSSY);
+
+		await enterRawMode(wrapper);
+
+		expect(wrapper.findComponent(InterfaceInputCode).exists()).toBe(true);
+		expect(editorContentHidden(wrapper)).toBe(true);
+		expect(wrapper.find('toolbar-stub').exists()).toBe(false);
+	});
+
+	test('raw edits emit the value verbatim, without schema normalization', async () => {
+		const { wrapper } = await mountWithValue(LOSSY);
+
+		await enterRawMode(wrapper);
+
+		const edited = '<marquee>edited</marquee>';
+		wrapper.findComponent(InterfaceInputCode).vm.$emit('input', edited);
+		await nextTick();
+
+		const emitted = wrapper.emitted('input');
+		expect(emitted?.at(-1)).toEqual([edited]);
+	});
+
+	test('leaving raw mode returns to the visual editor, still locked over lossy content', async () => {
+		const { wrapper, editor } = await mountWithValue(LOSSY);
+
+		await enterRawMode(wrapper);
+		await wrapper.find('.raw-mode-bar v-button-stub').trigger('click');
+		await nextTick();
+
+		expect(wrapper.findComponent(InterfaceInputCode).exists()).toBe(false);
+		expect(editorContentHidden(wrapper)).toBe(false);
+		expect(editor.isEditable).toBe(false);
+	});
+
+	test('raw content fixed to clean HTML unlocks the visual editor on return', async () => {
+		const { wrapper, editor } = await mountWithValue(LOSSY);
+
+		await enterRawMode(wrapper);
+		const clean = '<p>fixed</p>';
+		wrapper.findComponent(InterfaceInputCode).vm.$emit('input', clean);
+		await wrapper.setProps({ value: clean });
+		await wrapper.find('.raw-mode-bar v-button-stub').trigger('click');
+		await flushPromises();
+		await nextTick();
+
+		expect(editor.isEditable).toBe(true);
+		expect(editor.getHTML()).toBe(clean);
+	});
+});

--- a/app/src/interfaces/input-rich-text-html/raw-mode.test.ts
+++ b/app/src/interfaces/input-rich-text-html/raw-mode.test.ts
@@ -1,10 +1,9 @@
 import { type Editor, EditorContent } from '@tiptap/vue-3';
 import { flushPromises, mount } from '@vue/test-utils';
 import { createPinia } from 'pinia';
-import { afterEach, describe, expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { nextTick } from 'vue';
 import { createI18n } from 'vue-i18n';
-import { NORMALIZATION_WARNING_DISMISSED } from './composables/use-normalization-warning';
 import NormalizationWarningDialog from './drawers/normalization-warning-dialog.vue';
 import Interface from './input-rich-text-html.vue';
 import InterfaceInputCode from '@/interfaces/input-code/input-code.vue';
@@ -32,7 +31,6 @@ async function mountWithValue(value: string) {
 				SourceCodeDrawer: true,
 				NormalizationWarningDialog: true,
 				InterfaceInputCode: true,
-				VButton: true,
 			},
 		},
 	});
@@ -53,10 +51,6 @@ async function enterRawMode(wrapper: Awaited<ReturnType<typeof mountWithValue>>[
 function editorContentHidden(wrapper: Awaited<ReturnType<typeof mountWithValue>>['wrapper']) {
 	return (wrapper.findComponent(EditorContent).attributes('style') ?? '').includes('display: none');
 }
-
-afterEach(() => {
-	localStorage.removeItem(NORMALIZATION_WARNING_DISMISSED);
-});
 
 describe('raw editing mode', () => {
 	test('choosing raw editing from the warning swaps the visual editor for the code interface', async () => {
@@ -80,32 +74,5 @@ describe('raw editing mode', () => {
 
 		const emitted = wrapper.emitted('input');
 		expect(emitted?.at(-1)).toEqual([edited]);
-	});
-
-	test('leaving raw mode returns to the visual editor, still locked over lossy content', async () => {
-		const { wrapper, editor } = await mountWithValue(LOSSY);
-
-		await enterRawMode(wrapper);
-		await wrapper.find('.raw-mode-bar v-button-stub').trigger('click');
-		await nextTick();
-
-		expect(wrapper.findComponent(InterfaceInputCode).exists()).toBe(false);
-		expect(editorContentHidden(wrapper)).toBe(false);
-		expect(editor.isEditable).toBe(false);
-	});
-
-	test('raw content fixed to clean HTML unlocks the visual editor on return', async () => {
-		const { wrapper, editor } = await mountWithValue(LOSSY);
-
-		await enterRawMode(wrapper);
-		const clean = '<p>fixed</p>';
-		wrapper.findComponent(InterfaceInputCode).vm.$emit('input', clean);
-		await wrapper.setProps({ value: clean });
-		await wrapper.find('.raw-mode-bar v-button-stub').trigger('click');
-		await flushPromises();
-		await nextTick();
-
-		expect(editor.isEditable).toBe(true);
-		expect(editor.getHTML()).toBe(clean);
 	});
 });

--- a/app/src/interfaces/input-rich-text-html/toolbar/menus/table-bubble-menu.test.ts
+++ b/app/src/interfaces/input-rich-text-html/toolbar/menus/table-bubble-menu.test.ts
@@ -1,6 +1,7 @@
 import { Editor } from '@tiptap/vue-3';
 import { mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { nextTick } from 'vue';
 import { createI18n } from 'vue-i18n';
 import { editorExtensions } from '../../extensions';
 import TableBubbleMenu from './table-bubble-menu.vue';
@@ -76,6 +77,36 @@ describe('shouldShow', () => {
 
 		insertTable();
 		expect(vm.getReferencedVirtualElement()).not.toBeNull();
+	});
+});
+
+describe('root element', () => {
+	/**
+	 * Regression: the real BubbleMenu removes its own root element from the DOM on mount. If that
+	 * element is also this component's root, Vue later resolves patch containers/anchors from the
+	 * detached node and crashes mid-patch, leaving the editor half-rendered (e.g. on version switch
+	 * or when the normalization lock toggles the menu's v-if).
+	 *
+	 * Assert the fix's contract directly: the component root is the stable anchor, not tiptap's
+	 * detachable node. `isConnected` is a false check — BubbleMenuPlugin re-appends its element, so
+	 * it reads true with or without the wrapper.
+	 */
+	test('roots on a stable anchor, not the element BubbleMenu detaches', async () => {
+		alwaysEnabled(); // real BubbleMenu renders the button slot, which calls editor.can()
+
+		const wrapper = mount(TableBubbleMenu, {
+			props: { editor },
+			global: { ...global, stubs: baseStubs }, // real BubbleMenu
+			attachTo: document.body,
+		});
+
+		// BubbleMenu detaches its element in onMounted, then registers its plugin a tick later
+		await nextTick();
+		await nextTick();
+
+		expect(wrapper.element.classList.contains('table-bubble-menu-anchor')).toBe(true);
+
+		wrapper.unmount();
 	});
 });
 

--- a/app/src/interfaces/input-rich-text-html/toolbar/menus/table-bubble-menu.vue
+++ b/app/src/interfaces/input-rich-text-html/toolbar/menus/table-bubble-menu.vue
@@ -65,36 +65,46 @@ defineExpose({ shouldShow, getReferencedVirtualElement });
 </script>
 
 <template>
-	<BubbleMenu
-		v-if="editor"
-		:editor="editor"
-		plugin-key="tableBubbleMenu"
-		:should-show="shouldShow"
-		:get-referenced-virtual-element="getReferencedVirtualElement"
-		:options="options"
-	>
-		<div ref="menuEl" class="table-bubble-menu" :class="`placement-${placement}`">
-			<template v-for="(group, groupIndex) in tableActionGroups" :key="groupIndex">
-				<div v-if="groupIndex > 0" class="separator" />
-				<VButton
-					v-for="action in group"
-					:key="action.label"
-					v-tooltip="t(`wysiwyg_options.${action.label}`)"
-					class="toolbar-button"
-					ghost
-					small
-					icon
-					:disabled="!isEnabled(action)"
-					@click="runContextCommand(editor, action.command)"
-				>
-					<VIcon :name="action.icon" />
-				</VButton>
-			</template>
-		</div>
-	</BubbleMenu>
+	<div class="table-bubble-menu-anchor">
+		<!-- Stable attached root: BubbleMenu detaches its own root el on mount (el.remove()), so it must
+		never be this component's tracked root, or a structural patch that toggles/removes the menu (e.g.
+		the parent's normalization-lock v-if) crashes mid-patch and unmounts the editor body. -->
+		<BubbleMenu
+			v-if="editor"
+			:editor="editor"
+			plugin-key="tableBubbleMenu"
+			:should-show="shouldShow"
+			:get-referenced-virtual-element="getReferencedVirtualElement"
+			:options="options"
+		>
+			<div ref="menuEl" class="table-bubble-menu" :class="`placement-${placement}`">
+				<template v-for="(group, groupIndex) in tableActionGroups" :key="groupIndex">
+					<div v-if="groupIndex > 0" class="separator" />
+					<VButton
+						v-for="action in group"
+						:key="action.label"
+						v-tooltip="t(`wysiwyg_options.${action.label}`)"
+						class="toolbar-button"
+						ghost
+						small
+						icon
+						:disabled="!isEnabled(action)"
+						@click="runContextCommand(editor, action.command)"
+					>
+						<VIcon :name="action.icon" />
+					</VButton>
+				</template>
+			</div>
+		</BubbleMenu>
+	</div>
 </template>
 
 <style lang="scss" scoped>
+// layout-neutral wrapper; its only job is to be an attached, stable component root (see template comment)
+.table-bubble-menu-anchor {
+	display: contents;
+}
+
 .table-bubble-menu {
 	position: relative;
 	display: flex;

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1426,12 +1426,17 @@ wysiwyg_options:
   source_code_normalize_title: Some markup will be removed
   source_code_normalize_body: The editor can't represent the highlighted markup, so it will be removed when you save.
   save_anyway: Save Anyway
-  normalization_warning_title: Content may change when saved
+  normalization_warning_title: Some formatting here isn't supported
   normalization_warning_body:
-    This field contains markup the editor can't fully represent. Saving your edits will alter or remove the highlighted
-    parts of the stored HTML.
+    This content includes items the new editor doesn't support, so the field is read-only for now. If you edit anyway,
+    those items will be removed when you save. To keep the stored HTML exactly as is, edit the raw HTML instead. This
+    warning will go away once the unsupported items are gone.
   normalization_warning_view_changes: View changes
   normalization_warning_dont_show_again: Don't show this warning again
+  normalization_warning_keep_readonly: Keep Read-only
+  normalization_warning_edit_anyway: Edit Anyway
+  normalization_warning_edit_raw: Edit Raw HTML
+  back_to_visual_editor: Back to Visual Editor
   fullscreen: Full Screen
   directionality: Directionality
   ltr: Left to Right

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1432,11 +1432,13 @@ wysiwyg_options:
     those items will be removed when you save. To keep the stored HTML exactly as is, edit the raw HTML instead. This
     warning will go away once the unsupported items are gone.
   normalization_warning_view_changes: View changes
-  normalization_warning_dont_show_again: Don't show this warning again
   normalization_warning_keep_readonly: Keep Read-only
   normalization_warning_edit_anyway: Edit Anyway
   normalization_warning_edit_raw: Edit Raw HTML
-  back_to_visual_editor: Back to Visual Editor
+  normalization_locked_notice:
+    This field includes formatting the new editor doesn't support, so it's read-only. Select the field to choose how to
+    edit it.
+  normalization_locked_learn_more: Learn what changed
   fullscreen: Full Screen
   directionality: Directionality
   ltr: Left to Right

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1426,6 +1426,12 @@ wysiwyg_options:
   source_code_normalize_title: Some markup will be removed
   source_code_normalize_body: The editor can't represent the highlighted markup, so it will be removed when you save.
   save_anyway: Save Anyway
+  normalization_warning_title: Content may change when saved
+  normalization_warning_body:
+    This field contains markup the editor can't fully represent. Saving your edits will alter or remove the highlighted
+    parts of the stored HTML.
+  normalization_warning_view_changes: View changes
+  normalization_warning_dont_show_again: Don't show this warning again
   fullscreen: Full Screen
   directionality: Directionality
   ltr: Left to Right


### PR DESCRIPTION
## What's Changed

- When a Tiptap rich text field loads, the stored value is round-tripped through the editor schema; if saving would rewrite it, the editor stays read-only so no edit (or autosave) can alter the content before the user confirms
- While locked, a persistent warning notice sits above the field explaining the situation and linking to the migration docs (`releases/breaking-changes/version-12#wysiwyg-editor-rebuilt-on-tiptap`)
- Clicking the locked editor opens a warning dialog with plain-language copy and a collapsible "View changes" diff, offering three actions: **Keep Read-only**, **Edit Anyway** (unlocks visual editing; unsupported markup is removed on save), and **Edit Raw HTML**
- Raw HTML mode swaps the visual editor for the code interface (`input-code`, `htmlmixed`); edits emit verbatim without schema normalization. It's a one-way switch for the session (re-mount to return to the visual editor), keeping the flow simple
- The check runs on load and on external value changes (async load, revert, version switch), never on the editor's own emits, so the round-trip stays off the typing path; content that survives normalization unchanged (including anything authored in Tiptap) never locks
- New `computeValueNormalizationDiff()` compares both sides in the encoded (stored) representation so the page-break marker ↔ element boundary doesn't produce false positives
- Extracted the diff renderer from `source-code-normalize-dialog.vue` into a shared `diff-lines.vue` component used by both dialogs
- **Fixed the editor body disappearing (only the toolbar left visible) when the table bubble menu is removed mid-session** — e.g. when the lock engages after pasting unsupported markup via Edit Raw Value. `@tiptap/vue-3`'s `BubbleMenu` removes its own root element in `onMounted`, so making it `TableBubbleMenu`'s component root meant Vue patched against a detached node (`parentNode` → `null`) and crashed mid-patch. Fixed by rooting the component on a stable attached `.table-bubble-menu-anchor` wrapper (same class of bug as CMS-2859)

## Tested Scenarios

- Unit tests for the composable (`use-normalization-warning.test.ts`): lock on lossy vs clean content, page-break markers, empty/async-loaded values, re-lock after an external value change
- Raw-mode tests (`raw-mode.test.ts`): entering raw mode swaps in the code interface, emits pass through verbatim without normalization
- Integration tests mounting the full interface (`normalization-warning.test.ts`): read-only mount over a lossy value, dialog on click, toolbar and table bubble menu disabled/hidden while locked, unlock on confirm, cancel keeps it locked, a lossy value arriving after mount locks the editor
- Regression test for the crash (`table-bubble-menu.test.ts`): mounts the real (unstubbed) `BubbleMenu` and asserts the component root is the stable anchor — fails on the pre-fix implementation, passes with it
- Manually verified in the browser with legacy TinyMCE HTML (inline styles, `<font>`, `<marquee>`, `<center>`, HTML comments, `colgroup` widths, `align`/`bgcolor` attributes): read-only field with accurate diff, editable clean field with page breaks, raw mode preserving markup verbatim, and the specific crash repro (fresh field → type → Edit Raw Value → paste a `<script>` → click) no longer breaks the editor

## Review Notes / Questions / Concerns

- The ticket's scope says "first focus" while the AC says "first save"; this goes further than both — the field is read-only from load, so neither an edit nor autosave can rewrite the stored HTML before the user makes an explicit choice, and raw mode offers a loss-free way to keep editing
- Raw HTML mode is intentionally a one-way switch per mount (the earlier "Back to Visual Editor" toggle and the per-browser opt-out were dropped to keep the transitional flow minimal)
- The round-trip uses the shared `editorExtensions` only (same as the source-code drawer), so content relying on `customFormats` extensions could in theory false-positive; in practice class/id/data/aria preservation (CMS-2840) covers class-based formats
- The bubble-menu crash is the same footgun as the version-switch crash: CMS-2859 (#27907, merged) fixes the version-switch path with a remount `:key`, which does **not** cover this normalization-lock trigger (same version, no remount) — the stable-anchor root handles that path and any future `BubbleMenu`/`FloatingMenu` usage. Worth reporting upstream to tiptap

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [x] App translations added for new user-facing strings
- [ ] Security implications apply
