### PR TITLE
Fix missing translations for Datetime display timezone options

### DIFF
--- a/.changeset/fix-datetime-timezone-translations.md
+++ b/.changeset/fix-datetime-timezone-translations.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed missing translations for the Datetime display timezone options

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2877,7 +2877,6 @@ displays:
     nearest: Nearest
     up: Up
     timezone: Timezone
-    timezone_local: Local Timezone
     timezone_note: IANA timezone identifier (e.g., 'America/New_York', 'UTC'). Leave empty to use local timezone.
   file:
     file: File

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -2876,6 +2876,9 @@ displays:
     down: Down
     nearest: Nearest
     up: Up
+    timezone: Timezone
+    timezone_local: Local Timezone
+    timezone_note: IANA timezone identifier (e.g., 'America/New_York', 'UTC'). Leave empty to use local timezone.
   file:
     file: File
     description: Display files


### PR DESCRIPTION
## What's Changed

* Restored the `timezone`, `timezone_local`, and `timezone_note` keys under `displays.datetime` in the en-US source locale.
* [#26184](<https://github.com/directus/directus/issues/26184>) added these keys, and [#26940](<https://github.com/directus/directus/issues/26940>) dropped them while rebasing the English locale file. The Datetime display and interface still reference `$t:displays.datetime.timezone` and `$t:displays.datetime.timezone_note`, so the timezone options rendered the raw keys instead of their labels.

## Tested Scenarios

* Confirmed `app/src/displays/datetime/index.ts` and `app/src/interfaces/datetime/index.ts` reference `$t:displays.datetime.timezone` and `$t:displays.datetime.timezone_note`, which now resolve against the restored keys.

## Review Notes / Questions / Concerns

* `timezone_local` is not referenced in the app today, but it was part of the original set from [#26184](<https://github.com/directus/directus/issues/26184>), so it is restored here for parity.

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](<https://github.com/directus/openapi>)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes directus/directus#27998