### PR TITLE
fix(api): use continue instead of break for empty key in sanitizeDeep

### DIFF
--- a/.changeset/fix-sanitize-deep-break-to-continue.md
+++ b/.changeset/fix-sanitize-deep-break-to-continue.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fix `sanitizeDeep` silently dropping relation keys after an empty string key — `break` replaced with `continue` so only the empty key is skipped instead of aborting the entire loop

--- a/api/src/utils/sanitize-query.test.ts
+++ b/api/src/utils/sanitize-query.test.ts
@@ -421,6 +421,19 @@ describe('deep', () => {
 			},
 		});
 	});
+
+	test('should skip empty string keys but continue processing subsequent valid relation keys', async () => {
+		const deep = {
+			deep: {
+				'': { _sort: ['name'] },
+				valid_relation: { _sort: ['title'] },
+			},
+		};
+
+		const sanitizedQuery = await sanitizeQuery({ deep }, null as any);
+
+		expect(sanitizedQuery.deep).toEqual({ deep: { valid_relation: { _sort: ['title'] } } });
+	});
 });
 
 describe('alias', () => {

--- a/api/src/utils/sanitize-query.ts
+++ b/api/src/utils/sanitize-query.ts
@@ -261,7 +261,7 @@ async function sanitizeDeep(deep: Record<string, any>, schema: SchemaOverview, a
 		const parsedLevel: Record<string, any> = {};
 
 		for (const [key, value] of Object.entries(level)) {
-			if (!key) break;
+			if (!key) continue;
 
 			if (key.startsWith('_')) {
 				// Collect all sub query parameters without the leading underscore

--- a/contributors.yml
+++ b/contributors.yml
@@ -285,3 +285,12 @@
 - levgiorg
 - MahinAnowar
 - joeltco
+- alex-hsieh
+- amitmishra11
+- BIGSUS24
+- rajkumar0932
+- itsabhay1
+- tsushanth
+- apoorva-01
+- lazerg
+- Harshith-muddasani


### PR DESCRIPTION
## What

In `sanitizeDeep` (`api/src/utils/sanitize-query.ts`), the inner `parse()` function iterates over the entries of the deep query object and guards against empty string keys with:

```ts
if (!key) break;
```

`break` exits the entire `for...of` loop, so any relation keys that appear **after** the empty key in the same object are silently dropped. The correct statement is `continue`, which skips only the empty key and lets the loop process remaining entries.

## How to reproduce

Send a `deep` parameter that contains an empty bracket segment alongside a named relation segment where the empty key sorts before the named key (insertion order):

```
GET /items/articles?deep[][_limit]=5&deep[authors][_sort]=id
```

The parsed `deep` object becomes `{ "": { _limit: 5 }, authors: { _sort: "id" } }`. With `break`, the `authors` deep query is silently ignored; with `continue`, both are processed.

## Fix

```diff
- if (!key) break;
+ if (!key) continue;
```