### PR TITLE
Add from name field to send email flow operations

### DIFF
--- a/.changeset/mail-operation-from-name.md
+++ b/.changeset/mail-operation-from-name.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+'@directus/app': patch
+---
+
+Added an optional From Name option to the Send Email flow operation

--- a/api/src/operations/mail/index.test.ts
+++ b/api/src/operations/mail/index.test.ts
@@ -1,3 +1,4 @@
+import { useEnv } from '@directus/env';
 import knex from 'knex';
 import { MockClient } from 'knex-mock-client';
 import { beforeEach, describe, expect, type MockInstance, test, vi } from 'vitest';
@@ -164,5 +165,40 @@ describe('Operations / Mail', () => {
 				replyTo: options.replyTo,
 			}),
 		);
+	});
+
+	test('use fromName as sender name with the EMAIL_FROM address', async () => {
+		const options: Options = {
+			to: 'test@example.com',
+			subject: 'Test',
+			type: 'wysiwyg',
+			body: 'test body',
+			fromName: 'Acme Support',
+		};
+
+		await config.handler(options, mockOperationContext);
+
+		expect(mailServiceSendSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				from: { name: 'Acme Support', address: useEnv()['EMAIL_FROM'] },
+			}),
+		);
+	});
+
+	test.each([
+		{ scenario: 'unset', fromName: {} },
+		{ scenario: 'whitespace only', fromName: { fromName: '   ' } },
+	])('omit sender when fromName is $scenario', async ({ fromName }) => {
+		const options: Options = {
+			to: 'test@example.com',
+			subject: 'Test',
+			type: 'wysiwyg',
+			body: 'test body',
+			...fromName,
+		};
+
+		await config.handler(options, mockOperationContext);
+
+		expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ from: expect.anything() }));
 	});
 });

--- a/api/src/operations/mail/index.test.ts
+++ b/api/src/operations/mail/index.test.ts
@@ -6,198 +6,204 @@ import * as mdUtil from '../../utils/md.js';
 import type { Options } from './index.js';
 import config from './index.js';
 
+// Pin EMAIL_FROM so a local .env can't change what the sender address is asserted against
+vi.mock('@directus/env', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@directus/env')>();
+  return { ...actual, useEnv: () => ({ ...actual.useEnv(), EMAIL_FROM: 'no-reply@example.com' }) };
+});
+
 describe('Operations / Mail', () => {
-	let mockOperationContext: any;
-	let mailServiceSendSpy: MockInstance;
-	let mdSpy: MockInstance;
+  let mockOperationContext: any;
+  let mailServiceSendSpy: MockInstance;
+  let mdSpy: MockInstance;
 
-	beforeEach(async () => {
-		mockOperationContext = {
-			accountability: null,
-			database: vi.mocked(knex.default({ client: MockClient })),
-			getSchema: vi.fn().mockResolvedValue({}),
-			flow: {},
-		};
+  beforeEach(async () => {
+    mockOperationContext = {
+      accountability: null,
+      database: vi.mocked(knex.default({ client: MockClient })),
+      getSchema: vi.fn().mockResolvedValue({}),
+      flow: {},
+    };
 
-		mailServiceSendSpy = vi.spyOn(MailService.prototype, 'send').mockResolvedValue(true);
-		mdSpy = vi.spyOn(mdUtil, 'md');
-	});
+    mailServiceSendSpy = vi.spyOn(MailService.prototype, 'send').mockResolvedValue(true);
+    mdSpy = vi.spyOn(mdUtil, 'md');
+  });
 
-	test('use base template when type is template but no template was selected', async () => {
-		const options: Options = {
-			to: 'test@example.com',
-			subject: 'Test',
-			type: 'template',
-		};
+  test('use base template when type is template but no template was selected', async () => {
+    const options: Options = {
+      to: 'test@example.com',
+      subject: 'Test',
+      type: 'template',
+    };
 
-		await config.handler(options, mockOperationContext);
+    await config.handler(options, mockOperationContext);
 
-		expect(mailServiceSendSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ to: options.to, subject: options.subject, template: { name: 'base', data: {} } }),
-		);
+    expect(mailServiceSendSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ to: options.to, subject: options.subject, template: { name: 'base', data: {} } }),
+    );
 
-		expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ html: expect.any(String) }));
-	});
+    expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ html: expect.any(String) }));
+  });
 
