### PR TITLE
fix(app): defer v-focus el.focus() until after dialog transition

### DIFF
--- a/app/src/directives/focus.ts
+++ b/app/src/directives/focus.ts
@@ -1,9 +1,14 @@
-import { Directive } from 'vue';
+import { nextTick, type Directive } from 'vue';
 
 const Focus: Directive = {
 	mounted(el, binding) {
 		if (binding.value) {
-			el.focus();
+			// Defer focus until after the dialog transition completes and any
+			// previously focused element has blurred. Calling el.focus()
+			// synchronously in mounted() fires while the trigger element still
+			// holds focus, which causes mobile browsers to block the call and
+			// prevents the virtual keyboard from appearing inside dialogs.
+			nextTick(() => requestAnimationFrame(() => el.focus({ preventScroll: true })));
 		} else {
 			el.blur();
 		}


### PR DESCRIPTION
## Description

The `v-focus` directive called `el.focus()` synchronously inside `mounted()`. When a `VDialog` opens (e.g. the Flow confirmation dialog), the trigger button still holds document focus at that moment. Mobile browsers (iOS Safari, Android Chrome) block programmatic `focus()` calls that happen while another element holds focus outside a direct user gesture — the input stays unresponsive and the virtual keyboard never appears. Desktop browsers are unaffected.

**Fix:** defer with `nextTick(() => requestAnimationFrame(() => el.focus(...)))` so the focus call happens after the DOM has settled and the dialog transition has completed, at which point the trigger element has already blurred.

`preventScroll: true` avoids unexpected scroll jumps on focus.

Relates to #27872