### PR TITLE
Fix duplicate AI translation rows 🤖🤖🤖

### DIFF
--- a/.changeset/slow-plums-translate.md
+++ b/.changeset/slow-plums-translate.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed AI translations creating duplicate target language rows when streaming multiple fields.

--- a/app/src/interfaces/translations/use-translation-job.test.ts
+++ b/app/src/interfaces/translations/use-translation-job.test.ts
@@ -140,6 +140,21 @@ describe('useTranslationJob', () => {
 		expect(applyTranslatedFields).toHaveBeenCalledWith({ title: 'Bonjour' }, 'es');
 	});
 
+	test('applies fields from the same stream snapshot atomically', async () => {
+		const { job, applyTranslatedFields } = createJob();
+
+		mockFetchStream('{"title":"Bonjour","slug":"bonjour","description":"Corps"}');
+		job.start(multiFieldConfig);
+		await flushPromises();
+
+		expect(applyTranslatedFields).toHaveBeenCalledTimes(1);
+
+		expect(applyTranslatedFields).toHaveBeenCalledWith(
+			{ title: 'Bonjour', slug: 'bonjour', description: 'Corps' },
+			'fr',
+		);
+	});
+
 	test('cancel aborts requests and resets state', async () => {
 		const { job, applyTranslatedFields } = createJob();
 
@@ -429,8 +444,7 @@ describe('useTranslationJob', () => {
 		controller!.enqueue(encoder.encode('{"title":"Bonjour","content":"<p>Bon'));
 		await flushPromises();
 
-		expect(applyTranslatedFields).toHaveBeenCalledWith({ title: 'Bonjour' }, 'fr');
-		expect(applyTranslatedFields).toHaveBeenCalledWith({ content: '<p>Bon' }, 'fr');
+		expect(applyTranslatedFields).toHaveBeenCalledWith({ title: 'Bonjour', content: '<p>Bon' }, 'fr');
 
 		controller!.enqueue(encoder.encode('jour le monde</p>"}'));
 		controller!.close();

--- a/app/src/interfaces/translations/use-translation-job.ts
+++ b/app/src/interfaces/translations/use-translation-job.ts
@@ -285,12 +285,21 @@ export function useTranslationJob(options: {
 			const appliedFields = new Set<string>();
 			const streamedFieldValues = new Map<string, string>();
 
-			function applyField(key: string, value: string) {
-				if (streamedFieldValues.get(key) === value) return;
+			function applyFields(fields: Record<string, unknown>) {
+				const changedFields = Object.fromEntries(
+					Object.entries(fields).filter(
+						([key, value]) => typeof value === 'string' && streamedFieldValues.get(key) !== value,
+					),
+				) as Record<string, string>;
 
-				const normalized = normalizeAiTranslatedFields({ [key]: value }, selectedFieldDefinitions);
+				if (Object.keys(changedFields).length === 0) return;
+
+				const normalized = normalizeAiTranslatedFields(changedFields, selectedFieldDefinitions);
 				options.applyTranslatedFields(normalized, langCode);
-				streamedFieldValues.set(key, value);
+
+				for (const [key, value] of Object.entries(changedFields)) {
+					streamedFieldValues.set(key, value);
+				}
 			}
 
 			while (true) {
@@ -310,17 +319,12 @@ export function useTranslationJob(options: {
 						const obj = partialObject as Record<string, unknown>;
 						const receivedKeys = Object.keys(obj);
 						const completedKeys = receivedKeys.slice(0, -1);
-						const activeKey = receivedKeys[receivedKeys.length - 1];
+						applyFields(obj);
 
 						for (const key of completedKeys) {
 							if (!appliedFields.has(key) && typeof obj[key] === 'string') {
-								applyField(key, obj[key] as string);
 								appliedFields.add(key);
 							}
-						}
-
-						if (activeKey && typeof obj[activeKey] === 'string') {
-							applyField(activeKey, obj[activeKey] as string);
 						}
 
 						if (completedKeys.length > 0) {
@@ -334,12 +338,9 @@ export function useTranslationJob(options: {
 
 					if (finalObject && typeof finalObject === 'object' && !Array.isArray(finalObject)) {
 						const obj = finalObject as Record<string, string>;
+						applyFields(obj);
 
 						for (const key of Object.keys(obj)) {
-							if (typeof obj[key] === 'string') {
-								applyField(key, obj[key] as string);
-							}
-
 							appliedFields.add(key);
 						}
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -298,3 +298,4 @@
 - suhailopensource
 - Deluvio
 - Aniket-a14
+- xmflsct


### PR DESCRIPTION
## What’s Changed

* Applied each parsed streamed JSON snapshot as one translation update instead of yielding a Vue render cycle between individual fields.
* Preserved incremental streaming for later snapshots, including long-form rich-text fields.
* Added a regression test proving multiple fields from one snapshot are applied atomically, preventing duplicate target-language relation rows and Vue reconciliation errors.
* Added the required patch changeset for `@directus/app`.

## Root Cause

The previous implementation called `applyTranslatedFields` once per field and awaited `nextTick()` between calls. When the target-language relation was missing, Vue could reconcile the newly created row between those calls and crash while patching the relation DOM. Applying one snapshot in a single callback keeps the relation mutation atomic without coordinating against Vue’s renderer.

## Tested Scenarios

* Focused `useTranslationJob` suite: 16 tests passed.
* ESLint and Prettier passed for the changed files.
* Git diff validation passed.
* Terra’s Directus 12.2 custom image patch tests passed, and the compiled patched bundle parsed successfully.

## Review Notes / Questions / Concerns

* Streaming remains incremental between reader snapshots; fields present in the same snapshot are applied together.
* This fixes the missing target-language relation path without changing the translation data contract.

## Checklist

> Leave unchecked where not applicable

- [X] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](<https://github.com/directus/openapi>)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes directus/directus#28073