-	test('use custom template when type is template and custom template was selected', async () => {
-		const options: Options = {
-			to: 'test@example.com',
-			subject: 'Test',
-			type: 'template',
-			template: 'custom',
-		};
+  test('use custom template when type is template and custom template was selected', async () => {
+    const options: Options = {
+      to: 'test@example.com',
+      subject: 'Test',
+      type: 'template',
+      template: 'custom',
+    };
 
-		await config.handler(options, mockOperationContext);
+    await config.handler(options, mockOperationContext);
 
-		expect(mailServiceSendSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ to: options.to, subject: options.subject, template: { name: 'custom', data: {} } }),
-		);
+    expect(mailServiceSendSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ to: options.to, subject: options.subject, template: { name: 'custom', data: {} } }),
+    );
 
-		expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ html: expect.any(String) }));
-	});
+    expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ html: expect.any(String) }));
+  });
 
-	test('pass custom data with template when type is template and data is included', async () => {
-		const options: Options = {
-			to: 'test@example.com',
-			subject: 'Test',
-			type: 'template',
-			data: { key: 'value' },
-		};
+  test('pass custom data with template when type is template and data is included', async () => {
+    const options: Options = {
+      to: 'test@example.com',
+      subject: 'Test',
+      type: 'template',
+      data: { key: 'value' },
+    };
 
-		await config.handler(options, mockOperationContext);
+    await config.handler(options, mockOperationContext);
 
-		expect(mailServiceSendSpy).toHaveBeenCalledWith(
-			expect.objectContaining({
-				to: options.to,
-				subject: options.subject,
-				template: { name: 'base', data: { key: 'value' } },
-			}),
-		);
+    expect(mailServiceSendSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: options.to,
+        subject: options.subject,
+        template: { name: 'base', data: { key: 'value' } },
+      }),
+    );
 
-		expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ html: expect.any(String) }));
-	});
+    expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ html: expect.any(String) }));
+  });
 
-	test('pass custom data with template when type is template, custom template was selected and data is included', async () => {
-		const options: Options = {
-			to: 'test@example.com',
-			subject: 'Test',
-			type: 'template',
-			template: 'custom',
-			data: { key: 'value' },
-		};
+  test('pass custom data with template when type is template, custom template was selected and data is included', async () => {
+    const options: Options = {
+      to: 'test@example.com',
+      subject: 'Test',
+      type: 'template',
+      template: 'custom',
+      data: { key: 'value' },
+    };
 
-		await config.handler(options, mockOperationContext);
+    await config.handler(options, mockOperationContext);
 
-		expect(mailServiceSendSpy).toHaveBeenCalledWith(
-			expect.objectContaining({
-				to: options.to,
-				subject: options.subject,
-				template: { name: 'custom', data: { key: 'value' } },
-			}),
-		);
+    expect(mailServiceSendSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: options.to,
+        subject: options.subject,
+        template: { name: 'custom', data: { key: 'value' } },
+      }),
+    );
 
-		expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ html: expect.any(String) }));
-	});
+    expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ html: expect.any(String) }));
+  });
 
-	test('use body as is when type is wysiwyg', async () => {
-		const options: Options = {
-			to: 'test@example.com',
-			subject: 'Test',
-			type: 'wysiwyg',
-			body: 'test body',
-		};
+  test('use body as is when type is wysiwyg', async () => {
+    const options: Options = {
+      to: 'test@example.com',
+      subject: 'Test',
+      type: 'wysiwyg',
+      body: 'test body',
+    };
 
-		await config.handler(options, mockOperationContext);
+    await config.handler(options, mockOperationContext);
 
-		expect(mailServiceSendSpy).toHaveBeenCalledWith(
-			expect.objectContaining({
-				to: options.to,
-				subject: options.subject,
-				html: options.body,
-			}),
-		);
+    expect(mailServiceSendSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: options.to,
+        subject: options.subject,
+        html: options.body,
+      }),
+    );
 
-		expect(mdSpy).not.toHaveBeenCalled();
-	});
+    expect(mdSpy).not.toHaveBeenCalled();
+  });
 
