### PR TITLE
fix(app): apply display components per-item for nested scalar fields from O2M/alias relations

### DIFF
--- a/.changeset/fix-alias-nested-field-display-array.md
+++ b/.changeset/fix-alias-nested-field-display-array.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fix display components not applying to nested scalar fields from O2M/alias relations in tabular layout

--- a/app/src/views/private/components/render-display.vue
+++ b/app/src/views/private/components/render-display.vue
@@ -43,7 +43,7 @@ const displayInfo = useExtension('display', display);
 						<VTextOverflow class="display" :text="item" />
 					</template>
 				</VErrorBoundary>
-				<span v-if="i < value.length - 1">, </span>
+				<span v-if="i < value.length - 1">,</span>
 			</template>
 		</template>
 	</template>

--- a/app/src/views/private/components/render-display.vue
+++ b/app/src/views/private/components/render-display.vue
@@ -24,6 +24,29 @@ const displayInfo = useExtension('display', display);
 <template>
 	<ValueNull v-if="value === null || value === undefined" />
 	<VTextOverflow v-else-if="displayInfo === null" class="display" :text="value" />
+	<template v-else-if="Array.isArray(value) && !['alias', 'json'].includes(type)">
+		<ValueNull v-if="value.length === 0" />
+		<template v-else>
+			<template v-for="(item, i) in value" :key="i">
+				<VErrorBoundary :name="`display-${display}-${i}`">
+					<component
+						:is="`display-${display}`"
+						v-bind="options"
+						:interface="interface"
+						:interface-options="interfaceOptions"
+						:value="item"
+						:type="type"
+						:collection="collection"
+						:field="field"
+					/>
+					<template #fallback>
+						<VTextOverflow class="display" :text="item" />
+					</template>
+				</VErrorBoundary>
+				<span v-if="i < value.length - 1">, </span>
+			</template>
+		</template>
+	</template>
 	<VErrorBoundary v-else :name="`display-${display}`">
 		<component
 			:is="`display-${display}`"


### PR DESCRIPTION
Closes #27657

## Summary

When a user adds a nested field from an O2M / alias relation (e.g. `author_list.joined_at`) to the tabular layout, the `@directus/utils` `get` helper traverses the array of related items and returns a collected array of scalar values (e.g. `["2026-07-29T12:00:00"]`). `render-display` then forwarded this array directly to `display-datetime` (or any other scalar display), which cannot handle array input — showing the raw array string `[ "2026-07-29T12:00:00" ]` instead of a formatted date.

## Root cause

`get-with-arrays.ts` intentionally maps over arrays when traversing nested paths. The gap was that `render-display.vue` had no handling for the case where a scalar-typed display component receives an unexpected array.

## Fix

In `render-display.vue`, before delegating to the display component, detect when `value` is an array **and** the field `type` is a scalar (not `alias` or `json`, which are multi-value types whose display components already handle arrays). When that condition is met, render each element individually through the configured display component, joined with `, `.

| Column | Relation | Before | After |
| --- | --- | --- | --- |
| `author.joined_at` | M2O | `July 29th, 2026 12:00 PM` ✅ | `July 29th, 2026 12:00 PM` ✅ |
| `author_list.joined_at` | O2M (alias) | `[ "2026-07-29T12:00:00" ]` ❌ | `July 29th, 2026 12:00 PM` ✅ |

Empty arrays render as `ValueNull`. The error boundary is applied per-item so a single bad value does not suppress the rest.