### PR TITLE
fix(app): preserve cursor position in JSON code interface after auto-format

### DIFF
--- a/.changeset/fix-json-interface-cursor-jump.md
+++ b/.changeset/fix-json-interface-cursor-jump.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Preserve cursor position in JSON code interface after auto-format on paste

--- a/app/src/interfaces/input-code/input-code.vue
+++ b/app/src/interfaces/input-code/input-code.vue
@@ -117,7 +117,9 @@ watch(stringValue, () => {
 	if (props.type === 'json' && codemirror?.getValue() === props.value) return;
 
 	if (codemirror?.getValue() !== stringValue.value) {
+		const cursor = codemirror?.getCursor();
 		codemirror?.setValue(stringValue.value || '');
+		if (cursor) codemirror?.setCursor(cursor);
 	}
 });
 


### PR DESCRIPTION
Fixes #28045

## Root Cause

When editing a JSON field with the Code interface, pasting content triggers a `change` event. The handler parses the JSON and emits `input` with the parsed object. The parent stringifies it back (with consistent indentation), changing `stringValue`, which fires the `watch(stringValue)`. That watcher calls `codemirror.setValue()`, which always resets the cursor to `{ line: 0, ch: 0 }`.

## Fix

Save the cursor position via `getCursor()` before calling `setValue()` and restore it via `setCursor()` afterwards. CodeMirror automatically clamps the position to valid document bounds, so this is safe even when the reformatted content is shorter than what the user typed.

```diff
-    codemirror?.setValue(stringValue.value || '');
+    const cursor = codemirror?.getCursor();
+    codemirror?.setValue(stringValue.value || '');
+    if (cursor) codemirror?.setCursor(cursor);
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)