-	test('use md() on body when type is markdown', async () => {
-		const options: Options = {
-			to: 'test@example.com',
-			subject: 'Test',
-			type: 'markdown',
-			body: 'test body',
-		};
+  test('use md() on body when type is markdown', async () => {
+    const options: Options = {
+      to: 'test@example.com',
+      subject: 'Test',
+      type: 'markdown',
+      body: 'test body',
+    };
 
-		await config.handler(options, mockOperationContext);
+    await config.handler(options, mockOperationContext);
 
-		expect(mailServiceSendSpy).toHaveBeenCalledWith(
-			expect.objectContaining({
-				to: options.to,
-				subject: options.subject,
-				html: '<p>test body</p>\n',
-			}),
-		);
+    expect(mailServiceSendSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: options.to,
+        subject: options.subject,
+        html: '<p>test body</p>\n',
+      }),
+    );
 
-		expect(mdSpy).toHaveBeenCalled();
-	});
+    expect(mdSpy).toHaveBeenCalled();
+  });
 
-	test('include cc, bcc, and replyTo in email options', async () => {
-		const options: Options = {
-			to: 'test@example.com',
-			subject: 'Test',
-			type: 'wysiwyg',
-			body: 'test body',
-			cc: 'cc@example.com',
-			bcc: 'bcc@example.com',
-			replyTo: 'replyto@example.com',
-		};
+  test('include cc, bcc, and replyTo in email options', async () => {
+    const options: Options = {
+      to: 'test@example.com',
+      subject: 'Test',
+      type: 'wysiwyg',
+      body: 'test body',
+      cc: 'cc@example.com',
+      bcc: 'bcc@example.com',
+      replyTo: 'replyto@example.com',
+    };
 
-		await config.handler(options, mockOperationContext);
+    await config.handler(options, mockOperationContext);
 
-		expect(mailServiceSendSpy).toHaveBeenCalledWith(
-			expect.objectContaining({
-				to: options.to,
-				subject: options.subject,
-				html: options.body,
-				cc: options.cc,
-				bcc: options.bcc,
-				replyTo: options.replyTo,
-			}),
-		);
-	});
+    expect(mailServiceSendSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: options.to,
+        subject: options.subject,
+        html: options.body,
+        cc: options.cc,
+        bcc: options.bcc,
+        replyTo: options.replyTo,
+      }),
+    );
+  });
 
-	test('use fromName as sender name with the EMAIL_FROM address', async () => {
-		const options: Options = {
-			to: 'test@example.com',
-			subject: 'Test',
-			type: 'wysiwyg',
-			body: 'test body',
-			fromName: 'Acme Support',
-		};
+  test('use fromName as sender name with the EMAIL_FROM address', async () => {
+    const options: Options = {
+      to: 'test@example.com',
+      subject: 'Test',
+      type: 'wysiwyg',
+      body: 'test body',
+      fromName: 'Acme Support',
+    };
 
-		await config.handler(options, mockOperationContext);
+    await config.handler(options, mockOperationContext);
 
-		expect(mailServiceSendSpy).toHaveBeenCalledWith(
-			expect.objectContaining({
-				from: { name: 'Acme Support', address: 'no-reply@example.com' },
-			}),
-		);
-	});
+    expect(mailServiceSendSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: { name: 'Acme Support', address: 'no-reply@example.com' },
+      }),
+    );
+  });
 
-	test.each([
-		{ scenario: 'unset', fromName: {} },
-		{ scenario: 'whitespace only', fromName: { fromName: '   ' } },
-	])('omit sender when fromName is $scenario', async ({ fromName }) => {
-		const options: Options = {
-			to: 'test@example.com',
-			subject: 'Test',
-			type: 'wysiwyg',
-			body: 'test body',
-			...fromName,
-		};
+  test.each([
+    { scenario: 'unset', fromName: {} },
+    { scenario: 'whitespace only', fromName: { fromName: '   ' } },
+  ])('omit sender when fromName is $scenario', async ({ fromName }) => {
+    const options: Options = {
+      to: 'test@example.com',
+      subject: 'Test',
+      type: 'wysiwyg',
+      body: 'test body',
+      ...fromName,
+    };
 
-		await config.handler(options, mockOperationContext);
+    await config.handler(options, mockOperationContext);
 
-		expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ from: expect.anything() }));
-	});
+    expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ from: expect.anything() }));
+  });
 });

