### PR TITLE
Add global setting for default save action

### DIFF
--- a/.changeset/moody-pugs-push.md
+++ b/.changeset/moody-pugs-push.md
@@ -1,0 +1,8 @@
+---
+'@directus/system-data': minor
+'@directus/types': minor
+'@directus/app': minor
+'@directus/api': patch
+---
+
+Added global setting for default save action

--- a/api/src/database/migrations/20260727A-add-default-save-action.ts
+++ b/api/src/database/migrations/20260727A-add-default-save-action.ts
@@ -1,0 +1,13 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_settings', (table) => {
+		table.string('default_save_action').nullable();
+	});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_settings', (table) => {
+		table.dropColumn('default_save_action');
+	});
+}

--- a/api/src/database/migrations/20260727A-add-default-save-action.ts
+++ b/api/src/database/migrations/20260727A-add-default-save-action.ts
@@ -2,7 +2,7 @@ import type { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
 	await knex.schema.alterTable('directus_settings', (table) => {
-		table.string('default_save_action').nullable();
+		table.string('default_save_action').notNullable().defaultTo('save-and-quit');
 	});
 }
 

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -759,6 +759,7 @@ manual_string: Manually entered string
 save_and_create_new: Save and Create New
 save_and_stay: Save and Stay
 save_and_quit: Save and Quit
+default_save_action_note: The action the Save button performs by default when editing an item.
 publish_and_quit: Publish and Quit
 publish_without_review: Publish without Review
 publish_anyway: Publish Anyway

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -50,6 +50,7 @@ import { useVisualEditing } from '@/composables/use-visual-editing';
 import { BREAKPOINTS } from '@/constants';
 import { useAutoSave } from '@/modules/content/composables/use-auto-save';
 import { useNotificationsStore } from '@/stores/notifications';
+import { useSettingsStore } from '@/stores/settings';
 import { useUserStore } from '@/stores/user';
 import type { ContentVersionMaybeNew, ContentVersionWithType } from '@/types/versions';
 import { getDefaultValuesFromFields } from '@/utils/get-default-values-from-fields';
@@ -101,6 +102,7 @@ const { collectionRoute, backRoute } = useItemNavigation();
 
 const userStore = useUserStore();
 const notificationsStore = useNotificationsStore();
+const settingsStore = useSettingsStore();
 
 const isCurrentVersionNew = computed(() => currentVersion.value?.id === '+');
 
@@ -660,6 +662,19 @@ async function saveAndQuit() {
 	}
 }
 
