### PR TITLE
fix: expose AI translation entitlement to non-admin users via /server/info (Fixes #28070)

### DIFF
--- a/api/src/services/server.ts
+++ b/api/src/services/server.ts
@@ -127,6 +127,9 @@ export class ServerService {
 				});
 
 				info['ai_providers'] = providerConfigs.map((config) => config.type);
+
+				// Expose AI translation entitlement so non-admin users can see the Translate with AI button.
+				info['ai_translations_enabled'] = getEntitlementManager().getAppEntitlements().ai_translations_enabled;
 			}
 
 			info['files'] = {

--- a/app/src/interfaces/translations/translations.test.ts
+++ b/app/src/interfaces/translations/translations.test.ts
@@ -161,13 +161,7 @@ function mountTranslations() {
 						info: {
 							ai_enabled: true,
 							ai_providers: ['anthropic'],
-						},
-					},
-					licenseStore: {
-						info: {
-							entitlements: {
-								ai_translations_enabled: { default: true },
-							},
+							ai_translations_enabled: true,
 						},
 					},
 				},

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -15,7 +15,6 @@ import { useRelationM2M } from '@/composables/use-relation-m2m';
 import { DisplayItem, RelationQueryMultiple, useRelationMultiple } from '@/composables/use-relation-multiple';
 import vTooltip from '@/directives/tooltip';
 import { useFieldsStore } from '@/stores/fields';
-import { useLicenseStore } from '@/stores/license';
 import { useServerStore } from '@/stores/server';
 import { fetchAll } from '@/utils/fetch-all';
 import { unexpectedError } from '@/utils/unexpected-error';
@@ -64,7 +63,6 @@ const { relationInfo } = useRelationM2M(collection, field);
 const { locale } = useI18n();
 
 const fieldsStore = useFieldsStore();
-const licenseStore = useLicenseStore();
 const serverStore = useServerStore();
 const aiStore = useAiStore();
 
@@ -82,7 +80,7 @@ const aiTranslateAvailable = computed(() =>
 		availableModelCount: aiStore.models.length,
 		disabled: props.disabled,
 		nonEditable: props.nonEditable,
-		licenseEntitlement: licenseStore.aiTranslationsEnabled,
+		licenseEntitlement: serverStore.info.ai_translations_enabled,
 	}),
 );
 

--- a/app/src/stores/server.ts
+++ b/app/src/stores/server.ts
@@ -30,6 +30,7 @@ export type Info = {
 	mcp_enabled: boolean;
 	ai_enabled: boolean;
 	ai_providers?: string[];
+	ai_translations_enabled: boolean;
 	mcp_oauth_enabled: boolean;
 	mcp_oauth_dcr_enabled: boolean;
 	mcp_oauth_cimd_enabled: boolean;
@@ -157,6 +158,7 @@ export const useServerStore = defineStore('serverStore', () => {
 		info.mcp_enabled = serverInfoResponse.data.data?.mcp_enabled;
 		info.ai_enabled = serverInfoResponse.data.data?.ai_enabled;
 		info.ai_providers = serverInfoResponse.data.data?.ai_providers ?? [];
+		info.ai_translations_enabled = serverInfoResponse.data.data?.ai_translations_enabled ?? false;
 		info.mcp_oauth_enabled = serverInfoResponse.data.data?.mcp_oauth_enabled;
 		info.mcp_oauth_dcr_enabled = serverInfoResponse.data.data?.mcp_oauth_dcr_enabled;
 		info.mcp_oauth_cimd_enabled = serverInfoResponse.data.data?.mcp_oauth_cimd_enabled;


### PR DESCRIPTION
## Summary

Makes the "Translate with AI" button visible to non-admin App users who have the proper permissions.

## Root Cause

The `licenseStore.hydrate()` skips loading for non-admin users (line 158 of `license.ts`), so `aiTranslationsEnabled` always returns `false` for anyone without Admin Access.

## Fix

* **Backend** (`api/src/services/server.ts`): Expose `ai_translations_enabled` in `/server/info` response, resolved from `getAppEntitlements()` which is already available server-side.
* **Frontend** (`app/src/stores/server.ts`): Read the new field in `serverStore.hydrate()`.
* **Frontend** (`app/src/interfaces/translations/translations.vue`): Use `serverStore.info.ai_translations_enabled` instead of `licenseStore.aiTranslationsEnabled`.

## Test Plan

- [ ] As a non-admin App user with proper permissions on a translations field, open any item — the "Translate with AI" button should now be visible.
- [ ] As an admin, the button should still work as before.

Fixes directus/directus#28070