### PR TITLE
docs: add Sealos deployment option

### DIFF
--- a/directus/readme.md
+++ b/directus/readme.md
@@ -69,6 +69,15 @@ One click. Fully provisioned with PostgreSQL, Redis, and S3-compatible storage, 
 
 ---
 
+### Deploy on Sealos
+
+One click. Deploy Directus with PostgreSQL, Redis, and persistent file storage. Private S3-compatible object storage is
+available as an option.
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/directus)
+
+---
+
 ## 🙋 Community Help
 
 [The Directus Documentation](https://directus.com/docs) is a great place to start, or explore these other channels:


### PR DESCRIPTION
## What's Changed

- Added a Sealos deployment option to the README's one-click deployment section.
- Documented the managed PostgreSQL, Redis, persistent file storage, and optional private S3-compatible object storage provided by the template.

## Tested Scenarios

- Confirmed the Sealos Directus App Store page returns HTTP 200 and identifies the Directus template.
- Confirmed the Deploy on Sealos badge returns HTTP 200 as SVG.
- Ran Prettier against `directus/readme.md` and `git diff --check`.

## Review Notes / Questions / Concerns

- This is a documentation-only change; it does not affect Directus runtime behavior.
- The template deploys Directus 12.1.1 and includes persistent storage configuration.
- I can maintain this deployment path and follow up if its template or documentation needs updates.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply