### PR TITLE
Fix tool registry review regressions

### DIFF
--- a/.changeset/registry-chat-tools.md
+++ b/.changeset/registry-chat-tools.md
@@ -1,6 +1,6 @@
 ---
-'@directus/api': patch
-'@directus/app': patch
+'@directus/api': minor
+'@directus/app': minor
 ---
 
 Added search-first AI tool discovery for chat and MCP tools, with schema pinned as a root chat tool.

--- a/api/src/ai/mcp/server.test.ts
+++ b/api/src/ai/mcp/server.test.ts
@@ -50,6 +50,7 @@ vi.mock('../tools/index.js', async (importOriginal) => {
 			{
 				name: 'test-tool',
 				description: 'A test tool',
+				instructions: 'Full test tool instructions',
 				inputSchema: z.strictObject({
 					collection: z.string().optional(),
 					data: z.unknown().optional(),
@@ -231,6 +232,14 @@ describe('mcp server', () => {
 				'system-prompt',
 				'schema',
 			]);
+
+			expect(result.result.tools.find((tool: { name: string }) => tool.name === 'test-tool')).toMatchObject({
+				description: 'Full test tool instructions',
+			});
+
+			expect(result.result.tools.find((tool: { name: string }) => tool.name === 'schema')).not.toHaveProperty(
+				'outputSchema',
+			);
 		});
 
 		test('should list only MCP root tools in registry mode', async () => {
@@ -308,7 +317,7 @@ describe('mcp server', () => {
 						content: expect.arrayContaining([
 							expect.objectContaining({
 								type: 'text',
-								text: JSON.stringify({ data: 'test result' }),
+								text: JSON.stringify({ raw: 'test result' }),
 							}),
 						]),
 					}),
@@ -382,7 +391,7 @@ describe('mcp server', () => {
 						content: expect.arrayContaining([
 							expect.objectContaining({
 								type: 'text',
-								text: expect.stringContaining('UNKNOWN_TOOL'),
+								text: expect.stringContaining('INVALID_PAYLOAD'),
 							}),
 						]),
 					}),
@@ -419,12 +428,32 @@ describe('mcp server', () => {
 						content: expect.arrayContaining([
 							expect.objectContaining({
 								type: 'text',
-								text: expect.stringContaining("doesn't exist in the toolset"),
+								text: expect.stringMatching(/doesn't exist in the toolset.*INVALID_PAYLOAD/),
 							}),
 						]),
 					}),
 				}),
 			);
+		});
+
+		test('should preserve the forbidden error for non-admin callers of admin tools', async () => {
+			mockReq.body = {
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'tools/call',
+				params: {
+					name: 'admin-tool',
+					arguments: {},
+				},
+			};
+
+			directusMCP.handleRequest(mockReq as Request, mockRes as Response);
+
+			await awaitJsonResponse(directusMCP);
+
+			const response = vi.mocked(mockRes.json).mock.calls[0]![0] as any;
+			expect(response.result.content[0].text).toContain('FORBIDDEN');
+			expect(toolMocks.adminHandler).not.toHaveBeenCalled();
 		});
 
 		test('should return error for calling system-prompt if it is disabled', async () => {
@@ -494,7 +523,7 @@ describe('mcp server', () => {
 						content: expect.arrayContaining([
 							expect.objectContaining({
 								type: 'text',
-								text: JSON.stringify({ data: 'admin result' }),
+								text: JSON.stringify({ raw: 'admin result' }),
 							}),
 						]),
 					}),
@@ -1105,7 +1134,7 @@ describe('mcp server', () => {
 			expect(response).toEqual({ content: [] });
 		});
 
-		test('should format text type responses', () => {
+		test('should preserve the legacy text payload', () => {
 			const result = { type: 'text' as const, data: { message: 'hello' } };
 			const response = directusMCP.toResultResponse(result);
 
@@ -1113,19 +1142,19 @@ describe('mcp server', () => {
 				content: [
 					{
 						type: 'text',
-						text: JSON.stringify({ data: { message: 'hello' } }),
+						text: JSON.stringify({ raw: { message: 'hello' } }),
 					},
 				],
 			});
 		});
 
-		test('should attach structured content alongside the text payload', () => {
+		test('should attach structured content alongside the registry text payload', () => {
 			const result = {
 				type: 'text' as const,
 				data: [{ id: 1 }],
 			};
 
-			const response = directusMCP.toResultResponse(result, { data: [{ id: 1 }] });
+			const response = directusMCP.toResultResponse(result, { data: [{ id: 1 }] }, 'registry');
 
 			expect(response).toEqual({
 				content: [
@@ -1138,19 +1167,31 @@ describe('mcp server', () => {
 			});
 		});
 
+		test('should preserve structured content when registry data is null', () => {
+			const response = directusMCP.toResultResponse({ type: 'text', data: null }, { data: null }, 'registry');
+
+			expect(response).toEqual({
+				content: [],
+				structuredContent: { data: null },
+			});
+		});
+
 		test('should map registry errors to tool errors', () => {
-			const response = directusMCP.toToolResponse({
-				ok: false,
-				error: {
-					code: 'UNKNOWN_TOOL',
-					message: '"missing" does not exist',
-					recoverable: true,
-					next: {
-						tool: 'search',
-						input: { query: 'missing' },
+			const response = directusMCP.toToolResponse(
+				{
+					ok: false,
+					error: {
+						code: 'UNKNOWN_TOOL',
+						message: '"missing" does not exist',
+						recoverable: true,
+						next: {
+							tool: 'search',
+							input: { query: 'missing' },
+						},
 					},
 				},
-			});
+				'registry',
+			);
 
 			expect(response).toEqual({
 				isError: true,

--- a/api/src/ai/mcp/server.ts
+++ b/api/src/ai/mcp/server.ts
@@ -1,4 +1,4 @@
-import { isDirectusError } from '@directus/errors';
+import { ForbiddenError, InvalidPayloadError, isDirectusError } from '@directus/errors';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
 	type CallToolRequest,
@@ -24,6 +24,8 @@ import type { RootTool, ToolResult } from '../tools/types.js';
 import { DirectusTransport } from './transport.js';
 import type { MCPOptions, Prompt } from './types.js';
 import { buildMcpWWWAuthenticateHeader, getMcpUrls, MCP_ACCESS_SCOPE } from './utils.js';
+
+type McpToolMode = 'legacy' | 'registry';
 
 export class DirectusMCP {
 	promptsCollection?: string | null;
@@ -245,13 +247,13 @@ export class DirectusMCP {
 			systemPromptEnabled: this.systemPromptEnabled,
 		});
 
-		const useRegistryTools = req.query?.['tool_mode'] === 'registry';
+		const toolMode: McpToolMode = req.query?.['tool_mode'] === 'registry' ? 'registry' : 'legacy';
 
 		// listing tools
 		this.server.setRequestHandler(ListToolsRequestSchema, () => {
 			return {
-				tools: (useRegistryTools ? mountedRegistry.getRootTools() : mountedRegistry.tools).map((tool) =>
-					this.toMcpTool(tool),
+				tools: (toolMode === 'registry' ? mountedRegistry.getRootTools() : mountedRegistry.tools).map((tool) =>
+					this.toMcpTool(tool, toolMode),
 				),
 			};
 		});
@@ -259,11 +261,24 @@ export class DirectusMCP {
 		// calling tools
 		this.server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
 			try {
-				const result = useRegistryTools
-					? await mountedRegistry.executeRoot(request.params.name, request.params.arguments)
-					: await mountedRegistry.execute(request.params.name, request.params.arguments);
+				if (toolMode === 'legacy') {
+					const tool = ALL_TOOLS.find(({ name }) => name === request.params.name);
 
-				return this.toToolResponse(result);
+					if (!tool || (tool.name === 'system-prompt' && this.systemPromptEnabled === false)) {
+						throw new InvalidPayloadError({ reason: `"${request.params.name}" doesn't exist in the toolset` });
+					}
+
+					if (req.accountability?.admin !== true && tool.admin === true) {
+						throw new ForbiddenError({ reason: 'You must be an admin to access this tool' });
+					}
+				}
+
+				const result =
+					toolMode === 'registry'
+						? await mountedRegistry.executeRoot(request.params.name, request.params.arguments)
+						: await mountedRegistry.execute(request.params.name, request.params.arguments);
+
+				return this.toToolResponse(result, toolMode);
 			} catch (error) {
 				return this.toExecutionError(error);
 			}
@@ -298,42 +313,43 @@ export class DirectusMCP {
 		return response;
 	}
 
-	toMcpTool(tool: RootTool) {
+	toMcpTool(tool: RootTool, mode: McpToolMode = 'legacy') {
 		return {
 			name: tool.name,
-			description: tool.description,
+			description: mode === 'legacy' && tool.instructions ? tool.instructions : tool.description,
 			inputSchema: z.toJSONSchema(tool.inputSchema),
 			annotations: tool.annotations,
-			...(tool.output && { outputSchema: z.toJSONSchema(tool.output) }),
+			...(mode === 'registry' && tool.output && { outputSchema: z.toJSONSchema(tool.output) }),
 		};
 	}
 
-	toToolResponse(executeResult: RegistryExecuteResult): CallToolResult {
+	toToolResponse(executeResult: RegistryExecuteResult, mode: McpToolMode = 'legacy'): CallToolResult {
 		if (!executeResult.ok) {
-			return this.toRegistryErrorResponse(executeResult.error);
+			return this.toRegistryErrorResponse(executeResult.error, mode);
 		}
 
-		return this.toResultResponse(executeResult.result, executeResult.structuredContent);
+		return this.toResultResponse(executeResult.result, executeResult.structuredContent, mode);
 	}
 
-	toResultResponse(result?: ToolResult, structuredContent?: unknown): CallToolResult {
+	toResultResponse(result?: ToolResult, structuredContent?: unknown, mode: McpToolMode = 'legacy'): CallToolResult {
 		const response: CallToolResult = {
 			content: [],
 		};
 
-		if (!result || typeof result.data === 'undefined' || result.data === null) return response;
-
-		if (structuredContent !== undefined) {
+		if (mode === 'registry' && structuredContent !== undefined) {
 			response.structuredContent = structuredContent as CallToolResult['structuredContent'];
 		}
+
+		if (!result || typeof result.data === 'undefined' || result.data === null) return response;
 
 		if (result.type === 'text') {
 			response.content.push({
 				type: 'text',
-				text: JSON.stringify({
-					data: result.data,
-					...(result.url && { url: result.url }),
-				}),
+				text: JSON.stringify(
+					mode === 'legacy'
+						? { raw: result.data, url: result.url }
+						: { data: result.data, ...(result.url && { url: result.url }) },
+				),
 			});
 		} else {
 			response.content.push(result);
@@ -342,20 +358,23 @@ export class DirectusMCP {
 		return response;
 	}
 
-	toRegistryErrorResponse(error: RegistryError): CallToolResult {
+	toRegistryErrorResponse(error: RegistryError, mode: McpToolMode = 'legacy'): CallToolResult {
+		const serializedError =
+			mode === 'legacy'
+				? { error: error.message, ...(error.code !== 'TOOL_EXECUTION_FAILED' && { code: error.code }) }
+				: {
+						error: error.message,
+						code: error.code,
+						recoverable: error.recoverable,
+						...(error.next && { next: error.next }),
+					};
+
 		return {
 			isError: true,
 			content: [
 				{
 					type: 'text',
-					text: JSON.stringify([
-						{
-							error: error.message,
-							code: error.code,
-							recoverable: error.recoverable,
-							...(error.next && { next: error.next }),
-						},
-					]),
+					text: JSON.stringify([serializedError]),
 				},
 			],
 		};

--- a/api/src/ai/tools/collections/prompt.md
+++ b/api/src/ai/tools/collections/prompt.md
@@ -17,7 +17,7 @@ Perform CRUD operations on Directus Collections.
 	"meta": {
 		"collection": "products",
 		"icon": "inventory_2", // Any Material Symbols icons
-		"note": "Main product catalog with inventory tracking" // Helpful 1 sentence description
+		"note": "Main product catalog with inventory tracking", // Helpful 1 sentence description
 		"color": "#6366F1", // Color shown in content module sidebar
 		"singleton": false, // Single-item collections (settings, globals)
 		"hidden": false, // Hide from navigation
@@ -31,7 +31,7 @@ Perform CRUD operations on Directus Collections.
 		"versioning": false, // Enable content versioning for this collection
 		"sort": 2, // Sort order for this collection
 		"group": null, // Parent collection (use to group and nest collections in data model)
-		"collapse": "open" // Default collection to expanded or collapsed if child collections
+		"collapse": "open", // Default collection to expanded or collapsed if child collections
 		"preview_url": "https://store.example.com/products/{{slug}}", // Live preview URL to view items within collection - supports using template variables
 		"translations": [
 			{
@@ -46,7 +46,7 @@ Perform CRUD operations on Directus Collections.
 				"singular": "producto",
 				"plural": "productos"
 			}
-		],
+		]
 	}
 }
 ```

--- a/api/src/ai/tools/registry.test.ts
+++ b/api/src/ai/tools/registry.test.ts
@@ -349,6 +349,7 @@ describe('ToolRegistry', () => {
 
 		expect(mounted.search('target').results.map(({ name }) => name)).toEqual(['items']);
 		context.toolNames = [];
+		expect(mounted.search('target').results).toEqual([]);
 
 		await expect(mounted.execute('items', {})).resolves.toMatchObject({
 			ok: false,

--- a/api/src/ai/tools/registry.ts
+++ b/api/src/ai/tools/registry.ts
@@ -54,6 +54,13 @@ export type ToolRegistryMountContext = {
 
 type ToolRegistrySearchInput = { query: string; names?: never } | { names: string[]; query?: never };
 
+type SearchIndexCache = {
+	children: WeakMap<ToolConfig<any>, SearchIndexCache>;
+	index?: SearchIndex;
+};
+
+const searchIndexCache: SearchIndexCache = { children: new WeakMap() };
+
 export class ToolRegistry {
 	readonly #tools = new Map<string, ToolConfig<any>>();
 
@@ -75,7 +82,6 @@ export class ToolRegistry {
 export class MountedToolRegistry {
 	readonly #context: ToolRegistryMountContext;
 	readonly #catalog: Map<string, ToolConfig<any>>;
-	#searchIndex: SearchIndex | undefined;
 
 	constructor(tools: readonly ToolConfig<any>[], context: ToolRegistryMountContext) {
 		this.#context = context;
@@ -87,9 +93,9 @@ export class MountedToolRegistry {
 	}
 
 	search(query: string): ToolSearchResults {
-		this.#searchIndex ??= createSearchIndex(this.#getVisibleTools().filter((tool) => tool.exposure !== 'root'));
+		const tools = this.#getVisibleTools().filter((tool) => tool.exposure !== 'root');
 
-		return this.#searchIndex.search(query);
+		return getSearchIndex(tools).search(query);
 	}
 
 	detail(names: readonly string[]): ToolDetail[] {
@@ -305,6 +311,23 @@ export class MountedToolRegistry {
 			...(tool.instructions && { instructions: tool.instructions }),
 		};
 	}
+}
+
+function getSearchIndex(tools: readonly ToolConfig<any>[]): SearchIndex {
+	let cache = searchIndexCache;
+
+	for (const tool of tools) {
+		let child = cache.children.get(tool);
+
+		if (!child) {
+			child = { children: new WeakMap() };
+			cache.children.set(tool, child);
+		}
+
+		cache = child;
+	}
+
+	return (cache.index ??= createSearchIndex(tools));
 }
 
 const SearchInputSchema = z.object({

--- a/api/src/ai/tools/schema/index.test.ts
+++ b/api/src/ai/tools/schema/index.test.ts
@@ -108,6 +108,8 @@ describe('schema tool', () => {
 					accountability: mockAccountability,
 				});
 
+				expect(schema.output?.safeParse({ data: result?.data }).success).toBe(true);
+
 				expect(result).toEqual({
 					type: 'text',
 					data: {
@@ -224,6 +226,8 @@ describe('schema tool', () => {
 					schema: mockSchema,
 					accountability: mockAccountability,
 				});
+
+				expect(schema.output?.safeParse({ data: result?.data }).success).toBe(true);
 
 				expect(result).toEqual({
 					type: 'text',

--- a/api/src/ai/tools/system/index.ts
+++ b/api/src/ai/tools/system/index.ts
@@ -16,6 +16,7 @@ export const system = defineTool<z.infer<typeof SystemPromptValidateSchema>>({
 	name: 'system-prompt',
 	description:
 		'Returns the Directus Assistant system instructions. Use first to load role, behavior, and tool guidance.',
+	instructions: 'IMPORTANT! Always call this tool first. It will retrieve important information about your role.\n',
 	keywords: ['instructions', 'role', 'assistant prompt', 'system instructions'],
 	annotations: {
 		title: 'Directus - System Prompt',


### PR DESCRIPTION
## What's Changed

- Restored default MCP compatibility for tool descriptions, `raw` text payloads, error codes, and response shape.
- Limited MCP output schemas to registry root tools and preserved structured content for `null` results.
- Reused search indexes across mounts by tool identity while rechecking mutable visibility.
- Fixed the collections prompt example and changed the feature changesets to minor releases.

## Tested Scenarios

- `pnpm --filter @directus/api test src/ai` (558 tests)
- `pnpm --filter @directus/api build`
- `pnpm lint` (0 errors; 9 pre-existing warnings)
- `pnpm lint:style`
- Prettier check on every tracked file in this sub-PR

## Review Notes / Questions / Concerns

- Default MCP mode no longer advertises the unverified individual-tool output schemas. Registry mode advertises only the `schema` root output schema; representative lightweight and detailed handler outputs are validated in tests.
- This is the review-fix sub-PR for #27797.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs)
- [ ] OpenAPI updated
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Follow-up to #27797
