### PR TITLE
Fix Save as Copy moving relations nested inside a related collection

### DIFF
--- a/.changeset/nested-m2m-save-as-copy.md
+++ b/.changeset/nested-m2m-save-as-copy.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed Save as Copy moving relations nested inside a related collection, such as a Many-to-Many field within Translations, from the original item to the copy

--- a/app/src/composables/use-item/index.test.ts
+++ b/app/src/composables/use-item/index.test.ts
@@ -1016,3 +1016,183 @@ describe('Save As Copy with M2M relation', () => {
 		expect(saveBody.children.update).toEqual([]);
 	});
 });
+
+describe('Save As Copy with M2M relation nested in a related collection', () => {
+	const mockCollection = {
+		collection: 'test',
+	} as AppCollection;
+
+	const mockPrimaryKeyField = {
+		field: 'id',
+		schema: { has_auto_increment: true },
+	} as Field;
+
+	/**
+	 * Sets up a translations style relation (`test` -> `test_translations` -> `languages`) where the
+	 * related collection holds an M2M relation of its own (`test_translations` ->
+	 * `test_translations_tags` -> `tags`).
+	 */
+	function setupNestedM2MMocks(parentPrimaryKeyField: Field = mockPrimaryKeyField) {
+		const sdkSpy = vi.spyOn(sdk, 'request');
+
+		vi.mocked(useCollection).mockReturnValue({
+			info: computed(() => mockCollection),
+			primaryKeyField: computed(() => parentPrimaryKeyField),
+			fields: computed(() => [parentPrimaryKeyField] as Field[]),
+		} as any);
+
+		const fieldsStore = useFieldsStore();
+		const relationsStore = useRelationsStore();
+
+		const autoIncrementPk = { field: 'id', schema: { has_auto_increment: true } } as Field;
+		const manualPk = { field: 'code' } as Field;
+
+		vi.mocked(fieldsStore.getPrimaryKeyFieldForCollection).mockImplementation((collection: string) =>
+			collection === 'languages' ? manualPk : autoIncrementPk,
+		);
+
+		const translationsRelation = {
+			collection: 'test_translations',
+			field: 'test_id',
+			related_collection: 'test',
+			meta: { one_field: 'translations', junction_field: 'language' },
+		} as unknown as Relation;
+
+		const nestedTagsRelation = {
+			collection: 'test_translations_tags',
+			field: 'test_translations_id',
+			related_collection: 'test_translations',
+			meta: { one_field: 'tags', junction_field: 'tag_id' },
+		} as unknown as Relation;
+
+		vi.mocked(relationsStore.getRelationsForCollection).mockReturnValue([translationsRelation]);
+
+		vi.mocked(relationsStore).relations = [
+			translationsRelation,
+			{
+				collection: 'test_translations',
+				field: 'language',
+				related_collection: 'languages',
+				meta: { many_field: 'language', junction_field: null },
+			} as unknown as Relation,
+			nestedTagsRelation,
+			{
+				collection: 'test_translations_tags',
+				field: 'tag_id',
+				related_collection: 'tags',
+				meta: { many_field: 'tag_id', junction_field: null },
+			} as unknown as Relation,
+		];
+
+		return sdkSpy;
+	}
+
+	test('should fetch the nested relational fields of the related items expanded', async () => {
+		const sdkSpy = setupNestedM2MMocks();
+
+		sdkSpy
+			.mockResolvedValueOnce({}) // initial getItem
+			.mockResolvedValueOnce({ item: { id: 1, translations: [{ id: 10 }] } }) // graphql duplication fetch
+			.mockResolvedValueOnce([{ id: 10 }]) // findExistingRelatedItems
+			.mockResolvedValueOnce({ id: 2 }); // save
+
+		const { saveAsCopy } = useItem(ref('test'), ref(1));
+		await saveAsCopy();
+
+		const findCall = sdkSpy.mock.calls[2]?.[0]() as any;
+
+		expect(findCall.params.fields).toEqual(['*', 'tags.*']);
+	});
+
+	test('should duplicate the nested junction rows instead of relinking them', async () => {
+		const sdkSpy = setupNestedM2MMocks();
+
+		sdkSpy
+			.mockResolvedValueOnce({}) // initial getItem
+			.mockResolvedValueOnce({ item: { id: 1, translations: [{ id: 10 }] } }) // graphql duplication fetch
+			.mockResolvedValueOnce([
+				{
+					id: 10,
+					test_id: 1,
+					language: 'en-US',
+					tags: [{ id: 100, test_translations_id: 10, tag_id: 5 }],
+				},
+			]) // findExistingRelatedItems
+			.mockResolvedValueOnce({ id: 2 }); // save
+
+		const { saveAsCopy } = useItem(ref('test'), ref(1));
+		await saveAsCopy();
+
+		const saveBody = (sdkSpy.mock.lastCall?.[0]() as any).body;
+
+		// The junction PK is dropped so new junction rows are created for the copy, leaving the
+		// junction rows of the original item untouched
+		expect(saveBody.translations).toEqual([
+			{
+				test_id: 1,
+				language: 'en-US',
+				tags: [{ test_translations_id: 10, tag_id: 5 }],
+			},
+		]);
+	});
+
+	test('should duplicate the nested junction rows of edited related items', async () => {
+		const sdkSpy = setupNestedM2MMocks();
+
+		sdkSpy
+			.mockResolvedValueOnce({}) // initial getItem
+			.mockResolvedValueOnce({ item: { id: 1, translations: [{ id: 10 }] } }) // graphql duplication fetch
+			.mockResolvedValueOnce([
+				{
+					id: 10,
+					test_id: 1,
+					language: 'en-US',
+					tags: [{ id: 100, test_translations_id: 10, tag_id: 5 }],
+				},
+			]) // findExistingRelatedItems
+			.mockResolvedValueOnce({ id: 2 }); // save
+
+		const { saveAsCopy, edits } = useItem(ref('test'), ref(1));
+
+		edits.value = {
+			translations: {
+				create: [],
+				update: [{ id: 10, title: 'edited' }],
+				delete: [],
+			},
+		};
+
+		await saveAsCopy();
+
+		const saveBody = (sdkSpy.mock.lastCall?.[0]() as any).body;
+
+		expect(saveBody.translations.create).toEqual([
+			{
+				test_id: 1,
+				language: 'en-US',
+				title: 'edited',
+				tags: [{ test_translations_id: 10, tag_id: 5 }],
+			},
+		]);
+
+		expect(saveBody.translations.update).toEqual([]);
+	});
+
+	test('should omit the primary key of the related collection when the parent primary key is manually entered', async () => {
+		const sdkSpy = setupNestedM2MMocks({ field: 'code' } as Field);
+
+		sdkSpy
+			.mockResolvedValueOnce({}) // initial getItem
+			.mockResolvedValueOnce({ item: { code: 'abc', translations: [{ id: 10 }] } }) // graphql duplication fetch
+			.mockResolvedValueOnce([{ id: 10, test_id: 'abc', language: 'en-US' }]) // findExistingRelatedItems
+			.mockResolvedValueOnce({ code: 'def' }); // save
+
+		const { saveAsCopy } = useItem(ref('test'), ref(1));
+		await saveAsCopy();
+
+		const saveBody = (sdkSpy.mock.lastCall?.[0]() as any).body;
+
+		expect(saveBody.code).toBe('abc');
+		expect(saveBody.translations).toEqual([{ test_id: 'abc', language: 'en-US' }]);
+	});
+});

