### PR TITLE
Add OpenAPI specification for /shares endpoint

### DIFF
--- a/api/src/services/specifications.ts
+++ b/api/src/services/specifications.ts
@@ -546,6 +546,11 @@ class OASSpecsService implements SpecificationSubService {
 			}
 		}
 
+		// Fields with conceal or encrypt special type never return real data on reads
+		if (field.special?.includes('conceal') || field.special?.includes('encrypt')) {
+			propertyObject.writeOnly = true;
+		}
+
 		return propertyObject;
 	}
 

--- a/packages/specs/src/components/share.yaml
+++ b/packages/specs/src/components/share.yaml
@@ -1,0 +1,67 @@
+type: object
+properties:
+  id:
+    description: Unique identifier for the share.
+    example: 63716273-0f29-4648-8a2a-2af2948f6f78
+    type: string
+  name:
+    description: Optional name for the share.
+    example: My Share
+    type: string
+    nullable: true
+  collection:
+    description: The collection of the shared item.
+    example: articles
+    oneOf:
+      - type: string
+      - $ref: '../openapi.yaml#/components/schemas/Collections'
+  item:
+    description: The shared item.
+    example: '1'
+    type: string
+  role:
+    description: The role that has access to the shared item.
+    example: 50419801-0f30-8644-2b3c-9bc2d980d0a0
+    nullable: true
+    oneOf:
+      - type: string
+      - $ref: '../openapi.yaml#/components/schemas/Roles'
+  password:
+    description: Optional password required to access the share.
+    example: null
+    type: string
+    nullable: true
+  user_created:
+    description: User that created the share.
+    example: 63716273-0f29-4648-8a2a-2af2948f6f78
+    nullable: true
+    oneOf:
+      - type: string
+      - $ref: '../openapi.yaml#/components/schemas/Users'
+  date_created:
+    description: When the share was created.
+    type: string
+    example: '2024-01-23T12:34:56Z'
+    format: date-time
+    nullable: true
+  date_start:
+    description: When the share becomes available.
+    type: string
+    example: '2024-01-23T12:34:56Z'
+    format: date-time
+    nullable: true
+  date_end:
+    description: When the share expires.
+    type: string
+    example: '2024-01-23T12:34:56Z'
+    format: date-time
+    nullable: true
+  times_used:
+    description: How many times the share has been used.
+    example: 0
+    type: integer
+  max_uses:
+    description: The maximum number of times the share can be used.
+    example: null
+    type: integer
+    nullable: true

--- a/packages/specs/src/openapi.yaml
+++ b/packages/specs/src/openapi.yaml
@@ -223,6 +223,18 @@ paths:
   /roles/{id}:
     $ref: './paths/roles/role.yaml'
 
+  # Shares
+  /shares:
+    $ref: './paths/shares/shares.yaml'
+  /shares/{id}:
+    $ref: './paths/shares/share.yaml'
+  /shares/auth:
+    $ref: './paths/shares/share-auth.yaml'
+  /shares/info/{pk}:
+    $ref: './paths/shares/share-info.yaml'
+  /shares/invite:
+    $ref: './paths/shares/share-invite.yaml'
+
   # Schema
   /schema/snapshot:
     $ref: './paths/schema/snapshot.yaml'
@@ -329,6 +341,8 @@ components:
       $ref: './components/revision.yaml'
     Roles:
       $ref: './components/role.yaml'
+    Shares:
+      $ref: './components/share.yaml'
     Schema:
       $ref: './components/schema.yaml'
     Settings:

