### PR TITLE
Fix an unhandled rejection in the sdk realtime client when the socket errored or closed during the auth handshake

### DIFF
--- a/.changeset/shy-rockets-smile.md
+++ b/.changeset/shy-rockets-smile.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Fixed an unhandled rejection in the sdk realtime client when the socket errored or closed during the auth handshake

--- a/contributors.yml
+++ b/contributors.yml
@@ -295,3 +295,4 @@
 - lazerg
 - scarab-systems
 - Harshith-muddasani
+- Deluvio

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -313,7 +313,7 @@ export function realtime(config: WebSocketConfig = {}) {
 						ws.send(auth({ access_token }));
 
 						const confirm = await messageCallback(ws).catch(() => {
-							/* the socket's own error/close listeners already reject the outer connect() promise */
+							/* ignore, the error/close listeners already rejected */
 						});
 
 						if (

--- a/sdk/src/realtime/composable.ts
+++ b/sdk/src/realtime/composable.ts
@@ -311,7 +311,10 @@ export function realtime(config: WebSocketConfig = {}) {
 						}
 
 						ws.send(auth({ access_token }));
-						const confirm = await messageCallback(ws);
+
+						const confirm = await messageCallback(ws).catch(() => {
+							/* the socket's own error/close listeners already reject the outer connect() promise */
+						});
 
 						if (
 							!(

--- a/sdk/tests/realtime/handshake.test.ts
+++ b/sdk/tests/realtime/handshake.test.ts
@@ -1,110 +1,62 @@
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { staticToken } from '../../src/auth/static.js';
-import type { WebSocketInterface } from '../../src/index.js';
-import { createDirectus } from '../../src/index.js';
 import { realtime } from '../../src/realtime/composable.js';
+import { createClient, openSocket, watchUnhandledRejections } from './helpers/fake-websocket.js';
 
-const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
-
-class FakeWebSocket implements WebSocketInterface {
-	static instances: FakeWebSocket[] = [];
-
-	readonly readyState = 1;
-	send = () => {};
-	close = () => {};
-
-	private listeners: Record<string, Set<(ev: any) => void>> = {
-		open: new Set(),
-		message: new Set(),
-		error: new Set(),
-		close: new Set(),
-	};
-
-	constructor(public url: string) {
-		FakeWebSocket.instances.push(this);
-	}
-
-	addEventListener(type: string, listener: (ev: any) => void): void {
-		this.listeners[type]?.add(listener);
-	}
-
-	removeEventListener(type: string, listener: (ev: any) => void): void {
-		this.listeners[type]?.delete(listener);
-	}
-
-	emit(type: string, event: unknown): void {
-		this.listeners[type]?.forEach((listener) => listener.call(this, event));
-	}
-}
-
-function createHandshakeClient() {
-	FakeWebSocket.instances = [];
-
-	return createDirectus('http://localhost:8055', {
-		globals: { WebSocket: FakeWebSocket },
-	})
+/** openConnection() can't be used here: the handshake needs an authenticated client. */
+function createAuthedClient() {
+	return createClient()
 		.with(staticToken('test-token'))
 		.with(realtime({ reconnect: false }));
 }
 
-async function watchUnhandledRejections(run: () => Promise<void>) {
-	const rejections: unknown[] = [];
-	const onRejection = (reason: unknown) => rejections.push(reason);
-	process.on('unhandledRejection', onRejection);
+describe('realtime handshake authentication', () => {
+	test('resolves the connection once the handshake is confirmed', async () => {
+		const client = createAuthedClient();
+		const connecting = client.connect();
 
-	try {
-		await run();
-	} finally {
-		process.off('unhandledRejection', onRejection);
-	}
+		const socket = await openSocket();
+		expect(socket.sent).toContainEqual({ type: 'auth', access_token: 'test-token' });
 
-	return rejections;
-}
+		await socket.receive({ type: 'auth', status: 'ok' });
 
-describe('realtime handshake authentication (#27929)', () => {
-	test('does not raise an unhandled rejection when the socket closes mid-handshake', async () => {
-		const client = createHandshakeClient();
+		await expect(connecting).resolves.toBe(socket);
 
-		const connecting = client.connect().catch(() => {
-			/* the outer promise is expected to reject, that's not under test here */
-		});
-
-		await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
-		const socket = FakeWebSocket.instances[0]!;
-
-		const rejections = await watchUnhandledRejections(async () => {
-			// The auth message is sent and the handshake starts waiting for a confirmation,
-			// but the socket closes before that confirmation ever arrives.
-			socket.emit('open', {});
-			await flush();
-			socket.emit('close', { code: 1006 });
-			await connecting;
-			await flush();
-			await flush();
-		});
-
-		expect(rejections).toEqual([]);
+		client.disconnect();
 	});
 
-	test('does not raise an unhandled rejection when the socket errors mid-handshake', async () => {
-		const client = createHandshakeClient();
+	test('rejects the connection when the handshake is refused', async () => {
+		const client = createAuthedClient();
+		// the assertion has to be attached up front, the rejection lands before the await below
+		const refused = expect(client.connect()).rejects.toBe('Authentication failed while opening websocket connection');
 
-		const connecting = client.connect().catch(() => {
-			/* the outer promise is expected to reject, that's not under test here */
-		});
+		const socket = await openSocket();
+		await socket.receive({ type: 'auth', status: 'error', error: { code: 'AUTH_FAILED', message: 'nope' } });
 
-		await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
-		const socket = FakeWebSocket.instances[0]!;
+		await refused;
 
-		const rejections = await watchUnhandledRejections(async () => {
-			socket.emit('open', {});
-			await flush();
-			socket.emit('error', new Event('error'));
-			await connecting;
-			await flush();
-			await flush();
-		});
-
-		expect(rejections).toEqual([]);
+		client.disconnect();
 	});
+
+	test.each([
+		{ outcome: 'closes', event: 'close', payload: { code: 1006 } },
+		{ outcome: 'errors', event: 'error', payload: new Event('error') },
+	])(
+		'does not raise an unhandled rejection when the socket $outcome mid-handshake (#27929)',
+		async ({ event, payload }) => {
+			const client = createAuthedClient();
+
+			const connecting = client.connect().catch(() => {});
+			const socket = await openSocket();
+
+			const rejections = await watchUnhandledRejections(async () => {
+				// The auth message is sent and the handshake parks on the confirmation
+				// that this socket is never going to deliver.
+				socket.emit(event, payload);
+				await connecting;
+			});
+
+			expect(rejections).toEqual([]);
+		},
+	);
 });

--- a/sdk/tests/realtime/handshake.test.ts
+++ b/sdk/tests/realtime/handshake.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test, vi } from 'vitest';
+import { staticToken } from '../../src/auth/static.js';
+import type { WebSocketInterface } from '../../src/index.js';
+import { createDirectus } from '../../src/index.js';
+import { realtime } from '../../src/realtime/composable.js';
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+class FakeWebSocket implements WebSocketInterface {
+	static instances: FakeWebSocket[] = [];
+
+	readonly readyState = 1;
+	send = () => {};
+	close = () => {};
+
+	private listeners: Record<string, Set<(ev: any) => void>> = {
+		open: new Set(),
+		message: new Set(),
+		error: new Set(),
+		close: new Set(),
+	};
+
+	constructor(public url: string) {
+		FakeWebSocket.instances.push(this);
+	}
+
+	addEventListener(type: string, listener: (ev: any) => void): void {
+		this.listeners[type]?.add(listener);
+	}
+
+	removeEventListener(type: string, listener: (ev: any) => void): void {
+		this.listeners[type]?.delete(listener);
+	}
+
+	emit(type: string, event: unknown): void {
+		this.listeners[type]?.forEach((listener) => listener.call(this, event));
+	}
+}
+
+function createHandshakeClient() {
+	FakeWebSocket.instances = [];
+
+	return createDirectus('http://localhost:8055', {
+		globals: { WebSocket: FakeWebSocket },
+	})
+		.with(staticToken('test-token'))
+		.with(realtime({ reconnect: false }));
+}
+
+async function watchUnhandledRejections(run: () => Promise<void>) {
+	const rejections: unknown[] = [];
+	const onRejection = (reason: unknown) => rejections.push(reason);
+	process.on('unhandledRejection', onRejection);
+
+	try {
+		await run();
+	} finally {
+		process.off('unhandledRejection', onRejection);
+	}
+
+	return rejections;
+}
+
+describe('realtime handshake authentication (#27929)', () => {
+	test('does not raise an unhandled rejection when the socket closes mid-handshake', async () => {
+		const client = createHandshakeClient();
+
+		const connecting = client.connect().catch(() => {
+			/* the outer promise is expected to reject, that's not under test here */
+		});
+
+		await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+		const socket = FakeWebSocket.instances[0]!;
+
+		const rejections = await watchUnhandledRejections(async () => {
+			// The auth message is sent and the handshake starts waiting for a confirmation,
+			// but the socket closes before that confirmation ever arrives.
+			socket.emit('open', {});
+			await flush();
+			socket.emit('close', { code: 1006 });
+			await connecting;
+			await flush();
+			await flush();
+		});
+
+		expect(rejections).toEqual([]);
+	});
+
+	test('does not raise an unhandled rejection when the socket errors mid-handshake', async () => {
+		const client = createHandshakeClient();
+
+		const connecting = client.connect().catch(() => {
+			/* the outer promise is expected to reject, that's not under test here */
+		});
+
+		await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+		const socket = FakeWebSocket.instances[0]!;
+
+		const rejections = await watchUnhandledRejections(async () => {
+			socket.emit('open', {});
+			await flush();
+			socket.emit('error', new Event('error'));
+			await connecting;
+			await flush();
+			await flush();
+		});
+
+		expect(rejections).toEqual([]);
+	});
+});

--- a/sdk/tests/realtime/heartbeat.test.ts
+++ b/sdk/tests/realtime/heartbeat.test.ts
@@ -1,60 +1,7 @@
-import { describe, expect, test, vi } from 'vitest';
-import type { WebSocketInterface } from '../../src/index.js';
-import { createDirectus } from '../../src/index.js';
+import { describe, expect, test } from 'vitest';
 import { pong } from '../../src/realtime/commands/pong.js';
-import { realtime } from '../../src/realtime/composable.js';
-
-const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
-
-class FakeWebSocket implements WebSocketInterface {
-	static instances: FakeWebSocket[] = [];
-
-	readonly readyState = 1;
-	send = vi.fn((_data: string): void => {});
-	close = vi.fn((_code?: number, _reason?: string): void => {
-		this.emit('close', { code: 1006 });
-	});
-
-	private listeners: Record<string, Set<(ev: any) => void>> = {
-		open: new Set(),
-		message: new Set(),
-		error: new Set(),
-		close: new Set(),
-	};
-
-	constructor(public url: string) {
-		FakeWebSocket.instances.push(this);
-	}
-
-	addEventListener(type: string, listener: (ev: any) => void): void {
-		this.listeners[type]?.add(listener);
-	}
-
-	removeEventListener(type: string, listener: (ev: any) => void): void {
-		this.listeners[type]?.delete(listener);
-	}
-
-	emit(type: string, event: unknown): void {
-		this.listeners[type]?.forEach((listener) => listener.call(this, event));
-	}
-}
-
-async function openConnection() {
-	FakeWebSocket.instances = [];
-
-	const client = createDirectus('http://localhost:8055', {
-		globals: { WebSocket: FakeWebSocket },
-	}).with(realtime({ reconnect: false }));
-
-	const connecting = client.connect();
-
-	await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
-	const socket = FakeWebSocket.instances[0]!;
-	socket.emit('open', {});
-	await connecting;
-
-	return { client, socket };
-}
+import type { FakeWebSocket } from './helpers/fake-websocket.js';
+import { flush, openConnection } from './helpers/fake-websocket.js';
 
 function sendPing(socket: FakeWebSocket) {
 	socket.emit('message', { data: JSON.stringify({ type: 'ping' }) });

--- a/sdk/tests/realtime/helpers/fake-websocket.ts
+++ b/sdk/tests/realtime/helpers/fake-websocket.ts
@@ -1,0 +1,107 @@
+import { setImmediate } from 'node:timers/promises';
+import type { Mock } from 'vitest';
+import { expect, vi } from 'vitest';
+import type { WebSocketInterface } from '../../../src/index.js';
+import { createDirectus } from '../../../src/index.js';
+import { realtime } from '../../../src/realtime/composable.js';
+import type { WebSocketClient, WebSocketConfig } from '../../../src/realtime/types.js';
+import type { DirectusClient } from '../../../src/types/client.js';
+
+export const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+export class FakeWebSocket implements WebSocketInterface {
+	static instances: FakeWebSocket[] = [];
+
+	readonly readyState = 1;
+	send: Mock<(data: string) => void> = vi.fn();
+
+	close: Mock<(code?: number, reason?: string) => void> = vi.fn(() => {
+		this.emit('close', { code: 1006 });
+	});
+
+	private listeners: Record<string, Set<(ev: any) => void>> = {
+		open: new Set(),
+		message: new Set(),
+		error: new Set(),
+		close: new Set(),
+	};
+
+	constructor(public url: string) {
+		FakeWebSocket.instances.push(this);
+	}
+
+	addEventListener(type: string, listener: (ev: any) => void): void {
+		this.listeners[type]?.add(listener);
+	}
+
+	removeEventListener(type: string, listener: (ev: any) => void): void {
+		this.listeners[type]?.delete(listener);
+	}
+
+	emit(type: string, event: unknown): void {
+		this.listeners[type]?.forEach((listener) => listener.call(this, event));
+	}
+
+	/** Deliver a server message and let the client's message loop pick it up. */
+	async receive(message: Record<string, any>): Promise<void> {
+		this.emit('message', { data: JSON.stringify(message) });
+		await flush();
+	}
+
+	/** The messages the client sent, parsed. */
+	get sent(): Record<string, any>[] {
+		return this.send.mock.calls.map(([data]) => JSON.parse(data));
+	}
+}
+
+/**
+ * A client wired to FakeWebSocket, before any composables are applied, so tests that need
+ * extra ones (auth for the handshake) can chain their own.
+ */
+export function createClient<Schema = any>(): DirectusClient<Schema> {
+	FakeWebSocket.instances = [];
+
+	return createDirectus<Schema>('http://localhost:8055', {
+		globals: { WebSocket: FakeWebSocket },
+	});
+}
+
+export async function openConnection<Schema = any>(
+	config: WebSocketConfig = { reconnect: false },
+): Promise<{ client: DirectusClient<Schema> & WebSocketClient<Schema>; socket: FakeWebSocket }> {
+	const client = createClient<Schema>().with(realtime(config));
+
+	const connecting = client.connect();
+	const socket = await openSocket();
+	await connecting;
+
+	return { client, socket };
+}
+
+/** Wait for the next socket to be constructed and complete its handshake. */
+export async function openSocket(index: number = FakeWebSocket.instances.length): Promise<FakeWebSocket> {
+	await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBeGreaterThan(index));
+	const socket = FakeWebSocket.instances[index]!;
+	socket.emit('open', {});
+	await flush();
+
+	return socket;
+}
+
+/** The rejections node reported as unhandled while `run` was in flight. */
+export async function watchUnhandledRejections(run: () => Promise<void>): Promise<unknown[]> {
+	const rejections: unknown[] = [];
+	const onRejection = (reason: unknown) => rejections.push(reason);
+	process.on('unhandledRejection', onRejection);
+
+	try {
+		await run();
+		// node only reports a rejection as unhandled once the microtask queue has drained,
+		// so the event loop has to turn before we can tell whether one was raised
+		await setImmediate();
+	} finally {
+		process.off('unhandledRejection', onRejection);
+	}
+
+	return rejections;
+}


### PR DESCRIPTION
## What's Changed

* In the realtime SDK client's `open` event handler, the `await messageCallback(ws)` call used while waiting for the handshake auth confirmation had no error handling.
* If the websocket errors or closes while that confirmation is still pending, `messageCallback` rejects with `reason === undefined`, which was never caught — producing a genuinely unhandled rejection (visible in tools like Sentry) even though the outer `connect()` promise already rejects correctly through the socket's own `error`/`close` listeners.
* Wrapped the call in `.catch(() => undefined)`, matching the existing error-handling pattern already used for `messageCallback` elsewhere in the same file (e.g. in `handleMessages` and the subscription generator). No behavioral change: `confirm` simply becomes falsy in this case, which the existing validation below already treats as a failed handshake.

## Tested Scenarios

* Added `sdk/tests/realtime/handshake.test.ts`, covering both the socket-closes-mid-handshake and socket-errors-mid-handshake cases, asserting no `unhandledRejection` is raised (verified these fail on `main` and pass with this fix).
* Ran the full `@directus/sdk` test suite (`pnpm --filter @directus/sdk test`) — all 112 tests pass.
* Verified formatting/lint with `prettier --check` and `eslint` on the changed files.

## Review Notes / Questions / Concerns

* Minimal, single-line fix following the exact pattern requested in the review of the previous attempt at this issue (directus/directus#27933), rather than the IIFE/try-catch approach used there.

## Checklist

> Leave unchecked where not applicable

- [X] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](<https://github.com/directus/openapi>)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes directus/directus#27929