--- a/api/src/operations/mail/index.test.ts
+++ b/api/src/operations/mail/index.test.ts
@@ -8,202 +8,202 @@ import config from './index.js';
 
 // Pin EMAIL_FROM so a local .env can't change what the sender address is asserted against
 vi.mock('@directus/env', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@directus/env')>();
-  return { ...actual, useEnv: () => ({ ...actual.useEnv(), EMAIL_FROM: 'no-reply@example.com' }) };
+	const actual = await importOriginal<typeof import('@directus/env')>();
+	return { ...actual, useEnv: () => ({ ...actual.useEnv(), EMAIL_FROM: 'no-reply@example.com' }) };
 });
 
 describe('Operations / Mail', () => {
-  let mockOperationContext: any;
-  let mailServiceSendSpy: MockInstance;
-  let mdSpy: MockInstance;
+	let mockOperationContext: any;
+	let mailServiceSendSpy: MockInstance;
+	let mdSpy: MockInstance;
 
-  beforeEach(async () => {
-    mockOperationContext = {
-      accountability: null,
-      database: vi.mocked(knex.default({ client: MockClient })),
-      getSchema: vi.fn().mockResolvedValue({}),
-      flow: {},
-    };
+	beforeEach(async () => {
+		mockOperationContext = {
+			accountability: null,
+			database: vi.mocked(knex.default({ client: MockClient })),
+			getSchema: vi.fn().mockResolvedValue({}),
+			flow: {},
+		};
 
-    mailServiceSendSpy = vi.spyOn(MailService.prototype, 'send').mockResolvedValue(true);
-    mdSpy = vi.spyOn(mdUtil, 'md');
-  });
+		mailServiceSendSpy = vi.spyOn(MailService.prototype, 'send').mockResolvedValue(true);
+		mdSpy = vi.spyOn(mdUtil, 'md');
+	});
 
-  test('use base template when type is template but no template was selected', async () => {
-    const options: Options = {
-      to: 'test@example.com',
-      subject: 'Test',
-      type: 'template',
-    };
+	test('use base template when type is template but no template was selected', async () => {
+		const options: Options = {
+			to: 'test@example.com',
+			subject: 'Test',
+			type: 'template',
+		};
 
-    await config.handler(options, mockOperationContext);
+		await config.handler(options, mockOperationContext);
 
-    expect(mailServiceSendSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ to: options.to, subject: options.subject, template: { name: 'base', data: {} } }),
-    );
+		expect(mailServiceSendSpy).toHaveBeenCalledWith(
+			expect.objectContaining({ to: options.to, subject: options.subject, template: { name: 'base', data: {} } }),
+		);
 
-    expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ html: expect.any(String) }));
-  });
+		expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ html: expect.any(String) }));
+	});
 
-  test('use custom template when type is template and custom template was selected', async () => {
-    const options: Options = {
-      to: 'test@example.com',
-      subject: 'Test',
-      type: 'template',
-      template: 'custom',
-    };
+	test('use custom template when type is template and custom template was selected', async () => {
+		const options: Options = {
+			to: 'test@example.com',
+			subject: 'Test',
+			type: 'template',
+			template: 'custom',
+		};
 
-    await config.handler(options, mockOperationContext);
+		await config.handler(options, mockOperationContext);
 
-    expect(mailServiceSendSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ to: options.to, subject: options.subject, template: { name: 'custom', data: {} } }),
-    );
+		expect(mailServiceSendSpy).toHaveBeenCalledWith(
+			expect.objectContaining({ to: options.to, subject: options.subject, template: { name: 'custom', data: {} } }),
+		);
 
-    expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ html: expect.any(String) }));
-  });
+		expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ html: expect.any(String) }));
+	});
 
-  test('pass custom data with template when type is template and data is included', async () => {
-    const options: Options = {
-      to: 'test@example.com',
-      subject: 'Test',
-      type: 'template',
-      data: { key: 'value' },
-    };
+	test('pass custom data with template when type is template and data is included', async () => {
+		const options: Options = {
+			to: 'test@example.com',
+			subject: 'Test',
+			type: 'template',
+			data: { key: 'value' },
+		};
 
-    await config.handler(options, mockOperationContext);
+		await config.handler(options, mockOperationContext);
 
-    expect(mailServiceSendSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: options.to,
-        subject: options.subject,
-        template: { name: 'base', data: { key: 'value' } },
-      }),
-    );
+		expect(mailServiceSendSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				to: options.to,
+				subject: options.subject,
+				template: { name: 'base', data: { key: 'value' } },
+			}),
+		);
 
