### PR TITLE
Fix Markdown interface Edit/Preview buttons not showing the active view

### DIFF
--- a/.changeset/markdown-view-toggle-active.md
+++ b/.changeset/markdown-view-toggle-active.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the Markdown interface's Edit and Preview buttons not indicating which view is currently active

--- a/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
+++ b/app/src/interfaces/input-rich-text-md/input-rich-text-md.vue
@@ -397,10 +397,10 @@ const menuActive = computed(() => imageDialogOpen.value);
 				mandatory
 				@update:model-value="([value]: ['editor' | 'preview']) => (view = value)"
 			>
-				<VButton x-small value="editor" :disabled="disabled && !nonEditable" :class="[{ active: view !== 'preview' }]">
+				<VButton x-small value="editor" :disabled="disabled && !nonEditable" :active="view !== 'preview'">
 					{{ $t('interfaces.input-rich-text-md.edit') }}
 				</VButton>
-				<VButton x-small value="preview" :disabled="disabled && !nonEditable" :class="[{ active: view === 'preview' }]">
+				<VButton x-small value="preview" :disabled="disabled && !nonEditable" :active="view === 'preview'">
 					{{ $t('interfaces.input-rich-text-md.preview') }}
 				</VButton>
 			</VItemGroup>

--- a/contributors.yml
+++ b/contributors.yml
@@ -296,3 +296,4 @@
 - scarab-systems
 - Harshith-muddasani
 - Deluvio
+- Aniket-a14


### PR DESCRIPTION
The Markdown interface's view toggle passed `:class="[{ active: ... }]"` to `VButton`. As a fallthrough  <br>attribute that class lands on the component's root element, while the styling rule targets the inner  <br>button (`.active.button`), so it never applied. This uses the component's own `active` prop instead,  <br>which sets the class on the correct element.

## What's Changed

* `app/src/interfaces/input-rich-text-md/input-rich-text-md.vue`: replaced the `:class="[{ active: ... }]"`  <br>binding on the Edit/Preview `VButton`s with the documented `:active` prop
* Added a changeset (`@directus/app`, patch)

## Tested Scenarios

* Created a field using the Markdown interface, opened an item, and toggled between Edit and Preview —  <br>the active button is now visually distinct from the inactive one, matching v11 behaviour
* Confirmed the toggle still switches views correctly and that `VItemGroup`'s `mandatory` behaviour is  <br>unchanged (clicking the already-active button does not deselect it)
* Checked the disabled and non-editable states still render as before
* `pnpm lint`, `pnpm lint:style` and `pnpm format` pass on the changed files

## Review Notes / Questions / Concerns

* There is a second, broader cause worth a maintainer's opinion: `isActiveRoute` in `v-button.vue` only  <br>falls back to `useGroupable`'s `active` inside the `props.to` branch, so a `VButton` inside a  <br>`VItemGroup` never self-activates without an explicit `active` prop. Fixing that would make the  <br>grouping work out of the box, but it changes behaviour for every button in the app, so I kept this PR  <br>to the local fix. Happy to open a follow-up if you'd prefer the general fix.
* The Markdown interface was the only place in `app/src` binding `active` as a class on `VButton`, so no  <br>other call sites needed the same change.
* No test was added — the regression is purely CSS class placement. Let me know if you'd like a component  <br>test asserting the `active` class lands on the inner button.

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](<https://github.com/directus/openapi>)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes directus/directus#28013