### PR TITLE
fix(api): unwrap data envelope in schema diff and apply endpoints

### DIFF
--- a/.changeset/schema-unwrap-data-envelope.md
+++ b/.changeset/schema-unwrap-data-envelope.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Unwrapped data envelope property when passing snapshot or diff payloads to schema API endpoints.

--- a/api/src/controllers/schema.test.ts
+++ b/api/src/controllers/schema.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest';
+import { unwrapDataEnvelope } from './schema.js';
+
+describe('unwrapDataEnvelope', () => {
+	test('returns raw snapshot object directly when not wrapped in envelope', () => {
+		const rawSnapshot = {
+			version: 1,
+			directus: '12.2.0',
+			vendor: 'sqlite',
+			collections: [],
+			fields: [],
+			relations: [],
+		};
+
+		expect(unwrapDataEnvelope(rawSnapshot)).toEqual(rawSnapshot);
+	});
+
+	test('unwraps payload when object is wrapped in standard { data: payload } API envelope', () => {
+		const rawSnapshot = {
+			version: 1,
+			directus: '12.2.0',
+			vendor: 'sqlite',
+			collections: [],
+			fields: [],
+			relations: [],
+		};
+
+		const wrappedEnvelope = {
+			data: rawSnapshot,
+		};
+
+		expect(unwrapDataEnvelope(wrappedEnvelope)).toEqual(rawSnapshot);
+	});
+
+	test('unwraps diff payload when wrapped in standard { data: payload } API envelope', () => {
+		const rawDiff = {
+			hash: 'abc123hash',
+			diff: {
+				collections: [],
+				fields: [],
+				systemFields: [],
+				relations: [],
+			},
+		};
+
+		const wrappedDiffEnvelope = {
+			data: rawDiff,
+		};
+
+		expect(unwrapDataEnvelope(wrappedDiffEnvelope)).toEqual(rawDiff);
+	});
+
+	test('does not unwrap when object has other keys alongside data', () => {
+		const multiKeyObject = {
+			data: { version: 1 },
+			otherKey: 'value',
+		};
+
+		expect(unwrapDataEnvelope(multiKeyObject as any)).toEqual(multiKeyObject);
+	});
+
+	test('returns body as is when data is null or non-object', () => {
+		const primitiveEnvelope = {
+			data: 'string-payload',
+		};
+
+		expect(unwrapDataEnvelope(primitiveEnvelope as any)).toEqual(primitiveEnvelope);
+	});
+});

--- a/api/src/controllers/schema.ts
+++ b/api/src/controllers/schema.ts
@@ -13,34 +13,12 @@ import { SchemaService } from '../services/schema.js';
 import asyncHandler from '../utils/async-handler.js';
 import { getVersionedHash } from '../utils/get-versioned-hash.js';
 import { queryFlag } from '../utils/query-flag.js';
+import { unwrapDataEnvelope } from '../utils/schema/unwrap-data-envelope.js';
 
 const env = useEnv();
 const router = express.Router();
 
 const IMPORT_MAX_FILE_SIZE = bytes.parse(env['IMPORT_MAX_FILE_SIZE'] as string) ?? undefined;
-
-/**
- * Unwrap the standard Directus API response envelope (`{ data: T }`) from a request body.
- *
- * When a user pipes the JSON output of `GET /schema/snapshot` directly into
- * `POST /schema/diff` or `POST /schema/apply`, the body is already wrapped in
- * `{ "data": <payload> }` by the respond middleware. Both the raw form and the
- * envelope form are accepted transparently.
- */
-export function unwrapDataEnvelope<T extends object>(body: T | { data: T }): T {
-	if (
-		body !== null &&
-		typeof body === 'object' &&
-		'data' in body &&
-		Object.keys(body).length === 1 &&
-		typeof (body as { data?: unknown }).data === 'object' &&
-		(body as { data?: unknown }).data !== null
-	) {
-		return (body as { data: T }).data;
-	}
-
-	return body as T;
-}
 
 /** Accepts a single collection name or a list, always normalizing to a string array. */
 const collectionList = z.union([z.string(), z.array(z.string())]).transform((value) => toArray(value));

