### PR TITLE
tw ← Tiptap WYSIWYG: preserve title/role/lang/dir attributes (ENG-1472)

### DIFF
--- a/.changeset/eng-1472-wysiwyg-preserve-title.md
+++ b/.changeset/eng-1472-wysiwyg-preserve-title.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Preserved the `title`, `role`, `lang` and inline `dir` attributes on nodes and marks in the Tiptap rich text editor, so editing through the source code drawer no longer flags them as unsupported markup or strips them on save

--- a/app/src/interfaces/input-rich-text-html/composables/normalization-diff.test.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/normalization-diff.test.ts
@@ -15,6 +15,18 @@ describe('computeNormalizationDiff', () => {
 		expect(computeNormalizationDiff('<p>hello <strong>world</strong></p>')).toBeNull();
 	});
 
+	test('returns null for a title attribute the schema preserves', () => {
+		expect(computeNormalizationDiff('<p><span title="Tooltip">text</span></p>')).toBeNull();
+	});
+
+	test('returns null for role, lang and dir the schema preserves', () => {
+		// authored in the editor's canonical render order (role, lang, aria-*, dir) so the textual
+		// diff only surfaces genuine loss, not attribute reordering
+		expect(
+			computeNormalizationDiff('<p><span role="note" lang="fr" aria-label="Note" dir="rtl">text</span></p>'),
+		).toBeNull();
+	});
+
 	test('returns null for cosmetic-only reformatting', () => {
 		// Same document, arbitrary incoming indentation/whitespace — no semantic change.
 		expect(computeNormalizationDiff('<ul>\n\n    <li><p>one</p></li>\n  <li><p>two</p></li>\n</ul>')).toBeNull();

--- a/app/src/interfaces/input-rich-text-html/extensions/custom-formats.test.ts
+++ b/app/src/interfaces/input-rich-text-html/extensions/custom-formats.test.ts
@@ -147,7 +147,9 @@ describe('buildCustomFormats: round-trip + active state', () => {
 		const out = editor.getHTML();
 		editor.destroy();
 
-		expect(out).toBe('<p><span class="hl" style="color: #00ff00; font-size: 20px;" title="Highlighted">x</span></p>');
+		// `title` is a preserved global attribute, so it renders in the global-attr slot (with class)
+		// ahead of the format's own `style`; single span, single title
+		expect(out).toBe('<p><span class="hl" title="Highlighted" style="color: #00ff00; font-size: 20px;">x</span></p>');
 	});
 
 	test('coexists with text color: format applied over colored text keeps the color', () => {

--- a/app/src/interfaces/input-rich-text-html/extensions/preserved-attributes.ts
+++ b/app/src/interfaces/input-rich-text-html/extensions/preserved-attributes.ts
@@ -1,10 +1,10 @@
 import { Extension } from '@tiptap/core';
 
 /**
- * Round-trips `class`, `id`, `data-*` and `aria-*` on every node and mark type so stored HTML that
- * relies on them (styling hooks, anchors, tooltips) survives edit + save. Each wildcard prefix is
- * collected into one record attribute (tiptap has no native wildcard support). The whitelist is
- * exactly these four — event handlers (`on*`) and `style` are never preserved.
+ * Round-trips `class`, `id`, `title`, `role`, `lang`, `dir`, `data-*` and `aria-*` on every node and
+ * mark type so stored HTML that relies on them (styling hooks, anchors, tooltips, accessibility,
+ * i18n) survives edit + save. Each wildcard prefix is collected into one record attribute (tiptap
+ * has no native wildcard support). Event handlers (`on*`) and `style` are never preserved.
  */
 
 /**
@@ -13,12 +13,27 @@ import { Extension } from '@tiptap/core';
  */
 const EXCLUDED_TYPES = new Set(['doc', 'text', 'pageBreak', 'comparisonDiff']);
 
+/** Types that already model `title` on their own attributes; a global `title` would double-render. */
+const OWN_TITLE_TYPES = new Set(['link', 'abbreviation']);
+
+/** Block types the Direction extension already models `dir` on; a global `dir` would double-render. */
+const OWN_DIR_TYPES = new Set(['paragraph', 'heading', 'blockquote', 'bulletList', 'orderedList', 'listItem']);
+
 const WILDCARD_PREFIXES = ['data-', 'aria-'] as const;
 
 /** True when the element carries an attribute PreservedAttributes would round-trip. */
 export function hasPreservedAttributes(element: HTMLElement): boolean {
-	if (element.getAttribute('class') || element.getAttribute('id')) return true;
+	if (['class', 'id', 'title', 'role', 'lang', 'dir'].some((name) => element.getAttribute(name))) return true;
 	return Array.from(element.attributes).some(({ name }) => WILDCARD_PREFIXES.some((prefix) => name.startsWith(prefix)));
+}
+
+/** A plain string attribute round-tripped verbatim; empty → dropped so it never churns. */
+function passthroughAttribute(name: string) {
+	return {
+		default: null,
+		parseHTML: (element: HTMLElement) => element.getAttribute(name) || null,
+		renderHTML: (attributes: Record<string, unknown>) => (attributes[name] ? { [name]: attributes[name] } : {}),
+	};
 }
 
 function wildcardAttribute(name: string, prefix: (typeof WILDCARD_PREFIXES)[number]) {
@@ -53,25 +68,34 @@ export const PreservedAttributes = Extension.create({
 	name: 'preservedAttributes',
 
 	addGlobalAttributes() {
+		const types = this.extensions.map((extension) => extension.name).filter((name) => !EXCLUDED_TYPES.has(name));
+
 		return [
 			{
-				types: this.extensions.map((extension) => extension.name).filter((name) => !EXCLUDED_TYPES.has(name)),
+				types,
 				attributes: {
-					class: {
-						default: null,
-						parseHTML: (element) => element.getAttribute('class') || null,
-						renderHTML: (attributes) => (attributes.class ? { class: attributes.class } : {}),
-					},
+					class: passthroughAttribute('class'),
 					id: {
-						default: null,
+						...passthroughAttribute('id'),
 						// splitting a block must not duplicate a unique id
 						keepOnSplit: false,
-						parseHTML: (element) => element.getAttribute('id') || null,
-						renderHTML: (attributes) => (attributes.id ? { id: attributes.id } : {}),
 					},
+					role: passthroughAttribute('role'),
+					lang: passthroughAttribute('lang'),
 					dataAttributes: wildcardAttribute('dataAttributes', 'data-'),
 					ariaAttributes: wildcardAttribute('ariaAttributes', 'aria-'),
 				},
+			},
+			{
+				// link/abbreviation model their own `title`; a global one there would double-render
+				types: types.filter((name) => !OWN_TITLE_TYPES.has(name)),
+				attributes: { title: passthroughAttribute('title') },
+			},
+			{
+				// Direction models `dir` on block nodes (with commands); add it to the rest — inline
+				// marks, spans, cells — so mixed-direction inline runs like `<span dir="rtl">` survive
+				types: types.filter((name) => !OWN_DIR_TYPES.has(name)),
+				attributes: { dir: passthroughAttribute('dir') },
 			},
 		];
 	},

--- a/app/src/interfaces/input-rich-text-html/round-trip.test.ts
+++ b/app/src/interfaces/input-rich-text-html/round-trip.test.ts
@@ -118,9 +118,9 @@ describe('round-trip: semantic tags (preservation extensions)', () => {
 });
 
 /**
- * class, id, data-* and aria-* preserved on schema types by the PreservedAttributes extension.
- * Exact-equality: inputs are authored in serialized attribute order (global attrs render before a
- * type's own attrs, e.g. class before href).
+ * class, id, title, role, lang, dir, data-* and aria-* preserved on schema types by the
+ * PreservedAttributes extension. Exact-equality: inputs are authored in serialized attribute order
+ * (global attrs render before a type's own attrs, e.g. class before href).
  */
 const PRESERVED_ATTRIBUTES: Record<string, string> = {
 	'paragraph class': '<p class="intro">text</p>',
@@ -129,6 +129,14 @@ const PRESERVED_ATTRIBUTES: Record<string, string> = {
 	'paragraph data attributes': '<p data-uid="42" data-context="hero">text</p>',
 	'paragraph aria attributes': '<p aria-hidden="true">text</p>',
 	'combined data and aria': '<p data-note="a" aria-label="Note">text</p>',
+	'paragraph title': '<p title="Tooltip">text</p>',
+	'span title only': '<p><span title="More info">text</span></p>',
+	'span class before title': '<p><span class="fmt" title="Tip">text</span></p>',
+	'paragraph role': '<p role="note">text</p>',
+	'paragraph lang': '<p lang="fr">text</p>',
+	'span role only': '<p><span role="note">text</span></p>',
+	'span lang only': '<p><span lang="de">text</span></p>',
+	'inline dir on span': '<p><span dir="rtl">نص</span></p>',
 	'rtl paragraph with class': '<p dir="rtl" class="rtl-note">شسي</p>',
 	'span class (unconfigured custom format)': '<p><span class="my-format">text</span></p>',
 	'span id': '<p><span id="anchor-1">text</span></p>',
@@ -150,7 +158,7 @@ const PRESERVED_ATTRIBUTES: Record<string, string> = {
 	'abbr class before own title': '<p><abbr class="term" title="HyperText Markup Language">HTML</abbr> x</p>',
 };
 
-describe('round-trip: preserved attributes (class/id/data-*/aria-*)', () => {
+describe('round-trip: preserved attributes (class/id/title/role/lang/dir/data-*/aria-*)', () => {
 	test.each(Object.entries(PRESERVED_ATTRIBUTES))('%s survives round-trip unchanged', (_name, html) => {
 		expect(roundTrip(html)).toBe(html);
 	});
@@ -184,6 +192,26 @@ describe('round-trip: preserved attributes (class/id/data-*/aria-*)', () => {
 		expect(out).toContain('class="embed"');
 		expect(out).toContain('aria-label="Map"');
 		expect(out).toContain('src="about:blank"');
+	});
+
+	test('styled span keeps title', () => {
+		const out = roundTrip('<p><span style="color: #ff0000;" title="Tip">text</span></p>');
+
+		expect(out).toContain('title="Tip"');
+		expect(out).toContain('color: #ff0000');
+	});
+
+	test('span keeps role, lang and dir alongside aria', () => {
+		const out = roundTrip('<p><span aria-label="Note" role="note" lang="fr" dir="rtl">text</span></p>');
+
+		expect(out).toContain('aria-label="Note"');
+		expect(out).toContain('role="note"');
+		expect(out).toContain('lang="fr"');
+		expect(out).toContain('dir="rtl"');
+	});
+
+	test('block dir is not duplicated by the inline dir attribute', () => {
+		expect(roundTrip('<p dir="rtl">نص</p>')).toBe('<p dir="rtl">نص</p>');
 	});
 
 	test('event-handler attributes are dropped', () => {

--- a/app/src/interfaces/input-rich-text-html/round-trip.test.ts
+++ b/app/src/interfaces/input-rich-text-html/round-trip.test.ts
@@ -210,7 +210,11 @@ describe('round-trip: preserved attributes (class/id/title/role/lang/dir/data-*/
 		expect(out).toContain('dir="rtl"');
 	});
 
-	test('block dir is not duplicated by the inline dir attribute', () => {
+	test('block dir stays owned by the Direction extension (passthrough does not leak onto blocks)', () => {
+		// Direction models only ltr/rtl on block nodes; a value it rejects must be dropped, not
+		// preserved verbatim by the global passthrough. Fails if the passthrough double-registers
+		// `dir` on block types instead of excluding them (OWN_DIR_TYPES).
+		expect(roundTrip('<p dir="auto">نص</p>')).toBe('<p>نص</p>');
 		expect(roundTrip('<p dir="rtl">نص</p>')).toBe('<p dir="rtl">نص</p>');
 	});
 


### PR DESCRIPTION
## What's Changed

Fixes the source-code drawer flagging a `title` attribute as unsupported and stripping it on save (ENG-1472), and extends the same fix to the natural companion attributes.

- Preserve `title` globally on all schema nodes/marks (excluding `link`/`abbreviation`, which model their own `title`).
- Preserve `role` and `lang` alongside the `aria-*` attributes already kept, so accessibility/i18n semantics survive edit + save.
- Preserve inline `dir` on marks/spans/cells (the `Direction` extension only covered block nodes), so mixed-direction inline runs like `<span dir="rtl">` round-trip.
- `hasPreservedAttributes` now matches `title`/`role`/`lang`/`dir`, so style-less spans carrying only those are claimed instead of unwrapped.
- Extracted a small `passthroughAttribute` helper to remove the repeated attribute-spec boilerplate.

Root cause: the drawer's save flow re-parses HTML through the shared schema and warns about anything dropped. These global attributes were never in the `PreservedAttributes` whitelist, so any element carrying them lost them on round-trip and triggered the warning.

## Tested Scenarios

- `round-trip.test.ts`: exact-equality round-trip for `title`/`role`/`lang`/inline-`dir` on paragraphs and spans, a combined span carrying all of them, and a guard that block `dir` is not double-rendered by the new inline `dir` attribute.
- `normalization-diff.test.ts`: source-drawer diff returns `null` (no warning) for preserved `title` and for `role`/`lang`/`dir`.
- `custom-formats.test.ts`: updated the round-trip expectation — `title` now renders in the global-attr slot (with `class`, ahead of the format's `style`); still a single span with a single `title`.
- Full `input-rich-text-html` suite: 368 passing; touched files type-clean.

## Review Notes / Questions / Concerns

- `style` and `on*` remain intentionally excluded from preservation.
- Known pre-existing limitation (not introduced here): the normalization diff is textual, so HTML authored with attributes in a non-canonical order round-trips into the editor's fixed render order and can read as a change. This already affected `class`/`aria-*`; it only surfaces on first-time legacy content. Happy to file a follow-up to make the diff order-insensitive if wanted.
- Base is `feat/wysiwyg-tiptap` (the WYSIWYG integration branch), not `main`.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs)
- [ ] OpenAPI updated
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply