### PR TITLE
Add hidden location option to manual flow triggers

### DIFF
--- a/.changeset/humble-regions-return.md
+++ b/.changeset/humble-regions-return.md
@@ -2,4 +2,4 @@
 '@directus/app': minor
 ---
 
-Allow hiding flows from sidebar
+Added hidden location option to manual flow triggers

--- a/.changeset/humble-regions-return.md
+++ b/.changeset/humble-regions-return.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Allow hiding flows from sidebar

--- a/.changeset/humble-regions-return.md
+++ b/.changeset/humble-regions-return.md
@@ -1,5 +1,6 @@
 ---
 '@directus/app': minor
+'@directus/api': patch
 ---
 
 Added hidden location option to manual flow triggers

--- a/api/src/ai/tools/flows/prompt.md
+++ b/api/src/ai/tools/flows/prompt.md
@@ -164,7 +164,7 @@ UI button that users click to start flows
 	"trigger": "manual",
 	"options": {
 		"collections": ["posts", "products"],
-		"location": "item", // item|collection|both
+		"location": "item", // item|collection|both|hidden
 		"requireSelection": false, // Default true - requires item selection
 		"requireConfirmation": true,
 		"confirmationDescription": "AI Ghostwriter",

--- a/app/src/composables/use-flows.test.ts
+++ b/app/src/composables/use-flows.test.ts
@@ -169,7 +169,7 @@ describe('sidebarManualFlows', () => {
 
 		const { sidebarManualFlows } = useFlows(useFlowsOptions);
 
-		expect(sidebarManualFlows.value.length).toEqual(3);
+		expect(sidebarManualFlows.value.map((flow) => flow.id)).toEqual(['flow-1', 'flow-4', 'flow-5']);
 		expect(mockFlowsStore.getManualFlowsForCollection).toHaveBeenCalledWith('test_collection');
 	});
 
@@ -188,7 +188,7 @@ describe('sidebarManualFlows', () => {
 
 		const { sidebarManualFlows } = useFlows({ ...useFlowsOptions, collection: testCollection });
 
-		expect(sidebarManualFlows.value.length).toEqual(3);
+		expect(sidebarManualFlows.value.map((flow) => flow.id)).toEqual(['flow-1', 'flow-4', 'flow-5']);
 		expect(mockGetManualFlows).toHaveBeenLastCalledWith('test_collection');
 
 		mockGetManualFlows.mockReturnValue([]);
@@ -211,7 +211,9 @@ describe('sidebarManualFlows', () => {
 
 		const { sidebarManualFlows } = useFlows({ ...useFlowsOptions, location });
 
-		expect(sidebarManualFlows.value.map((flow) => flow.id)).not.toContain('flow-6');
+		expect(sidebarManualFlows.value.map((flow) => flow.id)).toEqual(
+			location === 'collection' ? ['flow-1', 'flow-4', 'flow-5'] : ['flow-2', 'flow-3'],
+		);
 	});
 });
 

--- a/app/src/composables/use-flows.test.ts
+++ b/app/src/composables/use-flows.test.ts
@@ -310,6 +310,23 @@ describe('runManualFlow', () => {
 		expect(api.post).not.toHaveBeenCalled();
 	});
 
+	test('returns early when the flow is not runnable from this location', async () => {
+		const mockFlowsStore = {
+			getManualFlowsForCollection: vi.fn().mockReturnValue(mockFlows),
+		};
+
+		vi.mocked(useFlowsStore).mockReturnValue(mockFlowsStore as any);
+
+		vi.mocked(api.post).mockResolvedValue({});
+
+		// flow-5 is collection-only, so an item page button must not be able to trigger it
+		const { runManualFlow } = useFlows({ ...useFlowsOptions, location: 'item', hasEdits: ref(false) });
+
+		await runManualFlow('flow-5');
+
+		expect(api.post).not.toHaveBeenCalled();
+	});
+
 	test('runs flows that are omitted from the sidebar, such as hidden ones', async () => {
 		const mockFlowsStore = {
 			getManualFlowsForCollection: vi.fn().mockReturnValue(mockFlows),

--- a/app/src/composables/use-flows.test.ts
+++ b/app/src/composables/use-flows.test.ts
@@ -133,9 +133,20 @@ const mockFlows = [
 			requireSelection: false,
 		},
 	},
+	{
+		id: 'flow-6',
+		name: 'Test Flow 6',
+		trigger: 'manual',
+		status: 'active',
+		options: {
+			collections: ['test_collection'],
+			location: 'hidden',
+			requireSelection: false,
+		},
+	},
 ];
 
-describe('manualFlows', () => {
+describe('sidebarManualFlows', () => {
 	test('returns empty array when no manual flows', () => {
 		const mockFlowsStore = {
 			getManualFlowsForCollection: vi.fn().mockReturnValue([]),
@@ -143,9 +154,9 @@ describe('manualFlows', () => {
 
 		vi.mocked(useFlowsStore).mockReturnValue(mockFlowsStore as any);
 
-		const { manualFlows } = useFlows(useFlowsOptions);
+		const { sidebarManualFlows } = useFlows(useFlowsOptions);
 
-		expect(manualFlows.value.length).toEqual(0);
+		expect(sidebarManualFlows.value.length).toEqual(0);
 		expect(mockFlowsStore.getManualFlowsForCollection).toHaveBeenCalledWith('test_collection');
 	});
 
@@ -156,9 +167,9 @@ describe('manualFlows', () => {
 
 		vi.mocked(useFlowsStore).mockReturnValue(mockFlowsStore as any);
 
-		const { manualFlows } = useFlows(useFlowsOptions);
+		const { sidebarManualFlows } = useFlows(useFlowsOptions);
 
-		expect(manualFlows.value.length).toEqual(3);
+		expect(sidebarManualFlows.value.length).toEqual(3);
 		expect(mockFlowsStore.getManualFlowsForCollection).toHaveBeenCalledWith('test_collection');
 	});
 
@@ -175,9 +186,9 @@ describe('manualFlows', () => {
 
 		const testCollection = ref('test_collection');
 
-		const { manualFlows } = useFlows({ ...useFlowsOptions, collection: testCollection });
+		const { sidebarManualFlows } = useFlows({ ...useFlowsOptions, collection: testCollection });
 
-		expect(manualFlows.value.length).toEqual(3);
+		expect(sidebarManualFlows.value.length).toEqual(3);
 		expect(mockGetManualFlows).toHaveBeenLastCalledWith('test_collection');
 
 		mockGetManualFlows.mockReturnValue([]);
@@ -186,9 +197,21 @@ describe('manualFlows', () => {
 
 		await nextTick();
 
-		expect(manualFlows.value.length).toEqual(0);
+		expect(sidebarManualFlows.value.length).toEqual(0);
 		expect(mockGetManualFlows).toHaveBeenLastCalledWith('test_collection_2');
 		expect(mockGetManualFlows).toHaveBeenCalledTimes(2);
+	});
+
+	test.each(['collection', 'item'] as const)('omits flows with location "hidden" on %s pages', (location) => {
+		const mockFlowsStore = {
+			getManualFlowsForCollection: vi.fn().mockReturnValue(mockFlows),
+		};
+
+		vi.mocked(useFlowsStore).mockReturnValue(mockFlowsStore as any);
+
+		const { sidebarManualFlows } = useFlows({ ...useFlowsOptions, location });
+
+		expect(sidebarManualFlows.value.map((flow) => flow.id)).not.toContain('flow-6');
 	});
 });
 
@@ -206,9 +229,9 @@ describe('manualFlow.isFlowDisabled', () => {
 
 			vi.mocked(useFlowsStore).mockReturnValue(mockFlowsStore as any);
 
-			const { manualFlows } = useFlows(testUseFlowsOptions);
+			const { sidebarManualFlows } = useFlows(testUseFlowsOptions);
 
-			manualFlows.value.forEach((manualFlow) => {
+			sidebarManualFlows.value.forEach((manualFlow) => {
 				expect(manualFlow.isFlowDisabled).toEqual(false);
 			});
 		});
@@ -220,9 +243,9 @@ describe('manualFlow.isFlowDisabled', () => {
 
 			vi.mocked(useFlowsStore).mockReturnValue(mockFlowsStore as any);
 
-			const { manualFlows } = useFlows(useFlowsOptions);
+			const { sidebarManualFlows } = useFlows(useFlowsOptions);
 
-			manualFlows.value.forEach((manualFlow) => {
+			sidebarManualFlows.value.forEach((manualFlow) => {
 				expect(manualFlow.isFlowDisabled).toEqual(false);
 			});
 		});
@@ -236,9 +259,9 @@ describe('manualFlow.isFlowDisabled', () => {
 
 			vi.mocked(useFlowsStore).mockReturnValue(mockFlowsStore as any);
 
-			const { manualFlows } = useFlows(useFlowsOptions);
+			const { sidebarManualFlows } = useFlows(useFlowsOptions);
 
-			manualFlows.value.forEach((manualFlow) => {
+			sidebarManualFlows.value.forEach((manualFlow) => {
 				expect(manualFlow.isFlowDisabled).toEqual(false);
 			});
 		});
@@ -259,9 +282,9 @@ describe('manualFlow.isFlowDisabled', () => {
 
 			vi.mocked(useFlowsStore).mockReturnValue(mockFlowsStore as any);
 
-			const { manualFlows } = useFlows(testUseFlowsOptions);
+			const { sidebarManualFlows } = useFlows(testUseFlowsOptions);
 
-			manualFlows.value.forEach((manualFlow) => {
+			sidebarManualFlows.value.forEach((manualFlow) => {
 				expect(manualFlow.isFlowDisabled).toEqual(true);
 			});
 		});
@@ -285,20 +308,24 @@ describe('runManualFlow', () => {
 		expect(api.post).not.toHaveBeenCalled();
 	});
 
-	test('returns early when flow is not in manualFlows (filtered out)', async () => {
+	test('runs flows that are omitted from the sidebar, such as hidden ones', async () => {
 		const mockFlowsStore = {
-			getManualFlowsForCollection: vi.fn().mockReturnValue([mockFlows[1]]),
+			getManualFlowsForCollection: vi.fn().mockReturnValue(mockFlows),
 		};
 
 		vi.mocked(useFlowsStore).mockReturnValue(mockFlowsStore as any);
 
 		vi.mocked(api.post).mockResolvedValue({});
 
-		const { runManualFlow } = useFlows(useFlowsOptions);
+		const { sidebarManualFlows, runManualFlow } = useFlows({ ...useFlowsOptions, hasEdits: ref(false) });
 
-		await runManualFlow(mockFlows[1]!.id);
+		expect(sidebarManualFlows.value.map((flow) => flow.id)).not.toContain('flow-6');
 
-		expect(api.post).not.toHaveBeenCalled();
+		await runManualFlow('flow-6');
+
+		expect(api.post).toHaveBeenCalledWith('/flows/trigger/flow-6', {
+			collection: 'test_collection',
+		});
 	});
 
 	test('successfully runs flow for collection with requireSelection false', async () => {

--- a/app/src/composables/use-flows.test.ts
+++ b/app/src/composables/use-flows.test.ts
@@ -317,7 +317,12 @@ describe('runManualFlow', () => {
 
 		vi.mocked(api.post).mockResolvedValue({});
 
-		const { sidebarManualFlows, runManualFlow } = useFlows({ ...useFlowsOptions, hasEdits: ref(false) });
+		// Hidden flows are only triggerable through a header or links button, which live in the item form
+		const { sidebarManualFlows, runManualFlow } = useFlows({
+			...useFlowsOptions,
+			location: 'item',
+			hasEdits: ref(false),
+		});
 
 		expect(sidebarManualFlows.value.map((flow) => flow.id)).not.toContain('flow-6');
 
@@ -325,6 +330,7 @@ describe('runManualFlow', () => {
 
 		expect(api.post).toHaveBeenCalledWith('/flows/trigger/flow-6', {
 			collection: 'test_collection',
+			keys: ['item_1'],
 		});
 	});
 

--- a/app/src/composables/use-flows.test.ts
+++ b/app/src/composables/use-flows.test.ts
@@ -326,7 +326,7 @@ describe('runManualFlow', () => {
 			hasEdits: ref(false),
 		});
 
-		expect(sidebarManualFlows.value.map((flow) => flow.id)).not.toContain('flow-6');
+		expect(sidebarManualFlows.value.map((flow) => flow.id)).toEqual(['flow-2', 'flow-3']);
 
 		await runManualFlow('flow-6');
 

--- a/app/src/composables/use-flows.ts
+++ b/app/src/composables/use-flows.ts
@@ -44,7 +44,7 @@ export function useFlows(options: UseFlowsOptions) {
 	const currentFlow = computed(() => {
 		if (!currentFlowId.value) return null;
 
-		return allManualFlows.value.find((flow) => flow.id === currentFlowId.value);
+		return runnableManualFlows.value.find((flow) => flow.id === currentFlowId.value);
 	});
 
 	const currentFlowConfirmations = computed(() => {
@@ -126,7 +126,7 @@ export function useFlows(options: UseFlowsOptions) {
 		return false;
 	});
 
-	const allManualFlows = computed<ManualFlow[]>(() => {
+	const collectionManualFlows = computed<ManualFlow[]>(() => {
 		const manualFlows = flowsStore.getManualFlowsForCollection(collection.value).map((flow) => ({
 			...flow,
 			name: translateLiteral(flow.name),
@@ -153,14 +153,28 @@ export function useFlows(options: UseFlowsOptions) {
 		return manualFlows;
 	});
 
+	/**
+	 * Flows that can be triggered from this location. Unlike `sidebarManualFlows` this includes flows
+	 * with location `hidden`, which are only triggerable through a header or links button.
+	 */
+	const runnableManualFlows = computed<ManualFlow[]>(() =>
+		collectionManualFlows.value.filter(
+			(flow) =>
+				!flow.options?.location ||
+				flow.options.location === 'hidden' ||
+				flow.options.location === 'both' ||
+				flow.options.location === location,
+		),
+	);
+
 	const sidebarManualFlows = computed<ManualFlow[]>(() =>
-		allManualFlows.value.filter(
+		collectionManualFlows.value.filter(
 			(flow) => !flow.options?.location || flow.options?.location === 'both' || flow.options?.location === location,
 		),
 	);
 
 	function isActiveFlow(flowId: string) {
-		const flow = allManualFlows.value.find((flow) => flow.id === flowId);
+		const flow = runnableManualFlows.value.find((flow) => flow.id === flowId);
 
 		return flow && flow.status === 'active';
 	}

--- a/app/src/composables/use-flows.ts
+++ b/app/src/composables/use-flows.ts
@@ -44,7 +44,7 @@ export function useFlows(options: UseFlowsOptions) {
 	const currentFlow = computed(() => {
 		if (!currentFlowId.value) return null;
 
-		return manualFlows.value.find((flow) => flow.id === currentFlowId.value);
+		return allManualFlows.value.find((flow) => flow.id === currentFlowId.value);
 	});
 
 	const currentFlowConfirmations = computed(() => {
@@ -126,19 +126,14 @@ export function useFlows(options: UseFlowsOptions) {
 		return false;
 	});
 
-	const manualFlows = computed<ManualFlow[]>(() => {
-		const manualFlows = flowsStore
-			.getManualFlowsForCollection(collection.value)
-			.filter(
-				(flow) => !flow.options?.location || flow.options?.location === 'both' || flow.options?.location === location,
-			)
-			.map((flow) => ({
-				...flow,
-				name: translateLiteral(flow.name),
-				options: flow.options ? translate(flow.options) : null,
-				tooltip: getFlowTooltip(flow),
-				isFlowDisabled: checkFlowDisabled(flow),
-			}));
+	const allManualFlows = computed<ManualFlow[]>(() => {
+		const manualFlows = flowsStore.getManualFlowsForCollection(collection.value).map((flow) => ({
+			...flow,
+			name: translateLiteral(flow.name),
+			options: flow.options ? translate(flow.options) : null,
+			tooltip: getFlowTooltip(flow),
+			isFlowDisabled: checkFlowDisabled(flow),
+		}));
 
 		function getFlowTooltip(manualFlow: FlowRaw) {
 			if (location === 'item') return t('run_flow_on_current');
@@ -158,8 +153,14 @@ export function useFlows(options: UseFlowsOptions) {
 		return manualFlows;
 	});
 
+	const sidebarManualFlows = computed<ManualFlow[]>(() =>
+		allManualFlows.value.filter(
+			(flow) => !flow.options?.location || flow.options?.location === 'both' || flow.options?.location === location,
+		),
+	);
+
 	function isActiveFlow(flowId: string) {
-		const flow = manualFlows.value.find((flow) => flow.id === flowId);
+		const flow = allManualFlows.value.find((flow) => flow.id === flowId);
 
 		return flow && flow.status === 'active';
 	}
@@ -261,9 +262,9 @@ export function useFlows(options: UseFlowsOptions) {
 
 	return {
 		flowDialogsContext,
-		manualFlows,
 		provideRunManualFlow,
 		runManualFlow,
+		sidebarManualFlows,
 	};
 }
 

--- a/app/src/interfaces/_system/system-manual-flow-select/system-manual-flow-select.test.ts
+++ b/app/src/interfaces/_system/system-manual-flow-select/system-manual-flow-select.test.ts
@@ -53,6 +53,14 @@ const mockFlows = [
 		trigger: 'manual',
 		status: 'active',
 	},
+	{
+		id: 'test-flow-5',
+		name: 'test-flow-5',
+		description: 'test-description-5',
+		options: { collections: ['test-collection'], location: 'hidden' },
+		trigger: 'manual',
+		status: 'active',
+	},
 ];
 
 const mountOptions = {
@@ -100,7 +108,7 @@ test('computes flows items correctly', () => {
 	const flowsItems = (wrapper.vm as any).flows;
 
 	expect(flowsItems).toBeInstanceOf(Array);
-	expect(flowsItems).toHaveLength(2);
+	expect(flowsItems).toHaveLength(3);
 
 	expect(flowsItems[0]).toHaveProperty('value');
 	expect(flowsItems[0]).toHaveProperty('text');
@@ -113,6 +121,10 @@ test('computes flows items correctly', () => {
 		{
 			value: 'test-flow-2',
 			text: 'test-flow-2: test-description-2 (inactive)',
+		},
+		{
+			value: 'test-flow-5',
+			text: 'test-flow-5: test-description-5',
 		},
 	]);
 });

--- a/app/src/interfaces/_system/system-manual-flow-select/system-manual-flow-select.vue
+++ b/app/src/interfaces/_system/system-manual-flow-select/system-manual-flow-select.vue
@@ -21,7 +21,8 @@ const flows = computed(() =>
 				flow.options &&
 				flow.options.collections &&
 				flow.options.collections.includes(props.collectionName) &&
-				flow.options.location !== 'collection',
+				// Only flows that can be triggered from an item-page button
+				['both', 'item', 'hidden'].includes(flow.options.location ?? 'both'),
 		)
 		.map((flow: FlowRaw) => ({
 			value: flow.id,

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -3184,6 +3184,7 @@ triggers:
     collection_and_item: Collection & Item Pages
     collection_only: Collection Page Only
     item_only: Item Page Only
+    hidden: None (Hidden)
     collection_page: Collection Page
     require_selection: Requires Selection
 a_flow_uuid: Select a Flow to trigger...

--- a/app/src/modules/content/routes/collection.vue
+++ b/app/src/modules/content/routes/collection.vue
@@ -200,7 +200,7 @@ const archiveFilter = computed<Filter | null>(() => {
 	}
 });
 
-const { flowDialogsContext, manualFlows, provideRunManualFlow } = useFlows({
+const { flowDialogsContext, provideRunManualFlow, sidebarManualFlows } = useFlows({
 	collection,
 	selection,
 	location: 'collection',
@@ -666,7 +666,7 @@ function clearFilters() {
 					:on-download="downloadHandler"
 					@refresh="refresh"
 				/>
-				<FlowSidebarDetail v-if="!isVersion" :manual-flows />
+				<FlowSidebarDetail v-if="!isVersion" :manual-flows="sidebarManualFlows" />
 			</template>
 
 			<VDialog :model-value="deleteError !== null" @esc="deleteError = null">

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -549,7 +549,7 @@ watch(
 	{ immediate: true },
 );
 
-const { flowDialogsContext, manualFlows, provideRunManualFlow } = useFlows({
+const { flowDialogsContext, provideRunManualFlow, sidebarManualFlows } = useFlows({
 	collection,
 	primaryKey: existingPrimaryKey,
 	location: 'item',
@@ -1412,7 +1412,7 @@ function useAutoSwitchToDraft() {
 					:primary-key="resolvedPrimaryKey"
 					:allowed="shareAllowed"
 				/>
-				<FlowSidebarDetail v-if="currentVersion === null" :manual-flows />
+				<FlowSidebarDetail v-if="currentVersion === null" :manual-flows="sidebarManualFlows" />
 			</template>
 		</template>
 

--- a/app/src/modules/settings/routes/flows/triggers.test.ts
+++ b/app/src/modules/settings/routes/flows/triggers.test.ts
@@ -46,3 +46,28 @@ describe('webhook trigger options', () => {
 		expect(cacheQueryParams!['meta']['hidden']).toBe(true);
 	});
 });
+
+describe('manual trigger options', () => {
+	const { triggers } = getTriggers();
+	const manual = triggers.find((t) => t.id === 'manual')!;
+	const options = (manual.options as (opts: Record<string, any>) => Record<string, any>[])({});
+
+	test('location field offers a hidden choice', () => {
+		const location = options.find((o) => o['field'] === 'location');
+
+		expect(location!['meta']['options']['choices'].map((choice: Record<string, any>) => choice['value'])).toEqual([
+			'both',
+			'collection',
+			'item',
+			'hidden',
+		]);
+	});
+
+	test('requireSelection field is hidden for item only and hidden locations', () => {
+		const requireSelection = options.find((o) => o['field'] === 'requireSelection');
+
+		expect(requireSelection!['meta']['conditions']).toEqual([
+			{ rule: { location: { _in: ['item', 'hidden'] } }, hidden: true },
+		]);
+	});
+});

--- a/app/src/modules/settings/routes/flows/triggers.ts
+++ b/app/src/modules/settings/routes/flows/triggers.ts
@@ -448,6 +448,10 @@ export function getTriggers() {
 									text: t('triggers.manual.item_only'),
 									value: 'item',
 								},
+								{
+									text: t('triggers.manual.hidden'),
+									value: 'hidden',
+								},
 							],
 						},
 					},
@@ -470,7 +474,7 @@ export function getTriggers() {
 							{
 								rule: {
 									location: {
-										_eq: 'item',
+										_in: ['item', 'hidden'],
 									},
 								},
 								hidden: true,


### PR DESCRIPTION
## What's Changed

Adds new "Hidden" option in the trigger setup section for flows. This allows the flow to be hidden from the sidebar.

## Tested Scenarios

- Verified setting "None (Hidden)" for a manual flows location value prevents the flow button from appearing in the sidebar.
- Verified these flows can still be selected and rendered in the button and/or the header interface.

## Review Notes / Questions / Concerns

None

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes [CMS-2933](https://linear.app/directus/issue/CMS-2933/sidebar-visibility-control)
