### PR TITLE
Update outdated type definitions for directus_notifications, directus_permissions, directus_extensions, directus_fields, directus_activity, directus_collections, and directus_revisions

### DIFF
--- a/.changeset/tame-hornets-cheer.md
+++ b/.changeset/tame-hornets-cheer.md
@@ -1,0 +1,6 @@
+---
+'@directus/types': minor
+'@directus/sdk': major
+---
+
+Updated outdated type definitions for `directus_permissions`, `directus_extensions`, `directus_fields`, `directus_activity`, `directus_collections`, and `directus_revisions`

--- a/.changeset/tame-hornets-cheer.md
+++ b/.changeset/tame-hornets-cheer.md
@@ -1,6 +1,7 @@
 ---
+'@directus/app': patch
 '@directus/types': minor
 '@directus/sdk': major
 ---
 
-Updated outdated type definitions for `directus_permissions`, `directus_extensions`, `directus_fields`, `directus_activity`, `directus_collections`, and `directus_revisions`
+Updated outdated type definitions for `directus_notifications`, `directus_permissions`, `directus_extensions`, `directus_fields`, `directus_activity`, `directus_collections`, and `directus_revisions`

--- a/app/src/views/private/components/notifications-drawer.vue
+++ b/app/src/views/private/components/notifications-drawer.vue
@@ -50,10 +50,10 @@ const notificationsStore = useNotificationsStore();
 const router = useRouter();
 
 const collection = ref<string | null>(null);
-const selection = ref<string[]>([]);
+const selection = ref<number[]>([]);
 const confirmDelete = ref(false);
 const tab = ref(['inbox']);
-const openNotifications = ref<string[]>([]);
+const openNotifications = ref<number[]>([]);
 const page = ref(1);
 const limit = ref(25);
 const search = ref<string | null>(null);
@@ -162,7 +162,7 @@ async function selectAll() {
 	}
 }
 
