### PR TITLE
fix(app): remove raw field path tooltip from O2M/M2M table layout cells

### DIFF
--- a/.changeset/fix-o2m-m2m-table-tooltip-raw-field-path.md
+++ b/.changeset/fix-o2m-m2m-table-tooltip-raw-field-path.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fix tooltip in O2M/M2M table layout showing raw field path instead of display value

--- a/app/src/interfaces/list-m2m/list-m2m.vue
+++ b/app/src/interfaces/list-m2m/list-m2m.vue
@@ -569,7 +569,6 @@ const menuActive = computed(() => editModalActive.value || selectModalActive.val
 			>
 				<template v-for="header in headers" :key="header.value" #[`item.${header.value}`]="{ item }">
 					<RenderTemplate
-						:title="header.value"
 						:collection="relationInfo.junctionCollection.collection"
 						:item="item"
 						:template="`{{${header.value}}}`"

--- a/app/src/interfaces/list-o2m/list-o2m.vue
+++ b/app/src/interfaces/list-o2m/list-o2m.vue
@@ -531,7 +531,6 @@ const menuActive = computed(() => Boolean(currentlyEditing.value) || selectModal
 			>
 				<template v-for="header in headers" :key="header.value" #[`item.${header.value}`]="{ item }">
 					<RenderTemplate
-						:title="header.value"
 						:collection="relationInfo.relatedCollection.collection"
 						:item="item"
 						:template="`{{${header.value}}}`"


### PR DESCRIPTION
Fixes directus/directus#27568

## Root Cause

In `list-o2m.vue` and `list-m2m.vue`, every `<RenderTemplate>` call inside the table cell slot was given `:title="header.value"`. Since `RenderTemplate` doesn't declare a `title` prop, Vue passes it through as a native HTML `title` attribute on the root element. Browsers show the HTML `title` attribute as a native tooltip on hover, so users saw the raw internal field path (e.g. `hardware_item.asset_tag`) instead of nothing or the rendered value.

## Fix

Remove the `:title="header.value"` attribute from both files. The `header.value` is only used to identify which template variable to render (`{{hardware_item.asset_tag}}`) and should not appear as a tooltip.

🤖 Generated with [Claude Code](<https://claude.ai/claude-code>)