--- a/api/src/controllers/schema.ts
+++ b/api/src/controllers/schema.ts
@@ -19,6 +19,29 @@ const router = express.Router();
 
 const IMPORT_MAX_FILE_SIZE = bytes.parse(env['IMPORT_MAX_FILE_SIZE'] as string) ?? undefined;
 
+/**
+ * Unwrap the standard Directus API response envelope (`{ data: T }`) from a request body.
+ *
+ * When a user pipes the JSON output of `GET /schema/snapshot` directly into
+ * `POST /schema/diff` or `POST /schema/apply`, the body is already wrapped in
+ * `{ "data": <payload> }` by the respond middleware. Both the raw form and the
+ * envelope form are accepted transparently.
+ */
+export function unwrapDataEnvelope<T extends object>(body: T | { data: T }): T {
+	if (
+		body !== null &&
+		typeof body === 'object' &&
+		'data' in body &&
+		Object.keys(body).length === 1 &&
+		typeof (body as { data?: unknown }).data === 'object' &&
+		(body as { data?: unknown }).data !== null
+	) {
+		return (body as { data: T }).data;
+	}
+
+	return body as T;
+}
+
 /** Accepts a single collection name or a list, always normalizing to a string array. */
 const collectionList = z.union([z.string(), z.array(z.string())]).transform((value) => toArray(value));
 
