### PR TITLE
fix: apply display per-item for relational array values in render-display

### DIFF
--- a/app/src/views/private/components/render-display.vue
+++ b/app/src/views/private/components/render-display.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { toRefs } from 'vue';
+import { toRefs, computed } from 'vue';
 import ValueNull from './value-null.vue';
 import VErrorBoundary from '@/components/v-error-boundary.vue';
 import VTextOverflow from '@/components/v-text-overflow.vue';
@@ -19,10 +19,38 @@ const props = defineProps<{
 const { display } = toRefs(props);
 
 const displayInfo = useExtension('display', display);
+
+const isArrayValue = computed(() => Array.isArray(props.value));
 </script>
 
 <template>
 	<ValueNull v-if="value === null || value === undefined" />
+	<template v-else-if="isArrayValue">
+		<span
+			v-for="(item, index) in (value as unknown[])"
+			:key="index"
+			class="display"
+		>
+			<span v-if="index > 0" class="separator">, </span>
+			<ValueNull v-if="item === null || item === undefined" />
+			<VTextOverflow v-else-if="displayInfo === null" :text="item" />
+			<VErrorBoundary v-else :name="`display-${display}`">
+				<component
+					:is="`display-${display}`"
+					v-bind="options"
+					:interface="interface"
+					:interface-options="interfaceOptions"
+					:value="item"
+					:type="type"
+					:collection="collection"
+					:field="field"
+				/>
+				<template #fallback>
+					<VTextOverflow :text="item" />
+				</template>
+			</VErrorBoundary>
+		</span>
+	</template>
 	<VTextOverflow v-else-if="displayInfo === null" class="display" :text="value" />
 	<VErrorBoundary v-else :name="`display-${display}`">
 		<component
@@ -35,7 +63,6 @@ const displayInfo = useExtension('display', display);
 			:collection="collection"
 			:field="field"
 		/>
-
 		<template #fallback>
 			<VTextOverflow class="display" :text="value" />
 		</template>
@@ -45,5 +72,9 @@ const displayInfo = useExtension('display', display);
 <style lang="scss" scoped>
 .display {
 	line-height: 1.25rem;
+}
+
+.separator {
+	white-space: pre;
 }
 </style>


### PR DESCRIPTION
## Description

Fixes directus/directus#27657

When a datetime column is added to a layout through a to-many (O2M/M2M) relation, the value arrives as an array (e.g. `["2026-07-29T12:00:00"]`). The `render-display.vue` component passed the entire array to the display component, which expects a single string value. This caused the display to fall back to the raw array value instead of formatting the datetime.

### Changes

Modified `render-display.vue` to handle array values by iterating over each item and applying the configured display component to each item individually. This ensures that:

* **M2O (Many-to-One)** relations continue to work as before (single value, no change)
* **O2M/M2M (to-many)** relations now properly format each item using the field's display configuration
* Array items are separated by a comma-space separator
* Null/undefined items in the array are handled gracefully
* Fallback to `VTextOverflow` works correctly when no display is configured

### Before

<!-- linear:table-colwidths:266,266,266 -->
| Column | Relation | Rendered |
| -- | -- | -- |
| `author.joined_at` | M2O | `July 29th, 2026 12:00 PM` ✅ |
| `author_list.joined_at` | O2M (alias) | `[ "2026-07-29T12:00:00" ]` ❌ raw |

### After

<!-- linear:table-colwidths:266,266,266 -->
| Column | Relation | Rendered |
| -- | -- | -- |
| `author.joined_at` | M2O | `July 29th, 2026 12:00 PM` ✅ |
| `author_list.joined_at` | O2M (alias) | `July 29th, 2026 12:00 PM` ✅ |
