### PR TITLE
fix(input-rich-text-html): WYSIWYG editor not responding to touch/trackpad on Safari

### DIFF
--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -351,7 +351,14 @@ onKeyStroke('Escape', () => {
 			@input="$emit('input', $event)"
 		/>
 
-		<EditorContent v-show="!rawMode" class="editor-content" :editor="editor" :dir="editorDir" @click="onEditorClick" />
+		<EditorContent
+			v-show="!rawMode"
+			class="editor-content"
+			:editor="editor"
+			:dir="editorDir"
+			@click="onEditorClick"
+			@touchstart.prevent="onEditorClick"
+		/>
 
 		<span
 			v-if="softLength && !comparisonMode && !rawMode"
@@ -506,6 +513,7 @@ onKeyStroke('Escape', () => {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	text-rendering: optimizeLegibility;
+	touch-action: manipulation;
 
 	h1,
 	h2,


### PR DESCRIPTION
Fixes directus/directus#27341, directus/directus#27028

## Changes

1. Added `@touchstart.prevent` handler on the `EditorContent` component so Safari (both macOS trackpad and iOS/mobile) recognizes touch input on the editor element.
2. Added `touch-action: manipulation` CSS on the `.ProseMirror` element to prevent Safari from intercepting touch events for zoom/scroll gestures, and to avoid a 300ms tap delay.

## Root Cause

Safari's contenteditable elements require explicit touch-event handling to receive focus and respond to editing gestures. Without these changes, clicks generated by a trackpad (macOS) or direct touch (iOS) fail to reach ProseMirror's internal focus handler, making the editor appear inert on those input methods.

Closes directus/directus#27341<br>Closes directus/directus#27028