### PR TITLE
Fix SSO login redirect landing on last_page instead of the intended URL

### DIFF
--- a/.changeset/tidy-boxes-shave.md
+++ b/.changeset/tidy-boxes-shave.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed SSO login redirecting to the last visited page instead of the originally requested page

--- a/app/src/routes/login/components/continue-as.test.ts
+++ b/app/src/routes/login/components/continue-as.test.ts
@@ -1,0 +1,195 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { beforeEach, expect, test, vi } from 'vitest';
+import { createI18n } from 'vue-i18n';
+import { createMemoryHistory, createRouter, type Router } from 'vue-router';
+import ContinueAs from './continue-as.vue';
+import type { GlobalMountOptions } from '@/__utils__/types';
+import api from '@/api';
+import VButton from '@/components/v-button.vue';
+import { hydrate } from '@/hydrate';
+
+vi.mock('@/api');
+
+vi.mock('@/hydrate', () => ({
+	hydrate: vi.fn(),
+}));
+
+vi.mock('@/auth', () => ({
+	logout: vi.fn(),
+}));
+
+vi.mock('@/utils/unexpected-error', () => ({
+	unexpectedError: vi.fn(),
+}));
+
+const i18n = createI18n({ legacy: false });
+
+// silences locale message not found warnings
+vi.spyOn(i18n.global, 't').mockImplementation((key: any) => key);
+
+let router: Router;
+let hydrateResolvers: Array<() => void>;
+
+/** Resolve every pending `hydrate()` call, then let the continuations run. */
+async function resolveHydrate() {
+	const resolvers = [...hydrateResolvers];
+	hydrateResolvers = [];
+
+	for (const resolve of resolvers) resolve();
+
+	await flushPromises();
+}
+
+function mountContinueAs() {
+	const global: GlobalMountOptions = {
+		plugins: [i18n, router],
+		stubs: { routerLink: true },
+	};
+
+	return mount(ContinueAs, { global, shallow: true });
+}
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+
+	hydrateResolvers = [];
+
+	vi.mocked(hydrate).mockImplementation(() => new Promise<void>((resolve) => hydrateResolvers.push(resolve)));
+
+	vi.mocked(api.get).mockResolvedValue({
+		data: { data: { email: 'admin@example.com', first_name: 'Ad', last_name: 'Min', last_page: '/file-view/xy' } },
+	});
+
+	router = createRouter({
+		history: createMemoryHistory(),
+		routes: [
+			{ name: 'login', path: '/login', component: { template: '<div />' } },
+			{ name: 'catch-all', path: '/:pathMatch(.*)*', component: { template: '<div />' } },
+		],
+	});
+
+	await router.push('/login?redirect=/settings/data-model&continue=');
+	await router.isReady();
+});
+
+test('navigates to the redirect query when continue is present', async () => {
+	const push = vi.spyOn(router, 'push');
+
+	mountContinueAs();
+	await flushPromises();
+	await resolveHydrate();
+
+	expect(push).toHaveBeenCalledOnce();
+	expect(push).toHaveBeenCalledWith('/settings/data-model');
+});
+
+test('navigates only once to the redirect query when the component re-mounts while hydrating', async () => {
+	const push = vi.spyOn(router, 'push');
+
+	// First mount starts hydrating
+	mountContinueAs();
+	await flushPromises();
+
+	// Registering the module routes re-navigates and re-mounts the component mid-hydration
+	mountContinueAs();
+	await flushPromises();
+
+	expect(push).not.toHaveBeenCalled();
+
+	await resolveHydrate();
+
+	expect(hydrate).toHaveBeenCalledOnce();
+	expect(push).toHaveBeenCalledOnce();
+	expect(push).toHaveBeenCalledWith('/settings/data-model');
+	expect(router.currentRoute.value.fullPath).toBe('/settings/data-model');
+});
+
+test('navigates again on a later mount once the previous login finished', async () => {
+	mountContinueAs();
+	await flushPromises();
+	await resolveHydrate();
+
+	await router.push('/login?redirect=/users&continue=');
+
+	const push = vi.spyOn(router, 'push');
+
+	mountContinueAs();
+	await flushPromises();
+	await resolveHydrate();
+
+	expect(push).toHaveBeenCalledOnce();
+	expect(push).toHaveBeenCalledWith('/users');
+});
+
+test('uses the captured redirect when the query is dropped while hydrating', async () => {
+	const push = vi.spyOn(router, 'push');
+
+	mountContinueAs();
+	await flushPromises();
+
+	// Still on /login, but the redirect param is gone from the current route
+	await router.replace('/login');
+
+	await resolveHydrate();
+
+	expect(push).toHaveBeenCalledWith('/settings/data-model');
+});
+
+test('falls back to last_page when there is no redirect query', async () => {
+	await router.push('/login?continue=');
+
+	const push = vi.spyOn(router, 'push');
+
+	mountContinueAs();
+	await flushPromises();
+	await resolveHydrate();
+
+	expect(push).toHaveBeenCalledWith('/file-view/xy');
+});
+
+test('falls back to /content when there is no redirect query and no last_page', async () => {
+	vi.mocked(api.get).mockResolvedValue({
+		data: { data: { email: 'admin@example.com', first_name: 'Ad', last_name: 'Min', last_page: null } },
+	});
+
+	await router.push('/login?continue=');
+
+	const push = vi.spyOn(router, 'push');
+
+	mountContinueAs();
+	await flushPromises();
+	await resolveHydrate();
+
+	expect(push).toHaveBeenCalledWith('/content');
+});
+
+test('uses the first value when the redirect query is repeated', async () => {
+	await router.push('/login?redirect=/settings/data-model&redirect=/users&continue=');
+
+	const push = vi.spyOn(router, 'push');
+
+	mountContinueAs();
+	await flushPromises();
+	await resolveHydrate();
+
+	expect(push).toHaveBeenCalledWith('/settings/data-model');
+});
+
+test('does not navigate without the continue query until the button is clicked', async () => {
+	await router.push('/login?redirect=/settings/data-model');
+
+	const push = vi.spyOn(router, 'push');
+
+	const wrapper = mountContinueAs();
+	await flushPromises();
+
+	expect(hydrate).not.toHaveBeenCalled();
+	expect(push).not.toHaveBeenCalled();
+
+	wrapper.findComponent(VButton).vm.$emit('click');
+	await flushPromises();
+	await resolveHydrate();
+
+	expect(push).toHaveBeenCalledOnce();
+	expect(push).toHaveBeenCalledWith('/settings/data-model');
+});

