### PR TITLE
Fix typo in readme.md

### DIFF
--- a/tests/e2e/readme.md
+++ b/tests/e2e/readme.md
@@ -60,7 +60,7 @@ test('Pinging the API', async () => {
 To make it simpler to write tests that require custom tables, the test suite provides a `useSnapshot` function. This
 function loads the `snaphot.json` file located in the same folder the test is located and applies the schema to the
 database when called. The function ensures uniqueness of collection names by replacing all `_1234` suffixes with a
-unique prefix. To improve type savety, an additional Schema can be provided. All collection names can be then accessed
+unique prefix. To improve type safety, an additional Schema can be provided. All collection names can be then accessed
 through the `collections` property of the returned snapshot.
 
 ```ts


### PR DESCRIPTION
Corrected a typo from 'savety' to 'safety' in documentation.

## What's Changed

- Fix Typo in README.txt

## Tested Scenarios

- none

## Review Notes / Questions / Concerns

- none

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---