@@ -60,7 +83,7 @@ router.post(
 		if (!parsed.success) throw new InvalidPayloadError({ reason: fromZodError(parsed.error).message });
 
 		const service = new SchemaService({ accountability: req.accountability });
-		const snapshot: Snapshot = req.body;
+		const snapshot: Snapshot = unwrapDataEnvelope(req.body);
 		const currentSnapshot = await service.snapshot();
 
 		const snapshotDiff = await service.diff(snapshot, {
@@ -84,7 +107,7 @@ router.post(
 	readFileUploadBody({ allowYaml: true, maxFileSize: IMPORT_MAX_FILE_SIZE }),
 	asyncHandler(async (req, _res, next) => {
 		const service = new SchemaService({ accountability: req.accountability });
-		const diff: SnapshotDiffWithHash = req.body;
+		const diff: SnapshotDiffWithHash = unwrapDataEnvelope(req.body);
 		await service.apply(diff, { force: queryFlag(req.query['force']) });
 		return next();
 	}),

--- a/api/src/services/schema.test.ts
+++ b/api/src/services/schema.test.ts
@@ -181,8 +181,8 @@ describe('Services / Schema', () => {
 			await expect(service.diff(testSnapshot, { currentSnapshot: testSnapshot, force: true })).resolves.toBeNull();
 		});
 
-		test('should return null for missing systeFields', async () => {
-			const testSnapshot = {
+		test('should return null for missing systemFields', async () => {
+			const snapshotWithoutSystemFields = {
 				directus: '0.0.0',
 				version: 1,
 				vendor: 'postgres',
@@ -193,7 +193,9 @@ describe('Services / Schema', () => {
 
 			const service = new SchemaService({ knex: db, accountability: { role: 'admin', admin: true } as Accountability });
 
-			await expect(service.diff(testSnapshot, { currentSnapshot: testSnapshot, force: true })).resolves.toBeNull();
+			await expect(
+				service.diff(snapshotWithoutSystemFields, { currentSnapshot: snapshotWithoutSystemFields, force: true }),
+			).resolves.toBeNull();
 		});
 
 		test('should return null in merge mode when the only change is a deletion', async () => {

--- a/api/src/utils/schema/unwrap-data-envelope.test.ts
+++ b/api/src/utils/schema/unwrap-data-envelope.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { unwrapDataEnvelope } from './schema.js';
+import { unwrapDataEnvelope } from './unwrap-data-envelope.js';
 
 describe('unwrapDataEnvelope', () => {
 	test('returns raw snapshot object directly when not wrapped in envelope', () => {

--- a/api/src/utils/schema/unwrap-data-envelope.ts
+++ b/api/src/utils/schema/unwrap-data-envelope.ts
@@ -1,0 +1,22 @@
+/**
+ * Unwrap the standard Directus API response envelope (`{ data: T }`) from a request body.
+ *
+ * When a user pipes the JSON output of `GET /schema/snapshot` directly into
+ * `POST /schema/diff` or `POST /schema/apply`, the body is already wrapped in
+ * `{ "data": <payload> }` by the respond middleware. Both the raw form and the
+ * envelope form are accepted transparently.
+ */
+export function unwrapDataEnvelope<T extends object>(body: T | { data: T }): T {
+	if (
+		body !== null &&
+		typeof body === 'object' &&
+		'data' in body &&
+		Object.keys(body).length === 1 &&
+		typeof (body as { data?: unknown }).data === 'object' &&
+		(body as { data?: unknown }).data !== null
+	) {
+		return (body as { data: T }).data;
+	}
+
+	return body as T;
+}

--- a/api/src/utils/schema/unwrap-data-envelope.ts
+++ b/api/src/utils/schema/unwrap-data-envelope.ts
@@ -2,9 +2,9 @@
  * Unwrap the standard Directus API response envelope (`{ data: T }`) from a request body.
  *
  * When a user pipes the JSON output of `GET /schema/snapshot` directly into
- * `POST /schema/diff` or `POST /schema/apply`, the body is already wrapped in
- * `{ "data": <payload> }` by the respond middleware. Both the raw form and the
- * envelope form are accepted transparently.
+ * `POST /schema/diff` or `POST /schema/apply`, the body is wrapped in
+ * `{ "data": <payload> }` by the API controller response payload. Both the raw form
+ * and the envelope form are accepted transparently.
  */
 export function unwrapDataEnvelope<T extends object>(body: T | { data: T }): T {
 	if (

--- a/contributors.yml
+++ b/contributors.yml
@@ -299,4 +299,3 @@
 - Deluvio
 - Aniket-a14
 - Sumith2104
-

--- a/contributors.yml
+++ b/contributors.yml
@@ -298,3 +298,5 @@
 - suhailopensource
 - Deluvio
 - Aniket-a14
+- Sumith2104
+


### PR DESCRIPTION
## What's Changed

* Added `unwrapDataEnvelope` helper in `api/src/controllers/schema.ts` to transparently unwrap `{ "data": ... }` response envelopes when passing payloads to `POST /schema/diff` and `POST /schema/apply`.
* Added unit tests in `api/src/controllers/schema.test.ts` verifying raw payloads, wrapped response envelopes, multi-key objects, and edge-case inputs.
* Created a changeset (`.changeset/schema-unwrap-data-envelope.md`) for a `@directus/api` patch release.

## Tested Scenarios

* Piping the raw output of `GET /schema/snapshot` (which includes the `{ "data": { "version": 1, ... } }` envelope) directly into `POST /schema/diff`.
* Posting raw unwrapped snapshot objects (`{ "version": 1, ... }`) to `POST /schema/diff`.
* Passing raw and envelope-wrapped snapshot diff objects into `POST /schema/apply`.
* Validated edge cases (multi-property objects and non-object `data` values) against `unwrapDataEnvelope`.

## Review Notes / Questions / Concerns

* Unwrapping is strictly localized to the HTTP controller layer (`api/src/controllers/schema.ts`) so `SchemaService` remains clean, strongly typed, and decoupled from HTTP response serialization formats.
* The `unwrapDataEnvelope` helper strictly checks that `Object.keys(body).length === 1` and that key `'data'` holds a non-null object, preventing any false-positive unwrapping.

## Checklist

- [X] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [ ] OpenAPI updated
- [ ] Local specs package (`@directus/specs`)
- [ ] PR created in [directus/openapi](<https://github.com/directus/openapi>)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes directus/directus#28054