### PR TITLE
fix(specs): document POST /assets/folder/{pk} and POST /assets/files/ (#28020)

### DIFF
--- a/.changeset/document-assets-folder-and-files.md
+++ b/.changeset/document-assets-folder-and-files.md
@@ -1,0 +1,5 @@
+---
+'@directus/specs': minor
+---
+
+Documented `POST /assets/folder/{pk}` and `POST /assets/files/` endpoints in OpenAPI spec

--- a/packages/specs/src/paths/assets/files.yaml
+++ b/packages/specs/src/paths/assets/files.yaml
@@ -1,0 +1,42 @@
+post:
+  tags:
+    - Assets
+  summary: Archive Multiple Files
+  description: >-
+    Archives an arbitrary set of files into a zip archive and streams it back.
+  operationId: archiveFiles
+  x-collection: directus_files
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - ids
+          properties:
+            ids:
+              type: array
+              minItems: 1
+              items:
+                type: string
+                format: uuid
+  responses:
+    '200':
+      description: Successful request
+      content:
+        application/zip:
+          schema:
+            type: string
+            format: binary
+      headers:
+        Content-Disposition:
+          schema:
+            type: string
+          example: attachment; filename="files-1700000000000.zip"
+    '400':
+      $ref: '../../openapi.yaml#/components/responses/BadRequestError'
+    '401':
+      $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
+    '403':
+      $ref: '../../openapi.yaml#/components/responses/ForbiddenError'

--- a/packages/specs/src/paths/assets/folder.yaml
+++ b/packages/specs/src/paths/assets/folder.yaml
@@ -1,0 +1,34 @@
+post:
+  tags:
+    - Assets
+  summary: Archive Folder
+  description: >-
+    Archives every file within the specified folder recursively into a zip archive and streams it back.
+  operationId: archiveFolder
+  x-collection: directus_folders
+  parameters:
+    - name: pk
+      in: path
+      required: true
+      description: Unique identifier of the folder.
+      schema:
+        type: string
+  responses:
+    '200':
+      description: Successful request
+      content:
+        application/zip:
+          schema:
+            type: string
+            format: binary
+      headers:
+        Content-Disposition:
+          schema:
+            type: string
+          example: attachment; filename="folder-documents-1700000000000.zip"
+    '401':
+      $ref: '../../openapi.yaml#/components/responses/UnauthorizedError'
+    '403':
+      $ref: '../../openapi.yaml#/components/responses/ForbiddenError'
+    '404':
+      $ref: '../../openapi.yaml#/components/responses/NotFoundError'


### PR DESCRIPTION
### Summary

Fixes directus/directus#28020 by adding OpenAPI spec coverage for `POST /assets/folder/{pk}` and `POST /assets/files/`.

### Changes

1. `POST /assets/files`: Added `packages/specs/src/paths/assets/files.yaml` documenting file archive streaming (`application/zip`), request body with `ids` array, and error responses (`x-collection: directus_files`).
2. `POST /assets/folder/{pk}`: Added `packages/specs/src/paths/assets/folder.yaml` documenting recursive folder archive streaming (`application/zip`) and error responses (`x-collection: directus_folders`).
3. `openapi.yaml`: Registered `/assets/files` and `/assets/folder/{pk}` paths in `packages/specs/src/openapi.yaml`.
4. **Changeset**: Added changeset in `.changeset/document-assets-folder-and-files.md`.