### PR TITLE
fix(input-code): preserve cursor position on paste + auto-format (Fixes #28045)

### DIFF
--- a/app/src/interfaces/input-code/input-code.test.ts
+++ b/app/src/interfaces/input-code/input-code.test.ts
@@ -12,6 +12,10 @@ vi.mock('codemirror', () => {
 			on: vi.fn(),
 			getValue: vi.fn(() => ''),
 			setValue: vi.fn(),
+			getCursor: vi.fn(() => ({ line: 0, ch: 0 })),
+			setCursor: vi.fn(),
+			getScrollInfo: vi.fn(() => ({ top: 0, left: 0 })),
+			scrollTo: vi.fn(),
 		})),
 		Pos: vi.fn(),
 		registerHelper: vi.fn(),
@@ -151,5 +155,35 @@ describe('InputCode', () => {
 		`);
 
 		expect(wrapper.find('.input-code v-button-stub').attributes('disabled')).toBe('true');
+	});
+
+	it('should preserve cursor position when setValue replaces editor content', async () => {
+		wrapper = mount(InputCode, {
+			props: {
+				language: 'json',
+				value: '{"hello": "world"}',
+			},
+			global,
+		});
+
+		// Simulate CodeMirror being mounted
+		const cm = (wrapper.vm as any).codemirror;
+		expect(cm).toBeTruthy();
+
+		// Simulate cursor at line 10, column 5
+		cm.getCursor.mockReturnValue({ line: 10, ch: 5 });
+		cm.getScrollInfo.mockReturnValue({ top: 200, left: 0, width: 800, height: 600 });
+
+		// Simulate a value change that triggers the watcher
+		await wrapper.setProps({ value: { hello: 'world' } });
+
+		// Verify setValue was called
+		expect(cm.setValue).toHaveBeenCalled();
+
+		// Verify cursor was restored to its previous position
+		expect(cm.setCursor).toHaveBeenCalledWith({ line: 10, ch: 5 });
+
+		// Verify scroll position was restored
+		expect(cm.scrollTo).toHaveBeenCalledWith(null, 200);
 	});
 });

--- a/app/src/interfaces/input-code/input-code.vue
+++ b/app/src/interfaces/input-code/input-code.vue
@@ -117,7 +117,18 @@ watch(stringValue, () => {
 	if (props.type === 'json' && codemirror?.getValue() === props.value) return;
 
 	if (codemirror?.getValue() !== stringValue.value) {
+		// Preserve cursor & scroll position when replacing editor content,
+		// so that auto-format (JSON.stringify re-serialization) after paste
+		// does not reset the cursor to the top of the document.
+		const cursor = codemirror?.getCursor();
+		const scrollInfo = codemirror?.getScrollInfo();
+
 		codemirror?.setValue(stringValue.value || '');
+
+		if (cursor && codemirror) {
+			codemirror.setCursor(cursor);
+			codemirror.scrollTo(null, scrollInfo?.top ?? 0);
+		}
 	}
 });
 


### PR DESCRIPTION
## Description

When editing a JSON field using the Code interface (input-code), pasting content causes the cursor to jump to the top of the editor (line 1, column 0). This makes editing large JSON documents painful — after every paste operation, the user must manually scroll and click back to where they were working.

### Root Cause

The `watch(stringValue)` handler calls `codemirror.setValue()` when the auto-formatted (re-serialized) JSON content differs from the user's raw input. CodeMirror's `setValue()` replaces the entire document content, which resets the cursor position to `(0, 0)` and scrolls to the top.

### Fix

Save the cursor position and scroll offset **before** calling `setValue()`, then restore them **after**. This keeps the user's editing position stable after paste + auto-format.

### Key Changes

* `input-code.vue`: Preserve cursor and scroll position when replacing editor content in the `stringValue` watcher
* `input-code.test.ts`: Add mocks for `getCursor`, `setCursor`, `getScrollInfo`, `scrollTo`; add a test verifying cursor position is preserved

### Testing

Added a new test case that verifies:

1. `setValue()` is called when the value prop changes
2. `setCursor()` is called with the previous cursor position
3. `scrollTo()` is called with the previous scroll position

Fixes directus/directus#28045