### PR TITLE
Drag-drop reorder for collection not working on iOS

### DIFF
--- a/app/src/components/v-list-item.vue
+++ b/app/src/components/v-list-item.vue
@@ -300,6 +300,7 @@ function onClick(event: PointerEvent) {
 		&:not(.disabled) {
 			:slotted(.drag-handle) {
 				cursor: grab;
+				touch-action: none;
 
 				&:hover {
 					color: var(--foreground-color);

--- a/app/src/components/v-table/table-row.vue
+++ b/app/src/components/v-table/table-row.vue
@@ -128,6 +128,7 @@ function onKeydown(e: KeyboardEvent) {
 
 	.drag-handle {
 		--v-icon-color: var(--theme--foreground-subdued);
+		touch-action: none;
 
 		&.sorted-manually {
 			--v-icon-color: var(--theme--foreground);

--- a/app/src/interfaces/_system/system-filter/Nodes.vue
+++ b/app/src/interfaces/_system/system-filter/Nodes.vue
@@ -543,6 +543,7 @@ function isExistingField(node: Record<string, any>): boolean {
 
 	.drag-handle {
 		--v-icon-color: var(--theme--form--field--input--foreground-subdued);
+		touch-action: none;
 
 		margin-inline-end: 0.25rem;
 		cursor: grab;

--- a/app/src/interfaces/_system/system-modules/system-modules.vue
+++ b/app/src/interfaces/_system/system-modules/system-modules.vue
@@ -273,6 +273,7 @@ function remove(id: string) {
 
 .drag-handle {
 	--v-icon-color: var(--theme--form--field--input--foreground-subdued);
+	touch-action: none;
 }
 
 .to {

--- a/app/src/interfaces/list/list-inline.vue
+++ b/app/src/interfaces/list/list-inline.vue
@@ -433,6 +433,7 @@ function emitValue(value?: Record<string, unknown>[]) {
 
 .drag-handle {
 	cursor: grab;
+	touch-action: none;
 
 	&:active {
 		cursor: grabbing;

--- a/app/src/layouts/tabular/options.vue
+++ b/app/src/layouts/tabular/options.vue
@@ -58,6 +58,7 @@ const tableSpacingWritable = useSync(props, 'tableSpacing', emit);
 	--v-icon-color: var(--theme--foreground-subdued);
 
 	cursor: ns-resize;
+	touch-action: none;
 
 	&:hover {
 		--v-icon-color: var(--theme--foreground);

--- a/app/src/modules/settings/routes/data-model/collections/components/CollectionItem.vue
+++ b/app/src/modules/settings/routes/data-model/collections/components/CollectionItem.vue
@@ -182,6 +182,7 @@ function onGroupSortChange(collections: Collection[]) {
 
 .drag-handle {
 	cursor: grab;
+	touch-action: none;
 }
 
 .collapse-toggle {

--- a/app/src/modules/settings/routes/data-model/fields/components/FieldSelect.vue
+++ b/app/src/modules/settings/routes/data-model/fields/components/FieldSelect.vue
@@ -414,6 +414,7 @@ const tFieldType = (type: string) => t(type === 'geometry' ? 'geometry.All' : ty
 
 .drag-handle {
 	cursor: grab !important;
+	touch-action: none;
 }
 
 .duplicate {


### PR DESCRIPTION
Add `touch-action: none` to all `.drag-handle` CSS selectors to fix iOS drag-and-drop by preventing the browser from claiming touch events for scrolling

Found via automated repo scanning, fix written and reviewed before opening.
