### PR TITLE
fix: remove leading slash from backslash-rooted paths in normalizePath

### DIFF
--- a/.changeset/normalize-path-remove-leading-backslash.md
+++ b/.changeset/normalize-path-remove-leading-backslash.md
@@ -1,0 +1,5 @@
+---
+'@directus/utils': patch
+---
+
+Fixed `normalizePath` not removing the leading slash from a backslash-rooted path (e.g. `\a\b\c`) when the `removeLeading` option is enabled

--- a/packages/utils/shared/normalize-path.test.ts
+++ b/packages/utils/shared/normalize-path.test.ts
@@ -88,6 +88,10 @@ describe('normalizePath', () => {
 		it('handles path without leading slash with removeLeading true', () => {
 			expect(normalizePath('a/b/c', { removeLeading: true })).toBe('a/b/c');
 		});
+
+		it('removes the leading slash from a backslash-rooted path', () => {
+			expect(normalizePath('\\a\\b\\c', { removeLeading: true })).toBe('a/b/c');
+		});
 	});
 
 	describe('edge cases', () => {

--- a/packages/utils/shared/normalize-path.ts
+++ b/packages/utils/shared/normalize-path.ts
@@ -32,7 +32,10 @@ export const normalizePath = (
 
 	const normalizedPath = prefix + segments.join('/');
 
-	if (removeLeading && path.startsWith('/')) {
+	// Check the normalized path, not the raw input: a backslash-rooted path such
+	// as `\a\b\c` becomes `/a/b/c` after normalization, and its leading slash
+	// should be removed too. The UNC prefix (`prefix`) is left untouched.
+	if (removeLeading && !prefix && normalizedPath.startsWith('/')) {
 		return normalizedPath.substring(1);
 	}
 


### PR DESCRIPTION
### Bug

`normalizePath` (`packages/utils/shared/normalize-path.ts`) checks `path.startsWith('/')` on the raw input when deciding whether to strip the leading slash for the `removeLeading` option. A backslash-rooted path such as `\a\b\c` normalizes to `/a/b/c`, but because the raw input starts with `\` (not `/`), the leading slash is not removed:

```ts
normalizePath("\\a\\b\\c", { removeLeading: true })
// before: "/a/b/c"
// after:  "a/b/c"
```

The existing `removeLeading` tests only cover forward-slash inputs, so this went unnoticed.

### Fix

Check `normalizedPath.startsWith('/')` (the normalized output) instead of the raw input, leaving the UNC prefix untouched. Existing forward-slash and non-leading cases are unchanged.

### Tests

Added a case for a backslash-rooted path with `removeLeading: true`.
