### PR TITLE
fix(sdk): declare RequestCredentials and CloseEvent locally to avoid DOM lib dependency

### DIFF
--- a/.changeset/sdk-dom-lib-types.md
+++ b/.changeset/sdk-dom-lib-types.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Fixed SDK type definitions requiring the `DOM` lib by declaring local `RequestCredentials` and `CloseEvent` equivalents

--- a/sdk/src/auth/types.ts
+++ b/sdk/src/auth/types.ts
@@ -1,3 +1,5 @@
+import type { RequestCredentials } from '../types/globals.js';
+
 export type AuthenticationMode = 'json' | 'cookie' | 'session';
 
 export type LocalLoginPayload = { email: string; password: string };

--- a/sdk/src/graphql/types.ts
+++ b/sdk/src/graphql/types.ts
@@ -1,3 +1,5 @@
+import type { RequestCredentials } from '../types/globals.js';
+
 export interface GraphqlClient<_Schema> {
 	query<Output extends object = Record<string, any>>(
 		query: string,

--- a/sdk/src/realtime/types.ts
+++ b/sdk/src/realtime/types.ts
@@ -1,4 +1,5 @@
 import type { ApplyQueryFields, CollectionType, WebSocketInterface } from '../index.js';
+import type { CloseEventInterface } from '../types/globals.js';
 import type { Query } from '../types/query.js';
 
 export type WebSocketAuthModes = 'public' | 'handshake' | 'strict';
@@ -29,7 +30,7 @@ export interface SubscribeOptions<Schema, Collection extends keyof Schema> {
 
 export type WebSocketEvents = 'open' | 'close' | 'error' | 'message';
 export type RemoveEventHandler = () => void;
-export type WebSocketEventHandler = (this: WebSocketInterface, ev: Event | CloseEvent | any) => any;
+export type WebSocketEventHandler = (this: WebSocketInterface, ev: Event | CloseEventInterface | any) => any;
 
 export interface WebSocketClient<Schema> {
 	isConnected(): Promise<boolean>;
@@ -37,7 +38,7 @@ export interface WebSocketClient<Schema> {
 	disconnect(): void;
 	onWebSocket(event: 'open', callback: (this: WebSocketInterface, ev: Event) => any): RemoveEventHandler;
 	onWebSocket(event: 'error', callback: (this: WebSocketInterface, ev: Event) => any): RemoveEventHandler;
-	onWebSocket(event: 'close', callback: (this: WebSocketInterface, ev: CloseEvent) => any): RemoveEventHandler;
+	onWebSocket(event: 'close', callback: (this: WebSocketInterface, ev: CloseEventInterface) => any): RemoveEventHandler;
 	onWebSocket(event: 'message', callback: (this: WebSocketInterface, ev: any) => any): RemoveEventHandler;
 	onWebSocket(event: WebSocketEvents, callback: WebSocketEventHandler): RemoveEventHandler;
 	sendMessage(message: string | Record<string, any>): void;

--- a/sdk/src/rest/types.ts
+++ b/sdk/src/rest/types.ts
@@ -1,3 +1,4 @@
+import type { RequestCredentials } from '../types/globals.js';
 import type { RequestOptions, RequestTransformer, ResponseTransformer } from '../types/request.js';
 
 export interface RestCommand<_Output extends object | unknown, _Schema> {

--- a/sdk/src/types/globals.ts
+++ b/sdk/src/types/globals.ts
@@ -1,6 +1,23 @@
 // using "| any" to ensure compatibility with various "Fetch" alternative function signatures
 export type FetchInterface = (input: string | any, init?: RequestInit | any) => Promise<unknown>;
 
+/**
+ * Structural equivalent of the DOM `RequestCredentials` type, redeclared here so the SDK's public
+ * type definitions don't require the `DOM` lib to be present in consuming projects (e.g. Node ESM).
+ */
+export type RequestCredentials = 'omit' | 'same-origin' | 'include';
+
+/**
+ * Minimal structural equivalent of the DOM `CloseEvent`, redeclared here so the SDK's public type
+ * definitions don't require the `DOM` lib to be present in consuming projects (e.g. Node ESM).
+ */
+export type CloseEventInterface = {
+	readonly type: string;
+	readonly code: number;
+	readonly reason: string;
+	readonly wasClean: boolean;
+};
+
 export type UrlInterface = typeof URL;
 
 /** While the standard says 'string | URL' for the 'url' parameter, some implementations (e.g. React Native) only accept 'string' */


### PR DESCRIPTION
## Scope

Fixes directus/directus#26850

## Problem

The SDK's generated type definitions reference the ambient **DOM** types `RequestCredentials` and `CloseEvent`. Consumers whose `tsconfig` does not include the `DOM` lib — e.g. Node ESM projects (`"type": "module"`) with `skipLibCheck: false` — get build errors:

```
node_modules/@directus/sdk/dist/auth/types.d.ts:41:17 - error TS2304: Cannot find name 'RequestCredentials'.
node_modules/@directus/sdk/dist/graphql/types.d.ts:6:17 - error TS2304: Cannot find name 'RequestCredentials'.
node_modules/@directus/sdk/dist/rest/types.d.ts:11:17 - error TS2304: Cannot find name 'RequestCredentials'.
node_modules/@directus/sdk/dist/realtime/types.d.ts:28:69 - error TS2304: Cannot find name 'CloseEvent'.
node_modules/@directus/sdk/dist/realtime/types.d.ts:35:72 - error TS2304: Cannot find name 'CloseEvent'.
```

The only current workaround is setting `skipLibCheck: true`.

## Root cause

`RequestCredentials` and `CloseEvent` are DOM lib types. The SDK is isomorphic and consumed in Node environments that legitimately don't load the `DOM` lib, so its **public** `.d.ts` should not depend on those ambient names being present. (Note `@types/node` exposes `RequestInit`/`Event` globally but not `RequestCredentials`/`CloseEvent`, which is exactly why only those two surface as errors.)

## Fix

Follow the SDK's existing self-contained-globals pattern (`FetchInterface`, `WebSocketInterface`, `UrlInterface` in `sdk/src/types/globals.ts`) and declare local structural equivalents:

* `RequestCredentials = 'omit' | 'same-origin' | 'include'` — identical to the DOM union, so values passed through to `fetch` remain valid.
* `CloseEventInterface` — minimal structural equivalent (`type`, `code`, `reason`, `wasClean`) covering what a WebSocket `close` handler reads.

The auth / graphql / rest / realtime public types now import these local types instead of relying on the ambient DOM globals. No runtime behavior changes — this is purely type surface.

## How I verified

* `pnpm --filter @directus/sdk test` (vitest `--typecheck`) — **all 105 tests pass, no type errors**, so the SDK still compiles internally (it builds with the `DOM` lib).
* Built the SDK and confirmed the emitted `dist/**/*.d.ts` now import `RequestCredentials` / `CloseEventInterface` from `./types/globals.js` rather than referencing bare DOM globals.
* Reproduced the reporter's setup in a scratch consumer (`lib: ["ES2023"]`, `types: ["node"]`, `skipLibCheck: false`) importing the built SDK: the five `TS2304` errors are gone.