### PR TITLE
fix: clean up websocket.message listeners between heartbeat cycles

### DIFF
--- a/api/src/websocket/handlers/heartbeat.ts
+++ b/api/src/websocket/handlers/heartbeat.ts
@@ -66,13 +66,6 @@ export class HeartbeatHandler {
 		const pendingClients = new Set<WebSocketClient>(this.controller.clients);
 		const activeClients = new Set<WebSocketClient>();
 
-		const timeout = setTimeout(() => {
-			// close connections that haven't responded
-			for (const client of pendingClients) {
-				client.close();
-			}
-		}, HEARTBEAT_FREQUENCY);
-
 		const messageWatcher: ActionHandler = ({ client }) => {
 			// any message means this connection is still open
 			if (!activeClients.has(client)) {
@@ -87,6 +80,19 @@ export class HeartbeatHandler {
 		};
 
 		emitter.onAction('websocket.message', messageWatcher);
+
+		const timeout = setTimeout(() => {
+			// close connections that haven't responded
+			for (const client of pendingClients) {
+				client.close();
+			}
+
+			// Clean up the per-cycle message watcher — if we reached this timeout, none of
+			// the pending clients sent a message, so messageWatcher will never run its
+			// cleanup path (pendingClients.size never reaches 0). Without this, listeners
+			// accumulate across heartbeat cycles, causing a memory leak
+			emitter.offAction('websocket.message', messageWatcher);
+		}, HEARTBEAT_FREQUENCY);
 
 		// ping all the clients
 		for (const client of pendingClients) {


### PR DESCRIPTION
## Description

The `pingClients()` method in `HeartbeatHandler` registers a new `websocket.message` event listener on every heartbeat cycle via `emitter.onAction('websocket.message', messageWatcher)`.

This listener was only cleaned up when `pendingClients.size === 0` (i.e., when all clients responded before the timeout). However, for idle clients that don't respond, the timeout fires and closes them, but the listener was never removed. Each subsequent heartbeat cycle added another listener, causing a memory leak and eventually a `MaxListenersExceededWarning`.

**Fix:** Clean up the per-cycle `messageWatcher` listener in the timeout callback, ensuring it's removed regardless of whether clients respond or not.

Additionally, reordered the `messageWatcher` and `timeout` declarations so they share the same scope via closure — necessary for the timeout to be able to clean up the watcher.

## Related

Fixes directus/directus#27830