### PR TITLE
fix(app): apply update field-level permissions in version editor to prevent unpromotable deltas

### DIFF
--- a/.changeset/fix-version-editor-field-update-permissions.md
+++ b/.changeset/fix-version-editor-field-update-permissions.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Mark fields without update permission as readonly when editing a content version, preventing them from entering the version delta and making the version impossible to promote

--- a/app/src/composables/use-permissions/item/lib/get-fields.ts
+++ b/app/src/composables/use-permissions/item/lib/get-fields.ts
@@ -33,9 +33,28 @@ export function getFields(
 			fields = fields.filter((field) => readableFields.includes(field.field));
 		}
 
-		// Version editing bypasses underlying collection write permissions entirely.
-		// Field-level access is enforced by the backend at promote time.
-		if (unref(isVersion)) return fields;
+		// For version editing, item-level conditions (e.g. "can update only when status=draft") are
+		// deferred to promote time because they depend on the live item state. However, field-level
+		// access lists are static and can be resolved up-front. Marking non-updatable fields as
+		// readonly in the editor prevents them from silently entering the version delta and making
+		// the version impossible to promote.
+		if (unref(isVersion)) {
+			const updatePermission = getPermission(collectionValue, 'update');
+
+			if (updatePermission?.fields && !updatePermission.fields.includes('*')) {
+				for (const field of fields) {
+					if (!updatePermission.fields.includes(field.field)) {
+						(field as FormField).meta = {
+							...(field.meta || {}),
+							readonly: true,
+							non_editable: true,
+						};
+					}
+				}
+			}
+
+			return fields;
+		}
 
 		let permission;
 


### PR DESCRIPTION
Closes #28068

## Problem

When a non-admin user edits a content version, the Studio rendered every **readable** field as editable, regardless of whether the user had **update** permission for that field. Edits to those fields were silently written into `directus_versions.delta`, and `POST /versions/:pk/promote` would then return `FORBIDDEN` for the entire delta — locking the user out of publishing any of their changes with no self-service recovery path.

The original bypass in `getFields()` was intended only for *item-level* conditions (e.g., "can update when status=draft"), which genuinely cannot be evaluated without the live item at save time. But field-level access lists are static — they don't depend on any item's current state — and can be applied up-front in the editor.

## Fix

In `getFields()`, when `isVersion` is true, look up the collection's `update` permission from the store and mark any field outside that permission's `fields` list as `readonly`/`non_editable` before returning. Item-level conditions are still deferred to promote time (the existing behavior for that case is unchanged).

```diff
-// Version editing bypasses underlying collection write permissions entirely.
-// Field-level access is enforced by the backend at promote time.
-if (unref(isVersion)) return fields;
+// For version editing, item-level conditions are deferred to promote time.
+// Field-level access lists are static and can be resolved up-front.
+if (unref(isVersion)) {
+    const updatePermission = getPermission(collectionValue, 'update');
+    if (updatePermission?.fields && !updatePermission.fields.includes('*')) {
+        for (const field of fields) {
+            if (!updatePermission.fields.includes(field.field)) {
+                (field as FormField).meta = {
+                    ...(field.meta || {}),
+                    readonly: true,
+                    non_editable: true,
+                };
+            }
+        }
+    }
+    return fields;
+}
```

## Impact

- Fields the user cannot update are now visibly locked (readonly) in the version editor, giving immediate feedback instead of silent delta poisoning.
- The version delta only contains fields the user is actually allowed to update, so `promote` no longer fails due to field permission violations from prior saves.
- Item-level conditional permissions (access depending on item state) are still deferred to promote time — no behaviour change for that case.