### PR TITLE
Fix repeater options editor emptying sub-fields that omit their key and type in meta

### DIFF
--- a/.changeset/large-poems-hear.md
+++ b/.changeset/large-poems-hear.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the repeater interface options showing empty sub-fields, and dropping their key and type on save, when the sub-fields were created through the API without repeating the key and type inside their meta

--- a/app/src/interfaces/list/options.test.ts
+++ b/app/src/interfaces/list/options.test.ts
@@ -1,0 +1,64 @@
+import { mount, VueWrapper } from '@vue/test-utils';
+import { createPinia } from 'pinia';
+import { describe, expect, it } from 'vitest';
+import Repeater from './list.vue';
+import Options from './options.vue';
+import { i18n } from '@/lang';
+
+const fields = [
+	{
+		field: 'street',
+		name: 'Street',
+		type: 'string',
+		meta: { interface: 'input', width: 'full' },
+	},
+	{
+		field: 'city',
+		name: 'City',
+		type: 'string',
+		meta: { interface: 'input', width: 'half' },
+	},
+];
+
+function mountOptions() {
+	return mount(Options, {
+		global: { plugins: [i18n, createPinia()], stubs: { VInput: { render: () => null } } },
+		props: { value: { fields }, collection: 'test' },
+		shallow: true,
+	}) as VueWrapper;
+}
+
+describe('list options', () => {
+	it('exposes the field key and type of sub-fields that do not repeat them in their meta', () => {
+		const wrapper = mountOptions();
+
+		expect(wrapper.findComponent(Repeater).props('value')).toEqual([
+			{ field: 'street', type: 'string', interface: 'input', width: 'full' },
+			{ field: 'city', type: 'string', interface: 'input', width: 'half' },
+		]);
+	});
+
+	it('keeps the field key and type of those sub-fields when saving', () => {
+		const wrapper = mountOptions();
+		const repeater = wrapper.findComponent(Repeater);
+
+		repeater.vm.$emit('input', repeater.props('value'));
+
+		expect(wrapper.emitted('input')![0]![0]).toEqual({
+			fields: [
+				{
+					field: 'street',
+					name: 'street',
+					type: 'string',
+					meta: { field: 'street', type: 'string', interface: 'input', width: 'full' },
+				},
+				{
+					field: 'city',
+					name: 'city',
+					type: 'string',
+					meta: { field: 'city', type: 'string', interface: 'input', width: 'half' },
+				},
+			],
+		});
+	});
+});

--- a/app/src/interfaces/list/options.vue
+++ b/app/src/interfaces/list/options.vue
@@ -25,7 +25,11 @@ const userStore = useUserStore();
 
 const repeaterValue = computed({
 	get() {
-		return props.value?.fields?.map((field: Field) => field.meta);
+		return props.value?.fields?.map((field: Field) => ({
+			field: field.field,
+			type: field.type,
+			...field.meta,
+		}));
 	},
 	set(newVal: FieldMeta[] | null) {
 		const fields = (newVal || []).map((meta: Record<string, any>) => ({


### PR DESCRIPTION
The repeater interface options editor only reads each sub-field's `meta`. Sub-fields built in the UI happen to duplicate their key and type inside `meta`, so they survive the round trip. Sub-fields created through the API (which is what the AI assistant does) usually carry `field` and `type` only at the top level, so every row in "Edit Fields" shows up with an empty key and type, and saving writes them back as `undefined`, wiping the repeater's configuration.

Options are now seeded from the sub-field's own `field` and `type`. Stored `meta` still wins where it has a value.

## Tested Scenarios

* Opened the interface options of a repeater created with the payload from directus/directus#27456. The sub-fields list their keys again, and saving keeps them.
* `app/src/interfaces/list/options.test.ts` covers both cases and fails against the current code.

Fixes directus/directus#27456