-function toggleSelected(id: string) {
+function toggleSelected(id: number) {
 	if (selection.value.includes(id)) {
 		selection.value.splice(selection.value.indexOf(id), 1);
 	} else {
@@ -170,7 +170,7 @@ function toggleSelected(id: string) {
 	}
 }
 
-function toggleNotification(id: string) {
+function toggleNotification(id: number) {
 	if (openNotifications.value.includes(id)) {
 		openNotifications.value.splice(openNotifications.value.indexOf(id), 1);
 	} else {
@@ -374,7 +374,13 @@ function clearFilters() {
 								@update:model-value="toggleSelected(notification.id)"
 							/>
 							<VTextOverflow class="title" :highlight="search" :text="notification.subject" />
-							<UseDatetime v-slot="{ datetime }" :value="notification.timestamp" type="timestamp" relative>
+							<UseDatetime
+								v-if="notification.timestamp"
+								v-slot="{ datetime }"
+								:value="notification.timestamp"
+								type="timestamp"
+								relative
+							>
 								<VTextOverflow class="datetime" :text="datetime" />
 							</UseDatetime>
 							<VIcon

--- a/packages/types/src/notifications.ts
+++ b/packages/types/src/notifications.ts
@@ -1,9 +1,9 @@
 import type { PrimaryKey } from './items.js';
 
 export type Notification = {
-	id: string;
-	status: string;
-	timestamp: string;
+	id: number;
+	status: string | null;
+	timestamp: string | null;
 	recipient: string;
 	sender: string | null;
 	subject: string;

--- a/sdk/src/rest/commands/delete/collections.ts
+++ b/sdk/src/rest/commands/delete/collections.ts
@@ -9,6 +9,6 @@ import type { RestCommand } from '../../types.js';
 export const deleteCollection =
 	<Schema>(collection: DirectusCollection<Schema>['collection']): RestCommand<void, Schema> =>
 	() => ({
-		path: `/collections/${collection}`,
+		path: `/collections/${collection as string}`,
 		method: 'DELETE',
 	});

--- a/sdk/src/rest/commands/delete/fields.ts
+++ b/sdk/src/rest/commands/delete/fields.ts
@@ -16,11 +16,11 @@ export const deleteField =
 		field: DirectusField<Schema>['field'],
 	): RestCommand<void, Schema> =>
 	() => {
-		throwIfEmpty(collection, 'Collection cannot be empty');
+		throwIfEmpty(String(collection), 'Collection cannot be empty');
 		throwIfEmpty(field, 'Field cannot be empty');
 
 		return {
-			path: `/fields/${collection}/${field}`,
+			path: `/fields/${collection as string}/${field}`,
 			method: 'DELETE',
 		};
 	};

--- a/sdk/src/rest/commands/delete/notifications.ts
+++ b/sdk/src/rest/commands/delete/notifications.ts
@@ -29,7 +29,7 @@ export const deleteNotifications =
 export const deleteNotification =
 	<Schema>(key: DirectusNotification<Schema>['id']): RestCommand<void, Schema> =>
 	() => {
-		throwIfEmpty(key, 'Key cannot be empty');
+		throwIfEmpty(String(key), 'Key cannot be empty');
 
 		return {
 			path: `/notifications/${key}`,

--- a/sdk/src/rest/commands/read/collections.ts
+++ b/sdk/src/rest/commands/read/collections.ts
@@ -29,10 +29,10 @@ export const readCollections =
 export const readCollection =
 	<Schema>(collection: DirectusCollection<Schema>['collection']): RestCommand<ReadCollectionOutput<Schema>, Schema> =>
 	() => {
-		throwIfEmpty(collection, 'Collection cannot be empty');
+		throwIfEmpty(String(collection), 'Collection cannot be empty');
 
 		return {
-			path: `/collections/${collection}`,
+			path: `/collections/${collection as string}`,
 			method: 'GET',
 		};
 	};

--- a/sdk/src/rest/commands/read/fields.ts
+++ b/sdk/src/rest/commands/read/fields.ts
@@ -26,10 +26,10 @@ export const readFields =
 export const readFieldsByCollection =
 	<Schema>(collection: DirectusField<Schema>['collection']): RestCommand<ReadFieldOutput<Schema>[], Schema> =>
 	() => {
-		throwIfEmpty(collection, 'Collection cannot be empty');
+		throwIfEmpty(String(collection), 'Collection cannot be empty');
 
 		return {
-			path: `/fields/${collection}`,
+			path: `/fields/${collection as string}`,
 			method: 'GET',
 		};
 	};
@@ -48,11 +48,11 @@ export const readField =
 		field: DirectusField<Schema>['field'],
 	): RestCommand<ReadFieldOutput<Schema>, Schema> =>
 	() => {
-		throwIfEmpty(collection, 'Collection cannot be empty');
+		throwIfEmpty(String(collection), 'Collection cannot be empty');
 		throwIfEmpty(field, 'Field cannot be empty');
 
 		return {
-			path: `/fields/${collection}/${field}`,
+			path: `/fields/${collection as string}/${field}`,
 			method: 'GET',
 		};
 	};

--- a/sdk/src/rest/commands/update/collections.ts
+++ b/sdk/src/rest/commands/update/collections.ts
@@ -24,10 +24,10 @@ export const updateCollection =
 		query?: TQuery,
 	): RestCommand<UpdateCollectionOutput<Schema, TQuery>, Schema> =>
 	() => {
-		throwIfEmpty(collection, 'Collection cannot be empty');
+		throwIfEmpty(String(collection), 'Collection cannot be empty');
 
 		return {
-			path: `/collections/${collection}`,
+			path: `/collections/${collection as string}`,
 			params: query ?? {},
 			body: JSON.stringify(item),
 			method: 'PATCH',

--- a/sdk/src/rest/commands/update/fields.ts
+++ b/sdk/src/rest/commands/update/fields.ts
@@ -27,11 +27,11 @@ export const updateField =
 		query?: TQuery,
 	): RestCommand<UpdateFieldOutput<Schema, TQuery>, Schema> =>
 	() => {
-		throwIfEmpty(collection, 'Keys cannot be empty');
+		throwIfEmpty(String(collection), 'Keys cannot be empty');
 		throwIfEmpty(field, 'Field cannot be empty');
 
 		return {
-			path: `/fields/${collection}/${field}`,
+			path: `/fields/${collection as string}/${field}`,
 			params: query ?? {},
 			body: JSON.stringify(item),
 			method: 'PATCH',
@@ -54,10 +54,10 @@ export const updateFields =
 		query?: TQuery,
 	): RestCommand<UpdateFieldOutput<Schema, TQuery>[], Schema> =>
 	() => {
-		throwIfEmpty(collection, 'Collection cannot be empty');
+		throwIfEmpty(String(collection), 'Collection cannot be empty');
 
 		return {
-			path: `/fields/${collection}`,
+			path: `/fields/${collection as string}`,
 			params: query ?? {},
 			body: JSON.stringify(items),
 			method: 'PATCH',

--- a/sdk/src/rest/commands/update/notifications.ts
+++ b/sdk/src/rest/commands/update/notifications.ts
@@ -67,7 +67,7 @@ export const updateNotification =
 		query?: TQuery,
 	): RestCommand<UpdateNotificationOutput<Schema, TQuery>, Schema> =>
 	() => {
-		throwIfEmpty(key, 'Key cannot be empty');
+		throwIfEmpty(String(key), 'Key cannot be empty');
 
 		return {
 			path: `/notifications/${key}`,

--- a/sdk/src/schema/activity.ts
+++ b/sdk/src/schema/activity.ts
@@ -1,4 +1,4 @@
-import type { MergeCoreCollection } from '../index.js';
+import type { CompleteSchema, MergeCoreCollection } from '../index.js';
 import type { DirectusRevision } from './revision.js';
 import type { DirectusUser } from './user.js';
 
@@ -12,7 +12,7 @@ export type DirectusActivity<Schema = any> = MergeCoreCollection<
 		timestamp: 'datetime';
 		ip: string | null;
 		user_agent: string | null;
-		collection: string;
+		collection: keyof CompleteSchema<Schema>;
 		item: string;
 		origin: string | null;
 		revisions: DirectusRevision<Schema>[] | number[] | null;

--- a/sdk/src/schema/activity.ts
+++ b/sdk/src/schema/activity.ts
@@ -1,4 +1,4 @@
-import type { CompleteSchema, MergeCoreCollection } from '../index.js';
+import type { AllCollections, MergeCoreCollection, SingletonCollections } from '../index.js';
 import type { DirectusRevision } from './revision.js';
 import type { DirectusUser } from './user.js';
 
@@ -12,7 +12,7 @@ export type DirectusActivity<Schema = any> = MergeCoreCollection<
 		timestamp: 'datetime';
 		ip: string | null;
 		user_agent: string | null;
-		collection: keyof CompleteSchema<Schema>;
+		collection: AllCollections<Schema> | SingletonCollections<Schema>;
 		item: string;
 		origin: string | null;
 		revisions: DirectusRevision<Schema>[] | number[] | null;

--- a/sdk/src/schema/activity.ts
+++ b/sdk/src/schema/activity.ts
@@ -1,4 +1,4 @@
-import type { AllCollections, MergeCoreCollection, SingletonCollections } from '../index.js';
+import type { CollectionName, MergeCoreCollection } from '../index.js';
 import type { DirectusRevision } from './revision.js';
 import type { DirectusUser } from './user.js';
 
@@ -12,7 +12,7 @@ export type DirectusActivity<Schema = any> = MergeCoreCollection<
 		timestamp: 'datetime';
 		ip: string | null;
 		user_agent: string | null;
-		collection: AllCollections<Schema> | SingletonCollections<Schema>;
+		collection: CollectionName<Schema>;
 		item: string;
 		origin: string | null;
 		revisions: DirectusRevision<Schema>[] | number[] | null;

--- a/sdk/src/schema/collection.ts
+++ b/sdk/src/schema/collection.ts
@@ -1,18 +1,12 @@
-import type {
-	AllCollections,
-	DirectusField,
-	MergeCoreCollection,
-	NestedPartial,
-	SingletonCollections,
-} from '../index.js';
+import type { CollectionName, DirectusField, MergeCoreCollection, NestedPartial } from '../index.js';
 
 export type DirectusCollection<Schema = any> = {
-	collection: AllCollections<Schema> | SingletonCollections<Schema>;
+	collection: CollectionName<Schema>;
 	meta: MergeCoreCollection<
 		Schema,
 		'directus_collections',
 		{
-			collection: AllCollections<Schema> | SingletonCollections<Schema>;
+			collection: CollectionName<Schema>;
 			icon: string | null;
 			note: string | null;
 			display_template: string | null;

--- a/sdk/src/schema/collection.ts
+++ b/sdk/src/schema/collection.ts
@@ -1,12 +1,12 @@
-import type { DirectusField, MergeCoreCollection, NestedPartial } from '../index.js';
+import type { CompleteSchema, DirectusField, MergeCoreCollection, NestedPartial } from '../index.js';
 
 export type DirectusCollection<Schema = any> = {
-	collection: string; // TODO keyof complete schema
+	collection: keyof CompleteSchema<Schema>;
 	meta: MergeCoreCollection<
 		Schema,
 		'directus_collections',
 		{
-			collection: string; // TODO keyof complete schema
+			collection: keyof CompleteSchema<Schema>;
 			icon: string | null;
 			note: string | null;
 			display_template: string | null;

--- a/sdk/src/schema/collection.ts
+++ b/sdk/src/schema/collection.ts
@@ -1,12 +1,18 @@
-import type { CompleteSchema, DirectusField, MergeCoreCollection, NestedPartial } from '../index.js';
+import type {
+	AllCollections,
+	DirectusField,
+	MergeCoreCollection,
+	NestedPartial,
+	SingletonCollections,
+} from '../index.js';
 
 export type DirectusCollection<Schema = any> = {
-	collection: keyof CompleteSchema<Schema>;
+	collection: AllCollections<Schema> | SingletonCollections<Schema>;
 	meta: MergeCoreCollection<
 		Schema,
 		'directus_collections',
 		{
-			collection: keyof CompleteSchema<Schema>;
+			collection: AllCollections<Schema> | SingletonCollections<Schema>;
 			icon: string | null;
 			note: string | null;
 			display_template: string | null;

--- a/sdk/src/schema/extension.ts
+++ b/sdk/src/schema/extension.ts
@@ -21,11 +21,21 @@ export type ExtensionSchema = Partial<{
 	entrypoint: string | { app: string; api: string };
 	partial: boolean;
 	entries: ExtensionSchemaEntry[];
+	sandbox: ExtensionSandboxOptions;
 }>;
 
 export type ExtensionSchemaEntry = {
 	name: string;
 	type: ExtensionTypes;
+};
+
+export type ExtensionSandboxOptions = {
+	enabled: boolean;
+	requestedScopes: {
+		request?: { urls: string[]; methods: ('GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE')[] };
+		log?: Record<string, never>;
+		sleep?: Record<string, never>;
+	};
 };
 
 export type ExtensionTypes =

--- a/sdk/src/schema/extension.ts
+++ b/sdk/src/schema/extension.ts
@@ -3,7 +3,7 @@ import type { MergeCoreCollection } from '../index.js';
 export type DirectusExtension<Schema = any> = {
 	id: string;
 	bundle: string | null;
-	schema: ExtensionSchema | null;
+	schema: ExtensionSchema | ExtensionSchemaEntry | null;
 	meta: MergeCoreCollection<
 		Schema,
 		'directus_extensions',
@@ -11,10 +11,21 @@ export type DirectusExtension<Schema = any> = {
 	>;
 };
 
-export type ExtensionSchema = {
-	type: ExtensionTypes;
+export type ExtensionSchema = Partial<{
+	path: string;
+	name: string;
 	local: boolean;
-	version?: string;
+	version: string;
+	host: string;
+	type: ExtensionTypes;
+	entrypoint: string | { app: string; api: string };
+	partial: boolean;
+	entries: ExtensionSchemaEntry[];
+}>;
+
+export type ExtensionSchemaEntry = {
+	name: string;
+	type: ExtensionTypes;
 };
 
 export type ExtensionTypes =

--- a/sdk/src/schema/field.ts
+++ b/sdk/src/schema/field.ts
@@ -1,7 +1,7 @@
-import type { AllCollections, MergeCoreCollection, SingletonCollections } from '../index.js';
+import type { CollectionName, MergeCoreCollection } from '../index.js';
 
 export type DirectusField<Schema = any> = {
-	collection: AllCollections<Schema> | SingletonCollections<Schema>;
+	collection: CollectionName<Schema>;
 	field: string;
 	type: string;
 	meta: MergeCoreCollection<
@@ -9,7 +9,7 @@ export type DirectusField<Schema = any> = {
 		'directus_fields',
 		{
 			id: number;
-			collection: AllCollections<Schema> | SingletonCollections<Schema>;
+			collection: CollectionName<Schema>;
 			field: string;
 			special: string[] | null;
 			interface: string | null;

--- a/sdk/src/schema/field.ts
+++ b/sdk/src/schema/field.ts
@@ -1,7 +1,7 @@
-import type { CompleteSchema, MergeCoreCollection } from '../index.js';
+import type { AllCollections, MergeCoreCollection, SingletonCollections } from '../index.js';
 
 export type DirectusField<Schema = any> = {
-	collection: keyof CompleteSchema<Schema>;
+	collection: AllCollections<Schema> | SingletonCollections<Schema>;
 	field: string;
 	type: string;
 	meta: MergeCoreCollection<
@@ -9,7 +9,7 @@ export type DirectusField<Schema = any> = {
 		'directus_fields',
 		{
 			id: number;
-			collection: keyof CompleteSchema<Schema>;
+			collection: AllCollections<Schema> | SingletonCollections<Schema>;
 			field: string;
 			special: string[] | null;
 			interface: string | null;

--- a/sdk/src/schema/field.ts
+++ b/sdk/src/schema/field.ts
@@ -34,7 +34,7 @@ export type DirectusField<Schema = any> = {
 	>;
 	schema: {
 		name: string;
-		table: string;
+		table: CollectionName<Schema>;
 		schema?: string;
 		data_type: string;
 		is_nullable: boolean;

--- a/sdk/src/schema/field.ts
+++ b/sdk/src/schema/field.ts
@@ -28,26 +28,28 @@ export type DirectusField<Schema = any> = {
 			group: string | null;
 			validation: Record<string, any> | null;
 			validation_message: string | null;
+			system?: true;
+			clear_hidden_value_on_save?: boolean;
 		}
 	>;
 	schema: {
 		name: string;
 		table: string;
-		schema: string;
+		schema?: string;
 		data_type: string;
 		is_nullable: boolean;
 		default_value: any | null;
 		is_indexed: boolean;
 		is_generated: boolean;
-		generation_expression: unknown | null;
+		generation_expression?: string | null;
 		max_length: number | null;
-		comment: string | null;
+		comment?: string | null;
 		numeric_precision: number | null;
 		numeric_scale: number | null;
 		is_unique: boolean;
 		is_primary_key: boolean;
 		has_auto_increment: boolean;
-		foreign_key_schema: string | null;
+		foreign_key_schema?: string | null;
 		foreign_key_table: string | null;
 		foreign_key_column: string | null;
 	};

--- a/sdk/src/schema/field.ts
+++ b/sdk/src/schema/field.ts
@@ -1,7 +1,7 @@
-import type { MergeCoreCollection } from '../index.js';
+import type { CompleteSchema, MergeCoreCollection } from '../index.js';
 
 export type DirectusField<Schema = any> = {
-	collection: string; // TODO keyof complete schema
+	collection: keyof CompleteSchema<Schema>;
 	field: string;
 	type: string;
 	meta: MergeCoreCollection<
@@ -9,7 +9,7 @@ export type DirectusField<Schema = any> = {
 		'directus_fields',
 		{
 			id: number;
-			collection: string; // TODO keyof complete schema
+			collection: keyof CompleteSchema<Schema>;
 			field: string;
 			special: string[] | null;
 			interface: string | null;

--- a/sdk/src/schema/notification.ts
+++ b/sdk/src/schema/notification.ts
@@ -1,4 +1,4 @@
-import type { MergeCoreCollection } from '../index.js';
+import type { CompleteSchema, MergeCoreCollection } from '../index.js';
 import type { DirectusUser } from './user.js';
 
 export type DirectusNotification<Schema = any> = MergeCoreCollection<
@@ -12,7 +12,7 @@ export type DirectusNotification<Schema = any> = MergeCoreCollection<
 		sender: DirectusUser<Schema> | string | null;
 		subject: string;
 		message: string | null;
-		collection: string | null; // TODO keyof complete schema
+		collection: keyof CompleteSchema<Schema> | null;
 		item: string | null;
 	}
 >;

--- a/sdk/src/schema/notification.ts
+++ b/sdk/src/schema/notification.ts
@@ -1,4 +1,4 @@
-import type { CompleteSchema, MergeCoreCollection } from '../index.js';
+import type { AllCollections, MergeCoreCollection, SingletonCollections } from '../index.js';
 import type { DirectusUser } from './user.js';
 
 export type DirectusNotification<Schema = any> = MergeCoreCollection<
@@ -12,7 +12,7 @@ export type DirectusNotification<Schema = any> = MergeCoreCollection<
 		sender: DirectusUser<Schema> | string | null;
 		subject: string;
 		message: string | null;
-		collection: keyof CompleteSchema<Schema> | null;
+		collection: (AllCollections<Schema> | SingletonCollections<Schema>) | null;
 		item: string | null;
 	}
 >;

--- a/sdk/src/schema/notification.ts
+++ b/sdk/src/schema/notification.ts
@@ -1,4 +1,4 @@
-import type { AllCollections, MergeCoreCollection, SingletonCollections } from '../index.js';
+import type { AllCollections, MergeCoreCollection, SingletonCollections, StringLiteralUnion } from '../index.js';
 import type { DirectusUser } from './user.js';
 
 export type DirectusNotification<Schema = any> = MergeCoreCollection<
@@ -7,7 +7,7 @@ export type DirectusNotification<Schema = any> = MergeCoreCollection<
 	{
 		id: number;
 		timestamp: 'datetime' | null;
-		status: string | null;
+		status: StringLiteralUnion<'inbox' | 'archived'> | null;
 		recipient: DirectusUser<Schema> | string;
 		sender: DirectusUser<Schema> | string | null;
 		subject: string;

--- a/sdk/src/schema/notification.ts
+++ b/sdk/src/schema/notification.ts
@@ -5,7 +5,7 @@ export type DirectusNotification<Schema = any> = MergeCoreCollection<
 	Schema,
 	'directus_notifications',
 	{
-		id: string;
+		id: number;
 		timestamp: 'datetime' | null;
 		status: string | null;
 		recipient: DirectusUser<Schema> | string;

--- a/sdk/src/schema/notification.ts
+++ b/sdk/src/schema/notification.ts
@@ -1,4 +1,4 @@
-import type { AllCollections, MergeCoreCollection, SingletonCollections, StringLiteralUnion } from '../index.js';
+import type { CollectionName, MergeCoreCollection, StringLiteralUnion } from '../index.js';
 import type { DirectusUser } from './user.js';
 
 export type DirectusNotification<Schema = any> = MergeCoreCollection<
@@ -12,7 +12,7 @@ export type DirectusNotification<Schema = any> = MergeCoreCollection<
 		sender: DirectusUser<Schema> | string | null;
 		subject: string;
 		message: string | null;
-		collection: (AllCollections<Schema> | SingletonCollections<Schema>) | null;
+		collection: CollectionName<Schema> | null;
 		item: string | null;
 	}
 >;

--- a/sdk/src/schema/permission.ts
+++ b/sdk/src/schema/permission.ts
@@ -6,7 +6,7 @@ export type DirectusPermission<Schema = any> = MergeCoreCollection<
 	'directus_permissions',
 	{
 		id: number;
-		policy: DirectusPolicy<Schema> | string | null;
+		policy: DirectusPolicy<Schema> | string;
 		collection: keyof CompleteSchema<Schema>;
 		action: string;
 		permissions: Record<string, any> | null;

--- a/sdk/src/schema/permission.ts
+++ b/sdk/src/schema/permission.ts
@@ -1,4 +1,4 @@
-import type { AllCollections, MergeCoreCollection, SingletonCollections } from '../index.js';
+import type { CollectionName, MergeCoreCollection } from '../index.js';
 import type { DirectusPolicy } from './policy.js';
 
 export type DirectusPermission<Schema = any> = MergeCoreCollection<
@@ -7,7 +7,7 @@ export type DirectusPermission<Schema = any> = MergeCoreCollection<
 	{
 		id: number;
 		policy: DirectusPolicy<Schema> | string | null;
-		collection: AllCollections<Schema> | SingletonCollections<Schema>;
+		collection: CollectionName<Schema>;
 		action: string;
 		permissions: Record<string, any> | null;
 		validation: Record<string, any> | null;

--- a/sdk/src/schema/permission.ts
+++ b/sdk/src/schema/permission.ts
@@ -1,4 +1,4 @@
-import type { MergeCoreCollection } from '../index.js';
+import type { CompleteSchema, MergeCoreCollection } from '../index.js';
 import type { DirectusPolicy } from './policy.js';
 
 export type DirectusPermission<Schema = any> = MergeCoreCollection<
@@ -7,7 +7,7 @@ export type DirectusPermission<Schema = any> = MergeCoreCollection<
 	{
 		id: number;
 		policy: DirectusPolicy<Schema> | string | null;
-		collection: string; // TODO keyof complete schema
+		collection: keyof CompleteSchema<Schema>;
 		action: string;
 		permissions: Record<string, any> | null;
 		validation: Record<string, any> | null;

--- a/sdk/src/schema/permission.ts
+++ b/sdk/src/schema/permission.ts
@@ -6,7 +6,7 @@ export type DirectusPermission<Schema = any> = MergeCoreCollection<
 	'directus_permissions',
 	{
 		id: number;
-		policy: DirectusPolicy<Schema> | string;
+		policy: DirectusPolicy<Schema> | string | null;
 		collection: keyof CompleteSchema<Schema>;
 		action: string;
 		permissions: Record<string, any> | null;

--- a/sdk/src/schema/permission.ts
+++ b/sdk/src/schema/permission.ts
@@ -1,4 +1,4 @@
-import type { CollectionName, MergeCoreCollection } from '../index.js';
+import type { CollectionName, MergeCoreCollection, StringLiteralUnion } from '../index.js';
 import type { DirectusPolicy } from './policy.js';
 
 export type DirectusPermission<Schema = any> = MergeCoreCollection<
@@ -8,7 +8,7 @@ export type DirectusPermission<Schema = any> = MergeCoreCollection<
 		id: number;
 		policy: DirectusPolicy<Schema> | string | null;
 		collection: CollectionName<Schema>;
-		action: string;
+		action: StringLiteralUnion<'create' | 'read' | 'update' | 'delete' | 'share'>;
 		permissions: Record<string, any> | null;
 		validation: Record<string, any> | null;
 		presets: Record<string, any> | null;

--- a/sdk/src/schema/permission.ts
+++ b/sdk/src/schema/permission.ts
@@ -1,4 +1,4 @@
-import type { CompleteSchema, MergeCoreCollection } from '../index.js';
+import type { AllCollections, MergeCoreCollection, SingletonCollections } from '../index.js';
 import type { DirectusPolicy } from './policy.js';
 
 export type DirectusPermission<Schema = any> = MergeCoreCollection<
@@ -7,7 +7,7 @@ export type DirectusPermission<Schema = any> = MergeCoreCollection<
 	{
 		id: number;
 		policy: DirectusPolicy<Schema> | string | null;
-		collection: keyof CompleteSchema<Schema>;
+		collection: AllCollections<Schema> | SingletonCollections<Schema>;
 		action: string;
 		permissions: Record<string, any> | null;
 		validation: Record<string, any> | null;

--- a/sdk/src/schema/revision.ts
+++ b/sdk/src/schema/revision.ts
@@ -1,4 +1,4 @@
-import type { CompleteSchema, MergeCoreCollection } from '../index.js';
+import type { AllCollections, MergeCoreCollection, SingletonCollections } from '../index.js';
 import type { DirectusActivity } from './activity.js';
 import type { DirectusVersion } from './version.js';
 
@@ -8,7 +8,7 @@ export type DirectusRevision<Schema = any> = MergeCoreCollection<
 	{
 		id: number;
 		activity: DirectusActivity<Schema> | number;
-		collection: keyof CompleteSchema<Schema>;
+		collection: AllCollections<Schema> | SingletonCollections<Schema>;
 		item: string;
 		data: Record<string, any> | null;
 		delta: Record<string, any> | null;

--- a/sdk/src/schema/revision.ts
+++ b/sdk/src/schema/revision.ts
@@ -1,4 +1,4 @@
-import type { AllCollections, MergeCoreCollection, SingletonCollections } from '../index.js';
+import type { CollectionName, MergeCoreCollection } from '../index.js';
 import type { DirectusActivity } from './activity.js';
 import type { DirectusVersion } from './version.js';
 
@@ -8,7 +8,7 @@ export type DirectusRevision<Schema = any> = MergeCoreCollection<
 	{
 		id: number;
 		activity: DirectusActivity<Schema> | number;
-		collection: AllCollections<Schema> | SingletonCollections<Schema>;
+		collection: CollectionName<Schema>;
 		item: string;
 		data: Record<string, any> | null;
 		delta: Record<string, any> | null;

--- a/sdk/src/schema/revision.ts
+++ b/sdk/src/schema/revision.ts
@@ -1,4 +1,4 @@
-import type { MergeCoreCollection } from '../index.js';
+import type { CompleteSchema, MergeCoreCollection } from '../index.js';
 import type { DirectusActivity } from './activity.js';
 import type { DirectusVersion } from './version.js';
 
@@ -8,7 +8,7 @@ export type DirectusRevision<Schema = any> = MergeCoreCollection<
 	{
 		id: number;
 		activity: DirectusActivity<Schema> | number;
-		collection: string; // TODO keyof complete schema
+		collection: keyof CompleteSchema<Schema>;
 		item: string;
 		data: Record<string, any> | null;
 		delta: Record<string, any> | null;


### PR DESCRIPTION
## What's Changed

- `directus_notifications`: `id` typed `number` (was `string`)<sup>1</sup>
  - The [migration in 2021](https://github.com/directus/directus/blob/main/api/src/database/migrations/20211118A-add-notifications.ts#L8-L10) sets `status` with a default (but nullable) and `timestamp` as notNullable()
  - The [migration in 2022](https://github.com/directus/directus/blob/main/api/src/database/migrations/20220801A-update-notifications-timestamp-column.ts#L8) sets `timestamp` to nullable
- `directus_permissions`: `policy` stays nullable; added missing `system?: true`
  - `directus_permissions.policy` is [`NOT NULL`](https://github.com/directus/directus/blob/main/api/src/database/migrations/20240806A-permissions-policies.ts#L166-L167) at the DB level, but [`default-permission.ts`](https://github.com/directus/directus/blob/main/api/src/permissions/utils/default-permission.ts) builds a synthetic deny-all fallback object with `policy: null`
  - [`PermissionsService.readByQuery`](https://github.com/directus/directus/blob/main/api/src/services/permissions.ts#L40-L43) routes results through [`withAppMinimalPermissions`](https://github.com/directus/directus/blob/main/api/src/permissions/lib/with-app-minimal-permissions.ts#L1-L20), which injects synthetic `system: true` rows into what a GET `/permissions` response can return; the internal [`Permission` type](https://github.com/directus/directus/blob/main/packages/types/src/permissions.ts#L15) already declares `system?: true`
- `directus_extensions`: `schema` expanded to match `ApiOutput.schema`; `ExtensionSandboxOptions` fields corrected to optional
  - [`ApiOutput.schema`](https://github.com/directus/directus/blob/main/packages/types/src/extensions/app-extension-config.ts#L74-L79) is typed `Partial<Extension> | BundleExtensionEntry | null`
  - The [zod schema](https://github.com/directus/directus/blob/main/packages/types/src/extensions/app-extension-config.ts#L52-L59) marks both `enabled` and `requestedScopes` optional
- `directus_fields`:
  - `schema` is now nullable; `schema.schema`, `schema.comment`, `schema.foreign_key_schema` marked optional; `generation_expression` corrected to `string | null` and optional
    - [`FieldsService`](https://github.com/directus/directus/blob/main/api/src/services/fields.ts#L218) (and [again here](https://github.com/directus/directus/blob/main/api/src/services/fields.ts#L353)) returns `schema: null` when the field type is `alias`
    - `comment`, `foreign_key_schema`, `generation_expression`, and `schema.schema` match the canonical [`Column` interface](https://github.com/directus/directus/blob/main/packages/schema/src/types/column.ts), which marks these optional (due to DB limitations noted in comments)
  - `FieldMetaConditionType`: resolved the TODOs + addressed missing and drifted fields
    - The internal [`Condition` type](https://github.com/directus/directus/blob/main/packages/types/src/fields.ts#L88) already has these fields optional
    - [`applyConditions`](https://github.com/directus/directus/blob/main/app/src/utils/apply-conditions.ts#L29-L41) only merges whichever key is actually set on the matching condition, `clear_hidden_value_on_save` included
    - Condition `options` [renders whatever interface the field uses](https://github.com/directus/directus/blob/main/app/src/modules/settings/routes/data-model/field-detail/field-detail-advanced/field-detail-advanced-conditions.vue#L119-L129)
  - `FieldMetaConditionType['rule']` typed as `FieldMetaConditionRule` instead of `unknown`<sup>2</sup>
    - Existing SDK filter type already mirrors [`@directus/types`' `Filter`](https://github.com/directus/directus/blob/main/packages/types/src/filter.ts#L37)
- `directus_collections`: added missing `system?: true`; `accountability`/`collapse`/`status` changed from bare `string` to `StringLiteralUnion<...>`
  - `system` isn't a real column. [`CollectionsService.readByQuery`](https://github.com/directus/directus/blob/main/api/src/services/collections.ts#L328-L341) (the `GET /collections` path) never includes it for regular collections; only [`system-data`'s injected rows](https://github.com/directus/directus/blob/main/packages/system-data/src/collections/index.ts#L9) set it, and always to `true`. So for what the API actually returns, `system?: true` is the only valid typing
  - `@directus/types`' `CollectionMeta.system` stays `boolean | null` on purpose, because that type also covers schema diff/apply, which does construct real `false` values (a different code path and shape, not just a GET response)
  - The [`accountability`](https://github.com/directus/directus/blob/main/api/src/database/migrations/20210416A-add-collections-accountability.ts#L5), [`collapse`](https://github.com/directus/directus/blob/main/api/src/database/migrations/20210924A-add-collection-organization.ts#L15), and [`status`](https://github.com/directus/directus/blob/main/api/src/database/migrations/20260507A-add-licensing.ts#L10) columns are all plain, unconstrained `string` columns; the fixed value lists are UI convention only
- Collection-name FK fields (`notification.ts`, `permission.ts`, `field.ts`, `collection.ts`, `revision.ts`, `activity.ts`) narrowed from bare `string` to `CollectionName<Schema>`
- `deleteCollection` now has a `throwIfEmpty` guard, matching [every sibling command, which already had one](https://github.com/directus/directus/blob/main/sdk/src/rest/commands/read/collections.ts#L32)
- `updateField`'s empty-collection error message fixed (was the wrong copy-pasted message: `'Keys cannot be empty'`)
- `readActivity`, `{read, update, delete}Permission`, and `readRevision` no longer have `String(key)` casts (clean up in #27970 was incomplete).

## Tested Scenarios

- <sup>2</sup>Tests for `FieldMetaConditionRule` were added to make sure I captured the TODO's with regression tests

## Review Notes / Questions / Concerns

- Mostly type-only; the `throwIfEmpty` fix above is the only runtime behavior change (backward compatible: `string`/`unknown[]` callers unaffected)
- `Permission.policy` (`@directus/types`/`@directus/sdk`) stays nullable on purpose: the DB column is `NOT NULL`, but `default-permission.ts`'s in-memory deny-all fallback sets `policy: null`
- <sup>1</sup>Fixed in [#27970](https://github.com/directus/directus/pull/27970#discussion_r4030904074); extended here to `permissions`/`activity`/`revisions`, which were missed there.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [x] SDK (`@directus/sdk`) updated to reflect the changes
- [x] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

- Fixes directus/directus#28065
