### PR TITLE
Fix the redirect after SSO login landing on the last visited page

### DIFF
--- a/.changeset/afraid-poems-repeat.md
+++ b/.changeset/afraid-poems-repeat.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the redirect after an SSO login landing on the last visited page instead of the originally requested one

--- a/app/src/routes/login/components/continue-as.test.ts
+++ b/app/src/routes/login/components/continue-as.test.ts
@@ -1,0 +1,87 @@
+import { useAppStore } from '@directus/stores';
+import { createTestingPinia } from '@pinia/testing';
+import { flushPromises, mount } from '@vue/test-utils';
+import { setActivePinia } from 'pinia';
+import { beforeEach, expect, test, vi } from 'vitest';
+import { defineComponent, nextTick } from 'vue';
+import { createI18n } from 'vue-i18n';
+import { createRouter, createWebHistory, type Router } from 'vue-router';
+import ContinueAs from './continue-as.vue';
+import type { GlobalMountOptions } from '@/__utils__/types';
+
+const { pendingUserRequests } = vi.hoisted(() => ({ pendingUserRequests: [] as ((value: unknown) => void)[] }));
+
+vi.mock('@/api', () => ({
+	default: {
+		get: () => new Promise((resolve) => pendingUserRequests.push(resolve)),
+	},
+}));
+
+vi.mock('@/hydrate', () => ({
+	hydrate: async () => {
+		const appStore = useAppStore();
+		if (appStore.hydrated) return;
+
+		appStore.hydrating = true;
+		await nextTick();
+		appStore.hydrating = false;
+		appStore.hydrated = true;
+	},
+}));
+
+const i18n = createI18n({ legacy: false });
+
+// silences locale message not found warnings
+vi.spyOn(i18n.global, 't').mockImplementation((key: any) => key);
+
+let router: Router;
+
+function resolveUserRequest() {
+	const resolve = pendingUserRequests.shift();
+	resolve!({ data: { data: { email: 'admin@example.com', last_page: '/users' } } });
+}
+
+beforeEach(() => {
+	pendingUserRequests.length = 0;
+
+	setActivePinia(createTestingPinia({ createSpy: vi.fn, stubActions: false }));
+
+	router = createRouter({
+		history: createWebHistory(),
+		routes: [
+			{ path: '/login', component: { template: '<div />' } },
+			{ path: '/logout', component: { template: '<div />' } },
+			{ path: '/users', component: { template: '<div />' } },
+			{ path: '/settings/data-model', component: { template: '<div />' } },
+		],
+	});
+});
+
+test('navigates to the redirect query when remounted by the hydration state', async () => {
+	// mirrors app.vue, which unmounts the router view while the app store is hydrating
+	const AppRoot = defineComponent({
+		components: { ContinueAs },
+		setup: () => ({ appStore: useAppStore() }),
+		template: '<ContinueAs v-if="!appStore.hydrating" />',
+	});
+
+	const global: GlobalMountOptions = { plugins: [i18n, router] };
+
+	router.push('/login?redirect=/settings/data-model&continue=');
+	await router.isReady();
+
+	mount(AppRoot, { global });
+	await flushPromises();
+
+	expect(pendingUserRequests).toHaveLength(2);
+
+	resolveUserRequest();
+	await flushPromises();
+
+	expect(router.currentRoute.value.fullPath).toBe('/settings/data-model');
+
+	resolveUserRequest();
+	await flushPromises();
+
+	expect(router.currentRoute.value.fullPath).toBe('/settings/data-model');
+});

--- a/app/src/routes/login/components/continue-as.vue
+++ b/app/src/routes/login/components/continue-as.vue
@@ -49,9 +49,9 @@ async function fetchUser() {
 }
 
 async function hydrateAndLogin() {
+	const redirectQuery = router.currentRoute.value.query.redirect as string;
 	await hydrate();
 	await userPromise;
-	const redirectQuery = router.currentRoute.value.query.redirect as string;
 	navigateAfterLogin(router, redirectQuery || lastPage.value || `/content`);
 }
 </script>


### PR DESCRIPTION
## What's Changed

* `hydrateAndLogin()` in `continue-as.vue` reads the `redirect` query parameter only after `await hydrate()` resolves. `hydrate()` flips `appStore.hydrating`, and `app.vue` drops the `RouterView` while that flag is set, so the login route unmounts and remounts and `onMounted` fires a second `hydrateAndLogin()`. By the time that second call reads the query, the first one has already navigated away and the parameter is gone, so it falls back to `last_page` and pushes there.
* Moved the query read above the awaits. Both calls now navigate to the page that was originally requested.
* SSO always hits this path, since `sso-links.vue` appends `&continue=` to the return URL. Clicking Continue by hand runs the function once, which is why that route was unaffected.

## Tested Scenarios

* Added `app/src/routes/login/components/continue-as.test.ts`. It mounts the component the way `app.vue` does and lets the remounted instance finish its `/users/me` request after the first navigation has landed. Without the fix it ends on `last_page`; with it, on the redirect target.
* `pnpm --filter @directus/app test` (326 files, 111496 tests)
* `pnpm exec vue-tsc --noEmit`, ESLint and Prettier on the changed files

## Checklist

> Leave unchecked where not applicable

- [X] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](<https://github.com/directus/openapi>)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes directus/directus#27426