--- a/app/src/routes/login/components/continue-as.test.ts
+++ b/app/src/routes/login/components/continue-as.test.ts
@@ -104,6 +104,37 @@ test('navigates only once to the redirect query when the component re-mounts whi
 	expect(router.currentRoute.value.fullPath).toBe('/settings/data-model');
 });
 
+test('navigates only once when the component re-mounts while the navigation is still pending', async () => {
+	// Slow guard on the target, so the navigation stays in flight while we re-mount
+	router.addRoute({
+		name: 'slow-target',
+		path: '/settings/data-model',
+		component: { template: '<div />' },
+		beforeEnter: () => new Promise<void>((resolve) => setTimeout(resolve, 10)).then(() => true),
+	});
+
+	const push = vi.spyOn(router, 'push');
+
+	mountContinueAs();
+	await flushPromises();
+	await resolveHydrate();
+
+	// Navigation has been started but has not settled yet
+	expect(push).toHaveBeenCalledOnce();
+	expect(router.currentRoute.value.name).toBe('login');
+
+	mountContinueAs();
+	await flushPromises();
+	await resolveHydrate();
+
+	expect(push).toHaveBeenCalledOnce();
+
+	await vi.waitUntil(() => router.currentRoute.value.name === 'slow-target');
+
+	expect(push).toHaveBeenCalledOnce();
+	expect(router.currentRoute.value.fullPath).toBe('/settings/data-model');
+});
+
 test('navigates again on a later mount once the previous login finished', async () => {
 	mountContinueAs();
 	await flushPromises();

--- a/app/src/routes/login/components/continue-as.vue
+++ b/app/src/routes/login/components/continue-as.vue
@@ -17,6 +17,9 @@ const loading = ref(false);
 const name = ref<string | null>(null);
 const lastPage = ref<string | null>(null);
 
+const redirectQuery = router.currentRoute.value.query.redirect;
+const initialRedirect = Array.isArray(redirectQuery) ? redirectQuery[0] : redirectQuery;
+
 const userPromise = fetchUser();
 
 onMounted(() => {
@@ -51,8 +54,10 @@ async function fetchUser() {
 async function hydrateAndLogin() {
 	await hydrate();
 	await userPromise;
-	const redirectQuery = router.currentRoute.value.query.redirect as string;
-	navigateAfterLogin(router, redirectQuery || lastPage.value || `/content`);
+
+	if (router.currentRoute.value.name !== 'login') return;
+
+	navigateAfterLogin(router, initialRedirect || lastPage.value || `/content`);
 }
 </script>
 

--- a/app/src/routes/login/components/continue-as.vue
+++ b/app/src/routes/login/components/continue-as.vue
@@ -1,3 +1,8 @@
+<script lang="ts">
+/** Shared between instances: hydrating re-mounts this component, so only the first should navigate. */
+let navigating = false;
+</script>
+
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
 import { I18nT } from 'vue-i18n';
@@ -52,12 +57,16 @@ async function fetchUser() {
 }
 
 async function hydrateAndLogin() {
-	await hydrate();
-	await userPromise;
+	if (navigating) return;
+	navigating = true;
 
-	if (router.currentRoute.value.name !== 'login') return;
-
-	navigateAfterLogin(router, initialRedirect || lastPage.value || `/content`);
+	try {
+		await hydrate();
+		await userPromise;
+		navigateAfterLogin(router, initialRedirect || lastPage.value || `/content`);
+	} finally {
+		navigating = false;
+	}
 }
 </script>
 

--- a/app/src/routes/login/components/continue-as.vue
+++ b/app/src/routes/login/components/continue-as.vue
@@ -63,7 +63,7 @@ async function hydrateAndLogin() {
 	try {
 		await hydrate();
 		await userPromise;
-		navigateAfterLogin(router, initialRedirect || lastPage.value || `/content`);
+		await navigateAfterLogin(router, initialRedirect || lastPage.value || `/content`);
 	} finally {
 		navigating = false;
 	}

--- a/app/src/routes/login/utils/navigate-after-login.ts
+++ b/app/src/routes/login/utils/navigate-after-login.ts
@@ -2,20 +2,20 @@ import type { Router } from 'vue-router';
 import { getRootPath } from '@/utils/get-root-path';
 
 /**
- * Navigate to the appropriate page after login.
+ * Navigate to the appropriate page after login. Resolves once the navigation settled.
  * API routes (e.g., /mcp-oauth/authorize) need full page navigation
  * since they're not SPA routes.
  */
-export function navigateAfterLogin(router: Router, target: string): void {
+export function navigateAfterLogin(router: Router, target: string): Promise<unknown> {
 	// Reject non-relative paths to prevent open redirect
 	if (!target.startsWith('/') || target.startsWith('//') || target.includes('\\')) {
-		router.push('/');
-		return;
+		return router.push('/');
 	}
 
 	if (target.startsWith('/mcp-oauth/')) {
 		window.location.href = getRootPath() + target.slice(1);
-	} else {
-		router.push(target);
+		return Promise.resolve();
 	}
+
+	return router.push(target);
 }


### PR DESCRIPTION
## What's Changed

Fixes a race condition where an SSO login that carried a `redirect` query param landed the user on their `last_page` instead of the page they originally requested.

`ContinueAs` read `router.currentRoute.value.query.redirect` *after* `await hydrate()`. Hydrating registers the module routes (`registerModules` → `router.addRoute()`), which re-navigates and re-mounts the component, so `onMounted` fires `hydrateAndLogin()` a second time. The second call's `hydrate()` short-circuits on `appStore.hydrating`, so it reaches the query read quickly — by which point the first call has already navigated, `query.redirect` is gone, and it falls back to `last_page`.

This only reproduces when `continue` is in the URL, which `sso-links.vue` always appends, so it affects every SSO login with a redirect. Clicking the Continue button manually is unaffected, since `hydrateAndLogin()` runs only once there.

* Capture the `redirect` query synchronously during setup, before any `await`, so the target survives the re-mount. Also handles a repeated `redirect` param, which was previously cast to `string` while actually being an array.
* Guard `hydrateAndLogin()` with a module-scope flag set synchronously on entry, so the second invocation never starts. A component-local `ref` would not work here: the double call comes from a re-mount, and a fresh instance gets a fresh ref. The flag is cleared in a `finally` so a later login in the same SPA session still works.

Related to [#19421](<https://github.com/directus/directus/issues/19421>) / [#25049](<https://github.com/directus/directus/issues/25049>) but distinct. [#25049](<https://github.com/directus/directus/issues/25049>) added `await userPromise`, which lengthened `hydrateAndLogin()` and made this race far more likely to lose.

## Tested Scenarios

Added `app/src/routes/login/components/continue-as.test.ts` (8 tests):

* Navigates to the `redirect` query when `continue` is present
* Re-mount mid-hydration navigates exactly once, to the redirect, not `last_page` — this is the regression test
* A later mount navigates again once the previous login finished (proves the guard clears)
* The captured redirect is used even if the query is dropped from the route mid-hydration
* Falls back to `last_page`, then to `/content`
* A repeated `redirect` param uses the first value
* Without `continue`, nothing happens until the Continue button is clicked

Reverting the component to its pre-fix state fails 3 of these 8, so they pin the actual bug rather than the new implementation.

Manual SSO verification against a live OpenID provider has **not** been done — I don't have one configured locally. Worth a reviewer sanity check on a real Entra/OIDC setup.

## Review Notes / Questions / Concerns

* The module-scope `let navigating` in a plain `<script>` block is the unusual part. It's deliberate: the state has to outlive a single component instance to close the race. There is precedent for dual script blocks in the repo (`private-view.vue`, `layouts/*/options.vue`), but happy to move it into a small util under `routes/login/utils/` if that reads better.
* `login-form.vue:89` and `ldap-form.vue:82` have the same late read of `query.redirect`. They aren't affected, since they run after a user-initiated `login()` with no re-mount in between, so I left them alone. Say the word if you'd rather they be made consistent.
* I deliberately did not try to suppress the re-navigation in `registerModules`/`hydrate`. That's a much larger blast radius than this bug warrants.

## Checklist

> Leave unchecked where not applicable

- [X] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](<https://github.com/directus/openapi>)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes directus/directus#27426

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)