### PR TITLE
Fix typos in test descriptions

### DIFF
--- a/.changeset/fix-typos-in-tests.md
+++ b/.changeset/fix-typos-in-tests.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+'@directus/app': patch
+---
+
+Fixed typos in test descriptions

--- a/api/src/utils/get-ip-from-req.test.ts
+++ b/api/src/utils/get-ip-from-req.test.ts
@@ -55,7 +55,7 @@ describe('getIPFromReq', () => {
 		expect(result).toBe('127.0.0.1');
 	});
 
-	test('Returns overriden ip if IP_CUSTOM_HEADER is set with valid IP', () => {
+	test('Returns overridden ip if IP_CUSTOM_HEADER is set with valid IP', () => {
 		vi.mocked(useEnv).mockReturnValue({
 			IP_TRUST_PROXY: true,
 			IP_CUSTOM_HEADER: 'X-CUSTOM-IP',

--- a/app/src/utils/get-local-type.test.ts
+++ b/app/src/utils/get-local-type.test.ts
@@ -72,7 +72,7 @@ test('Returns STANDARD with no relations', () => {
 	(fieldsStore.getField as Mock).mockReturnValue({
 		collection: 'test_collection',
 		field: 'test_fields',
-		type: 'unkown',
+		type: 'unknown',
 		meta: {
 			collection: 'test_collection',
 			field: 'test_fields',

--- a/contributors.yml
+++ b/contributors.yml
@@ -295,3 +295,4 @@
 - lazerg
 - scarab-systems
 - Harshith-muddasani
+- Pyolar


### PR DESCRIPTION
Fixed two typos in test files:

- `overriden` → `overridden` in get-ip-from-req test
- `unkown` → `unknown` in get-local-type test