### PR TITLE
fix(v-table): add touch-action: none to drag handle for iOS drag support

### DIFF
--- a/app/src/components/v-table/table-row.vue
+++ b/app/src/components/v-table/table-row.vue
@@ -128,6 +128,7 @@ function onKeydown(e: KeyboardEvent) {
 
 	.drag-handle {
 		--v-icon-color: var(--theme--foreground-subdued);
+		touch-action: none;
 
 		&.sorted-manually {
 			--v-icon-color: var(--theme--foreground);


### PR DESCRIPTION
Fixes directus/directus#27908

iOS Safari/Chrome intercepts `touchmove` events for native scrolling before SortableJS can claim them, preventing drag-and-drop row reordering from working on any iOS device.

The fix is a single CSS property on `.drag-handle` in `table-row.vue`:

```scss
.drag-handle {
  touch-action: none;
}
```

This tells the browser to hand off pointer events on the handle element to JavaScript rather than consuming them for scroll, which is the standard fix for SortableJS on iOS.

Kanban was checked — it has no discrete handle element (full-card dragging), so this change doesn't apply there.