### PR TITLE
fix(app): skip required validation for fields inside hidden conditional groups

### DIFF
--- a/app/src/utils/validate-item.ts
+++ b/app/src/utils/validate-item.ts
@@ -28,7 +28,13 @@ export function validateItem(
 		return conditionedField;
 	});
 
-	const requiredFields = fieldsWithConditions.filter((field) => field.meta?.required === true);
+	const hiddenFieldKeys = new Set(
+		fieldsWithConditions.filter((field) => field.meta?.hidden === true).map((field) => field.field),
+	);
+
+	const requiredFields = fieldsWithConditions.filter(
+		(field) => field.meta?.required === true && !hiddenFieldKeys.has(field.meta?.group ?? ''),
+	);
 
 	requiredFields.forEach((field) => {
 		applyRulesForRequiredFields(field.field, field, isNew);


### PR DESCRIPTION
Fixes directus/directus#26562.

`validateItem` collects `requiredFields` after running `applyConditions`, but never checks whether a field's parent group is itself hidden. This causes two problems: required validation fires on children of hidden groups (false positives), and may be silently skipped on children of condition-shown groups.

After `fieldsWithConditions` is built, a `Set` of hidden field keys is derived from it. The `requiredFields` filter now also excludes any field whose `meta.group` is in that set — so fields inside a hidden group are never required, regardless of their own `required` flag.

The change is \~5 lines inside `validate-item.ts`, touching only the filter step between `fieldsWithConditions` and the required-field loop.