### PR TITLE
Breadcrumb navigation is rendered incorrectly for MCP OAuth clients

### DIFF
--- a/app/src/modules/settings/routes/mcp-oauth-clients/collection.vue
+++ b/app/src/modules/settings/routes/mcp-oauth-clients/collection.vue
@@ -86,10 +86,7 @@ function useBatch() {
 		<PrivateView :title="$t('mcp_oauth_clients')" icon="key" show-back back-to="/settings/ai">
 			<template #headline>
 				<VBreadcrumb
-					:items="[
-						{ name: $t('settings'), to: '/settings' },
-						{ name: $t('settings_ai'), to: '/settings/ai' },
-					]"
+					:items="[{ name: $t('settings'), to: '/settings' }]"
 				/>
 			</template>
 

--- a/app/src/modules/settings/routes/mcp-oauth-clients/item.vue
+++ b/app/src/modules/settings/routes/mcp-oauth-clients/item.vue
@@ -49,7 +49,6 @@ async function revokeClient() {
 			<VBreadcrumb
 				:items="[
 					{ name: $t('settings'), to: '/settings' },
-					{ name: $t('settings_ai'), to: '/settings/ai' },
 					{ name: $t('mcp_oauth_clients'), to: '/settings/mcp-oauth-clients' },
 				]"
 			/>


### PR DESCRIPTION
Removed incorrect `settings_ai` breadcrumb parent from MCP OAuth clients collection and item views — these routes are siblings of `/settings/ai`, not children of it

Found via automated repo scanning, fix written and reviewed before opening.
