### PR TITLE
fix(app): add missing breadcrumb item on MCP OAuth clients collection view

### DIFF
--- a/.changeset/fix-mcp-oauth-clients-breadcrumb.md
+++ b/.changeset/fix-mcp-oauth-clients-breadcrumb.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fix breadcrumb navigation for MCP OAuth Clients showing two items instead of three

--- a/app/src/modules/settings/routes/mcp-oauth-clients/collection.vue
+++ b/app/src/modules/settings/routes/mcp-oauth-clients/collection.vue
@@ -89,6 +89,7 @@ function useBatch() {
 					:items="[
 						{ name: $t('settings'), to: '/settings' },
 						{ name: $t('settings_ai'), to: '/settings/ai' },
+						{ name: $t('mcp_oauth_clients'), to: '/settings/mcp-oauth-clients' },
 					]"
 				/>
 			</template>


### PR DESCRIPTION
## What's Changed

The MCP OAuth clients collection page was missing the third breadcrumb item, so the page title concatenated directly onto the parent without a separator. The browser showed "Settings > AIMCP OAuth Clients" instead of "Settings > AI > MCP OAuth Clients".

The item.vue for the same route already had the correct three-item breadcrumb. This just brings collection.vue in line with it by adding the missing `{ name: $t('mcp_oauth_clients'), to: '/settings/mcp-oauth-clients' }` entry.

## Tested Scenarios

* Visually confirmed by diffing `item.vue` (correct, three items) against `collection.vue` (two items, missing current-page entry)
* One-line change with no logic, no API calls, no schema impact

## Review Notes / Questions / Concerns

* No other files affected

## Checklist

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [ ] OpenAPI updated
- [ ] SDK updated
- [ ] Types updated
- [ ] GraphQL schema updated
- [ ] System data updated
- [ ] Database migration added
- [ ] Environment variables documented
- [X] App translations added for new user-facing strings — no new strings, `mcp_oauth_clients` key already exists
- [ ] Security implications apply

Fixes directus/directus#28007