### PR TITLE
tw ← Tiptap WYSIWYG: fix collab phantom updates + save crash (CMS-2885, ENG-1477, ENG-1478)

### DIFF
--- a/.changeset/hungry-planes-smile.md
+++ b/.changeset/hungry-planes-smile.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed WYSIWYG field breaking with an unexpected error when saving while focused, phantom edits and stolen field locks during collaborative editing, and media inserts not propagating to other collaborative editing sessions

--- a/app/src/interfaces/input-rich-text-html/editable-toggle.test.ts
+++ b/app/src/interfaces/input-rich-text-html/editable-toggle.test.ts
@@ -1,0 +1,69 @@
+import { type Editor, EditorContent } from '@tiptap/vue-3';
+import { flushPromises, mount } from '@vue/test-utils';
+import { createPinia } from 'pinia';
+import { describe, expect, test } from 'vitest';
+import { nextTick } from 'vue';
+import { createI18n } from 'vue-i18n';
+import Interface from './input-rich-text-html.vue';
+
+/**
+ * The `disabled` prop flips constantly without user interaction: `v-form` disables all fields
+ * while an item (re)loads, and collaborative editing disables a field while another user holds
+ * it. Tiptap's `setEditable` defaults to emitting an `update` event, which would surface here as
+ * a phantom `input` emit — broadcasting stale content and stealing the collab field lock
+ * (CMS-2885, ENG-1477, ENG-1478).
+ */
+const VALUE = '<p>hello world</p>';
+
+async function mountWithValue(value: string) {
+	const i18n = createI18n({ legacy: false, locale: 'en-US', messages: { 'en-US': {} } });
+
+	const wrapper = mount(Interface, {
+		props: { value },
+		global: {
+			plugins: [createPinia(), i18n],
+			stubs: {
+				Toolbar: true,
+				TableBubbleMenu: true,
+				ImageDrawer: true,
+				LinkDrawer: true,
+				MediaDrawer: true,
+				SourceCodeDrawer: true,
+				NormalizationWarningDialog: true,
+				InterfaceInputCode: true,
+			},
+		},
+	});
+
+	await flushPromises();
+	await nextTick();
+	const editor = wrapper.findComponent(EditorContent).props('editor') as Editor;
+	return { wrapper, editor };
+}
+
+describe('editable toggle', () => {
+	test('toggling disabled keeps the editor editable state in sync', async () => {
+		const { wrapper, editor } = await mountWithValue(VALUE);
+
+		expect(editor.isEditable).toBe(true);
+
+		await wrapper.setProps({ disabled: true });
+		await nextTick();
+		expect(editor.isEditable).toBe(false);
+
+		await wrapper.setProps({ disabled: false });
+		await nextTick();
+		expect(editor.isEditable).toBe(true);
+	});
+
+	test('toggling disabled emits no input (content did not change)', async () => {
+		const { wrapper } = await mountWithValue(VALUE);
+
+		await wrapper.setProps({ disabled: true });
+		await nextTick();
+		await wrapper.setProps({ disabled: false });
+		await nextTick();
+
+		expect(wrapper.emitted('input')).toBeUndefined();
+	});
+});

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -285,19 +285,32 @@ watch([imageDrawerOpen, linkDrawerOpen, mediaDrawerOpen, sourceCodeDrawerOpen], 
 	open.some(Boolean) ? pauseFocusTrap() : unpauseFocusTrap(),
 );
 
-// `editable` is only read at init, so keep it in sync when the prop flips
-watch(isEditable, (editable) => editor.value?.setEditable(editable));
+// `editable` is only read at init, so keep it in sync when the prop flips.
+// `emitUpdate: false` — the default emits `update`, turning every disabled flip (form loading,
+// collab field locks) into a phantom `input` that rebroadcasts content and steals the collab lock
+watch(isEditable, (editable) => editor.value?.setEditable(editable, false));
 
 // external value changes (async load, revert, version switch) — guard against echo loops
