### PR TITLE
Remove extra "save and quit" option from routes not leveraging default save action

### DIFF
--- a/.changeset/fine-apes-pump.md
+++ b/.changeset/fine-apes-pump.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Removed dead “Save and Quit” dropdown row outside the content item view

--- a/app/src/modules/files/routes/item.vue
+++ b/app/src/modules/files/routes/item.vue
@@ -367,7 +367,11 @@ function revert(values: Record<string, any>) {
 			>
 				<template #split-menu>
 					<SaveOptions
-						:disabled-options="createAllowed ? ['save-and-add-new'] : ['save-and-add-new', 'save-as-copy']"
+						:disabled-options="
+							createAllowed
+								? ['save-and-quit', 'save-and-add-new']
+								: ['save-and-quit', 'save-and-add-new', 'save-as-copy']
+						"
 						@save-and-stay="saveAndStay"
 						@save-as-copy="saveAsCopyAndNavigate"
 						@discard-and-stay="discardAndStay"

--- a/app/src/modules/settings/routes/policies/item.vue
+++ b/app/src/modules/settings/routes/policies/item.vue
@@ -155,7 +155,7 @@ function discardAndStay() {
 			>
 				<template #split-menu>
 					<SaveOptions
-						:disabled-options="['save-as-copy']"
+						:disabled-options="['save-and-quit', 'save-as-copy']"
 						@save-and-stay="saveAndStay"
 						@save-and-add-new="saveAndAddNew"
 						@discard-and-stay="discardAndStay"

--- a/app/src/modules/settings/routes/roles/item.vue
+++ b/app/src/modules/settings/routes/roles/item.vue
@@ -177,7 +177,7 @@ function discardAndStay() {
 			>
 				<template #split-menu>
 					<SaveOptions
-						:disabled-options="['save-as-copy']"
+						:disabled-options="['save-and-quit', 'save-as-copy']"
 						@save-and-stay="saveAndStay"
 						@save-and-add-new="saveAndAddNew"
 						@discard-and-stay="discardAndStay"

--- a/app/src/modules/settings/routes/roles/public-item.vue
+++ b/app/src/modules/settings/routes/roles/public-item.vue
@@ -217,7 +217,7 @@ function isAlterations<T extends Item>(value: any): value is Alterations<T> {
 			>
 				<template #split-menu>
 					<SaveOptions
-						:disabled-options="['save-as-copy']"
+						:disabled-options="['save-and-quit', 'save-as-copy']"
 						@save-and-stay="saveAndStay"
 						@save-and-add-new="saveAndAddNew"
 						@discard-and-stay="discardAndStay"

--- a/app/src/modules/settings/routes/translations/item.vue
+++ b/app/src/modules/settings/routes/translations/item.vue
@@ -98,8 +98,8 @@ const internalPrimaryKey = computed(() => {
 });
 
 const disabledOptions = computed(() => {
-	if (isNew.value) return ['save-as-copy'];
-	return [];
+	if (isNew.value) return ['save-and-quit', 'save-as-copy'];
+	return ['save-and-quit'];
 });
 
 async function saveAndQuit() {

--- a/app/src/modules/users/routes/item.vue
+++ b/app/src/modules/users/routes/item.vue
@@ -427,7 +427,9 @@ function revert(values: Record<string, any>) {
 			>
 				<template #split-menu>
 					<SaveOptions
-						:disabled-options="createAllowed ? [] : ['save-and-add-new', 'save-as-copy']"
+						:disabled-options="
+							createAllowed ? ['save-and-quit'] : ['save-and-quit', 'save-and-add-new', 'save-as-copy']
+						"
 						@save-and-stay="saveAndStay"
 						@save-and-add-new="saveAndAddNew"
 						@save-as-copy="saveAsCopyAndNavigate"

--- a/app/src/views/private/components/save-options.test.ts
+++ b/app/src/views/private/components/save-options.test.ts
@@ -1,0 +1,67 @@
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import SaveOptions from './save-options.vue';
+import { generateRouter } from '@/__utils__/router';
+import type { GlobalMountOptions } from '@/__utils__/types';
+import { i18n } from '@/lang';
+
+const OPTIONS = [
+	{ key: 'save-and-quit', event: 'save-and-quit', label: 'Save and Quit' },
+	{ key: 'save-and-stay', event: 'save-and-stay', label: 'Save and Stay' },
+	{ key: 'save-and-add-new', event: 'save-and-add-new', label: 'Save and Create New' },
+	{ key: 'save-as-copy', event: 'save-as-copy', label: 'Save as Copy' },
+	{ key: 'discard-and-stay', event: 'discard-and-stay', label: 'Discard All Changes' },
+] as const;
+
+let global: GlobalMountOptions;
+
+beforeEach(async () => {
+	const router = generateRouter();
+	router.push('/');
+	await router.isReady();
+
+	global = { plugins: [router, i18n, createTestingPinia({ createSpy: vi.fn })] };
+});
+
+function mountComponent(disabledOptions?: string[]) {
+	return mount(SaveOptions, { props: { disabledOptions }, global });
+}
+
+function labels(wrapper: ReturnType<typeof mountComponent>) {
+	return wrapper.findAll('.v-list-item .v-list-item-content').map((content) => content.text());
+}
+
+test('renders every option when none are disabled', () => {
+	const wrapper = mountComponent();
+
+	expect(labels(wrapper)).toEqual(OPTIONS.map(({ label }) => label));
+});
+
+describe.each(OPTIONS)('$key', ({ key, event, label }) => {
+	test('is hidden when disabled', () => {
+		const wrapper = mountComponent([key]);
+
+		expect(labels(wrapper)).toEqual(OPTIONS.filter((option) => option.key !== key).map((option) => option.label));
+	});
+
+	test(`emits "${event}" when clicked`, async () => {
+		const wrapper = mountComponent();
+
+		const item = wrapper
+			.findAll('.v-list-item')
+			.find((candidate) => candidate.find('.v-list-item-content').text() === label);
+
+		expect(item).toBeTruthy();
+
+		await item!.trigger('click');
+
+		expect(wrapper.emitted(event)).toHaveLength(1);
+	});
+});
+
+test('hides multiple options at once', () => {
+	const wrapper = mountComponent(['save-and-quit', 'save-as-copy']);
+
+	expect(labels(wrapper)).toEqual(['Save and Stay', 'Save and Create New', 'Discard All Changes']);
+});


### PR DESCRIPTION
## What's Changed

- Adds `'save-and-quit'` to the `disabled-options` passed to `SaveOptions` in the six item views that don't handle the
  new dropdown row introduced by #27993 (`f8a684c0cb`): users, files, roles, public role, policies, translations
- Removes a dead "Save and Quit" entry that always rendered in those views' dropdowns and did nothing when
  clicked — none of them bind `@save-and-quit`, and their primary Save buttons are already hardcoded to `saveAndQuit`

## Tested Scenarios

- Verified unhandled "Save and Quit" save button dropdown option removed from the following views
1. `app/src/modules/files/routes/item.vue` — File details
2. `app/src/modules/settings/routes/policies/item.vue` — Policy
3. `app/src/modules/settings/routes/roles/item.vue` — Role
4. `app/src/modules/settings/routes/roles/public-item.vue` — Public Role
5. `app/src/modules/settings/routes/translations/item.vue` — Translation Strings
6. `app/src/modules/users/routes/item.vue` — User

## Review Notes / Questions / Concerns

- This PR addresses the immediate issue - the extra dropdown item that inadvertently ended up in the above views. Whether or not we should allow the default save action to affect these areas in addition to the user-created collection item views it currently does, is a question worth raising with product.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply


---

Fixes [CMS-2930](https://linear.app/directus/issue/CMS-2930/remove-save-and-quit-option-from-dropdown-from-system-views-that-do)
