### PR TITLE
Update the onboarding flow to replace the Privacy Policy link with the Data Processing Agreement

### DIFF
--- a/.changeset/onboarding-dpa-replace-privacy.md
+++ b/.changeset/onboarding-dpa-replace-privacy.md
@@ -1,0 +1,6 @@
+---
+'@directus/app': patch
+'@directus/constants': patch
+---
+
+Replaced the Privacy Policy link with the Data Processing Agreement in the setup/onboarding license acceptance

--- a/.changeset/onboarding-dpa-replace-privacy.md
+++ b/.changeset/onboarding-dpa-replace-privacy.md
@@ -3,4 +3,4 @@
 '@directus/constants': patch
 ---
 
-Replaced the Privacy Policy link with the Data Processing Agreement in the setup/onboarding license acceptance
+Updated the onboarding flow to replace the Privacy Policy link with the Data Processing Agreement.

--- a/.changeset/onboarding-dpa-replace-privacy.md
+++ b/.changeset/onboarding-dpa-replace-privacy.md
@@ -3,4 +3,4 @@
 '@directus/constants': patch
 ---
 
-Updated the onboarding flow to replace the Privacy Policy link with the Data Processing Agreement.
+Updated the onboarding flow to replace the Privacy Policy link with the Data Processing Agreement

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -22,7 +22,7 @@
 
 about: About
 directus_mscl: Directus MSCL-1.0-GPL
-privacy_policy: Privacy Policy
+data_processing_agreement: Data Processing Agreement
 contact_support: contact support
 setup_welcome: Welcome to Directus
 setup_info: Let's create your admin account and get your project up and running.

--- a/app/src/routes/setup/form.vue
+++ b/app/src/routes/setup/form.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { DIRECTUS_MSCL_URL, DIRECTUS_PRIVACY_URL } from '@directus/constants';
+import { DIRECTUS_DPA_URL, DIRECTUS_MSCL_URL } from '@directus/constants';
 import { ValidationError as DirectusValidationError, SetupForm } from '@directus/types';
 import { storeToRefs } from 'pinia';
 import { computed, toRef } from 'vue';
@@ -141,11 +141,8 @@ const mergedErrors = computed<DirectusValidationError[]>(() => {
 					</a>
 				</template>
 				<template #privacyPolicy>
-					<a
-						:href="getDirectusUrlWithUtm(DIRECTUS_PRIVACY_URL, info.version, `${utmLocation}_privacy_link`)"
-						target="_blank"
-					>
-						{{ $t('privacy_policy') }}
+					<a :href="getDirectusUrlWithUtm(DIRECTUS_DPA_URL, info.version, `${utmLocation}_dpa_link`)" target="_blank">
+						{{ $t('data_processing_agreement') }}
 					</a>
 				</template>
 			</I18nT>
@@ -160,8 +157,8 @@ const mergedErrors = computed<DirectusValidationError[]>(() => {
 						</a>
 					</template>
 					<template #privacyPolicy>
-						<a :href="getDirectusUrlWithUtm(DIRECTUS_PRIVACY_URL, info.version, 'privacy_link')" target="_blank">
-							{{ $t('privacy_policy') }}
+						<a :href="getDirectusUrlWithUtm(DIRECTUS_DPA_URL, info.version, 'dpa_link')" target="_blank">
+							{{ $t('data_processing_agreement') }}
 						</a>
 					</template>
 				</I18nT>

--- a/packages/constants/src/urls.ts
+++ b/packages/constants/src/urls.ts
@@ -8,5 +8,6 @@ export const DIRECTUS_SUPPORT_URL: string = `https://${DIRECTUS_DOMAIN}/support`
 export const DIRECTUS_LICENSING_DOCS_URL: string = `https://${DIRECTUS_DOMAIN}/docs/licensing/overview`;
 export const DIRECTUS_MSCL_URL: string = `https://${DIRECTUS_DOMAIN}/mscl`;
 export const DIRECTUS_PRIVACY_URL: string = `https://${DIRECTUS_DOMAIN}/privacy`;
+export const DIRECTUS_DPA_URL: string = `https://${DIRECTUS_DOMAIN}/dpa`;
 
 export const LICENSING_EMAIL: string = 'licensing@directus.io';


### PR DESCRIPTION
## What's Changed

- Replaced the Privacy Policy reference on the setup / admin-bootstrap onboarding screen with a link to the new **Data Processing Agreement** (`directus.com/dpa`), per legal guidance that users should no longer be asked to "accept" the Privacy Policy anywhere.
- Updated **both** acceptance surfaces: the license-acceptance checkbox and the "By hitting save…" notice shown when license entry is skipped.
- Added `DIRECTUS_DPA_URL` (`https://directus.com/dpa`) to `@directus/constants`.
- Swapped the `privacy_policy` en-US string for a new `data_processing_agreement` string; UTM tracking updated (`privacy_link` → `dpa_link`).

<img width="3840" height="1868" alt="Setup-Project-·-Directus-07-17-2026_06_17_PM" src="https://github.com/user-attachments/assets/fd83ed3d-94e4-4cd8-88e8-b93b8b8fdcc1" />


## Tested Scenarios

- Fresh onboarding: checkbox reads "I accept the terms of the Directus MSCL-1.0-GPL and **Data Processing Agreement**", and the DPA link opens `directus.com/dpa`.
- Skip-license flow: the "By hitting save…" notice shows the DPA link + text.
- Non-English locale (e.g. `de-DE`): string still renders correctly — the DPA link shows the English "Data Processing Agreement" label until Crowdin localizes it, with no broken interpolation.
- `eslint` passes on changed files; `@directus/constants` builds.

## Review Notes / Questions / Concerns

- **Legal context:** per legal, we should not ask users to accept the Privacy Policy anywhere. This removes the only such acceptance in the app and surfaces the new DPA instead.
- **Intentional:** the i18n placeholder/slot is still named `privacyPolicy` (not renamed to `dataProcessingAgreement`). The locale files are Crowdin-generated and all still use `{privacyPolicy}`; renaming the source placeholder would break the interpolation in every non-English locale until Crowdin translators reconcile. Keeping the name means all languages render correctly immediately. Safe to clean up later via a Crowdin-side migration — happy to split that into a follow-up if desired.
- `DIRECTUS_PRIVACY_URL` left in place (now unused) since it's a public export of `@directus/constants` and the privacy page still exists — can remove if preferred.
- Other locales will display the English "Data Processing Agreement" label until Crowdin syncs the new string — expected with this workflow.

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [x] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes #cms-2862