-    expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ html: expect.any(String) }));
-  });
+		expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ html: expect.any(String) }));
+	});
 
-  test('pass custom data with template when type is template, custom template was selected and data is included', async () => {
-    const options: Options = {
-      to: 'test@example.com',
-      subject: 'Test',
-      type: 'template',
-      template: 'custom',
-      data: { key: 'value' },
-    };
+	test('pass custom data with template when type is template, custom template was selected and data is included', async () => {
+		const options: Options = {
+			to: 'test@example.com',
+			subject: 'Test',
+			type: 'template',
+			template: 'custom',
+			data: { key: 'value' },
+		};
 
-    await config.handler(options, mockOperationContext);
+		await config.handler(options, mockOperationContext);
 
-    expect(mailServiceSendSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: options.to,
-        subject: options.subject,
-        template: { name: 'custom', data: { key: 'value' } },
-      }),
-    );
+		expect(mailServiceSendSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				to: options.to,
+				subject: options.subject,
+				template: { name: 'custom', data: { key: 'value' } },
+			}),
+		);
 
-    expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ html: expect.any(String) }));
-  });
+		expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ html: expect.any(String) }));
+	});
 
-  test('use body as is when type is wysiwyg', async () => {
-    const options: Options = {
-      to: 'test@example.com',
-      subject: 'Test',
-      type: 'wysiwyg',
-      body: 'test body',
-    };
+	test('use body as is when type is wysiwyg', async () => {
+		const options: Options = {
+			to: 'test@example.com',
+			subject: 'Test',
+			type: 'wysiwyg',
+			body: 'test body',
+		};
 
-    await config.handler(options, mockOperationContext);
+		await config.handler(options, mockOperationContext);
 
-    expect(mailServiceSendSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: options.to,
-        subject: options.subject,
-        html: options.body,
-      }),
-    );
+		expect(mailServiceSendSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				to: options.to,
+				subject: options.subject,
+				html: options.body,
+			}),
+		);
 
-    expect(mdSpy).not.toHaveBeenCalled();
-  });
+		expect(mdSpy).not.toHaveBeenCalled();
+	});
 
-  test('use md() on body when type is markdown', async () => {
-    const options: Options = {
-      to: 'test@example.com',
-      subject: 'Test',
-      type: 'markdown',
-      body: 'test body',
-    };
+	test('use md() on body when type is markdown', async () => {
+		const options: Options = {
+			to: 'test@example.com',
+			subject: 'Test',
+			type: 'markdown',
+			body: 'test body',
+		};
 
-    await config.handler(options, mockOperationContext);
+		await config.handler(options, mockOperationContext);
 
-    expect(mailServiceSendSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: options.to,
-        subject: options.subject,
-        html: '<p>test body</p>\n',
-      }),
-    );
+		expect(mailServiceSendSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				to: options.to,
+				subject: options.subject,
+				html: '<p>test body</p>\n',
+			}),
+		);
 
-    expect(mdSpy).toHaveBeenCalled();
-  });
+		expect(mdSpy).toHaveBeenCalled();
+	});
 
-  test('include cc, bcc, and replyTo in email options', async () => {
-    const options: Options = {
-      to: 'test@example.com',
-      subject: 'Test',
-      type: 'wysiwyg',
-      body: 'test body',
-      cc: 'cc@example.com',
-      bcc: 'bcc@example.com',
-      replyTo: 'replyto@example.com',
-    };
+	test('include cc, bcc, and replyTo in email options', async () => {
+		const options: Options = {
+			to: 'test@example.com',
+			subject: 'Test',
+			type: 'wysiwyg',
+			body: 'test body',
+			cc: 'cc@example.com',
+			bcc: 'bcc@example.com',
+			replyTo: 'replyto@example.com',
+		};
 
-    await config.handler(options, mockOperationContext);
+		await config.handler(options, mockOperationContext);
 
-    expect(mailServiceSendSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: options.to,
-        subject: options.subject,
-        html: options.body,
-        cc: options.cc,
-        bcc: options.bcc,
-        replyTo: options.replyTo,
-      }),
-    );
-  });
+		expect(mailServiceSendSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				to: options.to,
+				subject: options.subject,
+				html: options.body,
+				cc: options.cc,
+				bcc: options.bcc,
+				replyTo: options.replyTo,
+			}),
+		);
+	});
 
