### PR TITLE
perf(api): O(1) nested-field dedup in parse-fields

### DIFF
--- a/.changeset/perf-parse-fields-dedup.md
+++ b/.changeset/perf-parse-fields-dedup.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Improved performance of field parsing by deduplicating nested relational fields with a Set lookup instead of a nested scan (O(fields) instead of O(fields²))

--- a/api/src/database/get-ast-from-query/lib/parse-fields.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.ts
@@ -339,15 +339,15 @@ export async function parseFields(
 		}
 	}
 
-	// Deduplicate any children fields that are included both as a regular field, and as a nested m2o field
-	const nestedCollectionNodes = children.filter((childNode) => childNode.type !== 'field');
+	// Deduplicate any children fields that are included both as a regular field, and as a nested m2o field.
+	// Collect the nested relational field keys into a Set so the check below is O(1) per child instead of a
+	// nested `find` scan — turning this dedup from O(fields²) into O(fields).
+	const nestedRelationalFieldKeys = new Set(
+		children.filter((childNode) => childNode.type !== 'field').map((childNode) => childNode.fieldKey),
+	);
 
 	return children.filter((childNode) => {
-		const existsAsNestedRelational = !!nestedCollectionNodes.find(
-			(nestedCollectionNode) => childNode.fieldKey === nestedCollectionNode.fieldKey,
-		);
-
-		if (childNode.type === 'field' && existsAsNestedRelational) return false;
+		if (childNode.type === 'field' && nestedRelationalFieldKeys.has(childNode.fieldKey)) return false;
 
 		return true;
 	});

--- a/contributors.yml
+++ b/contributors.yml
@@ -294,3 +294,4 @@
 - apoorva-01
 - lazerg
 - Harshith-muddasani
+- yoo-minho


### PR DESCRIPTION
### Scope

Small perf fix, no behaviour change.

### Summary

`parse-fields` deduplicates children that appear both as a regular field and as a nested m2o field. It did so by scanning `nestedCollectionNodes` with `find()` for every child:

```ts
const nestedCollectionNodes = children.filter((childNode) => childNode.type !== 'field');

return children.filter((childNode) => {
  const existsAsNestedRelational = !!nestedCollectionNodes.find(
    (nestedCollectionNode) => childNode.fieldKey === nestedCollectionNode.fieldKey,
  );
  if (childNode.type === 'field' && existsAsNestedRelational) return false;
  return true;
});
```

That's O(fields²) over the number of selected fields, which is client-controlled via the `fields` query parameter — a wide `fields=...` selection makes the dedup scan a lot.

This collects the nested relational field keys into a `Set` once and tests membership in O(1):

```ts
const nestedRelationalFieldKeys = new Set(
  children.filter((childNode) => childNode.type !== 'field').map((childNode) => childNode.fieldKey),
);

return children.filter((childNode) => {
  if (childNode.type === 'field' && nestedRelationalFieldKeys.has(childNode.fieldKey)) return false;
  return true;
});
```

Behaviour is identical — `find(key)` existence is exactly `Set.has(key)`. I couldn't run the full suite locally, but the change is local and type-preserving.
