### PR TITLE
Fix required M2M validation bypass when clearing all relations

### DIFF
--- a/.changeset/m2m-required-validation-clear.md
+++ b/.changeset/m2m-required-validation-clear.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed required Many-to-Many (and other relational) field validation being bypassed when all existing relations are cleared while editing an item

--- a/app/src/utils/validate-item.test.ts
+++ b/app/src/utils/validate-item.test.ts
@@ -120,6 +120,84 @@ test('Required fields', () => {
 	expect(result.length).toEqual(1);
 });
 
+test('Required relational field cleared on update via staged changes', () => {
+	// When editing an existing item and removing all related items, the relational
+	// interface stages the change as a `{ create, update, delete }` object rather
+	// than an empty array. This must still be treated as an empty value so the
+	// required validation fires (see directus/directus#27695).
+	let result = validateItem(
+		{
+			id: 1,
+			name: 'test',
+			email: 'test@test.com',
+			role: { create: [], update: [], delete: [1, 2] },
+		},
+		fields as Field[],
+		false,
+	);
+
+	expect(result.length).toEqual(1);
+
+	// A staged change that still results in related items (a create) must pass.
+	result = validateItem(
+		{
+			id: 1,
+			name: 'test',
+			email: 'test@test.com',
+			role: { create: [{ some: 'value' }], update: [], delete: [1] },
+		},
+		fields as Field[],
+		false,
+	);
+
+	expect(result.length).toEqual(0);
+
+	// An existing item being linked or modified via the update array counts as a
+	// surviving relation and must not be flagged.
+	result = validateItem(
+		{
+			id: 1,
+			name: 'test',
+			email: 'test@test.com',
+			role: { create: [], update: [{ id: 1, sort: 2 }], delete: [2] },
+		},
+		fields as Field[],
+		false,
+	);
+
+	expect(result.length).toEqual(0);
+
+	// A staged update with no creates/deletes (e.g. editing an existing relation)
+	// must not be treated as empty.
+	result = validateItem(
+		{
+			id: 1,
+			name: 'test',
+			email: 'test@test.com',
+			role: { create: [], update: [{ id: 1, some: 'value' }], delete: [] },
+		},
+		fields as Field[],
+		false,
+	);
+
+	expect(result.length).toEqual(0);
+
+	// No staged changes at all (empty create/update/delete) means no edits were
+	// made to the relation — the existing value is unchanged, so do not flag.
+	result = validateItem(
+		{
+			id: 1,
+			name: 'test',
+			email: 'test@test.com',
+			role: { create: [], update: [], delete: [] },
+		},
+		fields as Field[],
+		false,
+	);
+
+	expect(result.length).toEqual(0);
+});
+
 test('Custom validation with $NOW dynamic variable does not throw', () => {
 	const fieldsWithValidation: DeepPartial<Field>[] = [
 		{

--- a/app/src/utils/validate-item.ts
+++ b/app/src/utils/validate-item.ts
@@ -5,7 +5,7 @@ import {
 	FailedValidationErrorExtensions,
 	joiValidationErrorItemToErrorExtensions,
 } from '@directus/validation';
-import { cloneDeep, flatten, isEmpty, isNil } from 'lodash';
+import { cloneDeep, flatten, isEmpty, isNil, isPlainObject } from 'lodash';
 import { applyConditions } from './apply-conditions';
 import { isPresentationField } from './field-utils';
 import { parseFilter } from './parse-filter';
@@ -39,7 +39,21 @@ export function validateItem(
 		const relation = relationsStore.getRelationsForField(field.collection, field.field);
 		if (!relation.length) return;
 
-		const isEmptyArray = Array.isArray(updatedItem[field.field]) && isEmpty(updatedItem[field.field]);
+		const value = updatedItem[field.field];
+
+		// On update, relational interfaces stage their changes as a
+		// `{ create, update, delete }` object rather than a plain array. When no
+		// items are being created or linked via update, and items are only being
+		// deleted, the field is effectively being cleared — normalize to `null` so
+		// required validation fires (see directus/directus#27695).
+		if (isStagedRelationalChanges(value)) {
+			if (value.create.length > 0 || value.update.length > 0) return;
+
+			if (value.delete.length > 0) updatedItem[field.field] = null;
+			return;
+		}
+
+		const isEmptyArray = Array.isArray(value) && isEmpty(value);
 		if (isEmptyArray) updatedItem[field.field] = null;
 	});
 
@@ -79,4 +93,23 @@ export function validateItem(
 			validationRules._and.push(parseFilter(validation));
 		});
 	}
+}
+
+type StagedRelationalChanges = {
+	create: unknown[];
+	update: unknown[];
+	delete: unknown[];
+};
+
+/**
+ * Relational interfaces (o2m/m2m/m2a) stage their edits as a
+ * `{ create, update, delete }` object instead of a plain array of related items.
+ */
+function isStagedRelationalChanges(value: unknown): value is StagedRelationalChanges {
+	return (
+		isPlainObject(value) &&
+		Array.isArray((value as Record<string, unknown>)['create']) &&
+		Array.isArray((value as Record<string, unknown>)['update']) &&
+		Array.isArray((value as Record<string, unknown>)['delete'])
+	);
 }

--- a/contributors.yml
+++ b/contributors.yml
@@ -296,3 +296,4 @@
 - scarab-systems
 - Harshith-muddasani
 - Deluvio
+- Shevilll


### PR DESCRIPTION
## Scope

Fixes directus/directus#27695 — required Many-to-Many (and other relational) field validation was bypassed when clearing all existing relations while editing an item.

## Cause

The client-side required-field check in `app/src/utils/validate-item.ts` normalized an empty **array** to `null` so the `_nnull` rule could fail it. On edit, relational interfaces stage changes as a `{ create, update, delete }` object rather than an array, so removing all relations produced `{ create: [], update: [], delete: [...] }` — not an array — and the check was skipped, allowing the save.

## Fix

* In `validate-item.ts`, detect staged relational-change objects (`{ create, update, delete }`). When no items are created (`create.length === 0`) or linked/modified (`update.length === 0`) and items are deleted (`delete.length > 0`), normalize the field value to `null` so required validation fires immediately.
* This version addresses feedback from directus/directus#27758 by:
  1. Treating items in the `update` array as surviving relations (e.g. existing items being linked or updated).
  2. Eliminating the dependency on `originalItem` for relational counts, avoiding pagination-related miscounts.
* Unit tests covering staged changes scenarios.
* Changeset for `@directus/app`.