-  test('use fromName as sender name with the EMAIL_FROM address', async () => {
-    const options: Options = {
-      to: 'test@example.com',
-      subject: 'Test',
-      type: 'wysiwyg',
-      body: 'test body',
-      fromName: 'Acme Support',
-    };
+	test('use fromName as sender name with the EMAIL_FROM address', async () => {
+		const options: Options = {
+			to: 'test@example.com',
+			subject: 'Test',
+			type: 'wysiwyg',
+			body: 'test body',
+			fromName: 'Acme Support',
+		};
 
-    await config.handler(options, mockOperationContext);
+		await config.handler(options, mockOperationContext);
 
-    expect(mailServiceSendSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        from: { name: 'Acme Support', address: 'no-reply@example.com' },
-      }),
-    );
-  });
+		expect(mailServiceSendSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				from: { name: 'Acme Support', address: 'no-reply@example.com' },
+			}),
+		);
+	});
 
-  test.each([
-    { scenario: 'unset', fromName: {} },
-    { scenario: 'whitespace only', fromName: { fromName: '   ' } },
-  ])('omit sender when fromName is $scenario', async ({ fromName }) => {
-    const options: Options = {
-      to: 'test@example.com',
-      subject: 'Test',
-      type: 'wysiwyg',
-      body: 'test body',
-      ...fromName,
-    };
+	test.each([
+		{ scenario: 'unset', fromName: {} },
+		{ scenario: 'whitespace only', fromName: { fromName: '   ' } },
+	])('omit sender when fromName is $scenario', async ({ fromName }) => {
+		const options: Options = {
+			to: 'test@example.com',
+			subject: 'Test',
+			type: 'wysiwyg',
+			body: 'test body',
+			...fromName,
+		};
 
-    await config.handler(options, mockOperationContext);
+		await config.handler(options, mockOperationContext);
 
-    expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ from: expect.anything() }));
-  });
+		expect(mailServiceSendSpy).toHaveBeenCalledWith(expect.not.objectContaining({ from: expect.anything() }));
+	});
 });

--- a/api/src/operations/mail/index.test.ts
+++ b/api/src/operations/mail/index.test.ts
@@ -1,4 +1,3 @@
-import { useEnv } from '@directus/env';
 import knex from 'knex';
 import { MockClient } from 'knex-mock-client';
 import { beforeEach, describe, expect, type MockInstance, test, vi } from 'vitest';
@@ -180,7 +179,7 @@ describe('Operations / Mail', () => {
 
 		expect(mailServiceSendSpy).toHaveBeenCalledWith(
 			expect.objectContaining({
-				from: { name: 'Acme Support', address: useEnv()['EMAIL_FROM'] },
+				from: { name: 'Acme Support', address: 'no-reply@example.com' },
 			}),
 		);
 	});

--- a/api/src/operations/mail/index.ts
+++ b/api/src/operations/mail/index.ts
@@ -1,3 +1,4 @@
+import { useEnv } from '@directus/env';
 import { defineOperationApi } from '@directus/extensions';
 import { useLogger } from '../../logger/index.js';
 import type { EmailOptions } from '../../services/mail/index.js';
