### PR TITLE
Fix extensions that set `sandbox` without an `enabled` flag being rejected as invalid

### DIFF
--- a/.changeset/sandbox-scopes-optional.md
+++ b/.changeset/sandbox-scopes-optional.md
@@ -1,0 +1,6 @@
+---
+'@directus/extensions': patch
+'@directus/types': patch
+---
+
+Fixed extensions that set `sandbox` without `requestedScopes` being rejected as invalid

--- a/.changeset/sandbox-scopes-optional.md
+++ b/.changeset/sandbox-scopes-optional.md
@@ -3,4 +3,4 @@
 '@directus/types': patch
 ---
 
-Fixed extensions that set `sandbox` without `requestedScopes` being rejected as invalid
+Fixed extensions that set `sandbox` without `requestedScopes` or without `enabled` being rejected as invalid

--- a/.changeset/sandbox-scopes-optional.md
+++ b/.changeset/sandbox-scopes-optional.md
@@ -3,4 +3,4 @@
 '@directus/types': patch
 ---
 
-Fixed extensions that set `sandbox` without `requestedScopes` or without `enabled` being rejected as invalid
+Fixed extensions that set `sandbox` without an `enabled` flag being rejected as invalid

--- a/.changeset/sandbox-validator-findindex.md
+++ b/.changeset/sandbox-validator-findindex.md
@@ -1,0 +1,5 @@
+---
+'@directus/extensions-sdk': patch
+---
+
+Fixed `extension validate` crashing on extensions with a disabled sandbox due to an invalid `findIndex` call

