### PR TITLE
tw ← Tiptap WYSIWYG: media src sanitization, cut gating, picker a11y

### DIFF
--- a/.changeset/light-lies-cough.md
+++ b/.changeset/light-lies-cough.md
@@ -2,4 +2,4 @@
 '@directus/app': minor
 ---
 
-Added text directionality to tiptap editor
+Added text directionality to the Tiptap rich text editor

--- a/app/src/interfaces/input-rich-text-html/composables/use-media.test.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/use-media.test.ts
@@ -82,6 +82,33 @@ test('saveMedia (embed tab) rejects non-representable markup and flags it', () =
 	expect(mediaDrawerOpen.value).toBe(true);
 });
 
+test('saveMedia (embed tab) rejects javascript: srcs and flags invalid', () => {
+	const { editor, embed, embedInvalid, activeTab, saveMedia } = setup();
+	activeTab.value = ['embed'];
+	embed.value = '<iframe src="javascript:alert(1)"></iframe>';
+	saveMedia();
+	expect(editor.value.getHTML()).not.toContain('javascript:');
+	expect(embedInvalid.value).toBe(true);
+});
+
+test('saveMedia (file tab) does not insert an unsafe src', () => {
+	const { editor, mediaSelection, saveMedia } = setup();
+
+	mediaSelection.value = {
+		tag: 'video',
+		src: 'javascript:alert(1)',
+		type: 'video/mp4',
+		width: null,
+		height: null,
+		controls: true,
+		loop: false,
+		previewUrl: null,
+	};
+
+	saveMedia();
+	expect(editor.value.getHTML()).not.toContain('javascript:');
+});
+
 test('editing the embed markup clears the invalid flag', async () => {
 	const { embed, embedInvalid, activeTab, saveMedia } = setup();
 	activeTab.value = ['embed'];

--- a/app/src/interfaces/input-rich-text-html/composables/use-media.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/use-media.ts
@@ -2,7 +2,7 @@ import type { File } from '@directus/types';
 import { DOMParser as PMDOMParser } from '@tiptap/pm/model';
 import type { Editor } from '@tiptap/vue-3';
 import { Ref, ref, watch } from 'vue';
-import type { MediaAttrs, MediaTag } from '../extensions/media';
+import { type MediaAttrs, type MediaTag, sanitizeMediaSrc } from '../extensions/media';
 import { replaceUrlAccessToken } from './replace-url-access-token';
 import { getPublicURL } from '@/utils/get-root-path';
 
@@ -124,11 +124,13 @@ export function useMedia(editor: Ref<Editor>, imageToken: Ref<string | undefined
 
 	function selectionToAttrs(): Partial<MediaAttrs> | null {
 		const sel = mediaSelection.value;
-		if (!sel || !sel.src) return null;
+		// sanitize here too: the drawer form exposes src as a free-text field
+		const src = sel ? sanitizeMediaSrc(sel.src) : null;
+		if (!sel || !src) return null;
 
 		return {
 			tag: sel.tag,
-			src: sel.src,
+			src,
 			type: sel.type,
 			width: sel.width,
 			height: sel.height,

--- a/app/src/interfaces/input-rich-text-html/extensions/media.test.ts
+++ b/app/src/interfaces/input-rich-text-html/extensions/media.test.ts
@@ -54,6 +54,29 @@ describe('media node: parse + render', () => {
 	});
 });
 
+describe('media node: unsafe src', () => {
+	test('strips javascript: URLs from iframe src', () => {
+		const out = roundTrip('<iframe src="javascript:alert(1)" width="560" height="315"></iframe>');
+		expect(out).not.toContain('javascript:');
+		expect(out).toContain('<iframe');
+	});
+
+	test('strips obfuscated javascript: URLs (case/whitespace)', () => {
+		const out = roundTrip('<iframe src=" JaVaScRiPt:alert(1)"></iframe>');
+		expect(out).not.toContain('alert(1)');
+	});
+
+	test('strips data: URLs from video source src', () => {
+		const out = roundTrip('<video><source src="data:text/html,<script>alert(1)</script>" type="video/mp4"></video>');
+		expect(out).not.toContain('data:');
+	});
+
+	test('keeps https and root-relative srcs', () => {
+		expect(roundTrip('<iframe src="https://example.com/embed"></iframe>')).toContain('src="https://example.com/embed"');
+		expect(roundTrip('<video><source src="/assets/v.mp4" type="video/mp4"></video>')).toContain('src="/assets/v.mp4"');
+	});
+});
+
 describe('media node view', () => {
 	// Node views need draggable + data-drag-handle on the wrapper, otherwise tiptap cancels the
 	// drag (or the browser copy-drops it, duplicating the node). Images have no node view, so

--- a/app/src/interfaces/input-rich-text-html/extensions/media.ts
+++ b/app/src/interfaces/input-rich-text-html/extensions/media.ts
@@ -21,6 +21,20 @@ declare module '@tiptap/core' {
 	}
 }
 
+// script-capable URL schemes; a javascript:/data: iframe would execute in the dashboard origin
+const UNSAFE_PROTOCOLS = ['javascript:', 'data:', 'vbscript:'];
+
+// The URL parser normalizes case/whitespace obfuscation (" JaVaScRiPt:…") before the protocol check.
+export function sanitizeMediaSrc(src: string | null): string | null {
+	if (!src) return null;
+
+	try {
+		return UNSAFE_PROTOCOLS.includes(new URL(src, 'http://relative-url').protocol) ? null : src;
+	} catch {
+		return null;
+	}
+}
+
 // Parse a numeric attribute; empty/absent/non-numeric → null so it renders as omitted.
 function numberAttr(value: string | null): number | null {
 	if (value === null || value === '') return null;
@@ -33,7 +47,7 @@ function parseSourced(el: HTMLElement, tag: 'video' | 'audio'): MediaAttrs {
 	const source = el.querySelector('source');
 	return {
 		tag,
-		src: source?.getAttribute('src') ?? el.getAttribute('src') ?? null,
+		src: sanitizeMediaSrc(source?.getAttribute('src') ?? el.getAttribute('src')),
 		type: source?.getAttribute('type') ?? null,
 		width: numberAttr(el.getAttribute('width')),
 		height: numberAttr(el.getAttribute('height')),
@@ -58,7 +72,13 @@ export const Media = Node.create({
 		// flow through the HTMLAttributes param
 		return {
 			tag: { default: 'video' as MediaTag, rendered: false },
-			src: { default: null, rendered: false },
+			// explicit parseHTML: Tiptap's default (getAttribute) would override the sanitized
+			// getAttrs value with the raw one; video/audio carry src on a child <source>
+			src: {
+				default: null,
+				rendered: false,
+				parseHTML: (el) => sanitizeMediaSrc(el.querySelector('source')?.getAttribute('src') ?? el.getAttribute('src')),
+			},
 			type: { default: null, rendered: false },
 			width: { default: null, rendered: false },
 			height: { default: null, rendered: false },
@@ -78,7 +98,7 @@ export const Media = Node.create({
 					const iframe = el as HTMLElement;
 					return {
 						tag: 'iframe',
-						src: iframe.getAttribute('src'),
+						src: sanitizeMediaSrc(iframe.getAttribute('src')),
 						type: null,
 						width: numberAttr(iframe.getAttribute('width')),
 						height: numberAttr(iframe.getAttribute('height')),

--- a/app/src/interfaces/input-rich-text-html/toolbar/menus/table-grid-picker.test.ts
+++ b/app/src/interfaces/input-rich-text-html/toolbar/menus/table-grid-picker.test.ts
@@ -41,4 +41,28 @@ describe('table-grid-picker', () => {
 		await wrapper.findAll('.cell')[4]!.trigger('mouseover');
 		expect(wrapper.findAll('.cell.active')).toHaveLength(4);
 	});
+
+	test('grid exposes row and gridcell structure', () => {
+		const wrapper = mount(TableGridPicker, { props: { maxRows: 2, maxCols: 3 }, global });
+		const grid = wrapper.find('[role="grid"]');
+		expect(grid.exists()).toBe(true);
+		expect(grid.findAll('[role="row"]')).toHaveLength(2);
+		expect(grid.findAll('[role="row"] > [role="gridcell"]')).toHaveLength(6);
+	});
+
+	test('aria-activedescendant tracks the highlighted cell', async () => {
+		const wrapper = mount(TableGridPicker, { props: { maxRows: 3, maxCols: 3 }, global });
+		const grid = wrapper.find('[role="grid"]');
+		expect(grid.attributes('aria-activedescendant')).toBeUndefined();
+
+		await grid.trigger('focus');
+		await grid.trigger('keydown', { key: 'ArrowDown' });
+		await grid.trigger('keydown', { key: 'ArrowRight' });
+
+		// highlight is now row 2, col 2 → the active descendant is that gridcell's id
+		const active = grid.attributes('aria-activedescendant');
+		expect(active).toBeTruthy();
+		const cells = grid.findAll('[role="gridcell"]');
+		expect(cells[4]!.attributes('id')).toBe(active);
+	});
 });

--- a/app/src/interfaces/input-rich-text-html/toolbar/menus/table-grid-picker.vue
+++ b/app/src/interfaces/input-rich-text-html/toolbar/menus/table-grid-picker.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, useId } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const props = withDefaults(
@@ -17,9 +17,18 @@ const emit = defineEmits<{ select: [size: { rows: number; cols: number }] }>();
 
 const { t } = useI18n();
 
+const gridId = useId();
+
 // 1-based highlight extent; 0 means nothing is hovered/focused yet.
 const hoveredRows = ref(0);
 const hoveredCols = ref(0);
+
+function cellId(row: number, col: number): string {
+	return `${gridId}-cell-${row}-${col}`;
+}
+
+// The container holds focus; announce the highlighted cell as the active descendant.
+const activeCellId = computed(() => (hoveredRows.value > 0 ? cellId(hoveredRows.value, hoveredCols.value) : undefined));
 
 const rows = computed(() => Array.from({ length: props.maxRows }, (_, i) => i + 1));
 const cols = computed(() => Array.from({ length: props.maxCols }, (_, i) => i + 1));
@@ -86,21 +95,27 @@ defineExpose({ select });
 			role="grid"
 			tabindex="0"
 			:aria-label="t('wysiwyg_options.table_insert')"
+			:aria-activedescendant="activeCellId"
 			@mouseleave="reset"
 			@focus="highlight(1, 1)"
 			@keydown="onKeydown"
 		>
-			<button
-				v-for="cell in rows.flatMap((row) => cols.map((col) => ({ row, col })))"
-				:key="`${cell.row}-${cell.col}`"
-				type="button"
-				class="cell"
-				:class="{ active: cell.row <= hoveredRows && cell.col <= hoveredCols }"
-				:aria-label="t('wysiwyg_options.table_insert_size', { cols: cell.col, rows: cell.row })"
-				tabindex="-1"
-				@mouseover="highlight(cell.row, cell.col)"
-				@click="select(cell.row, cell.col)"
-			/>
+			<div v-for="row in rows" :key="row" class="row" role="row">
+				<button
+					v-for="col in cols"
+					:id="cellId(row, col)"
+					:key="`${row}-${col}`"
+					type="button"
+					role="gridcell"
+					class="cell"
+					:class="{ active: row <= hoveredRows && col <= hoveredCols }"
+					:aria-label="t('wysiwyg_options.table_insert_size', { cols: col, rows: row })"
+					:aria-selected="row <= hoveredRows && col <= hoveredCols"
+					tabindex="-1"
+					@mouseover="highlight(row, col)"
+					@click="select(row, col)"
+				/>
+			</div>
 		</div>
 		<div class="caption">{{ caption }}</div>
 	</div>
@@ -117,6 +132,11 @@ defineExpose({ select });
 	padding-block-start: 0.0625rem;
 	padding-inline-start: 0.0625rem;
 	outline: none;
+}
+
+// keep the cells as direct grid items while giving the a11y tree real rows
+.row {
+	display: contents;
 }
 
 .cell {

--- a/app/src/interfaces/input-rich-text-html/toolbar/use-clipboard-actions.test.ts
+++ b/app/src/interfaces/input-rich-text-html/toolbar/use-clipboard-actions.test.ts
@@ -66,6 +66,25 @@ describe('cut', () => {
 		expect(write).toHaveBeenCalledOnce();
 		expect(editor.getText()).toBe('');
 	});
+
+	test('does not delete the selection when the Clipboard API is unsupported', async () => {
+		// remove `clipboard` everywhere `'clipboard' in navigator` could find it
+		Reflect.deleteProperty(navigator, 'clipboard');
+		const proto = Object.getPrototypeOf(navigator);
+		const protoDescriptor = Object.getOwnPropertyDescriptor(proto, 'clipboard');
+		if (protoDescriptor) Reflect.deleteProperty(proto, 'clipboard');
+
+		try {
+			const editor = makeEditor();
+			editor.commands.selectAll();
+
+			await useClipboardActions().cutSelection(editor);
+
+			expect(editor.getText()).toBe('hello world');
+		} finally {
+			if (protoDescriptor) Object.defineProperty(proto, 'clipboard', protoDescriptor);
+		}
+	});
 });
 
 describe('paste', () => {

--- a/app/src/interfaces/input-rich-text-html/toolbar/use-clipboard-actions.ts
+++ b/app/src/interfaces/input-rich-text-html/toolbar/use-clipboard-actions.ts
@@ -30,7 +30,8 @@ export function useClipboardActions() {
 	}
 
 	async function cutSelection(editor: Editor) {
-		if (editor.state.selection.empty) return;
+		// bail when copy would no-op — deleting without copying loses content
+		if (editor.state.selection.empty || !isSupported.value) return;
 		await copySelection(editor);
 		editor.chain().focus().deleteSelection().run();
 	}


### PR DESCRIPTION
## What's Changed

Fixes for the accurate findings from the Copilot review on #27754:

- **Media `src` sanitization (security):** `javascript:`/`data:`/`vbscript:` URLs are now stripped from media nodes (`video`/`audio`/`iframe`) at every entry point — stored-content parsing, embed markup paste, and the media drawer's free-text src field. Previously a `javascript:` iframe src was stored and rendered unsandboxed in the dashboard origin. The sanitizer lives on the attribute-level `parseHTML` because Tiptap's default attribute parser (`getAttribute`) overrides rule-level `getAttrs` results for non-null values.
- **Clipboard cut gating:** `cutSelection` no longer deletes the selection when the async Clipboard API is unsupported (e.g. non-HTTPS deployments) — it previously deleted content it never copied.
- **Table grid picker ARIA:** the `role="grid"` container now exposes real `row`/`gridcell` structure (`display: contents` row wrappers keep the CSS grid layout), with `aria-activedescendant` tracking the keyboard-highlighted cell and `aria-selected` on the highlighted rectangle.
- **Changeset casing:** `light-lies-cough.md` now matches the other changesets' "Tiptap rich text editor" wording.

No new changeset: all fixes target unreleased feature code already covered by the feature branch's changesets.

## Tested Scenarios

- Unsafe protocol stripping for iframe src and video `<source>` src, including case/whitespace obfuscation (` JaVaScRiPt:…`); https and root-relative srcs are kept
- Embed tab rejects `javascript:` markup with the inline invalid error; file tab refuses to insert an unsafe src
- Cut leaves the selection intact when `navigator.clipboard` is unavailable; normal cut still copies + deletes
- Grid picker exposes 2×3 row/gridcell structure and `aria-activedescendant` follows arrow-key navigation
- Full `input-rich-text-html` suite: 41 files / 397 tests green; lint clean; no new type errors

## Review Notes / Questions / Concerns

- Sanitization is a protocol blocklist (matching TinyMCE's default behavior) rather than an allowlist, so exotic-but-harmless schemes like `about:blank` keep round-tripping
- Stored content that contains an unsafe src now round-trips differently (src dropped), which surfaces the existing normalization warning instead of silently rewriting

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [x] Security implications apply