### PR TITLE
Fix AI translate button only showing for admins

### DIFF
--- a/.changeset/sixty-clowns-build.md
+++ b/.changeset/sixty-clowns-build.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the translations interface AI translation button only showing for admins

--- a/app/src/interfaces/translations/translations.test.ts
+++ b/app/src/interfaces/translations/translations.test.ts
@@ -161,13 +161,7 @@ function mountTranslations() {
 						info: {
 							ai_enabled: true,
 							ai_providers: ['anthropic'],
-						},
-					},
-					licenseStore: {
-						info: {
-							entitlements: {
-								ai_translations_enabled: { default: true },
-							},
+							license: { entitlements: { ai_translations_enabled: true } },
 						},
 					},
 				},

--- a/app/src/interfaces/translations/translations.vue
+++ b/app/src/interfaces/translations/translations.vue
@@ -15,7 +15,6 @@ import { useRelationM2M } from '@/composables/use-relation-m2m';
 import { DisplayItem, RelationQueryMultiple, useRelationMultiple } from '@/composables/use-relation-multiple';
 import vTooltip from '@/directives/tooltip';
 import { useFieldsStore } from '@/stores/fields';
-import { useLicenseStore } from '@/stores/license';
 import { useServerStore } from '@/stores/server';
 import { fetchAll } from '@/utils/fetch-all';
 import { unexpectedError } from '@/utils/unexpected-error';
@@ -64,7 +63,6 @@ const { relationInfo } = useRelationM2M(collection, field);
 const { locale } = useI18n();
 
 const fieldsStore = useFieldsStore();
-const licenseStore = useLicenseStore();
 const serverStore = useServerStore();
 const aiStore = useAiStore();
 
@@ -82,7 +80,7 @@ const aiTranslateAvailable = computed(() =>
 		availableModelCount: aiStore.models.length,
 		disabled: props.disabled,
 		nonEditable: props.nonEditable,
-		licenseEntitlement: licenseStore.aiTranslationsEnabled,
+		licenseEntitlement: serverStore.info.license?.entitlements.ai_translations_enabled as boolean,
 	}),
 );
 


### PR DESCRIPTION
## What's Changed

- Switch `app/src/interfaces/translations/translations.vue` to determine hide/show logic of `licenseEntitlement`from globally available boolean entitlement from serverStore rather than admin only licenseStore

## Tested Scenarios

- Previously hidden ai translate button now shows for non-admin users

## Review Notes / Questions / Concerns

- Should this be derived from a top level `serverStore.info.ai_translations_enabled` rather than the deeply nested `serverStore.info.license?.entitlements.ai_translations_enabled`? Seemed unnecessary to me as this is the only place it's used

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes cms-2968