--- a/packages/specs/src/paths/shares/share-auth.yaml
+++ b/packages/specs/src/paths/shares/share-auth.yaml
@@ -1,0 +1,56 @@
+post:
+  summary: Authenticate a Share
+  description: Authenticate a share access by providing the share ID and optional password. Returns an access token if successful.
+  tags:
+    - Shares
+  operationId: authenticateShare
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - share
+          properties:
+            share:
+              description: The UUID of the share to authenticate against.
+              type: string
+              format: uuid
+            password:
+              description: The password set on the share (if password protected).
+              type: string
+            mode:
+              description: Authentication mode. One of `json`, `cookie`, or `session`.
+              type: string
+              enum:
+                - json
+                - cookie
+                - session
+              default: json
+  responses:
+    '200':
+      description: Successful request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  access_token:
+                    description: Access token for the share.
+                    type: string
+                  refresh_token:
+                    description: Refresh token for the share.
+                    type: string
+                  expires:
+                    description: Token expiration time in milliseconds.
+                    type: integer
+    '401':
+      $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
+    '404':
+      $ref: '../../openapi.yaml#/components/responses/NotFoundError'
+    '429':
+      $ref: '../../openapi.yaml#/components/responses/TooManyRequestsError'

--- a/packages/specs/src/paths/shares/share-info.yaml
+++ b/packages/specs/src/paths/shares/share-info.yaml
@@ -1,0 +1,50 @@
+get:
+  summary: Get Share Info
+  description: Retrieve information about a share. This is a public endpoint that does not require authentication.
+  tags:
+    - Shares
+  operationId: getShareInfo
+  parameters:
+    - name: pk
+      in: path
+      required: true
+      description: The UUID of the share to retrieve info for.
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '200':
+      description: Successful request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  collection:
+                    type: string
+                  item:
+                    type: string
+                  password:
+                    type: boolean
+                    description: Whether the share is password protected.
+                  max_uses:
+                    type: integer
+                    nullable: true
+                  times_used:
+                    type: integer
+                  date_start:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  date_end:
+                    type: string
+                    format: date-time
+                    nullable: true
+    '404':
+      $ref: '../../openapi.yaml#/components/responses/NotFoundError'

--- a/packages/specs/src/paths/shares/share-invite.yaml
+++ b/packages/specs/src/paths/shares/share-invite.yaml
@@ -1,0 +1,32 @@
+post:
+  summary: Invite to a Share
+  description: Send an email invitation to the given email address(es) with a link to the share.
+  tags:
+    - Shares
+  operationId: inviteShare
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - share
+          properties:
+            share:
+              description: The UUID of the share to invite to.
+              type: string
+              format: uuid
+            emails:
+              description: Array of email addresses to send the invitation to.
+              type: array
+              items:
+                type: string
+                format: email
+  responses:
+    '200':
+      description: Successful request
+    '401':
+      $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
+    '404':
+      $ref: '../../openapi.yaml#/components/responses/NotFoundError'

--- a/packages/specs/src/paths/shares/share.yaml
+++ b/packages/specs/src/paths/shares/share.yaml
@@ -1,0 +1,70 @@
+get:
+  summary: Retrieve a Share
+  description: Retrieve a single share by unique identifier.
+  tags:
+    - Shares
+  operationId: getShare
+  parameters:
+    - $ref: '../../openapi.yaml#/components/parameters/Fields'
+    - $ref: '../../openapi.yaml#/components/parameters/Meta'
+  responses:
+    '200':
+      description: Successful request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '../../openapi.yaml#/components/schemas/Shares'
+    '401':
+      $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
+    '404':
+      $ref: '../../openapi.yaml#/components/responses/NotFoundError'
+
+patch:
+  summary: Update a Share
+  description: Update an existing share.
+  tags:
+    - Shares
+  operationId: updateShare
+  parameters:
+    - $ref: '../../openapi.yaml#/components/parameters/Fields'
+    - $ref: '../../openapi.yaml#/components/parameters/Meta'
+  requestBody:
+    content:
+      application/json:
+        schema:
+          anyOf:
+            - $ref: '../../openapi.yaml#/components/schemas/Shares'
+  responses:
+    '200':
+      description: Successful request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '../../openapi.yaml#/components/schemas/Shares'
+    '401':
+      $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
+    '404':
+      $ref: '../../openapi.yaml#/components/responses/NotFoundError'
+
+delete:
+  summary: Delete a Share
+  description: Delete an existing share.
+  tags:
+    - Shares
+  operationId: deleteShare
+  responses:
+    '200':
+      description: Successful request
+    '401':
+      $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
+    '404':
+      $ref: '../../openapi.yaml#/components/responses/NotFoundError'
+
+parameters:
+  - $ref: '../../openapi.yaml#/components/parameters/UUId'