+let syncScheduled = false;
+
 watch(
 	() => props.value,
-	(value) => {
+	async () => {
+		if (syncScheduled) return;
+		syncScheduled = true;
+
+		// Defer past the current flush: setContent mid-patch (watchers run pre-flush) tears down Vue
+		// node views whose unmount re-enters Vue's queue and corrupts ProseMirror's view tree
+		// (CMS-2885); deferring also coalesces same-flush churn (save flows flip html -> null -> html)
+		await nextTick();
+		syncScheduled = false;
+
 		// raw mode edits flow straight through the code interface, never through the editor
 		if (rawMode.value) return;
 		if (!editor.value) return;
 		// compare the encoded (stored) form so a re-emitted page-break marker doesn't look like a change
-		if (encodePageBreaks(editor.value.getHTML()) === value) return;
-		syncValue(editor.value, value);
+		if (encodePageBreaks(editor.value.getHTML()) === props.value) return;
+		syncValue(editor.value, props.value);
 		if (!props.comparisonMode && !props.nonEditable) checkValue();
 	},
 );

--- a/app/src/interfaces/input-rich-text-html/value-sync.test.ts
+++ b/app/src/interfaces/input-rich-text-html/value-sync.test.ts
@@ -1,0 +1,91 @@
+import { type Editor, EditorContent } from '@tiptap/vue-3';
+import { flushPromises, mount } from '@vue/test-utils';
+import { createPinia } from 'pinia';
+import { describe, expect, test } from 'vitest';
+import { nextTick } from 'vue';
+import { createI18n } from 'vue-i18n';
+import Interface from './input-rich-text-html.vue';
+
+/**
+ * CMS-2885: save-and-stay nulls the item then two getItem calls restore it (use-item refresh +
+ * collab receiveSave), so props.value whiplashes html -> null -> html across back-to-back
+ * flushes. Dispatching a setContent per intermediate value tears down the Vue-managed node views
+ * (media) mid-churn and corrupts ProseMirror's view tree ("Cannot read properties of undefined
+ * (reading 'destroy')" in ViewTreeUpdater). External syncs must coalesce to the settled value.
+ */
+const VALUE = [
+	'<p>intro text</p>',
+	'<video width="300" height="150" controls=""><source src="http://localhost/assets/a" type="video/mp4"></video>',
+	'<p>middle</p>',
+	'<audio controls=""><source src="http://localhost/assets/b" type="audio/wav"></audio>',
+	'<img src="http://localhost/assets/c.jpg" alt="pic">',
+	'<!-- pagebreak -->',
+	'<p>outro</p>',
+].join('');
+
+async function mountWithValue(value: string) {
+	const i18n = createI18n({ legacy: false, locale: 'en-US', messages: { 'en-US': {} } });
+
+	const wrapper = mount(Interface, {
+		props: { value },
+		attachTo: document.body,
+		global: {
+			plugins: [createPinia(), i18n],
+			stubs: {
+				Toolbar: true,
+				TableBubbleMenu: true,
+				ImageDrawer: true,
+				LinkDrawer: true,
+				MediaDrawer: true,
+				SourceCodeDrawer: true,
+				NormalizationWarningDialog: true,
+				InterfaceInputCode: true,
+			},
+		},
+	});
+
+	await flushPromises();
+	await nextTick();
+	const editor = wrapper.findComponent(EditorContent).props('editor') as Editor;
+	return { wrapper, editor };
+}
+
+describe('external value sync coalescing', () => {
+	test('transient null between flushes never reaches the editor', async () => {
+		const { wrapper, editor } = await mountWithValue(VALUE);
+
+		editor.commands.focus('end');
+		await nextTick();
+
+		await wrapper.setProps({ value: null });
+		// the settled value arrives one flush later (refresh/collab refetch)
+		await wrapper.setProps({ value: VALUE });
+		await flushPromises();
+		await nextTick();
+
+		expect(editor.getHTML()).toContain('intro text');
+		expect(editor.getHTML()).toContain('outro');
+	});
+
+	test('a value change that settles still applies', async () => {
+		const { wrapper, editor } = await mountWithValue(VALUE);
+
+		await wrapper.setProps({ value: '<p>replaced</p>' });
+		await flushPromises();
+		await nextTick();
+		await nextTick();
+
+		expect(editor.getHTML()).toContain('replaced');
+	});
+
+	test('a sustained null clears the editor (unset/discard)', async () => {
+		const { wrapper, editor } = await mountWithValue(VALUE);
+
+		await wrapper.setProps({ value: null });
+		await flushPromises();
+		await nextTick();
+		await nextTick();
+
+		expect(editor.isEmpty).toBe(true);
+	});
+});


### PR DESCRIPTION
## What's Changed

Two root causes behind the collaborative-editing WYSIWYG bugs found while testing [CMS-2888](https://linear.app/directus/issue/CMS-2888/collaborative-editing):

* **Suppress the** `update` **event when syncing the editable state** (`setEditable(editable, false)`). Tiptap emits `update` by default on editable flips, so every `disabled` toggle (form loading during save/refresh, collab field locks) emitted a phantom `input` with re-normalized content. In collab this rebroadcast stale content, silently stole the server-side field lock (focus indicator jumping to the other user), and rejected legitimate updates with "Cannot update field without focusing on it first" ([CMS-2886](https://linear.app/directus/issue/CMS-2886/toast-message-when-saving-a-change-in-wysi-field-on-collab)), which also blocked drawer-inserted media from propagating ([CMS-2887](https://linear.app/directus/issue/CMS-2887/adding-media-on-collab-editing-on-a-wysiwyg-field-doesnt-update-right)).
* **Defer external value syncs past the current flush.** Save-and-stay whiplashes the value prop html → null → html (item refresh + collab `receiveSave` refetch). Running `setContent` from the pre-flush watcher mid-patch tears down Vue-managed node views (video/audio/iframe) whose unmount re-enters Vue's render queue and corrupts ProseMirror's view tree — `TypeError: Cannot read properties of undefined (reading 'destroy')` in `ViewTreeUpdater.destroyBetween`, surfacing as the "Unexpected error" boundary in place of the field ([CMS-2885](https://linear.app/directus/issue/CMS-2885/unexpected-error-while-saving-via-cmds-while-focus-on-collaborative)). Syncs now run after `nextTick` and coalesce to the settled value.

## Tested Scenarios

* Cmd+S while focused on the field in a collab session no longer breaks the interface ([CMS-2885](https://linear.app/directus/issue/CMS-2885/unexpected-error-while-saving-via-cmds-while-focus-on-collaborative))
* Header save in a collab session: no "focus first" toast, no focus shift to the other session ([CMS-2886](https://linear.app/directus/issue/CMS-2886/toast-message-when-saving-a-change-in-wysi-field-on-collab))
* Media/image inserted via drawer propagates to the other collab session immediately ([CMS-2887](https://linear.app/directus/issue/CMS-2887/adding-media-on-collab-editing-on-a-wysiwyg-field-doesnt-update-right))
* Full `input-rich-text-html` suite green (43 files, 393 tests), incl. new `editable-toggle.test.ts` and `value-sync.test.ts` (transient null never wipes content, settled changes apply, sustained null still clears)

## Review Notes / Questions / Concerns

* The ProseMirror view-tree crash only reproduces in a real browser (re-entrant `flushPostFlushCbs` from `VueRenderer.destroy`), not in happy-dom — the new tests guard the behavioral invariants instead
* Follow-ups intentionally out of scope: keeping the collab field lock while a field-owned drawer is open, and making the server-side auto-focus on UPDATE visible to the connection that receives it

## Checklist

> Leave unchecked where not applicable

- [X] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](<https://github.com/directus/openapi>)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes [CMS-2885](https://linear.app/directus/issue/CMS-2885/unexpected-error-while-saving-via-cmds-while-focus-on-collaborative), [CMS-2886](https://linear.app/directus/issue/CMS-2886/toast-message-when-saving-a-change-in-wysi-field-on-collab), [CMS-2887](https://linear.app/directus/issue/CMS-2887/adding-media-on-collab-editing-on-a-wysiwyg-field-doesnt-update-right) (found via [CMS-2888](https://linear.app/directus/issue/CMS-2888/collaborative-editing))