### PR TITLE
Fix tool registry cache and error fidelity

### DIFF
--- a/api/src/ai/mcp/server.test.ts
+++ b/api/src/ai/mcp/server.test.ts
@@ -1214,6 +1214,27 @@ describe('mcp server', () => {
 			});
 		});
 
+		test('should preserve native error codes in legacy responses', () => {
+			const response = directusMCP.toToolResponse({
+				ok: false,
+				error: {
+					code: 'ER_DUP_ENTRY',
+					message: 'Duplicate entry',
+					recoverable: false,
+				},
+			});
+
+			expect(response).toEqual({
+				isError: true,
+				content: [
+					{
+						type: 'text',
+						text: JSON.stringify([{ error: 'Duplicate entry', code: 'ER_DUP_ENTRY' }]),
+					},
+				],
+			});
+		});
+
 		test('should return result directly for non-text types', () => {
 			const result = { type: 'image' as const, data: 'base64data', mimeType: 'image/png' };
 			const response = directusMCP.toResultResponse(result);

--- a/api/src/ai/tools/registry.test.ts
+++ b/api/src/ai/tools/registry.test.ts
@@ -178,6 +178,33 @@ describe('ToolRegistry', () => {
 		});
 	});
 
+	test.each([
+		[
+			'coded errors',
+			Object.assign(new Error('Duplicate entry'), { code: 'ER_DUP_ENTRY' }),
+			'ER_DUP_ENTRY',
+			'Duplicate entry',
+		],
+		['plain objects', { code: 'DRIVER_ERROR', message: 'Driver failed' }, 'DRIVER_ERROR', 'Driver failed'],
+		['strings', 'String error', 'TOOL_EXECUTION_FAILED', 'String error'],
+	])('preserves generic %s for transport serialization', async (_label, thrown, code, message) => {
+		const registry = new ToolRegistry([
+			createTool({
+				name: 'failing',
+				description: 'Failing',
+				handler: async () => {
+					throw thrown;
+				},
+				readOnly: true,
+			}),
+		]);
+
+		await expect(registry.mount({ schema }).execute('failing', {})).resolves.toMatchObject({
+			ok: false,
+			error: { code, message, recoverable: false },
+		});
+	});
+
 	test('consent blocks writes and allows reads', async () => {
 		const registry = new ToolRegistry([
 			createTool({

--- a/api/src/ai/tools/registry.ts
+++ b/api/src/ai/tools/registry.ts
@@ -7,7 +7,7 @@ import { fromZodError } from 'zod-validation-error';
 import { Url } from '../../utils/url.js';
 import { schema as schemaTool } from './schema/index.js';
 import { getToolTypeStrings } from './schema-to-type-string.js';
-import { createSearchIndex, type SearchIndex, type ToolSearchResults } from './search-index.js';
+import { createSearchIndex, type ToolSearchResults } from './search-index.js';
 import type { RootTool, ToolConfig, ToolResult } from './types.js';
 import { coerceJsonFields } from './utils.js';
 
@@ -54,13 +54,6 @@ export type ToolRegistryMountContext = {
 
 type ToolRegistrySearchInput = { query: string; names?: never } | { names: string[]; query?: never };
 
-type SearchIndexCache = {
-	children: WeakMap<ToolConfig<any>, SearchIndexCache>;
-	index?: SearchIndex;
-};
-
-const searchIndexCache: SearchIndexCache = { children: new WeakMap() };
-
 export class ToolRegistry {
 	readonly #tools = new Map<string, ToolConfig<any>>();
 
@@ -95,7 +88,7 @@ export class MountedToolRegistry {
 	search(query: string): ToolSearchResults {
 		const tools = this.#getVisibleTools().filter((tool) => tool.exposure !== 'root');
 
-		return getSearchIndex(tools).search(query);
+		return createSearchIndex(tools).search(query);
 	}
 
 	detail(names: readonly string[]): ToolDetail[] {
@@ -313,23 +306,6 @@ export class MountedToolRegistry {
 	}
 }
 
-function getSearchIndex(tools: readonly ToolConfig<any>[]): SearchIndex {
-	let cache = searchIndexCache;
-
-	for (const tool of tools) {
-		let child = cache.children.get(tool);
-
-		if (!child) {
-			child = { children: new WeakMap() };
-			cache.children.set(tool, child);
-		}
-
-		cache = child;
-	}
-
-	return (cache.index ??= createSearchIndex(tools));
-}
-
 const SearchInputSchema = z.object({
 	query: z
 		.union([z.string(), z.null()])
@@ -418,17 +394,30 @@ function toRegistryError(error: unknown, tool?: ToolConfig<any>): RegistryError 
 		};
 	}
 
+	const code =
+		typeof error === 'object' && error !== null && 'code' in error && error.code
+			? String(error.code)
+			: 'TOOL_EXECUTION_FAILED';
+
 	if (error instanceof Error) {
 		return {
-			code: 'TOOL_EXECUTION_FAILED',
+			code,
 			message: error.message,
 			recoverable: false,
 		};
 	}
 
+	if (typeof error === 'object' && error !== null) {
+		return {
+			code,
+			message: 'message' in error ? String(error.message) : 'An unknown error occurred.',
+			recoverable: false,
+		};
+	}
+
 	return {
-		code: 'TOOL_EXECUTION_FAILED',
-		message: 'An unknown error occurred.',
+		code,
+		message: typeof error === 'string' ? error : 'An unknown error occurred.',
 		recoverable: false,
 	};
 }

--- a/api/src/ai/tools/search-index.ts
+++ b/api/src/ai/tools/search-index.ts
@@ -26,6 +26,8 @@ type IndexedTool = {
 	documentLength: number;
 };
 
+const indexedToolCache = new WeakMap<ToolConfig<any>, IndexedTool>();
+
 const BM25_K1 = 1.2;
 const BM25_B = 0.75;
 
@@ -38,7 +40,7 @@ const FIELD_WEIGHTS = {
 } as const;
 
 export function createSearchIndex(tools: readonly ToolConfig<any>[]): SearchIndex {
-	const indexedTools = tools.map(indexTool).sort((a, b) => a.tool.name.localeCompare(b.tool.name));
+	const indexedTools = tools.map(getIndexedTool).sort((a, b) => a.tool.name.localeCompare(b.tool.name));
 	const availableToolNames = indexedTools.map(({ tool }) => tool.name);
 
 	return {
@@ -67,6 +69,17 @@ export function createSearchIndex(tools: readonly ToolConfig<any>[]): SearchInde
 			};
 		},
 	};
+}
+
+function getIndexedTool(tool: ToolConfig<any>): IndexedTool {
+	let indexedTool = indexedToolCache.get(tool);
+
+	if (!indexedTool) {
+		indexedTool = indexTool(tool);
+		indexedToolCache.set(tool, indexedTool);
+	}
+
+	return indexedTool;
 }
 
 function indexTool(tool: ToolConfig<any>): IndexedTool {


### PR DESCRIPTION
## What's Changed

- Replaced the visible-tool subset trie with per-tool indexed-document memoization, bounding retained search data to the tool catalog.
- Preserved native codes and messages from generic tool errors so default MCP responses retain their pre-registry shape.
- Added focused registry and MCP compatibility coverage.

## Tested Scenarios

- `pnpm --filter @directus/api exec vitest run src/ai/tools/search-index.test.ts src/ai/tools/registry.test.ts src/ai/mcp/server.test.ts` (82 tests)
- `pnpm --filter @directus/api build`
- `pnpm lint` (passes with 9 existing warnings)
- `pnpm lint:style`
- Prettier check on all changed files

## Review Notes / Questions / Concerns

- This is a sub-PR for review feedback on #27797.
- The full API suite has one unrelated, reproducible failure in `src/utils/build-import-plan.test.ts` on the base branch area; 4,840 tests passed.
- Repository-wide Prettier checks the gitignored `.context/attachments` directory and reports its imported review files; every changed file passes.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [x] Security implications apply

---

Follow-up to #27797