### PR TITLE
Fix collection names with surrounding whitespace being accepted on creation

### DIFF
--- a/.changeset/violet-jokes-shave.md
+++ b/.changeset/violet-jokes-shave.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Trimmed surrounding whitespace from collection names on creation, so names like `" directus_test"` no longer bypass the reserved prefix check

--- a/.changeset/violet-jokes-shave.md
+++ b/.changeset/violet-jokes-shave.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Trimmed surrounding whitespace from collection names on creation, so names like `" directus_test"` no longer bypass the reserved prefix check
+Fixed collection names with surrounding whitespace being accepted on creation

--- a/api/src/services/collections.test.ts
+++ b/api/src/services/collections.test.ts
@@ -125,7 +125,8 @@ describe('Integration Tests', () => {
 				[{ collection: 'directus_test' }, 'collection names start with "directus_"'],
 				[{ collection: 'Folder/Test' }, 'collection name contains "/"'],
 				[{ collection: '   ' }, 'collection name only contains whitespace'],
-				[{ collection: ' directus_test' }, 'collection name starts with "directus_" after trimming'],
+				[{ collection: ' new_collection' }, 'collection name starts with whitespace'],
+				[{ collection: 'new_collection ' }, 'collection name ends with whitespace'],
 			];
 
 			test.each(invalidPayloads)('should throw InvalidPayloadError when %s', async (payload, _description) => {
@@ -146,19 +147,6 @@ describe('Integration Tests', () => {
 
 				const result = await service.createOne({
 					collection: 'new_collection',
-					schema: {},
-				});
-
-				expect(result).toBe('new_collection');
-				expect(mockSchemaBuilder.createTable).toHaveBeenCalledWith('new_collection', expect.any(Function));
-			});
-
-			test('should trim the collection name before creating', async () => {
-				tracker.on.select('directus_collections').response([]);
-				const service = new CollectionsService({ knex: db, schema, accountability: null });
-
-				const result = await service.createOne({
-					collection: ' new_collection ',
 					schema: {},
 				});
 

--- a/api/src/services/collections.test.ts
+++ b/api/src/services/collections.test.ts
@@ -124,6 +124,8 @@ describe('Integration Tests', () => {
 				[{ collection: '' }, 'collection name is empty'],
 				[{ collection: 'directus_test' }, 'collection names start with "directus_"'],
 				[{ collection: 'Folder/Test' }, 'collection name contains "/"'],
+				[{ collection: '   ' }, 'collection name only contains whitespace'],
+				[{ collection: ' directus_test' }, 'collection name starts with "directus_" after trimming'],
 			];
 
 			test.each(invalidPayloads)('should throw InvalidPayloadError when %s', async (payload, _description) => {
@@ -144,6 +146,19 @@ describe('Integration Tests', () => {
 
 				const result = await service.createOne({
 					collection: 'new_collection',
+					schema: {},
+				});
+
+				expect(result).toBe('new_collection');
+				expect(mockSchemaBuilder.createTable).toHaveBeenCalledWith('new_collection', expect.any(Function));
+			});
+
+			test('should trim the collection name before creating', async () => {
+				tracker.on.select('directus_collections').response([]);
+				const service = new CollectionsService({ knex: db, schema, accountability: null });
+
+				const result = await service.createOne({
+					collection: ' new_collection ',
 					schema: {},
 				});
 

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -75,15 +75,15 @@ export class CollectionsService {
 
 		// Reject rather than trim: knex trims table identifiers, so a padded name would mismatch between `directus_collections.collection` and table name
 		if (payload.collection !== payload.collection.trim()) {
-			throw new InvalidPayloadError({ reason: `Collection name can't start or end with whitespace` });
+			throw new InvalidPayloadError({ reason: `"collection" can't start or end with whitespace` });
 		}
 
 		if (payload.collection.startsWith('directus_')) {
-			throw new InvalidPayloadError({ reason: `Collections can't start with "directus_"` });
+			throw new InvalidPayloadError({ reason: `"collection" can't start with "directus_"` });
 		}
 
 		if (payload.collection.includes('/')) {
-			throw new InvalidPayloadError({ reason: `Collection name can't contain "/"` });
+			throw new InvalidPayloadError({ reason: `"collection" can't contain "/"` });
 		}
 
 		if (payload.schema && payload.meta && (!('status' in payload.meta) || payload.meta.status === 'active')) {

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -69,9 +69,11 @@ export class CollectionsService {
 
 		if (!('collection' in payload)) throw new InvalidPayloadError({ reason: `"collection" is required` });
 
-		if (typeof payload.collection !== 'string' || payload.collection === '') {
+		if (typeof payload.collection !== 'string' || payload.collection.trim() === '') {
 			throw new InvalidPayloadError({ reason: `"collection" must be a non-empty string` });
 		}
+
+		payload.collection = payload.collection.trim();
 
 		if (payload.collection.startsWith('directus_')) {
 			throw new InvalidPayloadError({ reason: `Collections can't start with "directus_"` });

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -69,12 +69,13 @@ export class CollectionsService {
 
 		if (!('collection' in payload)) throw new InvalidPayloadError({ reason: `"collection" is required` });
 
-		if (typeof payload.collection === 'string') {
-			payload.collection = payload.collection.trim();
-		}
-
 		if (typeof payload.collection !== 'string' || payload.collection === '') {
 			throw new InvalidPayloadError({ reason: `"collection" must be a non-empty string` });
+		}
+
+		// Reject rather than trim: knex trims table identifiers, so a padded name would mismatch between `directus_collections.collection` and table name
+		if (payload.collection !== payload.collection.trim()) {
+			throw new InvalidPayloadError({ reason: `Collection name can't start or end with whitespace` });
 		}
 
 		if (payload.collection.startsWith('directus_')) {

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -69,11 +69,13 @@ export class CollectionsService {
 
 		if (!('collection' in payload)) throw new InvalidPayloadError({ reason: `"collection" is required` });
 
-		if (typeof payload.collection !== 'string' || payload.collection.trim() === '') {
-			throw new InvalidPayloadError({ reason: `"collection" must be a non-empty string` });
+		if (typeof payload.collection === 'string') {
+			payload.collection = payload.collection.trim();
 		}
 
-		payload.collection = payload.collection.trim();
+		if (typeof payload.collection !== 'string' || payload.collection === '') {
+			throw new InvalidPayloadError({ reason: `"collection" must be a non-empty string` });
+		}
 
 		if (payload.collection.startsWith('directus_')) {
 			throw new InvalidPayloadError({ reason: `Collections can't start with "directus_"` });

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -69,7 +69,7 @@ export class CollectionsService {
 
 		if (!('collection' in payload)) throw new InvalidPayloadError({ reason: `"collection" is required` });
 
-		if (typeof payload.collection !== 'string' || payload.collection === '') {
+		if (typeof payload.collection !== 'string' || payload.collection.trim() === '') {
 			throw new InvalidPayloadError({ reason: `"collection" must be a non-empty string` });
 		}
 


### PR DESCRIPTION
## What's Changed

* `createOne` now rejects collection names with padding
* 

## Tested Scenarios

- [X] Creating collection with padded collection name rejects
- [X] Creating collection with non padded name succeeds

## Review Notes / Questions / Concerns

* knex currently auto trims table names but directus does not. Rejecting ensures no mismatch between the two
* Rejecting also ensures we are not silently changing the requested name

## Checklist

> Leave unchecked where not applicable

- [X] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](<https://github.com/directus/openapi>)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes directus/directus#28037