### PR TITLE
Flatten oauth2/openid userInfo before processing role mapping

### DIFF
--- a/api/src/auth/drivers/oauth2.test.ts
+++ b/api/src/auth/drivers/oauth2.test.ts
@@ -637,6 +637,159 @@ describe('OAuth2AuthDriver', () => {
 			});
 		});
 
+		describe('Nested claim flattening', () => {
+			test('maps role from a nested group claim referenced via dot-notation groupClaimName', async () => {
+				const config = createOAuth2Config({
+					identifierKey: 'sub',
+					defaultRoleId: 'default-role',
+					allowPublicRegistration: true,
+					groupClaimName: 'resource_access.roles',
+					roleMapping: {
+						'admin-group': 'admin-role-id',
+					},
+				});
+
+				const driver = new OAuth2AuthDriver({ knex: {} as any }, config);
+
+				vi.spyOn(driver.client, 'oauthCallback').mockResolvedValue({ access_token: 'token' } as any);
+
+				vi.spyOn(driver.client, 'userinfo').mockResolvedValue({
+					sub: '123',
+					email: 'test@test.com',
+					resource_access: { roles: ['admin-group'] },
+				} as any);
+
+				vi.spyOn(driver as any, 'fetchUserId').mockResolvedValue(undefined);
+
+				const createOneSpy = vi.fn().mockResolvedValue('new-user-id');
+				vi.spyOn(driver as any, 'getUsersService').mockReturnValue({ createOne: createOneSpy });
+
+				const payload = {
+					code: 'test-code',
+					codeVerifier: 'test-verifier',
+					state: 'test-state',
+				};
+
+				await driver.getUserID(payload);
+
+				expect(createOneSpy).toHaveBeenCalledWith(
+					expect.objectContaining({
+						role: 'admin-role-id',
+					}),
+				);
+			});
+
+			test('preserves the groups array (safe flatten) so a non-first member still maps to a role', async () => {
+				// Safe-mode flatten keeps arrays intact. Without it the array would be flattened into
+				// `groups.0`/`groups.1` keys and `userInfo['groups']` would be undefined, breaking mapping.
+				const config = createOAuth2Config({
+					identifierKey: 'sub',
+					defaultRoleId: 'default-role',
+					allowPublicRegistration: true,
+					roleMapping: {
+						'github-org-admins': 'admin-role-id',
+					},
+				});
+
+				const driver = new OAuth2AuthDriver({ knex: {} as any }, config);
+
+				vi.spyOn(driver.client, 'oauthCallback').mockResolvedValue({ access_token: 'token' } as any);
+
+				vi.spyOn(driver.client, 'userinfo').mockResolvedValue({
+					sub: '123',
+					email: 'test@test.com',
+					groups: ['other-group', 'github-org-admins'],
+				} as any);
+
+				vi.spyOn(driver as any, 'fetchUserId').mockResolvedValue(undefined);
+
+				const createOneSpy = vi.fn().mockResolvedValue('new-user-id');
+				vi.spyOn(driver as any, 'getUsersService').mockReturnValue({ createOne: createOneSpy });
+
+				const payload = {
+					code: 'test-code',
+					codeVerifier: 'test-verifier',
+					state: 'test-state',
+				};
+
+				await driver.getUserID(payload);
+
+				expect(createOneSpy).toHaveBeenCalledWith(
+					expect.objectContaining({
+						role: 'admin-role-id',
+					}),
+				);
+			});
+
+			test('resolves identifier from a nested dot-notation identifierKey', async () => {
+				const config = createOAuth2Config({
+					identifierKey: 'data.user.id',
+				});
+
+				const driver = new OAuth2AuthDriver({ knex: {} as any }, config);
+
+				vi.spyOn(driver.client, 'oauthCallback').mockResolvedValue({ access_token: 'token' } as any);
+
+				vi.spyOn(driver.client, 'userinfo').mockResolvedValue({
+					data: { user: { id: 'nested-user-id' } },
+					email: 'test@test.com',
+				} as any);
+
+				const fetchUserIdSpy = vi.spyOn(driver as any, 'fetchUserId').mockResolvedValue('existing-user');
+
+				const payload = {
+					code: 'test-code',
+					codeVerifier: 'test-verifier',
+					state: 'test-state',
+				};
+
+				await driver.getUserID(payload);
+
+				expect(fetchUserIdSpy).toHaveBeenCalledWith('nested-user-id');
+			});
+
+			test('resolves email/first_name/last_name from nested dot-notation keys', async () => {
+				const config = createOAuth2Config({
+					identifierKey: 'sub',
+					allowPublicRegistration: true,
+					emailKey: 'contact.email',
+					firstNameKey: 'name.first',
+					lastNameKey: 'name.last',
+				});
+
+				const driver = new OAuth2AuthDriver({ knex: {} as any }, config);
+
+				vi.spyOn(driver.client, 'oauthCallback').mockResolvedValue({ access_token: 'token' } as any);
+
+				vi.spyOn(driver.client, 'userinfo').mockResolvedValue({
+					sub: '123',
+					contact: { email: 'nested@test.com' },
+					name: { first: 'Ada', last: 'Lovelace' },
+				} as any);
+
+				vi.spyOn(driver as any, 'fetchUserId').mockResolvedValue(undefined);
+
+				const createOneSpy = vi.fn().mockResolvedValue('new-user-id');
+				vi.spyOn(driver as any, 'getUsersService').mockReturnValue({ createOne: createOneSpy });
+
+				const payload = {
+					code: 'test-code',
+					codeVerifier: 'test-verifier',
+					state: 'test-state',
+				};
+
+				await driver.getUserID(payload);
+
+				expect(createOneSpy).toHaveBeenCalledWith(
+					expect.objectContaining({
+						email: 'nested@test.com',
+						first_name: 'Ada',
+						last_name: 'Lovelace',
+					}),
+				);
+			});
+		});
+
 		describe('Identifier extraction', () => {
 			test('extracts identifier from custom identifierKey', async () => {
 				const config = createOAuth2Config({

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -165,8 +165,8 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			throw handleError(e);
 		}
 
-		// Flatten response to support dot indexes
-		userInfo = flatten(userInfo) as Record<string, unknown>;
+		// Flatten response to support dot indexes (safe mode preserves arrays, e.g. the groups claim)
+		userInfo = flatten(userInfo, { safe: true }) as Record<string, unknown>;
 
 		let role = this.config['defaultRoleId'];
 		const groupClaimName: string = this.config['groupClaimName'] ?? 'groups';

--- a/api/src/auth/drivers/oauth2.ts
+++ b/api/src/auth/drivers/oauth2.ts
@@ -165,6 +165,9 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 			throw handleError(e);
 		}
 
+		// Flatten response to support dot indexes
+		userInfo = flatten(userInfo) as Record<string, unknown>;
+
 		let role = this.config['defaultRoleId'];
 		const groupClaimName: string = this.config['groupClaimName'] ?? 'groups';
 		const groups = userInfo[groupClaimName] ? toArray(userInfo[groupClaimName]) : [];
@@ -180,9 +183,6 @@ export class OAuth2AuthDriver extends LocalAuthDriver {
 		} else if (Object.keys(this.roleMap).length > 0) {
 			logger.debug(`[OAuth2] Configured group claim with name "${groupClaimName}" does not exist or is empty.`);
 		}
-
-		// Flatten response to support dot indexes
-		userInfo = flatten(userInfo) as Record<string, unknown>;
 
 		const { provider, emailKey, identifierKey, allowPublicRegistration, syncUserInfo } = this.config;
 

--- a/api/src/auth/drivers/openid.test.ts
+++ b/api/src/auth/drivers/openid.test.ts
@@ -565,6 +565,123 @@ describe('OpenIDAuthDriver', () => {
 			});
 		});
 
+		describe('Nested claim flattening', () => {
+			test('maps role from a nested group claim referenced via dot-notation groupClaimName', async () => {
+				const config = createOpenIDConfig({
+					allowPublicRegistration: true,
+					groupClaimName: 'resource_access.roles',
+					roleMapping: {
+						'admin-group': 'admin-role-id',
+					},
+				});
+
+				const driver = new OpenIDAuthDriver({ knex: {} as any }, config);
+				await driver['getClient']();
+
+				vi.spyOn(driver.client!, 'callback').mockResolvedValue({
+					claims: () => ({}),
+				} as any);
+
+				vi.spyOn(driver.client!, 'userinfo').mockResolvedValue({
+					sub: '123',
+					email: 'test@test.com',
+					resource_access: { roles: ['admin-group'] },
+				} as any);
+
+				vi.spyOn(driver as any, 'fetchUserId').mockResolvedValue(undefined);
+
+				const createOneSpy = vi.fn().mockResolvedValue('new-user-id');
+				vi.spyOn(driver as any, 'getUsersService').mockReturnValue({ createOne: createOneSpy });
+
+				const payload = {
+					code: 'test-code',
+					codeVerifier: 'test-verifier',
+					state: 'test-state',
+				};
+
+				await driver.getUserID(payload);
+
+				expect(createOneSpy).toHaveBeenCalledWith(
+					expect.objectContaining({
+						role: 'admin-role-id',
+					}),
+				);
+			});
+
+			test('preserves the groups array (safe flatten) so a non-first member still maps to a role', async () => {
+				// Safe-mode flatten keeps arrays intact. Without it the array would be flattened into
+				// `groups.0`/`groups.1` keys and `userInfo['groups']` would be undefined, breaking mapping.
+				const config = createOpenIDConfig({
+					allowPublicRegistration: true,
+					roleMapping: {
+						'github-org-admins': 'admin-role-id',
+					},
+				});
+
+				const driver = new OpenIDAuthDriver({ knex: {} as any }, config);
+				await driver['getClient']();
+
+				vi.spyOn(driver.client!, 'callback').mockResolvedValue({
+					claims: () => ({}),
+				} as any);
+
+				vi.spyOn(driver.client!, 'userinfo').mockResolvedValue({
+					sub: '123',
+					email: 'test@test.com',
+					groups: ['other-group', 'github-org-admins'],
+				} as any);
+
+				vi.spyOn(driver as any, 'fetchUserId').mockResolvedValue(undefined);
+
+				const createOneSpy = vi.fn().mockResolvedValue('new-user-id');
+				vi.spyOn(driver as any, 'getUsersService').mockReturnValue({ createOne: createOneSpy });
+
+				const payload = {
+					code: 'test-code',
+					codeVerifier: 'test-verifier',
+					state: 'test-state',
+				};
+
+				await driver.getUserID(payload);
+
+				expect(createOneSpy).toHaveBeenCalledWith(
+					expect.objectContaining({
+						role: 'admin-role-id',
+					}),
+				);
+			});
+
+			test('resolves identifier from a nested dot-notation identifierKey', async () => {
+				const config = createOpenIDConfig({
+					identifierKey: 'data.user.id',
+				});
+
+				const driver = new OpenIDAuthDriver({ knex: {} as any }, config);
+				await driver['getClient']();
+
+				vi.spyOn(driver.client!, 'callback').mockResolvedValue({
+					claims: () => ({}),
+				} as any);
+
+				vi.spyOn(driver.client!, 'userinfo').mockResolvedValue({
+					data: { user: { id: 'nested-user-id' } },
+					email: 'test@test.com',
+				} as any);
+
+				const fetchUserIdSpy = vi.spyOn(driver as any, 'fetchUserId').mockResolvedValue('existing-user');
+
+				const payload = {
+					code: 'test-code',
+					codeVerifier: 'test-verifier',
+					state: 'test-state',
+				};
+
+				await driver.getUserID(payload);
+
+				expect(fetchUserIdSpy).toHaveBeenCalledWith('nested-user-id');
+			});
+		});
+
 		describe('Identifier extraction', () => {
 			test('extracts identifier from custom identifierKey', async () => {
 				const config = createOpenIDConfig({

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -246,8 +246,8 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			throw handleError(e);
 		}
 
-		// Flatten response to support dot indexes
-		userInfo = flatten(userInfo) as Record<string, unknown>;
+		// Flatten response to support dot indexes (safe mode preserves arrays, e.g. the groups claim)
+		userInfo = flatten(userInfo, { safe: true }) as Record<string, unknown>;
 
 		let role = this.config['defaultRoleId'];
 		const groupClaimName: string = this.config['groupClaimName'] ?? 'groups';

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -246,6 +246,9 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 			throw handleError(e);
 		}
 
+		// Flatten response to support dot indexes
+		userInfo = flatten(userInfo) as Record<string, unknown>;
+
 		let role = this.config['defaultRoleId'];
 		const groupClaimName: string = this.config['groupClaimName'] ?? 'groups';
 		const groups = userInfo[groupClaimName] ? toArray(userInfo[groupClaimName]) : [];
@@ -261,9 +264,6 @@ export class OpenIDAuthDriver extends LocalAuthDriver {
 		} else if (Object.keys(this.roleMap).length > 0) {
 			logger.debug(`[OpenID] Configured group claim with name "${groupClaimName}" does not exist or is empty.`);
 		}
-
-		// Flatten response to support dot indexes
-		userInfo = flatten(userInfo) as Record<string, unknown>;
 
 		const { provider, identifierKey, allowPublicRegistration, requireVerifiedEmail, syncUserInfo } = this.config;
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -255,6 +255,7 @@
 - alvarosabu
 - omkarg01
 - wotan-allfather
+- t7tran
 - danielbuechele
 - powerseed
 - aryanrichhariya1234-lang


### PR DESCRIPTION
## Scope

What's changed:

- OAuth2 & OpenID userinfo is flatten before processing role mapping

## Potential Risks / Drawbacks

- None

## Tested Scenarios

- SSO integration with Salesforce which custom attributes are returned as a map under `custom_attributes` property. Then the `AUTH_XXX_GROUP_CLAIM_NAME` can be `custom_attributes.Role`.

## Review Notes / Questions

- I would like to merge the change for others' benefits.
- No special attention

## Checklist

- [ ] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
- [ ] OpenAPI package PR created [here](https://github.com/directus/openapi) or not required
