### PR TITLE
Fix drag & drop of files with unrecognized extensions (CMS-2758)

### DIFF
--- a/.changeset/olive-pans-shout.md
+++ b/.changeset/olive-pans-shout.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed dragging & dropping files with an unrecognized extension into the file library failing silently

--- a/.changeset/olive-pans-shout.md
+++ b/.changeset/olive-pans-shout.md
@@ -2,4 +2,4 @@
 '@directus/app': patch
 ---
 
-Fixed dragging & dropping files with an unrecognized extension into the file library failing silently
+Fixed silent failure of dragging & dropping files with an unrecognized extension into the file library

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1053,6 +1053,7 @@ items: Items
 upload_file: Upload File
 upload_file_indeterminate: Uploading File...
 upload_file_success: File Uploaded
+upload_files_empty: No Files to Upload
 upload_files_indeterminate: 'Uploading files {done}/{total}'
 upload_files_success: '{count} Files Uploaded'
 upload_pending: Upload Pending

--- a/app/src/modules/files/routes/collection.vue
+++ b/app/src/modules/files/routes/collection.vue
@@ -26,6 +26,7 @@ import { useNotificationsStore } from '@/stores/notifications';
 import { useServerStore } from '@/stores/server';
 import { useUserStore } from '@/stores/user';
 import { getAssetUrl, getFilesUrl } from '@/utils/get-asset-url';
+import { getDroppedFiles } from '@/utils/get-dropped-files';
 import { getFolderFilter } from '@/utils/get-folder-filter';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { uploadFiles } from '@/utils/upload-files';
@@ -332,7 +333,16 @@ function useFileUpload() {
 			notificationsStore.remove(dragNotificationID);
 		}
 
-		const files = Array.from(event.dataTransfer.files).filter((file) => file.type);
+		const files = getDroppedFiles(event.dataTransfer);
+
+		if (files.length === 0) {
+			notificationsStore.add({
+				title: t('upload_files_empty'),
+				type: 'warning',
+			});
+
+			return;
+		}
 
 		fileUploadNotificationID = notificationsStore.add({
 			title: t(

--- a/app/src/utils/get-dropped-files.test.ts
+++ b/app/src/utils/get-dropped-files.test.ts
@@ -1,0 +1,66 @@
+import { expect, test, vi } from 'vitest';
+import { getDroppedFiles } from '@/utils/get-dropped-files';
+
+function mockItem(file: File | null, entry: { isFile: boolean; isDirectory: boolean } | null) {
+	return {
+		kind: 'file',
+		getAsFile: vi.fn(() => file),
+		webkitGetAsEntry: vi.fn(() => entry),
+	} as unknown as DataTransferItem;
+}
+
+function mockDataTransfer(items: DataTransferItem[], files: File[]) {
+	return { items, files } as unknown as DataTransfer;
+}
+
+const fileEntry = { isFile: true, isDirectory: false };
+const directoryEntry = { isFile: false, isDirectory: true };
+
+test('Keeps files without a mime type', () => {
+	const file = new File([''], 'rstadvancedsamplefamily.rfa', { type: '' });
+
+	const files = getDroppedFiles(mockDataTransfer([mockItem(file, fileEntry)], [file]));
+
+	expect(files).toEqual([file]);
+});
+
+test('Discards directories', () => {
+	const file = new File([''], 'image.png', { type: 'image/png' });
+	const directory = new File([''], 'folder', { type: '' });
+
+	const files = getDroppedFiles(
+		mockDataTransfer([mockItem(directory, directoryEntry), mockItem(file, fileEntry)], [directory, file]),
+	);
+
+	expect(files).toEqual([file]);
+});
+
+test('Ignores items that are not files', () => {
+	const file = new File([''], 'image.png', { type: 'image/png' });
+
+	const stringItem = {
+		kind: 'string',
+		getAsFile: () => null,
+		webkitGetAsEntry: () => null,
+	} as unknown as DataTransferItem;
+
+	const files = getDroppedFiles(mockDataTransfer([stringItem, mockItem(file, fileEntry)], [file]));
+
+	expect(files).toEqual([file]);
+});
+
+test('Keeps files when the entry cannot be resolved', () => {
+	const file = new File([''], 'archive.rfa', { type: '' });
+
+	const files = getDroppedFiles(mockDataTransfer([mockItem(file, null)], [file]));
+
+	expect(files).toEqual([file]);
+});
+
+test('Falls back to the file list when items are unavailable', () => {
+	const file = new File([''], 'archive.rfa', { type: '' });
+
+	const files = getDroppedFiles(mockDataTransfer([], [file]));
+
+	expect(files).toEqual([file]);
+});

--- a/app/src/utils/get-dropped-files.ts
+++ b/app/src/utils/get-dropped-files.ts
@@ -1,0 +1,25 @@
+/**
+ * Extract the files of a drop event, discarding dropped directories.
+ *
+ * Must be called synchronously within the drop handler, as the data transfer items are cleared once
+ * the event has been handled.
+ */
+export function getDroppedFiles(dataTransfer: DataTransfer): File[] {
+	const items = Array.from(dataTransfer.items ?? []).filter((item) => item.kind === 'file');
+
+	if (items.length === 0) return Array.from(dataTransfer.files);
+
+	const files: File[] = [];
+
+	for (const item of items) {
+		// A directory yields a `File` with an empty type, which is indistinguishable from a file with
+		// an extension the browser has no mime type for
+		if (item.webkitGetAsEntry?.()?.isDirectory) continue;
+
+		const file = item.getAsFile();
+
+		if (file) files.push(file);
+	}
+
+	return files;
+}


### PR DESCRIPTION
## What's Changed

- Dropping a file whose extension the browser has no mime type for (`.rfa`, `.dwg`, ...) into the file library did nothing: no upload, no error, just a phantom "Uploading files 0/0" toast.
- Root cause: `collection.vue` filtered dropped files with `.filter((file) => file.type)`, added in #23284 to keep dropped *folders* out of the upload. A dropped directory yields a `File` with an empty `type`, but so does any file with an extension the OS doesn't recognize, so those got dropped too. The resulting empty array made `uploadFiles([])` resolve immediately without a request.
- New `getDroppedFiles()` util detects directories properly via `DataTransferItem.webkitGetAsEntry().isDirectory` instead of guessing from the mime type, and falls back to `dataTransfer.files` when no file items are present.
- Drops that yield no uploadable files now show a warning notification instead of a 0/0 progress toast, so folder-only drops fail loudly.

## Tested Scenarios

- Unit tests for `getDroppedFiles()`: mime-less file kept, directory discarded, non-file (string) items ignored, file kept when the entry can't be resolved, fallback when `items` is empty.
- Manual: dropping `rstadvancedsamplefamily.rfa` onto the file library uploads it, matching the "Upload File" behaviour.
- Manual: dropping a folder onto the file library shows the warning instead of silently doing nothing.

## Review Notes / Questions / Concerns

- `webkitGetAsEntry()` and `getAsFile()` must be called synchronously inside the drop handler, before any `await`. That holds in `onDrop`, worth keeping in mind if the handler is reordered later.
- `v-upload.vue` still passes dropped folders straight through. It is not silent there (`validFiles` rejects the 0-byte directory with an error), so it is left out of this fix to keep the change focused. Happy to include it if preferred.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [x] App translations added for new user-facing strings
- [ ] Security implications apply

---

Closes CMS-2758