### PR TITLE
Run checks on non-main PRs and support skip label

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,8 +2,13 @@ name: Check
 
 on:
   pull_request:
-    branches:
-      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      # Re-trigger so toggling the 'Skip Checks' label re-evaluates the required checks
+      - labeled
+      - unlabeled
 
   push:
     branches:
@@ -22,6 +27,7 @@ env:
 jobs:
   lint:
     name: Lint
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'Skip Checks') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -46,6 +52,7 @@ jobs:
 
   stylelint:
     name: Stylelint
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'Skip Checks') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -65,6 +72,7 @@ jobs:
 
   format:
     name: Format
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'Skip Checks') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -84,6 +92,7 @@ jobs:
 
   unit:
     name: Unit Tests
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'Skip Checks') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## What's Changed

- Support running checks (lint, format, unit tests etc) on non-main branches
- Support a "Skip Checks" label that allows skipping these checks. Useful under certain scenarios we have encountered.

## Tested Scenarios

- N/A

## Review Notes / Questions / Concerns

- The "Skip Checks" label existence added temporarily for testing, can rename if a more appropriate name
- Kept `push` scoped to `main` to avoid duplicate runs but still run once merged on main


## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes N/A
