### PR TITLE
tw ← Tiptap WYSIWYG: revert font family to default (ENG-1471)

### DIFF
--- a/app/src/interfaces/input-rich-text-html/toolbar/buttons.test.ts
+++ b/app/src/interfaces/input-rich-text-html/toolbar/buttons.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'vitest';
+import { toolbarButtons } from './buttons';
+
+describe('font-family toolbar button', () => {
+	// The revert-to-default entry (value null → unsetFontFamily) must be the first item so users can
+	// clear a custom font and fall back to the editor's base font.
+	test('exposes a Default (null) revert entry first', () => {
+		const items = toolbarButtons.fontfamily!.componentProps!.items as { label: string; value: string | null }[];
+		expect(items[0]).toEqual({ label: 'wysiwyg_options.default', value: null });
+	});
+});

--- a/app/src/interfaces/input-rich-text-html/toolbar/buttons.ts
+++ b/app/src/interfaces/input-rich-text-html/toolbar/buttons.ts
@@ -65,7 +65,9 @@ const headings: Record<string, ToolbarButton> = Object.fromEntries(
 );
 
 // Mirrors TinyMCE's default `font_family_formats` so existing content maps to the same names.
+// The leading `null` entry reverts to the editor's base font (unsetFontFamily).
 const FONT_FAMILIES: { label: string; value: string | null }[] = [
+	{ label: 'wysiwyg_options.default', value: null },
 	{ label: 'Andale Mono', value: "'Andale Mono', monospace" },
 	{ label: 'Arial', value: 'Arial, Helvetica, sans-serif' },
 	{ label: 'Arial Black', value: "'Arial Black', sans-serif" },

--- a/app/src/interfaces/input-rich-text-html/toolbar/menus/style-list-menu.test.ts
+++ b/app/src/interfaces/input-rich-text-html/toolbar/menus/style-list-menu.test.ts
@@ -53,6 +53,60 @@ describe('style-list-menu', () => {
 		expect(readStyle(editor, 'fontSize')).toBeNull();
 	});
 
+	// The font-family picker has no `defaultValue` (its default is "unset"), so the null "Default" entry must
+	// highlight while nothing is applied, and clear once a real font is set.
+	test('highlights the Default (null) entry when nothing is applied', () => {
+		const wrapper = mount(StyleListMenu, {
+			props: {
+				editor,
+				icon: 'font_download',
+				label: 'wysiwyg_options.fontselect',
+				attr: 'fontFamily' as const,
+				items: [
+					{ label: 'wysiwyg_options.default', value: null },
+					{ label: 'Arial Black', value: "'Arial Black', sans-serif" },
+				],
+			},
+			global,
+		});
+
+		const vm = wrapper.vm as unknown as {
+			select: (v: string | null) => void;
+			isActive: (item: { label: string; value: string | null }) => boolean;
+		};
+
+		expect(vm.isActive({ label: 'wysiwyg_options.default', value: null })).toBe(true);
+
+		vm.select("'Arial Black', sans-serif");
+		expect(vm.isActive({ label: 'wysiwyg_options.default', value: null })).toBe(false);
+		expect(vm.isActive({ label: 'Arial Black', value: "'Arial Black', sans-serif" })).toBe(true);
+	});
+
+	// The null "Default" entry shows the editor's effective default font (the resolved theme family passed as
+	// `defaultLabel`) instead of the generic "Default", matching what the activator already shows.
+	test('shows the effective default font name for the null entry', () => {
+		const wrapper = mount(StyleListMenu, {
+			props: {
+				editor,
+				icon: 'font_download',
+				label: 'wysiwyg_options.fontselect',
+				attr: 'fontFamily' as const,
+				defaultLabel: 'Inter, system-ui, sans-serif',
+				items: [
+					{ label: 'wysiwyg_options.default', value: null },
+					{ label: 'Arial Black', value: "'Arial Black', sans-serif" },
+				],
+			},
+			global,
+		});
+
+		const vm = wrapper.vm as unknown as {
+			displayLabel: (item: { label: string; value: string | null }) => string;
+		};
+
+		expect(vm.displayLabel({ label: 'wysiwyg_options.default', value: null })).toBe('Inter, system-ui, sans-serif');
+	});
+
 	// A real browser rewrites the single quotes in our item values to double when it serializes the inline
 	// style, so the value read back differs from the item by quote style only. The activator label must still
 	// match the named font instead of falling back to the raw quoted value (the `"Arial Blac…` bug).

--- a/app/src/interfaces/input-rich-text-html/toolbar/menus/style-list-menu.vue
+++ b/app/src/interfaces/input-rich-text-html/toolbar/menus/style-list-menu.vue
@@ -51,19 +51,29 @@ function normalize(value: string | null): string | null {
 function isActive(item: Item): boolean {
 	const value = current();
 	// Nothing applied → highlight the default item, so the menu reflects the editor's effective value.
-	if (value === null) return props.defaultValue !== undefined && item.value === props.defaultValue;
+	// With no explicit `defaultValue` (e.g. font family, whose default is "unset"), the null entry matches.
+	if (value === null) return item.value === (props.defaultValue ?? null);
 	return item.value !== null && normalize(value) === normalize(item.value);
 }
 
-/** Item labels that are i18n keys (the "Default" entry) are translated; literal names shown as-is. */
+// The null "Default" entry shows the editor's effective default (e.g. the resolved base font family) when
+// known, falling back to a translated "Default". i18n-key labels are translated; literal names shown as-is.
 function displayLabel(item: Item): string {
+	if (item.value === null) return props.defaultLabel || t('wysiwyg_options.default');
 	return item.label.startsWith('wysiwyg_options.') ? t(item.label) : item.label;
+}
+
+/** Preview font for a list item: its own value, or the effective default for the null "Default" entry. */
+function previewStyle(item: Item): { fontFamily: string } | undefined {
+	if (!props.previewFont) return undefined;
+	const family = item.value ?? props.defaultLabel;
+	return family ? { fontFamily: family } : undefined;
 }
 
 /** The label shown on the activator: the matched item, the raw value as a fallback, or "Default". */
 const currentLabel = computed(() => {
 	const value = current();
-	if (value === null) return props.defaultLabel ?? t('wysiwyg_options.default');
+	if (value === null) return props.defaultLabel || t('wysiwyg_options.default');
 	const match = props.items.find((item) => normalize(item.value) === normalize(value));
 	return match ? displayLabel(match) : value;
 });
@@ -76,7 +86,7 @@ function select(value: string | null): void {
 	if (props.editor) applyStyle(props.editor, props.attr, value);
 }
 
-defineExpose({ select, currentLabel });
+defineExpose({ select, currentLabel, isActive, displayLabel });
 </script>
 
 <template>
@@ -101,7 +111,7 @@ defineExpose({ select, currentLabel });
 		<VList class="style-list">
 			<VListItem v-for="item in items" :key="item.label" clickable :active="isActive(item)" @click="select(item.value)">
 				<VListItemContent>
-					<span :style="previewFont && item.value ? { fontFamily: item.value } : undefined">
+					<span :style="previewStyle(item)">
 						{{ displayLabel(item) }}
 					</span>
 				</VListItemContent>


### PR DESCRIPTION
## What's Changed

- Add a **Default** entry to the font-family dropdown that reverts the selection to the editor's base font (calls `unsetFontFamily`). The command plumbing already existed; it just had no entry in the font list.
- The Default entry now shows the *resolved* base font name (e.g. `Inter, system-ui, sans-serif`) instead of a generic "Default", matching what the activator already displays, and previews the label in that font.
- Highlight the Default entry as active when no custom font is applied.

## Tested Scenarios

- Change a font, then select **Default** → reverts to the editor's base font.
- With nothing applied, the Default entry shows the resolved theme font name and is highlighted as active.
- Font-size dropdown behavior unchanged (its default stays the base size).
- Unit tests: `buttons.test.ts` (revert entry present) + `style-list-menu.test.ts` (default highlight + label). Full interface suite green (358 tests).

## Review Notes / Questions / Concerns

- Base branch is `feat/wysiwyg-tiptap` (this depends on the unmerged WYSIWYG work), not `main`.
- No new i18n strings: reuses the existing `wysiwyg_options.default` key.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs)
- [ ] App translations added for new user-facing strings

---

Closes ENG-1471