### PR TITLE
Mark concealed/encrypted fields as writeOnly in generated OAS schema

### DIFF
--- a/api/src/services/specifications.ts
+++ b/api/src/services/specifications.ts
@@ -546,6 +546,11 @@ class OASSpecsService implements SpecificationSubService {
 			}
 		}
 
+		// Fields with conceal or encrypt special type never return real data on reads
+		if (field.special?.includes('conceal') || field.special?.includes('encrypt')) {
+			propertyObject.writeOnly = true;
+		}
+
 		return propertyObject;
 	}
 


### PR DESCRIPTION
## Description

The dynamically generated OpenAPI spec (`GET /server/specs/oas`) documents fields tagged `special: [conceal]` or `special: [encrypt]` as plain typed properties with no indication that reads never return real data. At read time these fields always return a masked or empty value.

## Changes

In the OAS schema generation code (`api/src/services/specifications.ts`), this adds `writeOnly: true` to the schema property for any field whose `special` array includes `"conceal"` or `"encrypt"`.

This is a quick accuracy fix that properly documents the API behavior — consumers of the OpenAPI spec will know these fields should only be used for writes, not reads.

## Related

Fixes directus/directus#27890