### PR TITLE
fix(sdk): add missing RequestCredentials and CloseEvent types

### DIFF
--- a/.changeset/pr-26850-sdk-types.md
+++ b/.changeset/pr-26850-sdk-types.md
@@ -1,0 +1,5 @@
+---
+"@directus/sdk": patch
+---
+
+Fix missing `RequestCredentials` and `CloseEvent` types in SDK when used in non-DOM environments.

--- a/contributors.yml
+++ b/contributors.yml
@@ -295,3 +295,4 @@
 - lazerg
 - scarab-systems
 - Harshith-muddasani
+- Chehak7

--- a/sdk/src/auth/types.ts
+++ b/sdk/src/auth/types.ts
@@ -1,3 +1,5 @@
+import type { RequestCredentialsOption } from '../types/globals.js';
+
 export type AuthenticationMode = 'json' | 'cookie' | 'session';
 
 export type LocalLoginPayload = { email: string; password: string };
@@ -38,7 +40,7 @@ export interface AuthenticationStorage {
 export interface AuthenticationConfig {
 	autoRefresh: boolean;
 	msRefreshBeforeExpires: number;
-	credentials?: RequestCredentials;
+	credentials?: RequestCredentialsOption;
 	storage?: AuthenticationStorage;
 }
 

--- a/sdk/src/graphql/types.ts
+++ b/sdk/src/graphql/types.ts
@@ -1,3 +1,5 @@
+import type { RequestCredentialsOption } from '../types/globals.js';
+
 export interface GraphqlClient<_Schema> {
 	query<Output extends object = Record<string, any>>(
 		query: string,
@@ -7,7 +9,7 @@ export interface GraphqlClient<_Schema> {
 }
 
 export interface GraphqlConfig {
-	credentials?: RequestCredentials;
+	credentials?: RequestCredentialsOption;
 }
 
 // these utility types do not have schema fallback logic

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -313,13 +313,15 @@ export function realtime(config: WebSocketConfig = {}) {
 						ws.send(auth({ access_token }));
 						const confirm = await messageCallback(ws);
 
-						if (!(
-							confirm &&
-							'type' in confirm &&
-							'status' in confirm &&
-							confirm['type'] === 'auth' &&
-							confirm['status'] === 'ok'
-						)) {
+						if (
+							!(
+								confirm &&
+								'type' in confirm &&
+								'status' in confirm &&
+								confirm['type'] === 'auth' &&
+								confirm['status'] === 'ok'
+							)
+						) {
 							return reject('Authentication failed while opening websocket connection');
 						} else {
 							debug('info', 'Authentication successful!');

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -313,15 +313,13 @@ export function realtime(config: WebSocketConfig = {}) {
 						ws.send(auth({ access_token }));
 						const confirm = await messageCallback(ws);
 
-						if (
-							!(
-								confirm &&
-								'type' in confirm &&
-								'status' in confirm &&
-								confirm['type'] === 'auth' &&
-								confirm['status'] === 'ok'
-							)
-						) {
+						if (!(
+							confirm &&
+							'type' in confirm &&
+							'status' in confirm &&
+							confirm['type'] === 'auth' &&
+							confirm['status'] === 'ok'
+						)) {
 							return reject('Authentication failed while opening websocket connection');
 						} else {
 							debug('info', 'Authentication successful!');
@@ -360,7 +358,10 @@ export function realtime(config: WebSocketConfig = {}) {
 					state.connection.close();
 				}
 			},
-			onWebSocket(event: WebSocketEvents, callback: (this: WebSocketInterface, ev: Event | WebSocketCloseEvent | any) => any) {
+			onWebSocket(
+				event: WebSocketEvents,
+				callback: (this: WebSocketInterface, ev: Event | WebSocketCloseEvent | any) => any,
+			) {
 				if (event === 'message') {
 					// add some message parsing
 					const updatedCallback = function (this: WebSocketInterface, event: MessageEvent<any>) {

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -1,5 +1,5 @@
 import type { AuthenticationClient } from '../auth/types.js';
-import type { ConsoleInterface, ExtendedQuery, WebSocketInterface } from '../index.js';
+import type { ConsoleInterface, ExtendedQuery, WebSocketCloseEvent, WebSocketInterface } from '../index.js';
 import type { DirectusClient } from '../types/client.js';
 import { queryToParams } from '../utils/query-to-params.js';
 import { auth } from './commands/auth.js';
@@ -342,7 +342,7 @@ export function realtime(config: WebSocketConfig = {}) {
 					if (!resolved) reject(evt);
 				});
 
-				ws.addEventListener('close', (evt: CloseEvent) => {
+				ws.addEventListener('close', (evt: WebSocketCloseEvent) => {
 					debug('info', `Connection closed.`);
 					eventHandlers['close'].forEach((handler) => handler.call(ws, evt));
 					uid = generateUid();
@@ -360,7 +360,7 @@ export function realtime(config: WebSocketConfig = {}) {
 					state.connection.close();
 				}
 			},
-			onWebSocket(event: WebSocketEvents, callback: (this: WebSocketInterface, ev: Event | CloseEvent | any) => any) {
+			onWebSocket(event: WebSocketEvents, callback: (this: WebSocketInterface, ev: Event | WebSocketCloseEvent | any) => any) {
 				if (event === 'message') {
 					// add some message parsing
 					const updatedCallback = function (this: WebSocketInterface, event: MessageEvent<any>) {

--- a/sdk/src/realtime/types.ts
+++ b/sdk/src/realtime/types.ts
@@ -1,4 +1,4 @@
-import type { ApplyQueryFields, CollectionType, WebSocketInterface } from '../index.js';
+import type { ApplyQueryFields, CollectionType, WebSocketCloseEvent, WebSocketInterface } from '../index.js';
 import type { Query } from '../types/query.js';
 
 export type WebSocketAuthModes = 'public' | 'handshake' | 'strict';
@@ -29,15 +29,15 @@ export interface SubscribeOptions<Schema, Collection extends keyof Schema> {
 
 export type WebSocketEvents = 'open' | 'close' | 'error' | 'message';
 export type RemoveEventHandler = () => void;
-export type WebSocketEventHandler = (this: WebSocketInterface, ev: Event | CloseEvent | any) => any;
+export type WebSocketEventHandler = (this: WebSocketInterface, ev: Event | WebSocketCloseEvent | any) => any;
 
 export interface WebSocketClient<Schema> {
 	isConnected(): Promise<boolean>;
 	connect(): Promise<WebSocketInterface>;
 	disconnect(): void;
-	onWebSocket(event: 'open', callback: (this: WebSocketInterface, ev: Event) => any): RemoveEventHandler;
-	onWebSocket(event: 'error', callback: (this: WebSocketInterface, ev: Event) => any): RemoveEventHandler;
-	onWebSocket(event: 'close', callback: (this: WebSocketInterface, ev: CloseEvent) => any): RemoveEventHandler;
+	onWebSocket(event: 'open', callback: (this: WebSocketInterface, ev: Event | any) => any): RemoveEventHandler;
+	onWebSocket(event: 'error', callback: (this: WebSocketInterface, ev: Event | any) => any): RemoveEventHandler;
+	onWebSocket(event: 'close', callback: (this: WebSocketInterface, ev: WebSocketCloseEvent) => any): RemoveEventHandler;
 	onWebSocket(event: 'message', callback: (this: WebSocketInterface, ev: any) => any): RemoveEventHandler;
 	onWebSocket(event: WebSocketEvents, callback: WebSocketEventHandler): RemoveEventHandler;
 	sendMessage(message: string | Record<string, any>): void;

--- a/sdk/src/rest/types.ts
+++ b/sdk/src/rest/types.ts
@@ -1,3 +1,4 @@
+import type { RequestCredentialsOption } from '../types/globals.js';
 import type { RequestOptions, RequestTransformer, ResponseTransformer } from '../types/request.js';
 
 export interface RestCommand<_Output extends object | unknown, _Schema> {
@@ -9,7 +10,7 @@ export interface RestClient<Schema> {
 }
 
 export interface RestConfig {
-	credentials?: RequestCredentials;
+	credentials?: RequestCredentialsOption;
 	// onError?: (error: any) => any;
 	onRequest?: RequestTransformer;
 	onResponse?: ResponseTransformer;

--- a/sdk/src/types/globals.ts
+++ b/sdk/src/types/globals.ts
@@ -18,8 +18,19 @@ export type WebSocketInterface = {
 	close(code?: number, reason?: string): void;
 };
 
+export type RequestCredentialsOption = 'omit' | 'same-origin' | 'include';
+
+export type WebSocketCloseEvent = {
+	readonly code: number;
+	readonly reason: string;
+	readonly wasClean: boolean;
+	readonly target?: any;
+	readonly type?: string;
+} | any;
+
 export type LogLevels = 'log' | 'info' | 'warn' | 'error';
 
 export type ConsoleInterface = {
 	[level in LogLevels]: (...args: any) => any;
 };
+

--- a/sdk/src/types/globals.ts
+++ b/sdk/src/types/globals.ts
@@ -20,17 +20,18 @@ export type WebSocketInterface = {
 
 export type RequestCredentialsOption = 'omit' | 'same-origin' | 'include';
 
-export type WebSocketCloseEvent = {
-	readonly code: number;
-	readonly reason: string;
-	readonly wasClean: boolean;
-	readonly target?: any;
-	readonly type?: string;
-} | any;
+export type WebSocketCloseEvent =
+	| {
+			readonly code: number;
+			readonly reason: string;
+			readonly wasClean: boolean;
+			readonly target?: any;
+			readonly type?: string;
+	  }
+	| any;
 
 export type LogLevels = 'log' | 'info' | 'warn' | 'error';
 
 export type ConsoleInterface = {
 	[level in LogLevels]: (...args: any) => any;
 };
-

--- a/sdk/tests/realtime/heartbeat.test.ts
+++ b/sdk/tests/realtime/heartbeat.test.ts
@@ -92,4 +92,24 @@ describe('realtime heartbeat', () => {
 
 		expect(rejections).toEqual([]);
 	});
+
+	test('allows subscribing to websocket events via onWebSocket', async () => {
+		const { client, socket } = await openConnection();
+
+		const closeHandler = vi.fn();
+		client.onWebSocket('close', closeHandler);
+
+		const errorHandler = vi.fn();
+		client.onWebSocket('error', errorHandler);
+
+		socket.emit('error', new Error('test error'));
+		socket.emit('close', { code: 1000, reason: 'normal close', wasClean: true });
+
+		await flush();
+
+		expect(errorHandler).toHaveBeenCalled();
+		expect(closeHandler).toHaveBeenCalled();
+
+		client.disconnect();
+	});
 });


### PR DESCRIPTION
Fixes directus/directus#26850

### What's happening?

When using `@directus/sdk` in Node/ESM projects with `skipLibCheck: false` in `tsconfig.json`, TypeScript throws `TS2304: Cannot find name 'RequestCredentials'` and `Cannot find name 'CloseEvent'`. This happens because the SDK types rely on browser DOM types that aren't globally declared in non-DOM TypeScript environments.

### What changed?

* Added `RequestCredentialsOption` (`'omit' | 'same-origin' | 'include'`) to `sdk/src/types/globals.ts` — replaces the implicit DOM-only `RequestCredentials` global used in `AuthenticationConfig`, `RestConfig`, and `GraphqlConfig`
* Added `WebSocketCloseEvent` interface to `sdk/src/types/globals.ts` — replaces the implicit DOM-only `CloseEvent` global used in `WebSocketEventHandler`, `WebSocketClient.onWebSocket`, and the realtime composable
* All three config interfaces and both realtime files updated to use the new self-contained types

### Testing

* `tsc --noEmit` passes with **zero errors** on the full SDK including `tests/` directory
* Verified the original `TS2304` errors are resolved by our new type definitions
* No pre-existing errors introduced or modified