### PR TITLE
tw ← Tiptap WYSIWYG: fix editor body disappearing on version switch (CMS-2859)

### DIFF
--- a/.changeset/cms-2859-wysiwyg-version-switch.md
+++ b/.changeset/cms-2859-wysiwyg-version-switch.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the WYSIWYG editor body disappearing (only toolbar shown) when switching content versions

--- a/app/src/interfaces/input-rich-text-html/toolbar/menus/table-bubble-menu.test.ts
+++ b/app/src/interfaces/input-rich-text-html/toolbar/menus/table-bubble-menu.test.ts
@@ -1,6 +1,7 @@
 import { Editor } from '@tiptap/vue-3';
 import { mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { nextTick } from 'vue';
 import { createI18n } from 'vue-i18n';
 import { editorExtensions } from '../../extensions';
 import TableBubbleMenu from './table-bubble-menu.vue';
@@ -76,6 +77,29 @@ describe('shouldShow', () => {
 
 		insertTable();
 		expect(vm.getReferencedVirtualElement()).not.toBeNull();
+	});
+});
+
+describe('root element', () => {
+	/**
+	 * Regression: the real BubbleMenu removes its own root element from the DOM on mount. If that
+	 * element is also this component's root, Vue later resolves patch containers/anchors from the
+	 * detached node and crashes mid-patch, leaving the editor half-rendered (e.g. on version switch).
+	 */
+	test('stays attached while BubbleMenu detaches its own element', async () => {
+		const wrapper = mount(TableBubbleMenu, {
+			props: { editor },
+			global: { ...global, stubs: baseStubs }, // real BubbleMenu
+			attachTo: document.body,
+		});
+
+		// BubbleMenu detaches its element in onMounted, then registers its plugin a tick later
+		await nextTick();
+		await nextTick();
+
+		expect(wrapper.element.isConnected).toBe(true);
+
+		wrapper.unmount();
 	});
 });
 

--- a/app/src/interfaces/input-rich-text-html/toolbar/menus/table-bubble-menu.vue
+++ b/app/src/interfaces/input-rich-text-html/toolbar/menus/table-bubble-menu.vue
@@ -65,36 +65,45 @@ defineExpose({ shouldShow, getReferencedVirtualElement });
 </script>
 
 <template>
-	<BubbleMenu
-		v-if="editor"
-		:editor="editor"
-		plugin-key="tableBubbleMenu"
-		:should-show="shouldShow"
-		:get-referenced-virtual-element="getReferencedVirtualElement"
-		:options="options"
-	>
-		<div ref="menuEl" class="table-bubble-menu" :class="`placement-${placement}`">
-			<template v-for="(group, groupIndex) in tableActionGroups" :key="groupIndex">
-				<div v-if="groupIndex > 0" class="separator" />
-				<VButton
-					v-for="action in group"
-					:key="action.label"
-					v-tooltip="t(`wysiwyg_options.${action.label}`)"
-					class="toolbar-button"
-					ghost
-					small
-					icon
-					:disabled="!isEnabled(action)"
-					@click="runContextCommand(editor, action.command)"
-				>
-					<VIcon :name="action.icon" />
-				</VButton>
-			</template>
-		</div>
-	</BubbleMenu>
+	<!-- BubbleMenu detaches its own root element on mount (el.remove() in @tiptap/vue-3), so this component's
+	root must be a stable attached element — otherwise Vue resolves patch containers/anchors from the detached
+	node and crashes mid-patch, leaving the editor half-rendered (only the toolbar visible). -->
+	<div class="table-bubble-menu-anchor">
+		<BubbleMenu
+			v-if="editor"
+			:editor="editor"
+			plugin-key="tableBubbleMenu"
+			:should-show="shouldShow"
+			:get-referenced-virtual-element="getReferencedVirtualElement"
+			:options="options"
+		>
+			<div ref="menuEl" class="table-bubble-menu" :class="`placement-${placement}`">
+				<template v-for="(group, groupIndex) in tableActionGroups" :key="groupIndex">
+					<div v-if="groupIndex > 0" class="separator" />
+					<VButton
+						v-for="action in group"
+						:key="action.label"
+						v-tooltip="t(`wysiwyg_options.${action.label}`)"
+						class="toolbar-button"
+						ghost
+						small
+						icon
+						:disabled="!isEnabled(action)"
+						@click="runContextCommand(editor, action.command)"
+					>
+						<VIcon :name="action.icon" />
+					</VButton>
+				</template>
+			</div>
+		</BubbleMenu>
+	</div>
 </template>
 
 <style lang="scss" scoped>
+.table-bubble-menu-anchor {
+	display: contents;
+}
+
 .table-bubble-menu {
 	position: relative;
 	display: flex;


### PR DESCRIPTION
## What's Changed

- Fixed the WYSIWYG editor body disappearing (only toolbar visible) when switching content versions.
- Root cause: `@tiptap/vue-3`'s `BubbleMenu` removes its own root element from the DOM in `onMounted` (`el.remove()`, still present in 3.28.0). Since that element was `TableBubbleMenu`'s component root, Vue kept patching against a detached node — later structural patches resolve containers/anchors from it (`parentNode` → `null`) and throw (`Cannot read properties of null (reading 'insertBefore')`), aborting the update mid-patch and leaving the interface half-rendered: toolbar in the DOM, `EditorContent` never mounted.
- Fix: `table-bubble-menu.vue` now has a stable attached wrapper (`.table-bubble-menu-anchor`, `display: contents`) as its component root, so Vue never derives patch containers from the element BubbleMenu detaches.
- Added a regression test mounting the real (unstubbed) `BubbleMenu` asserting the component root stays connected — fails on the old code, passes with the fix.

## Tested Scenarios

- Real-browser harness (Playwright + dev server) mounting the actual interface through 56 remount/value-swap/prop-churn cycles simulating version switches: 37+ Vue patch errors before the fix, zero after.
- Full `input-rich-text-html` suite: 337 tests pass.
- New regression test verified to fail against the previous implementation.

## Review Notes / Questions / Concerns

- The bug is intermittent in the app because it depends on which re-render/remount path a version switch takes; once a patch throws, the subtree stays broken until reload.
- Same footgun applies to any future `BubbleMenu`/`FloatingMenu` usage (e.g. a link bubble menu) — worth reporting upstream to tiptap.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes CMS-2859