### PR TITLE
Remove phantom `timestamp` from directus_operations

### DIFF
--- a/.changeset/nine-shoes-prove.md
+++ b/.changeset/nine-shoes-prove.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Removed phantom `timestamp` from directus_operations

--- a/sdk/src/schema/operation.ts
+++ b/sdk/src/schema/operation.ts
@@ -12,7 +12,6 @@ export type DirectusOperation<Schema = any> = MergeCoreCollection<
 		type: string;
 		position_x: number;
 		position_y: number;
-		timestamp: string;
 		options: Record<string, any> | null;
 		resolve: DirectusOperation<Schema> | string | null;
 		reject: DirectusOperation<Schema> | string | null;


### PR DESCRIPTION
## What's Changed

* Removed the phantom `timestamp` field from SDK Schema for `directus_operations`. <br>It doesn't appear to have ever existed from migration:<br>[https://github.com/directus/directus/blob/19b000ed723e3773a2eb4bf07440844a9e98df2d/api/src/database/migrations/20220429A-add-flows.ts#L21-L34](<https://github.com/directus/directus/blob/19b000ed723e3773a2eb4bf07440844a9e98df2d/api/src/database/migrations/20220429A-add-flows.ts#L21-L34>)

  And doesn't exist on the @directus/types:<br>[https://github.com/directus/directus/blob/19b000ed723e3773a2eb4bf07440844a9e98df2d/packages/types/src/flows.ts#L45-L58](<https://github.com/directus/directus/blob/19b000ed723e3773a2eb4bf07440844a9e98df2d/packages/types/src/flows.ts#L45-L58>)

## Tested Scenarios

* Lorem ipsum dolor sit amet
* Consectetur adipiscing elit

## Review Notes / Questions / Concerns

* An adjacent issue is the nullability of `options`, `date_created`, and `user_created`:
  * `table.json('options');` leaves options as nullable, and it's correctly typed in the SDK Schema but it's not nullable in `OperationRaw` or `Operation` from @directus/types
  * `table.timestamp('date_created').defaultTo(knex.fn.now());` has a default but missing `.notNullable()` - This would harden the database for manual manipulation but I don't know how to fix this (is it a new migration (I don't think editing the existing migration would work)? would it be a breaking change, if so for what package?
  * `table.uuid('user_created').references('id').inTable('directus_users').onDelete('SET NULL');` sets null when the user is deleted but `Operation` and `OperationRaw` in @directus/types is missing ` | null;`

Depending on your answers here, I can expand the scope of this PR, defer indefinitely or create a new separate issue for someone else to fix.

As an aside, the number of small changes I'm working on that might touch major/minor and the speed at which it's reasonable to go through them might lend to giving a feature branch that I can merge into. The drift on a lot of the issues I'm finding is sometimes 2-3 years old so I'm not concerned about drift from main to my feature branch. It'd probably be a months worth of work on the feature branch and would prevent rapidly escalating release bumps.

This is the first of many that I had flagged for researching. I think I have 8 or so that the fix is hardening the DB migrations. 30 or so that have a mismatched null or other field incorrect in the SDK Schema and 10 or so that have a mismatched null or other field incorrect in the @directus/types library.

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](<https://github.com/directus/openapi>)
- [X] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

I didn't create an issue. Sorry. Found this when I was trying to work on directus/directus#27700