### PR TITLE
WebSocket heartbeat leaks websocket.message listeners for idle clients

### DIFF
--- a/api/src/websocket/handlers/heartbeat.ts
+++ b/api/src/websocket/handlers/heartbeat.ts
@@ -71,6 +71,8 @@ export class HeartbeatHandler {
 			for (const client of pendingClients) {
 				client.close();
 			}
+
+			emitter.offAction('websocket.message', messageWatcher);
 		}, HEARTBEAT_FREQUENCY);
 
 		const messageWatcher: ActionHandler = ({ client }) => {


### PR DESCRIPTION
Remove leaked `websocket.message` listener in `pingClients` when the heartbeat timeout fires for non-responding clients

Found via automated repo scanning, fix written and reviewed before opening.
