### PR TITLE
fix(app): skip required validation for fields inside hidden groups

### DIFF
--- a/.changeset/fix-required-validation-hidden-groups.md
+++ b/.changeset/fix-required-validation-hidden-groups.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fix required validation triggering on fields inside hidden groups

--- a/app/src/utils/validate-item.ts
+++ b/app/src/utils/validate-item.ts
@@ -29,8 +29,13 @@ export function validateItem(
 		return conditionedField;
 	});
 
+	const hiddenFieldKeys = new Set(
+		fieldsWithConditions.filter((field) => field.meta?.hidden === true).map((field) => field.field),
+	);
+
 	const requiredFields = fieldsWithConditions.filter(
-		(field) => field.meta?.required === true && !isPresentationField(field),
+		(field) =>
+			field.meta?.required === true && !isPresentationField(field) && !hiddenFieldKeys.has(field.meta?.group ?? ''),
 	);
 
 	requiredFields.forEach((field) => {


### PR DESCRIPTION
Closes #26562 (Bug 2)

## Summary

Required validation was triggering on fields whose **parent group** was hidden, preventing the form from saving even when the group (and its fields) were not visible to the user.

## Root cause

`validateItem` built `requiredFields` from all fields where `field.meta?.required === true`, without checking whether the field's parent group was hidden. After `applyConditions` ran, a group could be hidden while its children still passed the required filter.

## Fix

Before filtering required fields, build a `Set` of hidden field keys from the post-conditions field list:

```typescript
const hiddenFieldKeys = new Set(
    fieldsWithConditions
        .filter((field) => field.meta?.hidden === true)
        .map((field) => field.field),
);

const requiredFields = fieldsWithConditions.filter(
    (field) =>
        field.meta?.required === true &&
        !isPresentationField(field) &&
        !hiddenFieldKeys.has(field.meta?.group ?? ''),
);
```

Any required field whose `meta.group` resolves to a hidden group is excluded from validation. Fields with no group (empty string key) are never in `hiddenFieldKeys`, so ungrouped required fields are unaffected.

## Related

This addresses the second bug from #26562: *"required triggers even when [group is] hidden"*. The first bug (required not enforced when group transitions from hidden to shown via condition) is a separate issue.