### PR TITLE
tw ← Tiptap WYSIWYG: prevent custom formats triggering normalization warning (ENG-1474)

### DIFF
--- a/.changeset/eng-1474-custom-formats-normalization-warning.md
+++ b/.changeset/eng-1474-custom-formats-normalization-warning.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed configured custom formats falsely triggering the unsupported data warning in the Tiptap rich text editor, which locked the field on load

--- a/app/src/interfaces/input-rich-text-html/composables/normalization-diff.test.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/normalization-diff.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
-import { computeNormalizationDiff } from './normalization-diff';
+import { buildCustomFormats } from '../extensions/custom-formats';
+import { computeNormalizationDiff, computeValueNormalizationDiff } from './normalization-diff';
 
 function removedText(code: string): string {
 	const changes = computeNormalizationDiff(code);
@@ -30,5 +31,32 @@ describe('computeNormalizationDiff', () => {
 
 	test('returns null for iframe preserved by the media node', () => {
 		expect(computeNormalizationDiff('<iframe src="about:blank"></iframe>')).toBeNull();
+	});
+
+	// Custom-format marks live only on the editor instance, so the round-trip must be told about them
+	// or their markup reads as dropped/reordered and falsely triggers the warning (ENG-1474).
+	test('returns null for custom-format markup when its extensions are supplied', () => {
+		const { extensions } = buildCustomFormats([
+			{ title: 'Highlight', inline: 'span', classes: 'highlight', styles: { 'background-color': 'yellow' } },
+			{ title: 'Cite', inline: 'cite', classes: 'src' },
+		]);
+
+		expect(
+			computeNormalizationDiff(
+				'<p><span class="highlight" style="background-color: yellow;">a</span> <cite class="src">b</cite></p>',
+				extensions,
+			),
+		).toBeNull();
+	});
+
+	test('still flags custom-format markup when the extensions are missing', () => {
+		expect(removedText('<p><cite class="src">b</cite></p>')).toContain('cite');
+	});
+});
+
+describe('computeValueNormalizationDiff', () => {
+	test('returns null for custom-format markup when its extensions are supplied', () => {
+		const { extensions } = buildCustomFormats([{ title: 'Cite', inline: 'cite', classes: 'src' }]);
+		expect(computeValueNormalizationDiff('<p><cite class="src">b</cite></p>', extensions)).toBeNull();
 	});
 });

--- a/app/src/interfaces/input-rich-text-html/composables/normalization-diff.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/normalization-diff.ts
@@ -1,13 +1,14 @@
-import { Editor } from '@tiptap/vue-3';
+import { type AnyExtension, Editor } from '@tiptap/vue-3';
 import { type Change, diffLines } from 'diff';
 import { editorExtensions } from '../extensions';
 import { decodePageBreaks, encodePageBreaks } from '../extensions/page-break';
 import { formatHtml } from './format-html';
 
 // Re-parse through the schema exactly as saveSourceCode will, so the diff compares against what
-// actually gets stored.
-function roundTrip(html: string): string {
-	const editor = new Editor({ extensions: editorExtensions, content: html });
+// actually gets stored. `extraExtensions` carries the instance-only marks (custom formats) the live
+// editor was built with — without them their markup reads as dropped and falsely trips the warning.
+function roundTrip(html: string, extraExtensions: AnyExtension[]): string {
+	const editor = new Editor({ extensions: [...editorExtensions, ...extraExtensions], content: html });
 	const out = editor.getHTML();
 	editor.destroy();
 	return out;
@@ -28,8 +29,8 @@ function diffFormatted(rawBefore: string, rawAfter: string): Change[] | null {
  * Diffs the source-code drawer's HTML against what saving it would actually store. Returns null
  * when the document survives normalization unchanged.
  */
-export function computeNormalizationDiff(code: string): Change[] | null {
-	return diffFormatted(code, roundTrip(code));
+export function computeNormalizationDiff(code: string, extraExtensions: AnyExtension[] = []): Change[] | null {
+	return diffFormatted(code, roundTrip(code, extraExtensions));
 }
 
 /**
@@ -37,7 +38,7 @@ export function computeNormalizationDiff(code: string): Change[] | null {
  * representation so the page-break marker ↔ element boundary cancels out instead of reading
  * as a change.
  */
-export function computeValueNormalizationDiff(value: string): Change[] | null {
+export function computeValueNormalizationDiff(value: string, extraExtensions: AnyExtension[] = []): Change[] | null {
 	const decoded = decodePageBreaks(value);
-	return diffFormatted(encodePageBreaks(decoded), encodePageBreaks(roundTrip(decoded)));
+	return diffFormatted(encodePageBreaks(decoded), encodePageBreaks(roundTrip(decoded, extraExtensions)));
 }

--- a/app/src/interfaces/input-rich-text-html/composables/use-normalization-warning.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/use-normalization-warning.ts
@@ -1,3 +1,4 @@
+import type { AnyExtension } from '@tiptap/vue-3';
 import type { Change } from 'diff';
 import { Ref, ref } from 'vue';
 import { computeValueNormalizationDiff } from './normalization-diff';
@@ -18,7 +19,10 @@ type UsableNormalizationWarning = {
  * edit can reach the value — and thus autosave — until the warning dialog is confirmed. Content
  * that survives normalization never locks.
  */
-export function useNormalizationWarning(value: Ref<string | null>): UsableNormalizationWarning {
+export function useNormalizationWarning(
+	value: Ref<string | null>,
+	extraExtensions: AnyExtension[] = [],
+): UsableNormalizationWarning {
 	const normalizationLocked = ref(false);
 	const normalizationWarningOpen = ref(false);
 	const normalizationWarningDiff = ref<Change[]>([]);
@@ -42,7 +46,7 @@ export function useNormalizationWarning(value: Ref<string | null>): UsableNormal
 			return;
 		}
 
-		const diff = computeValueNormalizationDiff(value.value);
+		const diff = computeValueNormalizationDiff(value.value, extraExtensions);
 		normalizationLocked.value = diff !== null;
 		normalizationWarningDiff.value = diff ?? [];
 	}

--- a/app/src/interfaces/input-rich-text-html/composables/use-source-code.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/use-source-code.ts
@@ -1,4 +1,4 @@
-import type { Editor } from '@tiptap/vue-3';
+import type { AnyExtension, Editor } from '@tiptap/vue-3';
 import type { Change } from 'diff';
 import { Ref, ref } from 'vue';
 import { formatHtml } from './format-html';
@@ -16,7 +16,7 @@ type UsableSourceCode = {
 	cancelNormalize: () => void;
 };
 
-export function useSourceCode(editor: Ref<Editor>): UsableSourceCode {
+export function useSourceCode(editor: Ref<Editor>, extraExtensions: AnyExtension[] = []): UsableSourceCode {
 	const sourceCodeDrawerOpen = ref(false);
 	const code = ref('');
 	const normalizeConfirmOpen = ref(false);
@@ -47,7 +47,7 @@ export function useSourceCode(editor: Ref<Editor>): UsableSourceCode {
 	// If saving would drop markup the schema can't represent, surface the diff for confirmation;
 	// otherwise apply straight away.
 	function saveSourceCode() {
-		const diff = computeNormalizationDiff(code.value);
+		const diff = computeNormalizationDiff(code.value, extraExtensions);
 
 		if (diff === null) {
 			applySourceCode();

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -79,7 +79,7 @@ const {
 	onLockedClick,
 	confirmNormalizationWarning,
 	cancelNormalizationWarning,
-} = useNormalizationWarning(value);
+} = useNormalizationWarning(value, customFormatExtensions);
 
 // skipped for display-only modes; comparison values carry diff spans the base schema would flag as loss
 if (!props.comparisonMode && !props.nonEditable) checkValue();
@@ -245,7 +245,7 @@ const {
 	saveSourceCode,
 	confirmSaveSourceCode,
 	cancelNormalize,
-} = useSourceCode(editor as Ref<Editor>);
+} = useSourceCode(editor as Ref<Editor>, customFormatExtensions);
 
 // pause the surrounding view's focus trap while a drawer is open so its inputs stay reachable
 const { pauseFocusTrap, unpauseFocusTrap } = useInjectFocusTrapManager();

--- a/app/src/interfaces/input-rich-text-html/normalization-warning.test.ts
+++ b/app/src/interfaces/input-rich-text-html/normalization-warning.test.ts
@@ -12,11 +12,11 @@ import Interface from './input-rich-text-html.vue';
  * the editor read-only (so no edit can reach autosave) until the warning dialog is confirmed
  * (see use-normalization-warning.test.ts for the state machine itself).
  */
-async function mountWithValue(value: string | null) {
+async function mountWithValue(value: string | null, extraProps: Record<string, unknown> = {}) {
 	const i18n = createI18n({ legacy: false, locale: 'en-US', messages: { 'en-US': {} } });
 
 	const wrapper = mount(Interface, {
-		props: { value },
+		props: { value, ...extraProps },
 		global: {
 			plugins: [createPinia(), i18n],
 			stubs: {
@@ -105,6 +105,16 @@ describe('normalization warning wiring', () => {
 		await nextTick();
 
 		expect(editor.isEditable).toBe(false);
+	});
+
+	// custom-format marks live only on this editor instance; the guard's round-trip must know them
+	// or their stored markup falsely reads as lossy and locks the editor (ENG-1474)
+	test('a value using a configured custom format mounts editable', async () => {
+		const { editor } = await mountWithValue('<p><cite class="src">quoted</cite></p>', {
+			customFormats: [{ title: 'Cite', inline: 'cite', classes: 'src' }],
+		});
+
+		expect(editor.isEditable).toBe(true);
 	});
 
 	test('cancelling the warning keeps the editor read-only', async () => {


### PR DESCRIPTION
## What's Changed

- Fixed configured custom formats falsely triggering the "unsupported data" normalization warning, which locked the field on load
- The normalization guard's round-trip re-parsed HTML through only the static `editorExtensions`, never the dynamically-built custom-format marks the live editor actually runs with, so custom-format markup (e.g. `<cite class="src">`, or a `<span class="…" style="…">` reordered on parse) looked lossy to the guard even though it round-trips cleanly in the real editor
- Threaded the instance-only custom-format extensions into the round-trip: `roundTrip` / `computeNormalizationDiff` / `computeValueNormalizationDiff` now take an `extraExtensions` arg, forwarded from `useNormalizationWarning` and `useSourceCode`, which the interface wires from the already-built `customFormatExtensions`

## Tested Scenarios

- A stored value using a configured custom format mounts the editor editable instead of locked
- Custom-format markup returns no normalization diff when its extensions are supplied, and is still flagged when they are missing (both the value check and the source-code drawer check)
- Full `input-rich-text-html` suite passes (359 tests); lint and typecheck clean on touched files

## Review Notes / Questions / Concerns

- `customFormats` is design-time config, built once at init, so the extensions are stable for the round-trip; no reactivity concerns

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated

---

Closes ENG-1474