--- a/packages/specs/src/paths/shares/shares.yaml
+++ b/packages/specs/src/paths/shares/shares.yaml
@@ -1,0 +1,114 @@
+get:
+  summary: List Shares
+  description: List all shares.
+  tags:
+    - Shares
+  operationId: getShares
+  parameters:
+    - $ref: '../../openapi.yaml#/components/parameters/Fields'
+    - $ref: '../../openapi.yaml#/components/parameters/Limit'
+    - $ref: '../../openapi.yaml#/components/parameters/Offset'
+    - $ref: '../../openapi.yaml#/components/parameters/Sort'
+    - $ref: '../../openapi.yaml#/components/parameters/Filter'
+    - $ref: '../../openapi.yaml#/components/parameters/Search'
+    - $ref: '../../openapi.yaml#/components/parameters/Meta'
+  responses:
+    '200':
+      description: Successful request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '../../openapi.yaml#/components/schemas/Shares'
+              meta:
+                $ref: '../../openapi.yaml#/components/schemas/x-metadata'
+    '401':
+      $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
+    '404':
+      $ref: '../../openapi.yaml#/components/responses/NotFoundError'
+
+post:
+  summary: Create a Share
+  description: Create a new share.
+  tags:
+    - Shares
+  operationId: createShare
+  parameters:
+    - $ref: '../../openapi.yaml#/components/parameters/Fields'
+  requestBody:
+    content:
+      application/json:
+        schema:
+          anyOf:
+            - $ref: '../../openapi.yaml#/components/schemas/Shares'
+  responses:
+    '200':
+      description: Successful request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '../../openapi.yaml#/components/schemas/Shares'
+    '401':
+      $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
+    '404':
+      $ref: '../../openapi.yaml#/components/responses/NotFoundError'
+
+patch:
+  summary: Update Multiple Shares
+  description: Update multiple shares at the same time.
+  tags:
+    - Shares
+  operationId: updateShares
+  parameters:
+    - $ref: '../../openapi.yaml#/components/parameters/Fields'
+    - $ref: '../../openapi.yaml#/components/parameters/Limit'
+    - $ref: '../../openapi.yaml#/components/parameters/Offset'
+    - $ref: '../../openapi.yaml#/components/parameters/Sort'
+    - $ref: '../../openapi.yaml#/components/parameters/Filter'
+    - $ref: '../../openapi.yaml#/components/parameters/Search'
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            data:
+              anyOf:
+                - $ref: '../../openapi.yaml#/components/schemas/Shares'
+            keys:
+              type: array
+              items:
+                type: string
+  responses:
+    '200':
+      description: Successful request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '../../openapi.yaml#/components/schemas/Shares'
+    '401':
+      $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
+
+delete:
+  summary: Delete Multiple Shares
+  description: Delete multiple existing shares.
+  tags:
+    - Shares
+  operationId: deleteShares
+  responses:
+    '200':
+      description: Successful request
+    '401':
+      $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'


### PR DESCRIPTION
Fixes directus/directus#27763

Adds OpenAPI spec coverage for the `/shares` endpoint, including:

* `GET /shares`, `POST /shares`, `PATCH /shares`, `DELETE /shares` (collection CRUD)
* `GET /shares/{id}`, `PATCH /shares/{id}`, `DELETE /shares/{id}` (item CRUD)
* `POST /shares/auth` - public share authentication endpoint
* `POST /shares/invite` - email invitation endpoint
* `GET /shares/info/{pk}` - public share information endpoint

Adds the `Shares` schema component for `directus_shares` fields and a new `Shares` tag.