### PR TITLE
tw ← Fix WYSIWYG revisions hiding and losing unsupported markup

### DIFF
--- a/.changeset/wysiwyg-revision-unsupported-markup.md
+++ b/.changeset/wysiwyg-revision-unsupported-markup.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed WYSIWYG content the editor can't represent being hidden and unrestorable in the comparison modal

--- a/app/src/composables/use-comparison-diff.test.ts
+++ b/app/src/composables/use-comparison-diff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { useComparisonDiff } from './use-comparison-diff';
+import { sanitizeDropsContent, useComparisonDiff } from './use-comparison-diff';
 
 describe('useComparisonDiff - HTML Diff', () => {
 	const { computeDiff } = useComparisonDiff();
@@ -88,5 +88,24 @@ describe('useComparisonDiff - HTML Diff', () => {
 		expect(changes).toHaveLength(2);
 		expect(changes[0]?.removed).toBe(true);
 		expect(changes[0]?.value).toContain('<span class="comparison-diff--removed">Hello World</span>');
+	});
+});
+
+describe('sanitizeDropsContent', () => {
+	it.each([
+		['embeds', '<p>text</p><iframe src="https://example.com"></iframe>'],
+		['comments, e.g. page breaks', '<p>a</p><!-- pagebreak --><p>b</p>'],
+		['scripts', '<script>alert(1)</script><p>text</p>'],
+	])('detects dropped %s', (_name, html) => {
+		expect(sanitizeDropsContent(html)).toBe(true);
+	});
+
+	it.each([
+		['plain markup', '<p>text</p>'],
+		['media', '<video controls><source src="/assets/v.mp4" type="video/mp4"></video>'],
+		['attribute-only normalization', '<p onclick="x()" class="a">text</p>'],
+		['non-strings', null],
+	])('passes %s through', (_name, html) => {
+		expect(sanitizeDropsContent(html)).toBe(false);
 	});
 });

--- a/app/src/composables/use-comparison-diff.ts
+++ b/app/src/composables/use-comparison-diff.ts
@@ -19,6 +19,39 @@ export function isHtmlString(value: any): boolean {
 	return /<[a-z][\s\S]*>/i.test(value);
 }
 