--- a/app/src/composables/use-item/index.ts
+++ b/app/src/composables/use-item/index.ts
@@ -296,8 +296,9 @@ export function useItem<T extends Item>(
 						);
 
 						if (existingItem) {
-							clearPrimaryKey(primaryKeyField.value, existingItem);
+							clearPrimaryKey(relatedPrimaryKeyField, existingItem);
 							clearJunctionRelatedKey(relation, existsJunctionRelated, existingItem);
+							clearNestedRelatedKeys(relation.collection, existingItem);
 							relatedItem = existingItem;
 						}
 
@@ -331,12 +332,14 @@ export function useItem<T extends Item>(
 
 					clearPrimaryKey(relatedPrimaryKeyField, data);
 					clearJunctionRelatedKey(relation, existsJunctionRelated, data);
+					clearNestedRelatedKeys(relation.collection, data);
 
 					newRelatedItem.create.push(data);
 				}
 
 				for (const item of existingItems) {
 					clearPrimaryKey(relatedPrimaryKeyField, item);
+					clearNestedRelatedKeys(relation.collection, item);
 
 					newRelatedItem.create.push(item);
 				}
@@ -398,7 +401,19 @@ export function useItem<T extends Item>(
 				}, [] as string[]),
 			);
 
+			const nestedOneFields = getNestedRelations(relation.collection).map((relation) => relation.meta!.one_field!);
+
 			if (fieldsToFetch.size > 0) fieldsToFetch.add(relatedPrimaryKeyField.field);
+			else if (nestedOneFields.length > 0) fieldsToFetch.add('*');
+
+			// Without expanding them, nested relational fields are returned as plain keys which would
+			// relink the existing nested items to the copy instead of duplicating them
+			for (const nestedOneField of nestedOneFields) {
+				if (!fieldsToFetch.has(nestedOneField) && !fieldsToFetch.has('*')) continue;
+
+				fieldsToFetch.delete(nestedOneField);
+				fieldsToFetch.add(`${nestedOneField}.*`);
+			}
 
 			const endpoint = getEndpoint(relation.collection);
 			const requestFields = Array.from(fieldsToFetch);
