### PR TITLE
Fix CLA comment missing on fork PRs, add label and 7-day auto-close

### DIFF
--- a/.github/workflows/cla-comment.yml
+++ b/.github/workflows/cla-comment.yml
@@ -31,11 +31,19 @@ jobs:
             // request from the head branch instead of trusting anything the fork sends
             const run = context.payload.workflow_run;
 
+            // Null when the fork is deleted or made private between the check run and this event
+            const headOwner = run.head_repository?.owner?.login;
+
+            if (!headOwner) {
+              core.info('No head repository on the run, skipping');
+              return;
+            }
+
             const prs = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              head: `${run.head_repository.owner.login}:${run.head_branch}`,
+              head: `${headOwner}:${run.head_branch}`,
               per_page: 100,
             });
 
@@ -47,10 +55,16 @@ jobs:
             }
 
             core.setOutput('number', pr.number);
+            core.setOutput('draft', String(pr.draft));
 
+      # Drafts are not gated: close-unsigned-cla-prs.yml skips them, so promising a
+      # deadline would be a lie. The check re-runs on ready_for_review, and the comment
+      # and label land then. Skipping the download also skips every step keyed off it.
       - name: Download CLA handoff
         id: cla-missing
-        if: steps.pr.outputs.number && github.event.workflow_run.conclusion == 'failure'
+        if:
+          steps.pr.outputs.number && steps.pr.outputs.draft == 'false' && github.event.workflow_run.conclusion ==
+          'failure'
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/cla-comment.yml
+++ b/.github/workflows/cla-comment.yml
@@ -10,7 +10,11 @@ on:
 
 permissions:
   actions: read
+  issues: write
   pull-requests: write
+
+env:
+  CLA_LABEL: CLA Required
 
 jobs:
   comment:
