### PR TITLE
Add OpenAPI documentation for asset zip archive endpoints

### DIFF
--- a/.changeset/nervous-zips-archive.md
+++ b/.changeset/nervous-zips-archive.md
@@ -1,0 +1,5 @@
+---
+'@directus/specs': patch
+---
+
+Added OpenAPI documentation for the `POST /assets/folder/{pk}` and `POST /assets/files` endpoints

--- a/contributors.yml
+++ b/contributors.yml
@@ -296,3 +296,4 @@
 - scarab-systems
 - Harshith-muddasani
 - Deluvio
+- vedantchalke36

--- a/packages/specs/src/openapi.yaml
+++ b/packages/specs/src/openapi.yaml
@@ -118,7 +118,7 @@ paths:
     $ref: './paths/assets/assets.yaml'
   /assets/files:
     $ref: './paths/assets/files.yaml'
-  /assets/folder/{pk}:
+  /assets/folder/{id}:
     $ref: './paths/assets/folder.yaml'
 
   # Authentication

--- a/packages/specs/src/openapi.yaml
+++ b/packages/specs/src/openapi.yaml
@@ -114,12 +114,12 @@ paths:
     $ref: './paths/activity/activity.yaml'
 
   # Assets
+  /assets/{id}:
+    $ref: './paths/assets/assets.yaml'
   /assets/files:
     $ref: './paths/assets/files.yaml'
   /assets/folder/{pk}:
     $ref: './paths/assets/folder.yaml'
-  /assets/{id}:
-    $ref: './paths/assets/assets.yaml'
 
   # Authentication
   /auth/login:

--- a/packages/specs/src/openapi.yaml
+++ b/packages/specs/src/openapi.yaml
@@ -114,6 +114,10 @@ paths:
     $ref: './paths/activity/activity.yaml'
 
   # Assets
+  /assets/files:
+    $ref: './paths/assets/files.yaml'
+  /assets/folder/{pk}:
+    $ref: './paths/assets/folder.yaml'
   /assets/{id}:
     $ref: './paths/assets/assets.yaml'
 

--- a/packages/specs/src/paths/assets/files.yaml
+++ b/packages/specs/src/paths/assets/files.yaml
@@ -2,9 +2,10 @@ post:
   tags:
     - Assets
   x-collection: directus_files
+  x-action: read
   operationId: archiveFiles
   summary: Archive Files
-  description: Archives an arbitrary set of files into a zip file and streams it back.
+  description: Archives the specified files into a zip file and streams it back.
   requestBody:
     content:
       application/json:

--- a/packages/specs/src/paths/assets/files.yaml
+++ b/packages/specs/src/paths/assets/files.yaml
@@ -1,0 +1,31 @@
+post:
+  tags:
+    - Assets
+  x-collection: directus_files
+  operationId: archiveFiles
+  summary: Archive Files
+  description: Archives an arbitrary set of files into a zip file and streams it back.
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [ids]
+          properties:
+            ids:
+              type: array
+              minItems: 1
+              description: Unique identifiers of the files to archive.
+              items:
+                type: string
+                format: uuid
+  responses:
+    '200':
+      description: Successful request
+      content:
+        application/zip:
+          schema:
+            type: string
+            format: binary
+    '400':
+      $ref: '../../openapi.yaml#/components/responses/BadRequestError'

--- a/packages/specs/src/paths/assets/folder.yaml
+++ b/packages/specs/src/paths/assets/folder.yaml
@@ -2,6 +2,7 @@ post:
   tags:
     - Assets
   x-collection: directus_folders
+  x-action: read
   operationId: archiveFolder
   summary: Archive a Folder
   description: Archives every file within a folder (recursively) into a zip file and streams it back.
@@ -21,5 +22,5 @@ post:
           schema:
             type: string
             format: binary
-    '404':
-      $ref: '../../openapi.yaml#/components/responses/NotFoundError'
+    '403':
+      $ref: '../../openapi.yaml#/components/responses/ForbiddenError'

--- a/packages/specs/src/paths/assets/folder.yaml
+++ b/packages/specs/src/paths/assets/folder.yaml
@@ -7,7 +7,7 @@ post:
   summary: Archive a Folder
   description: Archives every file within a folder (recursively) into a zip file and streams it back.
   parameters:
-    - name: pk
+    - name: id
       in: path
       description: The id of the folder to archive.
       required: true

--- a/packages/specs/src/paths/assets/folder.yaml
+++ b/packages/specs/src/paths/assets/folder.yaml
@@ -1,0 +1,25 @@
+post:
+  tags:
+    - Assets
+  x-collection: directus_folders
+  operationId: archiveFolder
+  summary: Archive a Folder
+  description: Archives every file within a folder (recursively) into a zip file and streams it back.
+  parameters:
+    - name: pk
+      in: path
+      description: The id of the folder to archive.
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '200':
+      description: Successful request
+      content:
+        application/zip:
+          schema:
+            type: string
+            format: binary
+    '404':
+      $ref: '../../openapi.yaml#/components/responses/NotFoundError'


### PR DESCRIPTION
## What's Changed

* Added `packages/specs/src/paths/assets/files.yaml` and `packages/specs/src/paths/assets/folder.yaml`, registered in `openapi.yaml` as `/assets/files` and `/assets/folder/{pk}`, both under the `Assets` tag
* Documented `POST /assets/files/`: archives the specified files into a zip (`application/zip`, `Content-Disposition: attachment`); request body `{ "ids": string[] }` per the zod schema (UUIDs, min length 1), with the `InvalidPayloadError` (400) response for a malformed body
* Documented `POST /assets/folder/{pk}`: archives every file within folder `pk` (recursively) into a zip and streams it back
* Both operations use the `x-collection` operation-level override pattern from directus/directus#27883 (`directus_files` / `directus_folders`) with an `x-action: read` override, since neither endpoint creates anything — both are pure reads
* Response schema is `application/zip` with `type: string, format: binary`, following the closest precedent (`text/plain` string response on `GET /assets/{id}`)
* Added a changeset for `@directus/specs`

## Tested Scenarios

* `swagger-cli validate` on `packages/specs/src/openapi.yaml` passes (the only validation errors are pre-existing ones in `/items/{collection}` on main, unrelated to this PR)
* Both new path entries bundle correctly under the `Assets` tag with the expected request/response documentation

## Review Notes / Questions / Concerns

* Blocked on directus/directus#27883: the `x-action` override (and the dynamic-spec security behavior it feeds into) depends on the `x-action` implementation from that PR landing first. Converting to draft until it's resolved
* Part of the spec drift audit tracked in directus/directus#27700

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [X] OpenAPI updated
  - [X] Local specs package (`@directus/specs`)
  - [x] PR created in [directus/openapi](<https://github.com/directus/openapi>)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Contributes to directus/directus#27700

- Fixes https://github.com/directus/directus/issues/28020