+function saveDefault() {
+	const action = settingsStore.settings?.default_save_action;
+	const isSingleton = collectionInfo.value?.meta?.singleton === true;
+
+	if (action === 'save-and-stay') {
+		saveAndStay();
+	} else if (action === 'save-and-create-new' && !isSingleton && !disabledOptions.value.includes('save-and-add-new')) {
+		saveAndAddNew();
+	} else {
+		saveAndQuit();
+	}
+}
+
 async function deleteAndQuit() {
 	if (deleting.value) return;
 
@@ -1208,11 +1223,12 @@ function useAutoSwitchToDraft() {
 					icon="check"
 					:loading="saving"
 					:disabled="!isSavable"
-					@click="saveAndQuit()"
+					@click="saveDefault()"
 				>
 					<template v-if="collectionInfo.meta && collectionInfo.meta.singleton !== true" #split-menu>
 						<SaveOptions
 							:disabled-options="disabledOptions"
+							@save-and-quit="saveAndQuit"
 							@save-and-stay="saveAndStay"
 							@save-and-add-new="saveAndAddNew"
 							@save-as-copy="saveAsCopyAndNavigate"

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -402,11 +402,26 @@ const isFormNonEditable = computed(
 		!canAutoSwitchToDraft.value,
 );
 
-const disabledOptions = computed(() => {
+const baseDisabledOptions = computed(() => {
 	if (!createAllowed.value) return ['save-and-add-new', 'save-as-copy'];
 	if (isNew.value) return ['save-as-copy'];
 	return [];
 });
+
+const defaultSaveAction = computed(() => {
+	const action = settingsStore.settings?.default_save_action;
+	const isSingleton = collectionInfo.value?.meta?.singleton === true;
+
+	if (action === 'save-and-stay') return 'save-and-stay';
+
+	if (action === 'save-and-create-new' && !isSingleton && !baseDisabledOptions.value.includes('save-and-add-new')) {
+		return 'save-and-add-new';
+	}
+
+	return 'save-and-quit';
+});
+
+const disabledOptions = computed(() => [...baseDisabledOptions.value, defaultSaveAction.value]);
 
 const currentVersionId = computed(() => currentVersion.value?.id ?? null);
 
@@ -663,12 +678,9 @@ async function saveAndQuit() {
 }
 
 function saveDefault() {
-	const action = settingsStore.settings?.default_save_action;
-	const isSingleton = collectionInfo.value?.meta?.singleton === true;
-
-	if (action === 'save-and-stay') {
+	if (defaultSaveAction.value === 'save-and-stay') {
 		saveAndStay();
-	} else if (action === 'save-and-create-new' && !isSingleton && !disabledOptions.value.includes('save-and-add-new')) {
+	} else if (defaultSaveAction.value === 'save-and-add-new') {
 		saveAndAddNew();
 	} else {
 		saveAndQuit();

--- a/app/src/views/private/components/save-options.vue
+++ b/app/src/views/private/components/save-options.vue
@@ -12,6 +12,7 @@ defineProps<{
 }>();
 
 defineEmits<{
+	(e: 'save-and-quit'): void;
 	(e: 'save-and-stay'): void;
 	(e: 'save-and-add-new'): void;
 	(e: 'save-as-copy'): void;
@@ -21,6 +22,10 @@ defineEmits<{
 
 <template>
 	<VList>
+		<VListItem v-if="!disabledOptions?.includes('save-and-quit')" clickable @click="$emit('save-and-quit')">
+			<VListItemIcon><VIcon name="arrow_back" /></VListItemIcon>
+			<VListItemContent>{{ $t('save_and_quit') }}</VListItemContent>
+		</VListItem>
 		<VListItem v-if="!disabledOptions?.includes('save-and-stay')" clickable @click="$emit('save-and-stay')">
 			<VListItemIcon><VIcon name="check" /></VListItemIcon>
 			<VListItemContent>{{ $t('save_and_stay') }}</VListItemContent>

--- a/packages/system-data/src/fields/settings.yaml
+++ b/packages/system-data/src/fields/settings.yaml
@@ -32,6 +32,19 @@ fields:
       placeholder: en-US
     width: half
 
+  - field: default_save_action
+    interface: select-dropdown
+    width: half
+    options:
+      choices:
+        - value: save-and-quit
+          text: $t:save_and_quit
+        - value: save-and-stay
+          text: $t:save_and_stay
+        - value: save-and-create-new
+          text: $t:save_and_create_new
+    note: $t:default_save_action_note
+
   - field: project_owner
     interface: system-owner
     width: half

--- a/packages/system-data/src/fields/settings.yaml
+++ b/packages/system-data/src/fields/settings.yaml
@@ -36,6 +36,7 @@ fields:
     interface: select-dropdown
     width: half
     options:
+      placeholder: $t:save_and_quit
       choices:
         - value: save-and-quit
           text: $t:save_and_quit

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -42,6 +42,7 @@ export type Settings = {
 	report_bug_url: string | null;
 	report_feature_url: string | null;
 	default_language: string | null;
+	default_save_action: 'save-and-quit' | 'save-and-stay' | 'save-and-create-new' | null;
 	project_color: string | null;
 	project_logo: string | null;
 	public_foreground: string | null;

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -42,7 +42,7 @@ export type Settings = {
 	report_bug_url: string | null;
 	report_feature_url: string | null;
 	default_language: string | null;
-	default_save_action: 'save-and-quit' | 'save-and-stay' | 'save-and-create-new' | null;
+	default_save_action: 'save-and-quit' | 'save-and-stay' | 'save-and-create-new';
 	project_color: string | null;
 	project_logo: string | null;
 	public_foreground: string | null;


### PR DESCRIPTION
## What's Changed

- Added `default_save_action` setting (`save-and-quit` | `save-and-stay` | `save-and-create-new` | `null`) to
  `directus_settings`, with migration `20260727A-add-default-save-action.ts`
- `item.vue`'s primary Save button now calls `saveDefault()`, which reads the setting and dispatches to `saveAndStay()`,
  `saveAndAddNew()`, or `saveAndQuit()` accordingly (falls back to save-and-quit for singletons)

## Tested Scenarios

- Set default save action to "Save and Stay", edited an item, clicked Save button — stayed on the item
- Set default save action to "Save and Create New" — taken to new item form after saving
- Left default save action unset — Save button behaves as before (save and quit)

## Review Notes / Questions / Concerns

- Behavior for singleton collections and collections without create permission always falls back to save-and-quit, even
  if the global default is set to save-and-create-new.

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [x] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [x] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [x] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [x] App translations added for new user-facing strings
- [ ] Security implications apply

Fixes [CMS-1852](https://linear.app/directus/issue/CMS-1852/default-save-and-stay-request)