@@ -18,9 +22,35 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve pull request
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // workflow_run.pull_requests is empty for fork PRs, so resolve the pull
+            // request from the head branch instead of trusting anything the fork sends
+            const run = context.payload.workflow_run;
+
+            const prs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${run.head_repository.owner.login}:${run.head_branch}`,
+              per_page: 100,
+            });
+
+            const pr = prs.data.find((pr) => pr.head.sha === run.head_sha);
+
+            if (!pr) {
+              core.info('No open pull request points at this commit, skipping');
+              return;
+            }
+
+            core.setOutput('number', pr.number);
+
       - name: Download CLA handoff
         id: cla-missing
-        if: github.event.workflow_run.conclusion == 'failure'
+        if: steps.pr.outputs.number && github.event.workflow_run.conclusion == 'failure'
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
@@ -29,21 +59,72 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
 
+      - name: Read missing contributors
+        id: missing
+        if: steps.cla-missing.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { readFileSync } = require('node:fs');
+
+            // Fork-controlled content reaching a write-scoped job: only use it when it
+            // is exactly the list of mentions the CLA bot is meant to hand over
+            const handoff = readFileSync('cla-missing/missing', 'utf8').trim();
+            const isMentionList = /^@[\w-]{1,39}(, @[\w-]{1,39})*$/.test(handoff);
+
+            if (!isMentionList) core.warning('Unexpected CLA handoff contents, falling back to a generic greeting');
+
+            core.setOutput('mentions', isMentionList ? handoff : 'there');
+
       - name: Comment on missing CLA
         if: steps.cla-missing.outcome == 'success'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          number: ${{ steps.pr.outputs.number }}
           message: |
-            Thank you for contributing to Directus.
+            Hi ${{ steps.missing.outputs.mentions }} 👋
 
-            Before we can consider this pull request, every contributor needs to sign the Contributor License Agreement (CLA).
+            Thank you for contributing to Directus! Before we can consider this pull request, every contributor needs to sign our Contributor License Agreement (CLA).
 
-            Please review https://github.com/directus/directus/blob/main/cla.md and add the missing GitHub username(s) to contributors.yml in this pull request.
+            To sign it, add the missing GitHub username(s) to `contributors.yml` in this pull request. See the [CLA section of our contribution docs](https://directus.com/docs/community/contribution/pull-requests#copyright-license-agreement-cla) for details.
+
+            If the CLA is still unsigned after 7 days, this pull request will be closed automatically. You can reopen it at any time once it has been signed.
+
+      - name: Add CLA label
+        if: steps.cla-missing.outcome == 'success'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.PR_NUMBER),
+              labels: [process.env.CLA_LABEL],
+            });
 
       - name: Delete CLA comment
-        if: github.event.workflow_run.conclusion == 'success'
+        if: steps.pr.outputs.number && github.event.workflow_run.conclusion == 'success'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          number: ${{ steps.pr.outputs.number }}
           delete: true
+
+      - name: Remove CLA label
+        if: steps.pr.outputs.number && github.event.workflow_run.conclusion == 'success'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: Number(process.env.PR_NUMBER),
+                name: process.env.CLA_LABEL,
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - reopened
       - synchronize
+      - ready_for_review
 
 permissions:
   contents: read

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types:
       - opened
+      - reopened
       - synchronize
 
 permissions:
@@ -21,9 +22,11 @@ jobs:
 
       - name: Create missing CLA handoff
         if: steps.check.outcome == 'failure' && steps.check.outputs.missing
+        env:
+          MISSING: ${{ steps.check.outputs.missing }}
         run: |
           mkdir -p cla-missing
-          touch cla-missing/missing
+          printf '%s' "$MISSING" > cla-missing/missing
 
       - name: Upload missing CLA handoff
         if: steps.check.outcome == 'failure' && steps.check.outputs.missing

--- a/.github/workflows/close-unsigned-cla-prs.yml
+++ b/.github/workflows/close-unsigned-cla-prs.yml
@@ -1,0 +1,117 @@
+name: Close PRs without a Signed CLA
+
+on:
+  schedule:
+    - cron: '30 2 * * *'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Log what would happen without closing anything
+        type: boolean
+        default: true
+
+permissions:
+  actions: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  close-unsigned-prs:
+    if: github.repository == 'directus/directus'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          DRY_RUN: ${{ inputs.dry-run || false }}
+        with:
+          script: |
+            const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+            const LABEL_NAME = 'CLA Required';
+            const DOCS_URL = 'https://directus.com/docs/community/contribution/pull-requests#copyright-license-agreement-cla';
+            const dryRun = process.env.DRY_RUN === 'true';
+            const now = new Date();
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            for (const pr of prs) {
+              try {
+                if (pr.draft) continue;
+                if (!pr.labels.some((label) => label.name === LABEL_NAME)) continue;
+
+                const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  per_page: 100,
+                });
+
+                // Find the most recent time this label was applied
+                const [labeledAt] = events
+                  .filter((event) => event.event === 'labeled' && event.label?.name === LABEL_NAME)
+                  .map((event) => new Date(event.created_at))
+                  .sort((a, b) => b - a);
+
+                if (!labeledAt || now - labeledAt < ONE_WEEK_MS) continue;
+
+                // The label only refreshes when the PR is pushed to, so confirm against
+                // the CLA check for the commit the PR currently points at
+                const runs = await github.rest.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'cla.yml',
+                  head_sha: pr.head.sha,
+                  per_page: 100,
+                });
+
+                const [latestRun] = runs.data.workflow_runs
+                  .filter((run) => run.status === 'completed')
+                  .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+                if (!latestRun) {
+                  core.warning(`Skipped PR #${pr.number} — no completed CLA check for ${pr.head.sha}`);
+                  continue;
+                }
+
+                if (latestRun.conclusion === 'success') {
+                  if (!dryRun) {
+                    await github.rest.issues.removeLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: pr.number,
+                      name: LABEL_NAME,
+                    });
+                  }
+
+                  core.info(`Removed label from PR #${pr.number} — the CLA has since been signed: ${pr.title}`);
+                  continue;
+                }
+
+                if (dryRun) {
+                  core.info(`Would close PR #${pr.number}: ${pr.title}`);
+                  continue;
+                }
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: `Hi @${pr.user.login}! 👋 We're closing this PR because the Contributor License Agreement (CLA) hasn't been signed in the past week. We can't consider a contribution until every contributor on it has signed. To sign it, add the missing GitHub username(s) to \`contributors.yml\` — see [our contribution docs](${DOCS_URL}) for details. Feel free to reopen this PR once that's done. Thank you for contributing to Directus! 🐰`,
+                });
+
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                  state: 'closed',
+                });
+
+                core.info(`Closed PR #${pr.number}: ${pr.title}`);
+              } catch (error) {
+                core.warning(`Failed to process PR #${pr.number}: ${error.message}`);
+              }
+            }

--- a/.github/workflows/close-unsigned-cla-prs.yml
+++ b/.github/workflows/close-unsigned-cla-prs.yml
@@ -2,7 +2,7 @@ name: Close PRs without a Signed CLA
 
 on:
   schedule:
-    - cron: '30 2 * * *'
+    - cron: '30 3 * * *'
   workflow_dispatch:
     inputs:
       dry-run:
@@ -15,6 +15,9 @@ permissions:
   pull-requests: write
   issues: write
 
+env:
+  CLA_LABEL: CLA Required
+
 jobs:
   close-unsigned-prs:
     if: github.repository == 'directus/directus'
@@ -26,7 +29,7 @@ jobs:
         with:
           script: |
             const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