+/**
+ * True when sanitizing would remove nodes (iframes, comments, …), which the diff view would then
+ * hide from the compared values. Callers skip diff marking for those and show them verbatim.
+ */
+export function sanitizeDropsContent(value: any): boolean {
+	if (typeof value !== 'string' || value === '') return false;
+
+	const sanitized = dompurify.sanitize(value);
+
+	// comments (the legacy page-break marker) never survive sanitizing
+	if (value.includes('<!--') && !sanitized.includes('<!--')) return true;
+
+	// DOMParser is inert: nothing executes and no resource loads while the raw markup is inspected
+	const parse = (html: string) => new DOMParser().parseFromString(html, 'text/html').body;
+	return nodeSignature(parse(value)) !== nodeSignature(parse(sanitized));
+}
+
+// attribute-level normalization is ignored on purpose — only missing nodes matter here
+function nodeSignature(root: HTMLElement): string {
+	const parts: string[] = [];
+
+	function walk(node: Node) {
+		for (const child of Array.from(node.childNodes)) {
+			if (child.nodeType === Node.ELEMENT_NODE) parts.push((child as HTMLElement).tagName);
+			else if (child.nodeType === Node.TEXT_NODE) parts.push(`#text:${child.textContent}`);
+			walk(child);
+		}
+	}
+
+	walk(root);
+	return parts.join('|');
+}
+
 function isFormattingElement(node: Node): boolean {
 	if (node.nodeType !== Node.ELEMENT_NODE) return false;
 	const tag = (node as HTMLElement).tagName;

--- a/app/src/composables/use-comparison-diff.ts
+++ b/app/src/composables/use-comparison-diff.ts
@@ -19,16 +19,12 @@ export function isHtmlString(value: any): boolean {
 	return /<[a-z][\s\S]*>/i.test(value);
 }
 
-/**
- * True when sanitizing would remove nodes (iframes, comments, …), which the diff view would then
- * hide from the compared values. Callers skip diff marking for those and show them verbatim.
- */
+/** True when sanitizing removes nodes (iframes, comments, …), which the diff view would then hide. */
 export function sanitizeDropsContent(value: any): boolean {
 	if (typeof value !== 'string' || value === '') return false;
 
 	const sanitized = dompurify.sanitize(value);
 
-	// comments (the legacy page-break marker) never survive sanitizing
 	if (value.includes('<!--') && !sanitized.includes('<!--')) return true;
 
 	// DOMParser is inert: nothing executes and no resource loads while the raw markup is inspected
@@ -36,7 +32,7 @@ export function sanitizeDropsContent(value: any): boolean {
 	return nodeSignature(parse(value)) !== nodeSignature(parse(sanitized));
 }
 
-// attribute-level normalization is ignored on purpose — only missing nodes matter here
+// only missing nodes matter here, attribute-level normalization is ignored
 function nodeSignature(root: HTMLElement): string {
 	const parts: string[] = [];
 

--- a/app/src/interfaces/input-rich-text-html/comparison-source.test.ts
+++ b/app/src/interfaces/input-rich-text-html/comparison-source.test.ts
@@ -1,0 +1,72 @@
+import { EditorContent } from '@tiptap/vue-3';
+import { flushPromises, mount } from '@vue/test-utils';
+import { createPinia } from 'pinia';
+import { describe, expect, test } from 'vitest';
+import { nextTick } from 'vue';
+import { createI18n } from 'vue-i18n';
+import Interface from './input-rich-text-html.vue';
+import InterfaceInputCode from '@/interfaces/input-code/input-code.vue';
+
+/**
+ * Comparison view of a value the schema can't represent: rendering it through the editor would
+ * silently drop the unsupported markup, so the revision would look empty and restoring it would be
+ * impossible to judge. Those values fall back to a read-only source view instead.
+ */
+const LOSSY = '<p>hello</p><marquee>legacy</marquee>';
+const DIFF_MARKED = '<p>hello<span class="comparison-diff--added"> world</span></p>';
+
+async function mountComparison(value: string) {
+	const i18n = createI18n({ legacy: false, locale: 'en-US', messages: { 'en-US': {} } });
+
+	const wrapper = mount(Interface, {
+		props: { value, comparisonMode: true, nonEditable: true },
+		global: {
+			plugins: [createPinia(), i18n],
+			stubs: {
+				Toolbar: true,
+				TableBubbleMenu: true,
+				ImageDrawer: true,
+				LinkDrawer: true,
+				MediaDrawer: true,
+				SourceCodeDrawer: true,
+				NormalizationWarningDialog: true,
+				InterfaceInputCode: true,
+			},
+		},
+	});
+
+	await flushPromises();
+	await nextTick();
+	return wrapper;
+}
+
+// isVisible() is unreliable for v-show under jsdom; assert on the inline style it toggles
+function editorContentHidden(wrapper: Awaited<ReturnType<typeof mountComparison>>) {
+	return (wrapper.findComponent(EditorContent).attributes('style') ?? '').includes('display: none');
+}
+
+describe('comparison mode source fallback', () => {
+	test('unsupported markup is shown as read-only source instead of being dropped by the editor', async () => {
+		const wrapper = await mountComparison(LOSSY);
+
+		const code = wrapper.findComponent(InterfaceInputCode);
+		expect(code.exists()).toBe(true);
+		expect(code.props('value')).toBe(LOSSY);
+		expect(code.props('disabled')).toBe(true);
+		expect(editorContentHidden(wrapper)).toBe(true);
+	});
+
+	test('diff-marked values still render in the editor', async () => {
+		const wrapper = await mountComparison(DIFF_MARKED);
+
+		expect(wrapper.findComponent(InterfaceInputCode).exists()).toBe(false);
+		expect(editorContentHidden(wrapper)).toBe(false);
+	});
+
+	test('the source fallback never emits, so opening a comparison cannot dirty the field', async () => {
+		const wrapper = await mountComparison(LOSSY);
+
+		expect(wrapper.emitted('input')).toBeUndefined();
+		expect(wrapper.emitted('setFieldValue')).toBeUndefined();
+	});
+});

--- a/app/src/interfaces/input-rich-text-html/composables/normalization-diff.test.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/normalization-diff.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { buildCustomFormats } from '../extensions/custom-formats';
-import { computeNormalizationDiff, computeValueNormalizationDiff } from './normalization-diff';
+import { comparisonSchema, computeNormalizationDiff, computeValueNormalizationDiff } from './normalization-diff';
 
 function removedText(code: string): string {
 	const changes = computeNormalizationDiff(code);
@@ -75,5 +75,39 @@ describe('computeValueNormalizationDiff', () => {
 	test('returns null for custom-format markup when its extensions are supplied', () => {
 		const { extensions } = buildCustomFormats([{ title: 'Cite', inline: 'cite', classes: 'src' }]);
 		expect(computeValueNormalizationDiff('<p><cite class="src">b</cite></p>', extensions)).toBeNull();
+	});
+
+	test('reuses the verdict for a value already checked against the same schema', () => {
+		const value = '<p><cite class="src">b</cite></p>';
+		const first = computeValueNormalizationDiff(value);
+
+		expect(first).not.toBeNull();
+		expect(computeValueNormalizationDiff(value)).toBe(first);
+	});
+
+	test('keeps the verdicts of two custom-format schemas apart', () => {
+		const cite = buildCustomFormats([{ title: 'Cite', inline: 'cite', classes: 'src' }]);
+		const highlight = buildCustomFormats([{ title: 'Highlight', inline: 'span', classes: 'highlight' }]);
+		const value = '<p><cite class="src">b</cite></p>';
+
+		expect(computeValueNormalizationDiff(value, cite.extensions, cite.key)).toBeNull();
+		expect(computeValueNormalizationDiff(value, highlight.extensions, highlight.key)).not.toBeNull();
+	});
+
+	test('does not cache a schema it cannot identify', () => {
+		const { extensions } = buildCustomFormats([{ title: 'Cite', inline: 'cite', classes: 'src' }]);
+		const value = '<p><cite class="other">b</cite></p>';
+
+		expect(computeValueNormalizationDiff(value, extensions)).not.toBe(computeValueNormalizationDiff(value, extensions));
+	});
+});
+
+describe('comparisonSchema', () => {
+	test('accepts the diff spans the comparison view feeds the editor', () => {
+		const value = '<p><span class="comparison-diff--added">a</span></p>';
+		const { extensions, schemaKey } = comparisonSchema(null);
+
+		expect(computeValueNormalizationDiff(value, extensions, schemaKey)).toBeNull();
+		expect(computeValueNormalizationDiff(value)).not.toBeNull();
 	});
 });

--- a/app/src/interfaces/input-rich-text-html/composables/normalization-diff.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/normalization-diff.ts
@@ -1,6 +1,8 @@
 import { type AnyExtension, Editor } from '@tiptap/vue-3';
 import { type Change, diffLines } from 'diff';
 import { editorExtensions } from '../extensions';
+import { ComparisonDiff } from '../extensions/comparison-diff';
+import { buildCustomFormats } from '../extensions/custom-formats';
 import { decodePageBreaks, encodePageBreaks } from '../extensions/page-break';
 import { formatHtml } from './format-html';
 
@@ -37,8 +39,41 @@ export function computeNormalizationDiff(code: string, extraExtensions: AnyExten
  * Same check for the stored field value: both sides are compared in the encoded (stored)
  * representation so the page-break marker ↔ element boundary cancels out instead of reading
  * as a change.
+ *
+ * Each miss builds a throwaway editor, and a comparison asks the same question about the same value
+ * repeatedly (per side, per rendered interface, per revision pick), so verdicts are cached against
+ * `schemaKey`. Without one, only the base schema is cached — dynamic custom format marks reuse names.
  */
-export function computeValueNormalizationDiff(value: string, extraExtensions: AnyExtension[] = []): Change[] | null {
+export function computeValueNormalizationDiff(
+	value: string,
+	extraExtensions: AnyExtension[] = [],
+	schemaKey?: string,
+): Change[] | null {
+	const key = schemaKey ?? (extraExtensions.length === 0 ? '' : null);
+
+	if (key === null) return valueNormalizationDiff(value, extraExtensions);
+
+	const cacheKey = `${key}\u0000${value}`;
+	if (verdictCache.has(cacheKey)) return verdictCache.get(cacheKey)!;
+
+	const verdict = valueNormalizationDiff(value, extraExtensions);
+
+	if (verdictCache.size >= VERDICT_CACHE_SIZE) verdictCache.delete(verdictCache.keys().next().value!);
+	verdictCache.set(cacheKey, verdict);
+
+	return verdict;
+}
+
+/** The schema the comparison view renders with, so its verdicts are shared with the interface. */
+export function comparisonSchema(customFormats: unknown): { extensions: AnyExtension[]; schemaKey: string } {
+	const { extensions, key } = buildCustomFormats(customFormats);
+	return { extensions: [...extensions, ComparisonDiff], schemaKey: `comparison\u0000${key}` };
+}
+
+const VERDICT_CACHE_SIZE = 24;
+const verdictCache = new Map<string, Change[] | null>();
+
+function valueNormalizationDiff(value: string, extraExtensions: AnyExtension[]): Change[] | null {
 	const decoded = decodePageBreaks(value);
 	return diffFormatted(encodePageBreaks(decoded), encodePageBreaks(roundTrip(decoded, extraExtensions)));
 }

--- a/app/src/interfaces/input-rich-text-html/composables/use-normalization-warning.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/use-normalization-warning.ts
@@ -22,6 +22,7 @@ type UsableNormalizationWarning = {
 export function useNormalizationWarning(
 	value: Ref<string | null>,
 	extraExtensions: AnyExtension[] = [],
+	schemaKey?: string,
 ): UsableNormalizationWarning {
 	const normalizationLocked = ref(false);
 	const normalizationWarningOpen = ref(false);
@@ -46,7 +47,7 @@ export function useNormalizationWarning(
 			return;
 		}
 
-		const diff = computeValueNormalizationDiff(value.value, extraExtensions);
+		const diff = computeValueNormalizationDiff(value.value, extraExtensions, schemaKey);
 		normalizationLocked.value = diff !== null;
 		normalizationWarningDiff.value = diff ?? [];
 	}

--- a/app/src/interfaces/input-rich-text-html/extensions/custom-formats.ts
+++ b/app/src/interfaces/input-rich-text-html/extensions/custom-formats.ts
@@ -23,6 +23,8 @@ export interface CustomFormat {
 export interface BuiltCustomFormats {
 	extensions: AnyExtension[];
 	formats: CustomFormat[];
+	/** identifies the built schema; the generated mark names don't, they're positional */
+	key: string;
 }
 
 /** `type: json` field meta may hand back an already-parsed array or a raw JSON string. */
@@ -113,6 +115,7 @@ function buildMark(entry: CustomFormatEntry, name: string): AnyExtension {
 export function buildCustomFormats(raw: unknown): BuiltCustomFormats {
 	const extensions: AnyExtension[] = [];
 	const formats: CustomFormat[] = [];
+	const accepted: CustomFormatEntry[] = [];
 
 	parseOption(raw).forEach((entry, index) => {
 		if (!isSupported(entry)) {
@@ -133,7 +136,8 @@ export function buildCustomFormats(raw: unknown): BuiltCustomFormats {
 		const name = `customFormat_${index}`;
 		extensions.push(buildMark(entry, name));
 		formats.push({ name, title: entry.title, previewStyle: serializeStyles(entry.styles) });
+		accepted.push(entry);
 	});
 
-	return { extensions, formats };
+	return { extensions, formats, key: accepted.length > 0 ? JSON.stringify(accepted) : '' };
 }

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -88,6 +88,11 @@ const fontFamily = computed(() => {
 	return `var(--theme--fonts--${token}--font-family)`;
 });
 
+// ComparisonDiff joins the check in comparison mode so the precomputed diff spans don't read as loss
+const normalizationExtensions = props.comparisonMode
+	? [...customFormatExtensions, ComparisonDiff]
+	: customFormatExtensions;
+
 const {
 	normalizationLocked,
 	normalizationWarningOpen,
@@ -96,10 +101,13 @@ const {
 	onLockedClick,
 	confirmNormalizationWarning,
 	cancelNormalizationWarning,
-} = useNormalizationWarning(value, customFormatExtensions);
+} = useNormalizationWarning(value, normalizationExtensions);
 
-// skipped for display-only modes; comparison values carry diff spans the base schema would flag as loss
-if (!props.comparisonMode && !props.nonEditable) checkValue();
+// comparison runs it to pick the source fallback below; plain read-only display has nothing to act on
+if (!props.nonEditable || props.comparisonMode) checkValue();
+
+// the editor would drop what it can't represent, hiding the content a revision is opened for
+const comparisonSource = computed(() => props.comparisonMode && normalizationLocked.value);
 
 // surface the lock to the form so the field menu can gate raw editing, which would bypass this guard
 watch(normalizationLocked, (locked) => emit('readonly', locked), { immediate: true });
@@ -302,7 +310,7 @@ watch(
 		// compare the encoded (stored) form so a re-emitted page-break marker doesn't look like a change
 		if (encodePageBreaks(editor.value.getHTML()) === props.value) return;
 		syncValue(editor.value, props.value);
-		if (!props.comparisonMode && !props.nonEditable) checkValue();
+		if (!props.nonEditable || props.comparisonMode) checkValue();
 	},
 );
 
@@ -316,8 +324,8 @@ onKeyStroke('Escape', () => {
 
 <template>
 	<VNotice v-if="normalizationLocked && !rawMode" type="warning" multiline class="normalization-notice">
-		{{ t('wysiwyg_options.normalization_locked_notice') }}
-		<a :href="normalizationDocsUrl" target="_blank" rel="noopener noreferrer">
+		{{ t(`wysiwyg_options.${comparisonMode ? 'normalization_comparison_notice' : 'normalization_locked_notice'}`) }}
+		<a v-if="!comparisonMode" :href="normalizationDocsUrl" target="_blank" rel="noopener noreferrer">
 			{{ t('wysiwyg_options.normalization_locked_learn_more') }}
 		</a>
 	</VNotice>
@@ -343,15 +351,21 @@ onKeyStroke('Escape', () => {
 			@open-source-code="openSourceCodeDrawer"
 		/>
 		<InterfaceInputCode
-			v-if="rawMode"
+			v-if="rawMode || comparisonSource"
 			:value="value"
 			language="htmlmixed"
 			:line-number="false"
-			:disabled="disabled"
+			:disabled="disabled || comparisonSource"
 			@input="$emit('input', $event)"
 		/>
 
-		<EditorContent v-show="!rawMode" class="editor-content" :editor="editor" :dir="editorDir" @click="onEditorClick" />
+		<EditorContent
+			v-show="!rawMode && !comparisonSource"
+			class="editor-content"
+			:editor="editor"
+			:dir="editorDir"
+			@click="onEditorClick"
+		/>
 
 		<span
 			v-if="softLength && !comparisonMode && !rawMode"

--- a/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
+++ b/app/src/interfaces/input-rich-text-html/input-rich-text-html.vue
@@ -4,6 +4,7 @@ import { type Editor, EditorContent, useEditor } from '@tiptap/vue-3';
 import { onKeyStroke } from '@vueuse/core';
 import { computed, nextTick, ref, type Ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { comparisonSchema } from './composables/normalization-diff';
 import { useImage } from './composables/use-image';
 import { useLink } from './composables/use-link';
 import { useMedia } from './composables/use-media';
@@ -78,7 +79,11 @@ if (
 }
 
 // built once at init: `customFormats` is design-time config, not reactive
-const { extensions: customFormatExtensions, formats: customFormatList } = buildCustomFormats(props.customFormats);
+const {
+	extensions: customFormatExtensions,
+	formats: customFormatList,
+	key: customFormatsKey,
+} = buildCustomFormats(props.customFormats);
 
 const pageBreakLabel = computed(() => `"${t('wysiwyg_options.pagebreak')}"`);
 
@@ -88,10 +93,10 @@ const fontFamily = computed(() => {
 	return `var(--theme--fonts--${token}--font-family)`;
 });
 
-// ComparisonDiff joins the check in comparison mode so the precomputed diff spans don't read as loss
-const normalizationExtensions = props.comparisonMode
-	? [...customFormatExtensions, ComparisonDiff]
-	: customFormatExtensions;
+// in comparison mode ComparisonDiff joins the check, so precomputed diff spans don't read as loss
+const { extensions: normalizationExtensions, schemaKey: normalizationSchemaKey } = props.comparisonMode
+	? comparisonSchema(props.customFormats)
+	: { extensions: customFormatExtensions, schemaKey: customFormatsKey };
 
 const {
 	normalizationLocked,
@@ -101,7 +106,7 @@ const {
 	onLockedClick,
 	confirmNormalizationWarning,
 	cancelNormalizationWarning,
-} = useNormalizationWarning(value, normalizationExtensions);
+} = useNormalizationWarning(value, normalizationExtensions, normalizationSchemaKey);
 
 // comparison runs it to pick the source fallback below; plain read-only display has nothing to act on
 if (!props.nonEditable || props.comparisonMode) checkValue();

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1445,8 +1445,8 @@ wysiwyg_options:
     edit it.
   normalization_locked_learn_more: Learn what changed
   normalization_comparison_notice:
-    This version includes formatting the new editor can't display, so the stored HTML is shown as is. Applying it
-    restores the content unchanged.
+    This version includes formatting the editor can't display, so the stored HTML is shown as is. Applying it restores
+    the content unchanged.
   fullscreen: Full Screen
   directionality: Directionality
   ltr: Left to Right

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1434,7 +1434,8 @@ wysiwyg_options:
   normalization_warning_body:
     This content includes items the new editor doesn't support, so the field is read-only for now. If you edit anyway,
     those items will be removed when you save. To keep the stored HTML exactly as is, edit the raw HTML instead. This
-    warning will go away once the unsupported items are gone.
+    warning will go away once the unsupported items are gone. If you already saved without them, you can bring the
+    original content back from Revisions.
   normalization_warning_view_changes: View changes
   normalization_warning_keep_readonly: Keep Read-only
   normalization_warning_edit_anyway: Edit Anyway
@@ -1443,6 +1444,9 @@ wysiwyg_options:
     This field includes formatting the new editor doesn't support, so it's read-only. Select the field to choose how to
     edit it.
   normalization_locked_learn_more: Learn what changed
+  normalization_comparison_notice:
+    This version includes formatting the new editor can't display, so the stored HTML is shown as is. Applying it
+    restores the content unchanged.
   fullscreen: Full Screen
   directionality: Directionality
   ltr: Left to Right

--- a/app/src/views/private/components/comparison/comparison-modal.vue
+++ b/app/src/views/private/components/comparison/comparison-modal.vue
@@ -255,7 +255,7 @@ function usePublish() {
 								<VForm
 									:collection="collection"
 									:primary-key="primaryKey"
-									:initial-values="comparisonData?.base || {}"
+									:initial-values="comparisonData?.displayBase ?? comparisonData?.base ?? {}"
 									:collab-context="collabContext"
 									:comparison="{
 										side: 'base',
@@ -299,7 +299,7 @@ function usePublish() {
 								<VForm
 									:collection="collection"
 									:primary-key="primaryKey"
-									:initial-values="comparisonData?.incoming || {}"
+									:initial-values="comparisonData?.displayIncoming ?? comparisonData?.incoming ?? {}"
 									:comparison="{
 										side: 'incoming',
 										fields: comparisonFields,

--- a/app/src/views/private/components/comparison/types.ts
+++ b/app/src/views/private/components/comparison/types.ts
@@ -45,8 +45,12 @@ export type NormalizedComparison = {
 };
 
 export type ComparisonData = {
+	/** Raw stored values — what a restore writes back. Never diff-marked. */
 	base: Record<string, any>;
 	incoming: Record<string, any>;
+	/** Same values with rich text diff-marked for rendering; falls back to the raw ones when absent. */
+	displayBase?: Record<string, any>;
+	displayIncoming?: Record<string, any>;
 	mainVersionMeta?: Pick<Activity, 'timestamp' | 'user'>;
 	selectableDeltas?: Revision[] | ContentVersion[];
 	revisionFields?: Set<string>;

--- a/app/src/views/private/components/comparison/types.ts
+++ b/app/src/views/private/components/comparison/types.ts
@@ -45,10 +45,8 @@ export type NormalizedComparison = {
 };
 
 export type ComparisonData = {
-	/** Raw stored values — what a restore writes back. Never diff-marked. */
 	base: Record<string, any>;
 	incoming: Record<string, any>;
-	/** Same values with rich text diff-marked for rendering; falls back to the raw ones when absent. */
 	displayBase?: Record<string, any>;
 	displayIncoming?: Record<string, any>;
 	mainVersionMeta?: Pick<Activity, 'timestamp' | 'user'>;

--- a/app/src/views/private/components/comparison/use-comparison.test.ts
+++ b/app/src/views/private/components/comparison/use-comparison.test.ts
@@ -208,6 +208,92 @@ describe('useComparison', () => {
 		});
 	});
 
+	// Diff-marked HTML is display-only: it is sanitized (dropping iframes, custom elements, …) and
+	// carries comparison-diff spans, so restoring from it would rewrite the field. The raw revision
+	// values stay on `base`/`incoming`, which is what the restore payload is built from.
+	describe('rich text fields', () => {
+		function getRichTextTestCase(baseBody: string, incomingBody: string) {
+			return getTestData('revision', {
+				currentRevisionOverwrites: {
+					id: 1234,
+					data: { body: incomingBody },
+					delta: { body: incomingBody },
+				},
+				revisionsListOverwrites: [
+					{
+						id: 1233,
+						collection: 'test_collection',
+						item: 1,
+						data: { body: baseBody },
+						delta: { body: baseBody },
+						activity: { action: 'update', timestamp: '2025-10-29T09:00:00.000Z', user: null },
+					},
+					{
+						id: 1234,
+						collection: 'test_collection',
+						item: 1,
+						data: { body: incomingBody },
+						delta: { body: incomingBody },
+						activity: { action: 'update', timestamp: '2025-10-29T10:00:00.000Z', user: null },
+					},
+				],
+			});
+		}
+
+		it('should keep the raw values and expose the diff-marked ones separately', async () => {
+			const testCase = getRichTextTestCase('<p>hello there</p>', '<p>hello world</p>');
+			mockApi.get.mockImplementation(testCase.mockApiGet);
+
+			const { comparisonData, fetchComparisonData } = useComparison(testCase.comparisonOptions);
+
+			await fetchComparisonData();
+
+			expect(comparisonData.value?.base.body).toBe('<p>hello there</p>');
+			expect(comparisonData.value?.incoming.body).toBe('<p>hello world</p>');
+
+			expect(comparisonData.value?.displayBase?.body).toContain('comparison-diff--removed');
+			expect(comparisonData.value?.displayIncoming?.body).toContain('comparison-diff--added');
+		});
+
+		it('should not diff-mark values the editor cannot represent, so nothing is stripped', async () => {
+			const lossy = '<p>hello</p><marquee>legacy</marquee>';
+			const testCase = getRichTextTestCase(lossy, '<p>hello edited</p>');
+			mockApi.get.mockImplementation(testCase.mockApiGet);
+
+			const { comparisonData, fetchComparisonData } = useComparison(testCase.comparisonOptions);
+
+			await fetchComparisonData();
+
+			expect(comparisonData.value?.base.body).toBe(lossy);
+			expect(comparisonData.value?.displayBase?.body).toBe(lossy);
+			expect(comparisonData.value?.displayIncoming?.body).toBe('<p>hello edited</p>');
+		});
+
+		it('should not diff-mark values whose nodes the diff sanitizer drops, like embeds', async () => {
+			const withEmbed = '<p>hello</p><iframe src="https://example.com"></iframe>';
+			const testCase = getRichTextTestCase(withEmbed, '<p>hello world</p><iframe src="https://example.com"></iframe>');
+			mockApi.get.mockImplementation(testCase.mockApiGet);
+
+			const { comparisonData, fetchComparisonData } = useComparison(testCase.comparisonOptions);
+
+			await fetchComparisonData();
+
+			expect(comparisonData.value?.displayBase?.body).toBe(withEmbed);
+			expect(comparisonData.value?.displayIncoming?.body).toContain('<iframe src="https://example.com"></iframe>');
+		});
+
+		it('should list the field as different when only the unsupported markup was removed', async () => {
+			const testCase = getRichTextTestCase('<p>hello</p><marquee>legacy</marquee>', '<p>hello</p>');
+			mockApi.get.mockImplementation(testCase.mockApiGet);
+
+			const { comparisonFields, fetchComparisonData } = useComparison(testCase.comparisonOptions);
+
+			await fetchComparisonData();
+
+			expect(Array.from(comparisonFields.value ?? [])).toContain('body');
+		});
+	});
+
 	describe('revision mode with Previous compareTo option', () => {
 		it('should compare current revision with previous revision data', async () => {
 			const previousRevisionData = {
@@ -1433,6 +1519,51 @@ function getFieldData({
 				validation_message: null,
 			},
 			name: 'Description',
+		},
+		{
+			collection: collection,
+			field: 'body',
+			type: 'text',
+			schema: {
+				name: 'body',
+				table: collection,
+				data_type: 'text',
+				default_value: null,
+				max_length: null,
+				numeric_precision: null,
+				numeric_scale: null,
+				is_generated: false,
+				generation_expression: null,
+				is_nullable: true,
+				is_unique: false,
+				is_indexed: false,
+				is_primary_key: false,
+				has_auto_increment: false,
+				foreign_key_column: null,
+				foreign_key_table: null,
+			},
+			meta: {
+				id: 203,
+				collection: collection,
+				field: 'body',
+				special: null,
+				interface: 'input-rich-text-html',
+				options: null,
+				display: null,
+				display_options: null,
+				readonly: false,
+				hidden: false,
+				sort: 9,
+				width: 'full',
+				translations: null,
+				note: null,
+				conditions: null,
+				required: false,
+				group: null,
+				validation: null,
+				validation_message: null,
+			},
+			name: 'Body',
 		},
 		{
 			collection: collection,

--- a/app/src/views/private/components/comparison/use-comparison.ts
+++ b/app/src/views/private/components/comparison/use-comparison.ts
@@ -13,8 +13,10 @@ import type {
 } from './types';
 import api from '@/api';
 import { isHtmlString, sanitizeDropsContent, useComparisonDiff } from '@/composables/use-comparison-diff';
-import { computeValueNormalizationDiff } from '@/interfaces/input-rich-text-html/composables/normalization-diff';
-import { buildCustomFormats } from '@/interfaces/input-rich-text-html/extensions/custom-formats';
+import {
+	comparisonSchema,
+	computeValueNormalizationDiff,
+} from '@/interfaces/input-rich-text-html/composables/normalization-diff';
 import { i18n } from '@/lang';
 import { useFieldsStore } from '@/stores/fields';
 import type { Revision } from '@/types/revisions';
@@ -274,10 +276,7 @@ export function useComparison(options: UseComparisonOptions) {
 		}
 	}
 
-	/**
-	 * Builds the diff-marked copies the comparison form renders. Diff marking is display-only: it
-	 * sanitizes the HTML and injects diff spans, so the originals are left untouched for restoring.
-	 */
+	/** Diff-marked copies for the form to render; the originals stay untouched for restoring. */
 	function processRichTextHtmlFields(
 		base: Record<string, any>,
 		incoming: Record<string, any>,
@@ -306,12 +305,15 @@ export function useComparison(options: UseComparisonOptions) {
 				shouldShowComparisonDiff(true, 'base', baseValue, incomingValue) &&
 				(isHtmlString(baseValue) || isHtmlString(incomingValue))
 			) {
-				// Diff marking would drop the very content a revision is opened for — markup the editor
-				// can't represent (shown verbatim in the interface's source fallback) or nodes the diff's
-				// sanitizer removes. Those values are compared without highlighting instead.
-				const { extensions } = buildCustomFormats(field.meta?.options?.['customFormats']);
-				if (isLossyForEditor(baseValue, extensions) || isLossyForEditor(incomingValue, extensions)) continue;
+				// diff marking would drop the very content a revision is opened for: nodes the diff's
+				// sanitizer removes, or markup the editor can't represent (rendered verbatim as source
+				// instead). Those values are compared without highlighting.
 				if (sanitizeDropsContent(baseValue) || sanitizeDropsContent(incomingValue)) continue;
+
+				const { extensions, schemaKey } = comparisonSchema(field.meta?.options?.['customFormats']);
+				const isLossy = (value: unknown) => isLossyForEditor(value, extensions, schemaKey);
+
+				if (isLossy(baseValue) || isLossy(incomingValue)) continue;
 
 				const changes = computeDiff(baseValue, incomingValue, field);
 
@@ -333,9 +335,9 @@ export function useComparison(options: UseComparisonOptions) {
 		return { displayBase, displayIncoming };
 	}
 
-	function isLossyForEditor(value: unknown, extensions: AnyExtension[]): boolean {
+	function isLossyForEditor(value: unknown, extensions: AnyExtension[], schemaKey: string): boolean {
 		if (typeof value !== 'string' || value === '') return false;
-		return computeValueNormalizationDiff(value, extensions) !== null;
+		return computeValueNormalizationDiff(value, extensions, schemaKey) !== null;
 	}
 
 	async function buildVersionComparison(version: ContentVersion): Promise<ComparisonData> {

--- a/app/src/views/private/components/comparison/use-comparison.ts
+++ b/app/src/views/private/components/comparison/use-comparison.ts
@@ -1,5 +1,6 @@
 import type { ContentVersion, Field, Item, PrimaryKey, User } from '@directus/types';
 import { getEndpoint } from '@directus/utils';
+import type { AnyExtension } from '@tiptap/vue-3';
 import { has, isEqual, mergeWith, orderBy } from 'lodash';
 import { computed, type Ref, ref, watch } from 'vue';
 import type {
@@ -11,7 +12,9 @@ import type {
 	VersionComparisonResponse,
 } from './types';
 import api from '@/api';
-import { isHtmlString, useComparisonDiff } from '@/composables/use-comparison-diff';
+import { isHtmlString, sanitizeDropsContent, useComparisonDiff } from '@/composables/use-comparison-diff';
+import { computeValueNormalizationDiff } from '@/interfaces/input-rich-text-html/composables/normalization-diff';
+import { buildCustomFormats } from '@/interfaces/input-rich-text-html/extensions/custom-formats';
 import { i18n } from '@/lang';
 import { useFieldsStore } from '@/stores/fields';
 import type { Revision } from '@/types/revisions';
@@ -271,15 +274,21 @@ export function useComparison(options: UseComparisonOptions) {
 		}
 	}
 
+	/**
+	 * Builds the diff-marked copies the comparison form renders. Diff marking is display-only: it
+	 * sanitizes the HTML and injects diff spans, so the originals are left untouched for restoring.
+	 */
 	function processRichTextHtmlFields(
 		base: Record<string, any>,
 		incoming: Record<string, any>,
 		collectionName: string,
-	): { base: Record<string, any>; incoming: Record<string, any> } {
+	): { displayBase: Record<string, any>; displayIncoming: Record<string, any> } {
+		const displayBase = { ...base };
+		const displayIncoming = { ...incoming };
 		const fields = fieldsStore.getFieldsForCollection(collectionName);
 
 		if (!fields || fields.length === 0) {
-			return { base, incoming };
+			return { displayBase, displayIncoming };
 		}
 
 		const { computeDiff } = useComparisonDiff();
@@ -297,6 +306,13 @@ export function useComparison(options: UseComparisonOptions) {
 				shouldShowComparisonDiff(true, 'base', baseValue, incomingValue) &&
 				(isHtmlString(baseValue) || isHtmlString(incomingValue))
 			) {
+				// Diff marking would drop the very content a revision is opened for — markup the editor
+				// can't represent (shown verbatim in the interface's source fallback) or nodes the diff's
+				// sanitizer removes. Those values are compared without highlighting instead.
+				const { extensions } = buildCustomFormats(field.meta?.options?.['customFormats']);
+				if (isLossyForEditor(baseValue, extensions) || isLossyForEditor(incomingValue, extensions)) continue;
+				if (sanitizeDropsContent(baseValue) || sanitizeDropsContent(incomingValue)) continue;
+
 				const changes = computeDiff(baseValue, incomingValue, field);
 
 				if (changes.length > 0) {
@@ -304,17 +320,22 @@ export function useComparison(options: UseComparisonOptions) {
 					const incomingHtml = reconstructComparisonHtml(changes, 'incoming', false);
 
 					if (baseHtml !== null) {
-						base[fieldKey] = baseHtml;
+						displayBase[fieldKey] = baseHtml;
 					}
 
 					if (incomingHtml !== null) {
-						incoming[fieldKey] = incomingHtml;
+						displayIncoming[fieldKey] = incomingHtml;
 					}
 				}
 			}
 		}
 
-		return { base, incoming };
+		return { displayBase, displayIncoming };
+	}
+
+	function isLossyForEditor(value: unknown, extensions: AnyExtension[]): boolean {
+		if (typeof value !== 'string' || value === '') return false;
+		return computeValueNormalizationDiff(value, extensions) !== null;
 	}
 
 	async function buildVersionComparison(version: ContentVersion): Promise<ComparisonData> {
@@ -326,15 +347,13 @@ export function useComparison(options: UseComparisonOptions) {
 
 			const mainVersionMeta = await fetchLatestRevisionActivityOfMainVersion(collection.value, primaryKey.value);
 
-			const { base: processedBase, incoming: processedIncoming } = processRichTextHtmlFields(
-				base,
-				incomingMerged,
-				collection.value,
-			);
+			const { displayBase, displayIncoming } = processRichTextHtmlFields(base, incomingMerged, collection.value);
 
 			return {
-				base: processedBase,
-				incoming: processedIncoming,
+				base,
+				incoming: incomingMerged,
+				displayBase,
+				displayIncoming,
 				mainVersionMeta,
 				selectableDeltas: [version],
 				comparisonType: 'version',
@@ -435,15 +454,13 @@ export function useComparison(options: UseComparisonOptions) {
 		const specialFields = applyValuesToSpecialFields(fields, incoming, base, activity);
 		incoming = mergeWith({}, incoming, specialFields, replaceArraysInMergeCustomizer);
 
-		const { base: processedBase, incoming: processedIncoming } = processRichTextHtmlFields(
-			base,
-			incoming,
-			targetCollection,
-		);
+		const { displayBase, displayIncoming } = processRichTextHtmlFields(base, incoming, targetCollection);
 
 		return {
-			base: processedBase,
-			incoming: processedIncoming,
+			base,
+			incoming,
+			displayBase,
+			displayIncoming,
 			selectableDeltas: revisionsList,
 			revisionFields,
 			comparisonType: 'revision',


### PR DESCRIPTION
## What's Changed

Restoring a revision of a WYSIWYG field could not bring back markup the editor can't represent (iframes, custom elements, page-break comments, legacy tags): the content was invisible in the comparison modal, and applying it wrote back a mangled value.

Root cause: `processRichTextHtmlFields()` overwrote `comparisonData.base/incoming` with display-only diff HTML, and the restore payload in `comparison-modal.vue` was built from that same object. That HTML is lossy twice (DOMPurify strips nodes, then diff spans are injected), and whatever survived was then rendered through the Tiptap editor, which drops non-schema markup.

- **Restore now uses the stored values.** `base`/`incoming` stay raw; the diff-marked copies moved to new `displayBase`/`displayIncoming`, which only the comparison form renders. As a side effect, a field whose only difference was the stripped markup now shows up as a difference at all (previously the sanitized values compared equal, so it wasn't selectable).
- **Diff marking is skipped when it would lose content.** Two guards: values that don't survive the editor round trip (`computeValueNormalizationDiff`), and values whose nodes the diff's sanitizer removes (new `sanitizeDropsContent` in `use-comparison-diff.ts`, covering iframes, comments/page breaks, scripts). Those fields lose add/remove highlighting but are compared verbatim.
- **The comparison view shows unsupported markup as read-only source.** In comparison mode the normalization check now runs (with `ComparisonDiff` in the extension list so the diff spans don't read as loss); when it locks, the field renders the disabled code view plus a notice instead of an editor that would silently drop the content.
- **Callout copy** points at Revisions as a way to get the original content back (`normalization_warning_body`), and a new `normalization_comparison_notice` string covers the comparison view.

## Tested Scenarios

- Unit tests (all new tests fail against the previous code):
  - `comparison-source.test.ts` — comparison mode renders the read-only source view for unsupported markup, keeps the editor for diff-marked values, and never emits.
  - `use-comparison.test.ts` — raw vs. display split, no diff marking for values the editor can't represent or the sanitizer would strip, and the field is listed as different when only the unsupported markup was removed.
  - `use-comparison-diff.test.ts` — `sanitizeDropsContent` detects dropped embeds/comments/scripts and passes plain markup, media and attribute-only normalization through.
- Full app suite: 330 files / 111552 tests pass. ESLint clean, no new `vue-tsc` errors.
- Not yet walked through in a running instance — the original repro (edit anyway → save → open the earlier revision → apply) is worth a manual pass.

## Review Notes / Questions / Concerns

- Two lossiness checks now run per rich text field: `use-comparison` decides whether to diff-mark, and the interface re-runs the normalization check on the value it receives. Each builds a throwaway Tiptap editor, so a comparison with several rich text fields does a bit more work than before. There's no channel to pass the verdict down through `initial-values`, so it's recomputed.
- `use-comparison.ts` now imports from `@/interfaces/input-rich-text-html/*` — the interface's schema is the thing that defines "representable", so the check lives there, but it's a new direction of dependency for that composable.
- Known residual gaps, both display-only: table `colwidth` is still dropped in the diff view (attribute-level, below the node signature check), and fields shown verbatim get no add/remove highlighting.
- Collab collisions never ran rich text diff marking, so they fall back to the raw values (`displayBase ?? base`) — unchanged behavior, but worth a look if diff highlighting is wanted there too.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [x] App translations added for new user-facing strings
- [ ] Security implications apply

---

Closes [CMS-2961](https://linear.app/directus/issue/CMS-2961/check-on-revisions-for-unsupported-tags-wysiwyg)