### PR TITLE
Fix missing breadcrumb separator on MCP OAuth clients settings pages

### DIFF
--- a/.changeset/mcp-oauth-clients-breadcrumb.md
+++ b/.changeset/mcp-oauth-clients-breadcrumb.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the missing separator between the breadcrumb and the page title on the MCP OAuth clients settings pages

--- a/app/src/modules/settings/routes/mcp-oauth-clients/collection.vue
+++ b/app/src/modules/settings/routes/mcp-oauth-clients/collection.vue
@@ -11,6 +11,7 @@ import VCardTitle from '@/components/v-card-title.vue';
 import VCard from '@/components/v-card.vue';
 import VDialog from '@/components/v-dialog.vue';
 import VError from '@/components/v-error.vue';
+import VIcon from '@/components/v-icon/v-icon.vue';
 import VInfo from '@/components/v-info.vue';
 import { PrivateViewHeaderBarActionButton } from '@/views/private';
 import { PrivateView } from '@/views/private';
@@ -84,13 +85,16 @@ function useBatch() {
 		:clear-filters="clearFilters"
 	>
 		<PrivateView :title="$t('mcp_oauth_clients')" icon="key" show-back back-to="/settings/ai">
-			<template #headline>
-				<VBreadcrumb
-					:items="[
-						{ name: $t('settings'), to: '/settings' },
-						{ name: $t('settings_ai'), to: '/settings/ai' },
-					]"
-				/>
+			<template #title:prepend>
+				<span class="breadcrumb">
+					<VBreadcrumb
+						:items="[
+							{ name: $t('settings'), to: '/settings' },
+							{ name: $t('settings_ai'), to: '/settings/ai' },
+						]"
+					/>
+					<VIcon class="breadcrumb-divider" name="chevron_right" small />
+				</span>
 			</template>
 
 			<template #actions:prepend>
@@ -163,6 +167,17 @@ function useBatch() {
 </template>
 
 <style lang="scss" scoped>
+.breadcrumb {
+	display: flex;
+	align-items: center;
+}
+
+.breadcrumb-divider {
+	--v-icon-color: var(--theme--foreground-subdued);
+
+	margin-inline: 0.25rem;
+}
+
 .action-delete {
 	--v-button-background-color-hover: var(--theme--danger) !important;
 	--v-button-color-hover: var(--white) !important;

--- a/app/src/modules/settings/routes/mcp-oauth-clients/item.vue
+++ b/app/src/modules/settings/routes/mcp-oauth-clients/item.vue
@@ -11,6 +11,7 @@ import VCardTitle from '@/components/v-card-title.vue';
 import VCard from '@/components/v-card.vue';
 import VDialog from '@/components/v-dialog.vue';
 import VForm from '@/components/v-form/v-form.vue';
+import VIcon from '@/components/v-icon/v-icon.vue';
 import { useItem } from '@/composables/use-item';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { PrivateViewHeaderBarActionButton } from '@/views/private';
@@ -45,14 +46,17 @@ async function revokeClient() {
 
 <template>
 	<PrivateView :title="item?.client_name ?? '...'" icon="key" show-back back-to="/settings/mcp-oauth-clients">
-		<template #headline>
-			<VBreadcrumb
-				:items="[
-					{ name: $t('settings'), to: '/settings' },
-					{ name: $t('settings_ai'), to: '/settings/ai' },
-					{ name: $t('mcp_oauth_clients'), to: '/settings/mcp-oauth-clients' },
-				]"
-			/>
+		<template #title:prepend>
+			<span class="breadcrumb">
+				<VBreadcrumb
+					:items="[
+						{ name: $t('settings'), to: '/settings' },
+						{ name: $t('settings_ai'), to: '/settings/ai' },
+						{ name: $t('mcp_oauth_clients'), to: '/settings/mcp-oauth-clients' },
+					]"
+				/>
+				<VIcon class="breadcrumb-divider" name="chevron_right" small />
+			</span>
 		</template>
 
 		<template #actions>
@@ -102,6 +106,17 @@ async function revokeClient() {
 </template>
 
 <style lang="scss" scoped>
+.breadcrumb {
+	display: flex;
+	align-items: center;
+}
+
+.breadcrumb-divider {
+	--v-icon-color: var(--theme--foreground-subdued);
+
+	margin-inline: 0.25rem;
+}
+
 .content {
 	padding: var(--content-padding);
 	padding-block-end: var(--content-padding-bottom);

--- a/contributors.yml
+++ b/contributors.yml
@@ -296,3 +296,4 @@
 - scarab-systems
 - Harshith-muddasani
 - Deluvio
+- Aniket-a14


### PR DESCRIPTION
`PrivateView`'s `headline` slot is deprecated and now renders prepended to the title rather than above<br>it, so on the MCP OAuth clients pages the breadcrumb ran straight into the page title with no separator<br>— `Settings > AIMCP OAuth Clients` on the overview, and `Settings > AI > MCP OAuth ClientsOpenCode` on a<br>client detail page.

These two routes are the only remaining users of that slot. This moves them to the non-deprecated<br>`title:prepend` slot and renders the trailing chevron that separates the last crumb from the title.

## What's Changed

* `app/src/modules/settings/routes/mcp-oauth-clients/collection.vue` and `item.vue`: moved the breadcrumb<br>from the deprecated `headline` slot to `title:prepend`, and added the trailing `chevron_right` divider
* Styled the divider to match `v-breadcrumb`'s own separators (`--v-icon-color` subdued, `0.25rem`<br>inline margin)
* Added a changeset (`@directus/app`, patch)

## Tested Scenarios

* With `MCP_OAUTH_ENABLED` set and a registered client, opened `/admin/settings/mcp-oauth-clients` and<br>confirmed the breadcrumb reads `Settings > AI > MCP OAuth Clients`
* Opened a client detail page and confirmed it reads `Settings > AI > MCP OAuth Clients > OpenCode`
* Verified the crumbs still navigate correctly and the divider spacing/colour matches the separators<br>rendered inside `v-breadcrumb`
* `pnpm lint`, `pnpm lint:style` and `pnpm format` pass on the changed files

## Review Notes / Questions / Concerns

* I kept the deprecated `v-breadcrumb` component rather than replacing it with an inline<br>`v-icon` + `router-link` breadcrumb as its deprecation notice suggests. That felt like a separate<br>cleanup, and keeping it meant the existing crumb rendering was untouched. Happy to do the full<br>migration here instead if you'd prefer.
* The divider styling is duplicated in both route files. If you'd rather it lived in one place, I can<br>extract a small local component.
* After this change nothing in `app/src` uses `PrivateView`'s `headline` slot, so it could be removed in<br>a follow-up.

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](<https://github.com/directus/openapi>)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes directus/directus#28007