### PR TITLE
fix(api): always skip cache for Data Studio requests 🤖🤖🤖

### DIFF
--- a/.changeset/fix-studio-stale-cache.md
+++ b/.changeset/fix-studio-stale-cache.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed the Data Studio serving stale cached data by always skipping the cache for Data Studio requests, regardless of `CACHE_AUTO_PURGE` and cache-skip settings

--- a/api/src/utils/should-skip-cache.test.ts
+++ b/api/src/utils/should-skip-cache.test.ts
@@ -40,7 +40,7 @@ test.each([
 	{ scenario: 'relative', publicURL: '/', refererHost: 'http://ignore.domain' },
 	{ scenario: 'relative with subdirectory', publicURL: '/test/subfolder', refererHost: 'http://ignore.domain' },
 ])(
-	'should not skip cache for requests coming from data studio when public URL is $scenario and CACHE_AUTO_PURGE is true',
+	'should skip cache for requests coming from data studio when public URL is $scenario and CACHE_AUTO_PURGE is true',
 	({ publicURL, refererHost }) => {
 		vi.mocked(useEnv).mockReturnValue({
 			PUBLIC_URL: publicURL,
@@ -61,7 +61,7 @@ test.each([
 			originalUrl: 'http://admin.example.com/items/some_collection',
 		} as unknown as Request;
 
-		expect(shouldSkipCache(req)).toBe(false);
+		expect(shouldSkipCache(req)).toBe(true);
 	},
 );
 

--- a/api/src/utils/should-skip-cache.ts
+++ b/api/src/utils/should-skip-cache.ts
@@ -1,6 +1,4 @@
-import url from 'url';
 import { useEnv } from '@directus/env';
-import { getEndpoint } from '@directus/utils';
 import type { Request } from 'express';
 import { Url } from './url.js';
 
@@ -13,7 +11,8 @@ import { Url } from './url.js';
 export function shouldSkipCache(req: Request): boolean {
 	const env = useEnv();
 
-	// Always skip cache for requests coming from the data studio based on Referer header
+	// Always skip cache for requests coming from the data studio (based on the Referer header) so the
+	// studio returns the latest data regardless of cache settings.
 	const referer = req.get('Referer');
 
 	if (referer) {
@@ -21,8 +20,8 @@ export function shouldSkipCache(req: Request): boolean {
 
 		if (adminUrl.isRootRelative()) {
 			const refererUrl = new Url(referer);
-			if (refererUrl.path.join('/').startsWith(adminUrl.path.join('/')) && checkAutoPurge()) return true;
-		} else if (referer.startsWith(adminUrl.toString()) && checkAutoPurge()) {
+			if (refererUrl.path.join('/').startsWith(adminUrl.path.join('/'))) return true;
+		} else if (referer.startsWith(adminUrl.toString())) {
 			return true;
 		}
 	}
@@ -30,22 +29,4 @@ export function shouldSkipCache(req: Request): boolean {
 	if (env['CACHE_SKIP_ALLOWED'] && req.get('cache-control')?.includes('no-store')) return true;
 
 	return false;
-
-	function checkAutoPurge() {
-		if (env['CACHE_AUTO_PURGE'] === false) return true;
-
-		const path = url.parse(req.originalUrl).pathname;
-
-		if (!path) return false;
-
-		for (const collection of env['CACHE_AUTO_PURGE_IGNORE_LIST'] as string[]) {
-			const ignoredPath = getEndpoint(collection);
-
-			if (path.startsWith(ignoredPath)) {
-				return true;
-			}
-		}
-
-		return false;
-	}
 }


### PR DESCRIPTION
## What's Changed

`shouldSkipCache` now always bypasses the cache for requests originating from the Data Studio (detected via the `Referer` header), regardless of `CACHE_AUTO_PURGE` / cache-skip settings.

Previously the studio-Referer path was gated by an internal `checkAutoPurge()` helper. When `CACHE_AUTO_PURGE=true`, that helper returned `false` for regular collections, so studio reads were served from the cache and showed stale data after edits (the originally reported symptom). The helper — and its now-unused `url` / `getEndpoint` imports — has been removed.

This implements the approach @ComfortablyCoding described when closing the earlier attempt (#26659):

> The studio should always return the latest data regardless of cache settings.

The generic `CACHE_SKIP_ALLOWED` + `Cache-Control: no-store` request-header path is intentionally left unchanged, so this does not re-introduce the previously-rejected `no-cache`-under-`CACHE_SKIP_ALLOWED` behavior. `CACHE_AUTO_PURGE_IGNORE_LIST` remains consumed by `should-clear-cache.ts`, so no configuration option is orphaned.

## Tested Scenarios

- Unit tests in `api/src/utils/should-skip-cache.test.ts`:
  - Data Studio request with `CACHE_AUTO_PURGE=false` → skips cache (unchanged).
  - Data Studio request with `CACHE_AUTO_PURGE=true`, regular collection → now skips cache (regression coverage for this issue; expectation updated from `false` to `true`).
  - Data Studio request with `CACHE_AUTO_PURGE=true`, ignore-listed collection → skips cache (unchanged).
  - Non-studio request → does not skip (unchanged).
  - `CACHE_SKIP_ALLOWED` + `no-store` request header → honored as before (unchanged).

## Review Notes / Questions / Concerns

- This is an intentional behavior change: studio traffic now always bypasses the response cache. It only affects `Referer`-detected Data Studio requests, not public API clients, trading a small cache-hit-rate reduction on interactive admin traffic for correctness.
- One existing test's expectation was inverted to match the new intended behavior; happy to adjust naming/coverage if you'd prefer a different framing.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs)
- [ ] OpenAPI updated
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes #26278