@@ -7,6 +8,7 @@ import { useFlowsEmailRateLimiter } from './rate-limiter.js';
 
 export type Options = {
 	to: string;
+	fromName?: string;
 	type: 'wysiwyg' | 'markdown' | 'template';
 	subject: string;
 	body?: string;
@@ -23,13 +25,23 @@ export default defineOperationApi<Options>({
 	id: 'mail',
 
 	handler: async (
-		{ body, template, data, to, type, subject, cc, bcc, replyTo },
+		{ body, template, data, to, fromName, type, subject, cc, bcc, replyTo },
 		{ accountability, database, getSchema, flow },
 	) => {
 		await useFlowsEmailRateLimiter(flow!.id);
 
+		const env = useEnv();
+
 		const mailService = new MailService({ schema: await getSchema({ database }), accountability, knex: database });
 		const mailObject: EmailOptions = { to, subject, cc, bcc, replyTo };
+
+		const trimmedFromName = fromName?.trim();
+
+		// An incomplete `from` object is rejected by the mail service, so only set it when there's a name to use
+		if (trimmedFromName) {
+			mailObject.from = { name: trimmedFromName, address: env['EMAIL_FROM'] as string };
+		}
+
 		const safeBody = typeof body !== 'string' ? JSON.stringify(body) : body;
 
 		if (type === 'template') {

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -3247,6 +3247,8 @@ operations:
   mail:
     name: Send Email
     description: Send an email to one or more people
+    from_name: From Name
+    from_name_placeholder: Defaults to the project name
     to: To
     to_placeholder: Add email addresses and press enter...
     body: Body

--- a/app/src/operations/mail/index.ts
+++ b/app/src/operations/mail/index.ts
@@ -19,7 +19,7 @@ export default defineOperationApp({
 			text: type || 'markdown',
 		},
 		...[
-			fromName && {
+			fromName?.trim() && {
 				label: '$t:operations.mail.from_name',
 				text: fromName,
 			},

--- a/app/src/operations/mail/index.ts
+++ b/app/src/operations/mail/index.ts
@@ -5,7 +5,7 @@ export default defineOperationApp({
 	icon: 'mail',
 	name: '$t:operations.mail.name',
 	description: '$t:operations.mail.description',
-	overview: ({ subject, to, type, cc, bcc, replyTo }) => [
+	overview: ({ subject, to, fromName, type, cc, bcc, replyTo }) => [
 		{
 			label: '$t:subject',
 			text: subject,
@@ -19,6 +19,10 @@ export default defineOperationApp({
 			text: type || 'markdown',
 		},
 		...[
+			fromName && {
+				label: '$t:operations.mail.from_name',
+				text: fromName,
+			},
 			cc && {
 				label: '$t:operations.mail.cc',
 				text: Array.isArray(cc) ? cc.join(', ') : cc,
@@ -35,6 +39,19 @@ export default defineOperationApp({
 	],
 	options: (panel) => {
 		return [
+			{
+				field: 'fromName',
+				name: '$t:operations.mail.from_name',
+				type: 'string',
+				meta: {
+					width: 'full',
+					interface: 'input',
+					options: {
+						placeholder: '$t:operations.mail.from_name_placeholder',
+						iconRight: 'badge',
+					},
+				},
+			},
 			{
 				field: 'to',
 				name: '$t:operations.mail.to',

--- a/app/src/operations/mail/index.ts
+++ b/app/src/operations/mail/index.ts
@@ -19,10 +19,6 @@ export default defineOperationApp({
 			text: type || 'markdown',
 		},
 		...[
-			fromName?.trim() && {
-				label: '$t:operations.mail.from_name',
-				text: fromName,
-			},
 			cc && {
 				label: '$t:operations.mail.cc',
 				text: Array.isArray(cc) ? cc.join(', ') : cc,
@@ -35,23 +31,14 @@ export default defineOperationApp({
 				label: '$t:operations.mail.reply_to',
 				text: Array.isArray(replyTo) ? replyTo.join(', ') : replyTo,
 			},
+			fromName?.trim() && {
+				label: '$t:operations.mail.from_name',
+				text: fromName,
+			},
 		].filter((v) => v),
 	],
 	options: (panel) => {
 		return [
-			{
-				field: 'fromName',
-				name: '$t:operations.mail.from_name',
-				type: 'string',
-				meta: {
-					width: 'full',
-					interface: 'input',
-					options: {
-						placeholder: '$t:operations.mail.from_name_placeholder',
-						iconRight: 'badge',
-					},
-				},
-			},
 			{
 				field: 'to',
 				name: '$t:operations.mail.to',
@@ -114,6 +101,19 @@ export default defineOperationApp({
 					options: {
 						placeholder: '$t:operations.mail.reply_to_placeholder',
 						iconRight: 'reply',
+					},
+				},
+			},
+			{
+				field: 'fromName',
+				name: '$t:operations.mail.from_name',
+				type: 'string',
+				meta: {
+					width: 'full',
+					interface: 'input',
+					options: {
+						placeholder: '$t:operations.mail.from_name_placeholder',
+						iconRight: 'badge',
 					},
 				},
 			},


### PR DESCRIPTION
## What's Changed

- Added an optional `fromName` field to the Send Email flow operation (`app/src/operations/mail/index.ts`)

## Tested Scenarios

- Sent email with and without fromName populated

## Review Notes / Questions / Concerns

- Only the display name is overridable — the address stays pinned to the `EMAIL_FROM` env variable.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [x] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes [CMS-2940](https://linear.app/directus/issue/CMS-2940)
