### PR TITLE
fix(websocket): deregister messageWatcher in heartbeat timeout path to prevent listener leak

### DIFF
--- a/.changeset/fix-websocket-heartbeat-listener-leak.md
+++ b/.changeset/fix-websocket-heartbeat-listener-leak.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fix WebSocket heartbeat leaking `websocket.message` listeners for idle clients

--- a/api/src/websocket/handlers/heartbeat.ts
+++ b/api/src/websocket/handlers/heartbeat.ts
@@ -71,6 +71,8 @@ export class HeartbeatHandler {
 			for (const client of pendingClients) {
 				client.close();
 			}
+
+			emitter.offAction('websocket.message', messageWatcher);
 		}, HEARTBEAT_FREQUENCY);
 
 		const messageWatcher: ActionHandler = ({ client }) => {


### PR DESCRIPTION
Closes #27830

## Summary

`HeartbeatHandler.pingClients()` registers a `websocket.message` listener (`messageWatcher`) on every heartbeat cycle. The listener was only removed in **one** of two exit paths:

- ✅ All pending clients respond → `pendingClients.size === 0` → `emitter.offAction` is called
- ❌ Timeout fires (idle clients don't respond) → clients are closed, but `messageWatcher` is **never** removed

Every heartbeat cycle with at least one idle client permanently adds a `websocket.message` listener. After 10 cycles, Node.js emits `MaxListenersExceededWarning` and memory usage climbs steadily.

## Fix

Call `emitter.offAction('websocket.message', messageWatcher)` inside the `setTimeout` callback, before closing the non-responding clients. This ensures the listener is always cleaned up regardless of which path resolves the heartbeat cycle.

```typescript
// before
const timeout = setTimeout(() => {
    for (const client of pendingClients) {
        client.close();
    }
}, HEARTBEAT_FREQUENCY);

// after
const timeout = setTimeout(() => {
    for (const client of pendingClients) {
        client.close();
    }
    emitter.offAction('websocket.message', messageWatcher);  // ← added
}, HEARTBEAT_FREQUENCY);
```

Also reorders the declaration so `messageWatcher` is defined before `timeout` to avoid the temporal dead zone between the two closures (the prior code happened to work at runtime since setTimeout fires asynchronously, but the declaration order is now cleaner).