-            const LABEL_NAME = 'CLA Required';
+            const LABEL_NAME = process.env.CLA_LABEL;
             const DOCS_URL = 'https://directus.com/docs/community/contribution/pull-requests#copyright-license-agreement-cla';
             const dryRun = process.env.DRY_RUN === 'true';
             const now = new Date();

--- a/.github/workflows/close-unsigned-cla-prs.yml
+++ b/.github/workflows/close-unsigned-cla-prs.yml
@@ -90,7 +90,7 @@ jobs:
                     });
                   }
 
-                  core.info(`Removed label from PR #${pr.number} — the CLA has since been signed: ${pr.title}`);
+                  core.info(`${dryRun ? 'Would remove' : 'Removed'} label from PR #${pr.number} — the CLA has since been signed: ${pr.title}`);
                   continue;
                 }
 


### PR DESCRIPTION
## What's Changed

`workflow_run.pull_requests` is empty when the triggering `pull_request` run came from a fork, so the sticky CLA comment resolved a blank PR number and silently no-oped while reporting success. Verified on [run 31556065878](https://github.com/directus/directus/actions/runs/31556065878) against #28082 (fork `waterWang/directus`): the CLA check failed, the comment job reported success, and the PR has no comment. External contributors, the only audience for this comment, were the only ones never getting it.

**`cla-comment.yml`**

- Resolve the pull request from `head_repository.owner.login` + `head_branch`, keeping only the one whose `head.sha` matches the run, instead of reading `workflow_run.pull_requests`. Fixes forks, and the sha match also drops stale runs whose commit has since been superseded.
- The comment now @s the contributors who haven't signed, links the CLA section of the contribution docs rather than `cla.md`, and states the 7-day deadline up front. The handoff artifact is fork-controlled content entering a `pull-requests: write` job, so it is only used when it matches `^@[\w-]{1,39}(, @[\w-]{1,39})*$`; anything else falls back to a generic greeting instead of failing the job.
- Adds the `CLA Required` label on failure, and removes it (404-tolerant) alongside the comment deletion on success. Permissions gain `issues: write`.

**`cla.yml`**

- `reopened` added to the triggers, so a reopened PR re-checks rather than staying red.
- The handoff artifact carries the bot's `missing` output instead of being an empty marker, passed through `env:` rather than inline interpolation.

**`close-unsigned-cla-prs.yml`** (new)

Daily sweep, staggered from the existing 01:30 stale-PR workflow. Labelled → not a draft → newest `labeled` event at least 7 days old → re-verify against the newest completed `cla.yml` run for the PR's current head sha. A passing run means the CLA was signed elsewhere, so the label comes off and the PR stays open; no completed run warns and skips; a failing run gets a comment and then closes. Since this workflow closes other people's PRs it also has `workflow_dispatch` with a `dry-run` input defaulting to true, and a per-PR `try/catch` so one bad PR can't abort the sweep.

The `CLA Required` label has already been created in the repo.

## Tested Scenarios

GitHub Actions has no local test surface, so every `github-script` body was extracted from the YAML and replayed against the live API with a stub Octokit whose write endpoints throw:

- Fork run with `pull_requests: []` → resolves #28082.
- Fork run with three open PRs from the same fork owner → resolves #28085, matching both branch and head sha.
- Same-repo run whose payload names 27792 → resolves 27792, so the common path is unaffected.
- Stale head sha → resolves nothing and skips.
- Handoff sanitizing across 7 inputs, including ``@ok`)](evil`` and `hello @ok` → passed through or fell back to the generic greeting as expected.
- Cron sweep over real repo data with the label temporarily swapped for `Changes Requested` → selected #27873, and re-verification saw a passing CLA and chose label removal over closing.
- Close branch forced, dry run → logged "Would close", no write endpoint reached.
- Close branch forced, live → comment attempted before the close, and the blocked write surfaced as a per-PR warning with the loop continuing.
- Cron sweep with the real `CLA Required` label → selects nothing, correct while no PR carries it yet.

Needs a real fork PR to confirm after merge: comment and label appearing end to end on an unsigned fork PR, and both clearing after a signing commit.

## Review Notes / Questions / Concerns

- **Rollout.** This is the first time external contributors will actually receive the CLA comment. Every currently open unsigned fork PR gets commented and labelled on its next push, and becomes closable a week later. If that backlog is large, worth dispatching the cron in dry-run first to see what it would pick up.
- **What the cron trusts.** The label plus a re-check of the CLA run for the PR's current head sha. It deliberately does not re-implement the bot's `contributors.yml` logic, so a contributor who signed via a separate merged PR and never pushed again keeps the label until their next push; the re-check clears it as soon as the CLA workflow has re-run for that sha.
- **Title has no team prefix** because every `.github/` change in recent history uses a plain descriptive title.

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [x] Security implications apply

---

Closes CMS-2976