@@ -420,6 +435,37 @@ export function useItem<T extends Item>(
 		function clearPrimaryKey(primaryKeyField: Field | null, item: Item) {
 			if (primaryKeyField?.schema?.has_auto_increment || primaryKeyField?.meta?.special?.includes('uuid')) {
 				delete item[primaryKeyField.field];
+			}
+		}
+
+		function getNestedRelations(collection: string) {
+			return relationsStore.relations.filter(
+				(relation) => relation.related_collection === collection && relation.meta?.one_field,
+			);
+		}
+
+		function clearNestedRelatedKeys(collection: string, item: Item) {
+			for (const nestedRelation of getNestedRelations(collection)) {
+				const nestedOneField = nestedRelation.meta!.one_field!;
+
+				if (!Array.isArray(item[nestedOneField])) continue;
+
+				const nestedPrimaryKeyField = fieldsStore.getPrimaryKeyFieldForCollection(nestedRelation.collection);
+				if (!nestedPrimaryKeyField) continue;
+
+				const existsNestedJunctionRelated = relationsStore.relations.find(
+					(r) =>
+						r.collection === nestedRelation.collection && r.meta?.many_field === nestedRelation.meta?.junction_field,
+				);
+
+				// Nested items that were not fetched expanded are dropped, as keeping their keys would
+				// move them from the original item to the copy
+				item[nestedOneField] = item[nestedOneField].filter(isObject).map((nestedItem: Item) => {
+					clearPrimaryKey(nestedPrimaryKeyField, nestedItem);
+					clearJunctionRelatedKey(nestedRelation, existsNestedJunctionRelated, nestedItem);
+
+					return nestedItem;
+				});
 			}
 		}
 


### PR DESCRIPTION
## What's Changed

Using "Save as Copy" on an item whose related collection has a relational field of its own (for example a Many-to-Many field inside `<collection>_translations`) moved that data from the original item to the copy instead of duplicating it, leaving the field empty on the original.

Root cause, in `saveAsCopy()` in `app/src/composables/use-item/index.ts`:

* `findExistingRelatedItems()` builds an empty `fields` list when `item_duplication_fields` is not configured. The SDK omits an empty array, so the API falls back to `*`, which includes alias fields. A Many-to-Many field on the related collection therefore comes back as an array of **existing junction primary keys** (`bar: [1]`).
* Nothing clears those keys, so the create payload re-points the existing junction rows at the copy. The API moves them, and the original ends up empty. Only the first level was handled: `clearJunctionRelatedKey()` reaches the junction field of the related item, but never the relations of the related collection itself. That is why a Many-to-Many placed directly on the parent keeps working while the same field inside Translations does not.
* Separately, the array branch called `clearPrimaryKey(primaryKeyField.value, existingItem)`, passing the **parent** collection's primary key descriptor while operating on a row of the **related** collection. When the two collections' primary keys differ in name or in schema flags, the related row kept its key and got moved as well. The Alterations branch already used `relatedPrimaryKeyField` here.

Changes:

* `findExistingRelatedItems()` now requests the relational fields of the related collection expanded (`*`, `<field>.*`), so their rows arrive as objects rather than as bare keys.
* New `clearNestedRelatedKeys()` clears the primary key of those nested rows (and of their junction related item, reusing `clearJunctionRelatedKey()`) in both the array and the Alterations branch. Nested values that were not returned expanded are dropped rather than kept, since keeping them would move them off the original.
* The array branch now uses `relatedPrimaryKeyField` instead of the parent's primary key field.

The copy now gets its own junction rows pointing at the same related items, matching how a Many-to-Many directly on the parent collection already behaves.

## Tested Scenarios

* Unit tests added to `app/src/composables/use-item/index.test.ts` covering the reporter's shape (parent -> translations -> Many-to-Many): the fields requested for the related items, the plain array branch, the Alterations branch produced by editing a translated field, and a parent whose primary key is manually entered while the related collection's is auto-increment. All four fail on `main` and pass with this change.
* `pnpm --filter @directus/app test`: 323 files, 111452 tests passing.
* Manual end-to-end against a local instance on SQLite with the schema from the issue (`foo` with a Translations field, a Many-to-Many field inside `foo_translations`, plus a Many-to-Many and a Many-to-One directly on `foo`):
  * Before: after Save as Copy the original's nested Many-to-Many is empty and the junction row now points at the copy.
  * After: the original keeps its junction row and the copy gets a new junction row referencing the same related item. The Many-to-Many and Many-to-One at the top level are unaffected, as before.
* Checked with a non-admin policy that has read access to the parent and translations collections but not to the nested junction collection: the API silently omits the non-permitted nested field instead of erroring, so restricted roles keep working.

## Review Notes / Questions / Concerns

* The expansion goes one level past the related collection, which is what this issue needs. Relations nested three levels deep are still returned as bare keys and are now dropped from the payload rather than moved — safer than today's behaviour, but not a full deep copy. Happy to make it recursive if you'd prefer.
* `findExistingRelatedItems()` now sends an explicit `*` when `item_duplication_fields` is not configured, where previously it sent no `fields` param at all. That is the same server-side default, just spelled out so the nested expansions can be appended alongside it.
* The `clearPrimaryKey(primaryKeyField.value, ...)` -> `relatedPrimaryKeyField` change is a separate defect in the same block. It is invisible whenever both collections use an auto-increment `id`, which is why it has gone unnoticed; it is covered by its own test.

## Checklist

> Leave unchecked where not applicable

- [X] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](<https://github.com/directus/openapi>)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes directus/directus#26841