--- a/packages/extensions-sdk/src/cli/commands/validators/check-directus-config.test.ts
+++ b/packages/extensions-sdk/src/cli/commands/validators/check-directus-config.test.ts
@@ -13,23 +13,31 @@ vi.mock('fs-extra', () => ({
 
 const spinner = { text: '', fail: vi.fn() } as unknown as Ora;
 
+const mockConfig = (sandbox: unknown) => {
+	vi.mocked(fse.readJson).mockResolvedValue({
+		'directus:extension': {
+			type: 'endpoint',
+			path: 'dist/index.js',
+			source: 'src/index.ts',
+			host: '^11.0.0',
+			sandbox,
+		},
+	});
+};
+
 beforeEach(() => {
 	vi.clearAllMocks();
 	vi.mocked(fse.pathExists).mockResolvedValue(true as never);
 });
 
 describe('check-directus-config', () => {
-	// Previously crashed with a TypeError from API_EXTENSION_TYPES.findIndex(type)
-	it('warns instead of crashing for an API extension with a disabled sandbox', async () => {
-		vi.mocked(fse.readJson).mockResolvedValue({
-			'directus:extension': {
-				type: 'endpoint',
-				path: 'dist/index.js',
-				source: 'src/index.ts',
-				host: '^11.0.0',
-				sandbox: { enabled: false },
-			},
-		});
+	it.each([
+		{ description: 'a disabled sandbox', sandbox: { enabled: false } },
+		{ description: 'an empty sandbox object', sandbox: {} },
+		{ description: 'requested scopes but no enabled flag', sandbox: { requestedScopes: { log: {} } } },
+		{ description: 'no sandbox at all', sandbox: undefined },
+	])('warns for an API extension with $description', async ({ sandbox }) => {
+		mockConfig(sandbox);
 
 		const reports: Array<Report> = [];
 
@@ -42,15 +50,7 @@ describe('check-directus-config', () => {
 	});
 
 	it('does not warn for an API extension with an enabled sandbox', async () => {
-		vi.mocked(fse.readJson).mockResolvedValue({
-			'directus:extension': {
-				type: 'endpoint',
-				path: 'dist/index.js',
-				source: 'src/index.ts',
-				host: '^11.0.0',
-				sandbox: { enabled: true, requestedScopes: {} },
-			},
-		});
+		mockConfig({ enabled: true, requestedScopes: {} });
 
 		const reports: Array<Report> = [];
 

--- a/packages/extensions-sdk/src/cli/commands/validators/check-directus-config.test.ts
+++ b/packages/extensions-sdk/src/cli/commands/validators/check-directus-config.test.ts
@@ -1,0 +1,61 @@
+import fse from 'fs-extra';
+import type { Ora } from 'ora';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Report } from '../../types.js';
+import checkDirectusConfig from './check-directus-config.js';
+
+vi.mock('fs-extra', () => ({
+	default: {
+		pathExists: vi.fn(),
+		readJson: vi.fn(),
+	},
+}));
+
+const spinner = { text: '', fail: vi.fn() } as unknown as Ora;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(fse.pathExists).mockResolvedValue(true as never);
+});
+
+describe('check-directus-config', () => {
+	// Previously crashed with a TypeError from API_EXTENSION_TYPES.findIndex(type)
+	it('warns instead of crashing for an API extension with a disabled sandbox', async () => {
+		vi.mocked(fse.readJson).mockResolvedValue({
+			'directus:extension': {
+				type: 'endpoint',
+				path: 'dist/index.js',
+				source: 'src/index.ts',
+				host: '^11.0.0',
+				sandbox: { enabled: false },
+			},
+		});
+
+		const reports: Array<Report> = [];
+
+		await expect(checkDirectusConfig.handler(spinner, reports)).resolves.toBe('Valid directus:extension Object');
+
+		expect(reports).toContainEqual({
+			level: 'warn',
+			message: `directus-config: Extension won't be generally visible in the Directus Marketplace`,
+		});
+	});
+
+	it('does not warn for an API extension with an enabled sandbox', async () => {
+		vi.mocked(fse.readJson).mockResolvedValue({
+			'directus:extension': {
+				type: 'endpoint',
+				path: 'dist/index.js',
+				source: 'src/index.ts',
+				host: '^11.0.0',
+				sandbox: { enabled: true, requestedScopes: {} },
+			},
+		});
+
+		const reports: Array<Report> = [];
+
+		await expect(checkDirectusConfig.handler(spinner, reports)).resolves.toBe('Valid directus:extension Object');
+
+		expect(reports.filter((report) => report.level === 'warn')).toEqual([]);
+	});
+});

--- a/packages/extensions-sdk/src/cli/commands/validators/check-directus-config.ts
+++ b/packages/extensions-sdk/src/cli/commands/validators/check-directus-config.ts
@@ -97,7 +97,7 @@ const checkDirectusConfig = {
 
 		spinner.text = 'Checking if it will publish to the Directus Marketplace';
 
-		if (type === 'bundle' || (sandbox && !sandbox?.enabled && API_EXTENSION_TYPES.findIndex(type) >= 0)) {
+		if (type === 'bundle' || (sandbox && !sandbox.enabled && API_EXTENSION_TYPES.includes(type))) {
 			reports.push({
 				level: 'warn',
 				message: `${checkDirectusConfig.name}: Extension won't be generally visible in the Directus Marketplace`,

--- a/packages/extensions-sdk/src/cli/commands/validators/check-directus-config.ts
+++ b/packages/extensions-sdk/src/cli/commands/validators/check-directus-config.ts
@@ -97,7 +97,8 @@ const checkDirectusConfig = {
 
 		spinner.text = 'Checking if it will publish to the Directus Marketplace';
 
-		if (type === 'bundle' || (sandbox && !sandbox.enabled && API_EXTENSION_TYPES.includes(type))) {
+		// Only an explicitly enabled sandbox is marketplace-visible
+		if (type === 'bundle' || (!sandbox?.enabled && API_EXTENSION_TYPES.includes(type))) {
 			reports.push({
 				level: 'warn',
 				message: `${checkDirectusConfig.name}: Extension won't be generally visible in the Directus Marketplace`,

--- a/packages/extensions/src/shared/schemas/options.test.ts
+++ b/packages/extensions/src/shared/schemas/options.test.ts
@@ -27,6 +27,30 @@ describe('ExtensionOptions', () => {
 		expect(result.success).toBe(true);
 	});
 
+	it('accepts an empty sandbox object', () => {
+		const result = ExtensionOptions.safeParse({
+			host: '^11.0.0',
+			type: 'hook',
+			path: 'dist/index.js',
+			source: 'src/index.js',
+			sandbox: {},
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts requested scopes without the enabled flag', () => {
+		const result = ExtensionOptions.safeParse({
+			host: '^11.0.0',
+			type: 'hook',
+			path: 'dist/index.js',
+			source: 'src/index.js',
+			sandbox: { requestedScopes: { log: {} } },
+		});
+
+		expect(result.success).toBe(true);
+	});
+
 	it('keeps requested scopes when they are provided', () => {
 		const result = ExtensionOptions.safeParse({
 			host: '^11.0.0',

--- a/packages/extensions/src/shared/schemas/options.test.ts
+++ b/packages/extensions/src/shared/schemas/options.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { ExtensionOptions } from './options.js';
+
+describe('ExtensionOptions', () => {
+	it('accepts an API extension without a sandbox', () => {
+		const result = ExtensionOptions.safeParse({
+			host: '^11.0.0',
+			type: 'hook',
+			path: 'dist/index.js',
+			source: 'src/index.js',
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	// Scopes are only meaningful while the sandbox is enabled, so requiring them made valid
+	// published extensions unloadable and blocked them from updating in the marketplace
+	it('accepts a sandbox without requested scopes', () => {
+		const result = ExtensionOptions.safeParse({
+			host: '^11.0.0',
+			type: 'hook',
+			path: 'dist/index.js',
+			source: 'src/index.js',
+			sandbox: { enabled: false },
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('keeps requested scopes when they are provided', () => {
+		const result = ExtensionOptions.safeParse({
+			host: '^11.0.0',
+			type: 'hook',
+			path: 'dist/index.js',
+			source: 'src/index.js',
+			sandbox: { enabled: true, requestedScopes: { log: {}, sleep: {} } },
+		});
+
+		expect(result.success).toBe(true);
+
+		expect(result.data).toEqual(
+			expect.objectContaining({
+				sandbox: { enabled: true, requestedScopes: { log: {}, sleep: {} } },
+			}),
+		);
+	});
+
+	it('rejects a sandbox with invalid requested scopes', () => {
+		const result = ExtensionOptions.safeParse({
+			host: '^11.0.0',
+			type: 'hook',
+			path: 'dist/index.js',
+			source: 'src/index.js',
+			sandbox: { enabled: true, requestedScopes: { request: { urls: ['https://directus.io'] } } },
+		});
+
+		expect(result.success).toBe(false);
+	});
+});

--- a/packages/extensions/src/shared/schemas/options.test.ts
+++ b/packages/extensions/src/shared/schemas/options.test.ts
@@ -1,80 +1,42 @@
 import { describe, expect, it } from 'vitest';
 import { ExtensionOptions } from './options.js';
 
+const API_EXTENSION = {
+	host: '^11.0.0',
+	type: 'hook',
+	path: 'dist/index.js',
+	source: 'src/index.js',
+};
+
+// Requiring `enabled` made valid published extensions unloadable
+const VALID_SANDBOX_CASES = [
+	{ description: 'a disabled sandbox without requested scopes', sandbox: { enabled: false } },
+	{ description: 'an empty sandbox object', sandbox: {} },
+	{ description: 'requested scopes without the enabled flag', sandbox: { requestedScopes: { log: {} } } },
+	{
+		description: 'an enabled sandbox with requested scopes',
+		sandbox: { enabled: true, requestedScopes: { log: {}, sleep: {} } },
+	},
+];
+
 describe('ExtensionOptions', () => {
 	it('accepts an API extension without a sandbox', () => {
-		const result = ExtensionOptions.safeParse({
-			host: '^11.0.0',
-			type: 'hook',
-			path: 'dist/index.js',
-			source: 'src/index.js',
-		});
+		const result = ExtensionOptions.safeParse(API_EXTENSION);
 
 		expect(result.success).toBe(true);
 	});
 
-	// Scopes are only meaningful while the sandbox is enabled, so requiring them made valid
-	// published extensions unloadable and blocked them from updating in the marketplace
-	it('accepts a sandbox without requested scopes', () => {
-		const result = ExtensionOptions.safeParse({
-			host: '^11.0.0',
-			type: 'hook',
-			path: 'dist/index.js',
-			source: 'src/index.js',
-			sandbox: { enabled: false },
-		});
-
-		expect(result.success).toBe(true);
-	});
-
-	it('accepts an empty sandbox object', () => {
-		const result = ExtensionOptions.safeParse({
-			host: '^11.0.0',
-			type: 'hook',
-			path: 'dist/index.js',
-			source: 'src/index.js',
-			sandbox: {},
-		});
-
-		expect(result.success).toBe(true);
-	});
-
-	it('accepts requested scopes without the enabled flag', () => {
-		const result = ExtensionOptions.safeParse({
-			host: '^11.0.0',
-			type: 'hook',
-			path: 'dist/index.js',
-			source: 'src/index.js',
-			sandbox: { requestedScopes: { log: {} } },
-		});
-
-		expect(result.success).toBe(true);
-	});
-
-	it('keeps requested scopes when they are provided', () => {
-		const result = ExtensionOptions.safeParse({
-			host: '^11.0.0',
-			type: 'hook',
-			path: 'dist/index.js',
-			source: 'src/index.js',
-			sandbox: { enabled: true, requestedScopes: { log: {}, sleep: {} } },
-		});
+	it.each(VALID_SANDBOX_CASES)('accepts $description', ({ sandbox }) => {
+		const result = ExtensionOptions.safeParse({ ...API_EXTENSION, sandbox });
 
 		expect(result.success).toBe(true);
 
-		expect(result.data).toEqual(
-			expect.objectContaining({
-				sandbox: { enabled: true, requestedScopes: { log: {}, sleep: {} } },
-			}),
-		);
+		expect(result.data).toEqual(expect.objectContaining({ sandbox }));
 	});
 
 	it('rejects a sandbox with invalid requested scopes', () => {
 		const result = ExtensionOptions.safeParse({
-			host: '^11.0.0',
-			type: 'hook',
-			path: 'dist/index.js',
-			source: 'src/index.js',
+			...API_EXTENSION,
 			sandbox: { enabled: true, requestedScopes: { request: { urls: ['https://directus.io'] } } },
 		});
 

--- a/packages/extensions/src/shared/schemas/options.ts
+++ b/packages/extensions/src/shared/schemas/options.ts
@@ -23,7 +23,7 @@ export const ExtensionSandboxRequestedScopes = z.object({
 
 export const ExtensionSandboxOptions = z.optional(
 	z.object({
-		enabled: z.boolean(),
+		enabled: z.optional(z.boolean()),
 		requestedScopes: z.optional(ExtensionSandboxRequestedScopes),
 	}),
 );

--- a/packages/extensions/src/shared/schemas/options.ts
+++ b/packages/extensions/src/shared/schemas/options.ts
@@ -24,7 +24,7 @@ export const ExtensionSandboxRequestedScopes = z.object({
 export const ExtensionSandboxOptions = z.optional(
 	z.object({
 		enabled: z.boolean(),
-		requestedScopes: ExtensionSandboxRequestedScopes,
+		requestedScopes: z.optional(ExtensionSandboxRequestedScopes),
 	}),
 );
 

--- a/packages/types/src/extensions/app-extension-config.ts
+++ b/packages/types/src/extensions/app-extension-config.ts
@@ -52,7 +52,7 @@ export type ExtensionSandboxRequestedScopes = z.infer<typeof ExtensionSandboxReq
 export const ExtensionSandboxOptions = z.optional(
 	z.object({
 		enabled: z.boolean(),
-		requestedScopes: ExtensionSandboxRequestedScopes,
+		requestedScopes: z.optional(ExtensionSandboxRequestedScopes),
 	}),
 );
 

--- a/packages/types/src/extensions/app-extension-config.ts
+++ b/packages/types/src/extensions/app-extension-config.ts
@@ -51,7 +51,7 @@ export type ExtensionSandboxRequestedScopes = z.infer<typeof ExtensionSandboxReq
 
 export const ExtensionSandboxOptions = z.optional(
 	z.object({
-		enabled: z.boolean(),
+		enabled: z.optional(z.boolean()),
 		requestedScopes: z.optional(ExtensionSandboxRequestedScopes),
 	}),
 );


### PR DESCRIPTION
## What's Changed

- `requestedScopes` and `enabled` are now both optional in `ExtensionSandboxOptions`, so `sandbox: { enabled: false }`, `sandbox: {}` and `sandbox: { requestedScopes: { log: {} } }` are all valid manifests
- Mirrored in `@directus/types`, since `Extension.sandbox` is typed from that copy of the schema and `get-extensions.ts` assigns the parsed value straight into it
- Fixed `extension validate` crashing on API extensions with a disabled sandbox: `check-directus-config.ts` called `API_EXTENSION_TYPES.findIndex(type)` with a string instead of a callback, now `includes(type)`
- Unit tests added for `ExtensionOptions` and the validator

## Tested Scenarios

- API extension with no `sandbox` key parses
- `sandbox: { enabled: false }`, `sandbox: {}` and `sandbox: { requestedScopes: { log: {} } }` all parse, all fail on main
- `requestedScopes` are preserved when present
- Malformed `requestedScopes` are still rejected (`request` without `methods`)
- Validator regression test fails against the old `findIndex` code, passes with the fix
- `@directus/extensions` and `@directus/extensions-sdk` suites pass

## Review Notes / Questions / Concerns

- Missing `enabled` behaves as disabled at runtime: `api/src/extensions/manager.ts` gates on `sandbox?.enabled` truthiness, so the schema now matches what the runtime already does
- No security loosening. `manager.ts` already passes `extension.sandbox?.requestedScopes ?? {}`, so an absent scopes object grants nothing, which is the most restrictive outcome.
- Two visible effects of the current behaviour: the extension fails to load, because `get-extensions.ts` parses the same schema, and the marketplace stops updating the package at all, because the registry scraper can't format the newest version and gives up on the whole thing. `directus-extension-image-upload-resizer` has been stuck at 2.0.1 in the marketplace since 2.1.0 switched to `sandbox: { enabled: false }` on 15 Jul. `directus-extension-db-email-template` has the same manifest.
- The registry pins `@directus/extensions` 0.3.0, so it needs a dependency bump before this reaches the marketplace. There's a separate resilience fix there so one unparseable version can't freeze a package either way.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [x] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply
