### PR TITLE
Show collection name alongside the rendered display template in item headers

### DIFF
--- a/.changeset/wide-cycles-admire.md
+++ b/.changeset/wide-cycles-admire.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Added the collection name appended to display template in item and drawer headers

--- a/app/src/modules/content/routes/item.vue
+++ b/app/src/modules/content/routes/item.vue
@@ -1074,6 +1074,7 @@ function useAutoSwitchToDraft() {
 					:collection="collectionInfo.collection"
 					:item="templateData"
 					:template="collectionInfo.meta!.display_template"
+					show-collection-name
 				/>
 			</h1>
 		</template>

--- a/app/src/views/private/components/overlay-item.vue
+++ b/app/src/views/private/components/overlay-item.vue
@@ -651,7 +651,12 @@ function popoverClickOutsideMiddleware(e: Event) {
 			<VSkeletonLoader v-if="loading || templateDataLoading" class="title-loader" type="text" />
 
 			<h1 v-else class="type-title">
-				<RenderTemplate :collection="templateCollection?.collection" :item="templateData" :template="template" />
+				<RenderTemplate
+					:collection="templateCollection?.collection"
+					:item="templateData"
+					:template="template"
+					show-collection-name
+				/>
 			</h1>
 		</template>
 

--- a/app/src/views/private/components/render-template.test.ts
+++ b/app/src/views/private/components/render-template.test.ts
@@ -1,0 +1,110 @@
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createI18n } from 'vue-i18n';
+import RenderTemplate from './render-template.vue';
+
+const mockCollectionsStore = vi.hoisted(() => ({
+	getCollection: vi.fn(),
+}));
+
+const mockFieldsStore = vi.hoisted(() => ({
+	getField: vi.fn(),
+}));
+
+const mockRelationsStore = vi.hoisted(() => ({
+	getRelationsForField: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock('@/stores/collections', () => ({
+	useCollectionsStore: () => mockCollectionsStore,
+}));
+
+vi.mock('@/stores/fields', () => ({
+	useFieldsStore: () => mockFieldsStore,
+}));
+
+vi.mock('@/stores/relations', () => ({
+	useRelationsStore: () => mockRelationsStore,
+}));
+
+function mountRenderTemplate(props: Record<string, any> = {}, messages: Record<string, any> = {}) {
+	const i18n = createI18n({
+		legacy: false,
+		missingWarn: false,
+		locale: 'en-US',
+		messages: { 'en-US': messages },
+	});
+
+	return mount(RenderTemplate, {
+		props: {
+			collection: 'projects',
+			item: { title: 'Acme redesign' },
+			template: '{{ title }}',
+			...props,
+		},
+		global: {
+			plugins: [i18n],
+		},
+	});
+}
+
+describe('collection name', () => {
+	beforeEach(() => {
+		mockCollectionsStore.getCollection.mockReturnValue({ collection: 'projects', name: 'Projects' });
+		// Falling back to the raw value keeps the assertions off the display extensions
+		mockFieldsStore.getField.mockReturnValue(null);
+	});
+
+	it('does not render the collection name by default', () => {
+		const wrapper = mountRenderTemplate();
+
+		expect(wrapper.find('.collection-name').exists()).toBe(false);
+		expect(wrapper.find('.vertical-aligner').exists()).toBe(true);
+		expect(wrapper.classes()).not.toContain('has-collection-name');
+		expect(wrapper.text()).toBe('Acme redesign');
+	});
+
+	it('renders the collection name before the template when enabled', () => {
+		const wrapper = mountRenderTemplate({ showCollectionName: true });
+
+		expect(wrapper.find('.collection-name').text()).toBe('Projects:');
+		// The separator is a non-breaking space, so the prefix never wraps away from the value
+		expect(wrapper.text()).toBe('Projects:\u00a0Acme redesign');
+	});
+
+	it('replaces the vertical aligner with the collection name', () => {
+		const wrapper = mountRenderTemplate({ showCollectionName: true });
+
+		expect(wrapper.find('.vertical-aligner').exists()).toBe(false);
+		expect(wrapper.classes()).toContain('has-collection-name');
+	});
+
+	it('prefers the singular collection name translation over the collection name', () => {
+		const wrapper = mountRenderTemplate(
+			{ showCollectionName: true },
+			{ collection_names_singular: { projects: 'Project' } },
+		);
+
+		expect(wrapper.find('.collection-name').text()).toBe('Project:');
+	});
+
+	it('does not render the collection name without a collection', () => {
+		const wrapper = mountRenderTemplate({
+			collection: undefined,
+			showCollectionName: true,
+			fields: [{ field: 'title', type: 'string' }],
+		});
+
+		expect(wrapper.find('.collection-name').exists()).toBe(false);
+		expect(wrapper.text()).toBe('Acme redesign');
+	});
+
+	it('does not render the collection name for an unknown collection', () => {
+		mockCollectionsStore.getCollection.mockReturnValue(null);
+
+		const wrapper = mountRenderTemplate({ showCollectionName: true });
+
+		expect(wrapper.find('.collection-name').exists()).toBe(false);
+		expect(wrapper.text()).toBe('Acme redesign');
+	});
+});

--- a/app/src/views/private/components/render-template.vue
+++ b/app/src/views/private/components/render-template.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import type { DeepPartial, Field } from '@directus/types';
 import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 import ValueNull from './value-null.vue';
 import VErrorBoundary from '@/components/v-error-boundary.vue';
 import { useExtension } from '@/composables/use-extension';
+import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
 import { useRelationsStore } from '@/stores/relations';
 import { getDefaultDisplayForType } from '@/utils/get-default-display-for-type';
@@ -17,15 +19,30 @@ const props = withDefaults(
 		fields?: DeepPartial<Field>[];
 		item?: Record<string, any>;
 		direction?: string;
+		showCollectionName?: boolean;
 	}>(),
 	{
 		fields: () => [],
 		item: () => ({}),
+		showCollectionName: false,
 	},
 );
 
+const { t, te } = useI18n();
+
+const collectionsStore = useCollectionsStore();
 const fieldsStore = useFieldsStore();
 const relationsStore = useRelationsStore();
+
+const collectionName = computed(() => {
+	if (!props.showCollectionName || !props.collection) return null;
+
+	if (te(`collection_names_singular.${props.collection}`)) {
+		return t(`collection_names_singular.${props.collection}`);
+	}
+
+	return collectionsStore.getCollection(props.collection)?.name ?? null;
+});
 
 const regex = /({{.*?}})/g;
 
@@ -140,8 +157,9 @@ const parts = computed(() =>
 </script>
 
 <template>
-	<div class="render-template">
-		<span class="vertical-aligner" />
+	<div class="render-template" :class="{ 'has-collection-name': collectionName }">
+		<span v-if="!collectionName" class="vertical-aligner" />
+		<span v-else class="collection-name">{{ collectionName }}:&nbsp;</span>
 		<template v-for="(part, index) in parts" :key="index">
 			<template v-for="(subPart, subIndex) in part" :key="subIndex">
 				<VErrorBoundary>
@@ -192,6 +210,14 @@ const parts = computed(() =>
 
 	.render-template {
 		display: inline;
+	}
+
+	&.has-collection-name > * {
+		vertical-align: baseline;
+	}
+
+	.collection-name {
+		color: var(--theme--foreground-subdued);
 	}
 }
 


### PR DESCRIPTION
## What's Changed

- Added a `showCollectionName` prop to `RenderTemplate`. When enabled, and a `collection` is passed, the collection name is rendered in front of the template output as `Collection name: <rendered template>`, in the subdued foreground color so the template value keeps the visual emphasis.
- The name resolves from the `collection_names_singular.<collection>` translation key when one exists (matching the existing header title logic in `item.vue`), falling back to the collection's display name from the collections store. No name is rendered when the collection is unknown or no `collection` prop is passed.
- The prefix takes the place of the `.vertical-aligner` element, whose full-height box centers children rather than letting a text prefix and the rendered template share a baseline. In that case the children align on the baseline instead.
- Enabled the prop on the item page header (`item.vue`) and the drawer/overlay item header (`overlay-item.vue`), which previously showed only the rendered display template with no indication of which collection the item belonged to.

The prop defaults to `false`, so every other consumer (tables, cards, kanban, map, related-values, dropdowns, list interfaces) renders exactly as before.

## Tested Scenarios

- Item page header with a display template set on the collection: shows `Collection name: <template>`, truncating with an ellipsis as one unit when the header is narrow.
- Item page header with no display template: unchanged, still falls back to the `Editing item in <Collection>` title.
- Drawer item header with a display template: same prefix, including when opened for a related collection (`templateCollection`).
- Singleton header: unchanged, it does not go through `RenderTemplate`.
- Collection with a translated singular name: uses the singular form rather than the (usually plural) collection name.
- Nested `RenderTemplate` usage (`related-values`, `translations` displays) and table/card/kanban layouts: no prefix, unchanged rendering.
- `pnpm typecheck` in `app`: error set identical to the `main` baseline (the touched files already have pre-existing errors on `main`; no new ones).
- Full `app` test suite passes (329 files). Worth noting because `RenderTemplate` now calls `useI18n()`, which would break any suite mounting a consumer without the i18n plugin — none do.

## Review Notes / Questions / Concerns

- Singular vs. plural name for the prefix: this uses the singular translation when available, since `Project: Acme redesign` reads better than `Projects: Acme redesign`. Collections without that translation key fall back to the stored name, which is typically plural. Happy to always use the plural stored name if that inconsistency is worse than the wording.
- Separator is a hardcoded `:` followed by a non-breaking space, not a translatable string. Let me know if that should go through i18n.
- The drawer header change is in its own commit (`561c05f`) so it can be dropped if we want the fix scoped to the item page header only.
- This supersedes #27913, which hardcoded the prefix in `item.vue` instead of putting it behind an opt-in prop on `RenderTemplate`.
- The issue also suggests the collection name could sit above or below the title in smaller text (as in v11) rather than inline. This PR does the inline variant; say the word if the stacked layout is preferred.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes cms-2652
