### PR TITLE
Fix policy creation modal writing app access permission rows 

### DIFF
--- a/.changeset/tricky-mails-cheat.md
+++ b/.changeset/tricky-mails-cheat.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Stopped the policy creation modal from writing app access permission rows to the database, matching the policy detail page where app access permissions are applied at runtime instead of stored

--- a/app/src/modules/settings/routes/policies/use-save.test.ts
+++ b/app/src/modules/settings/routes/policies/use-save.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { useSave } from './use-save';
+
+const pushMock = vi.fn();
+
+vi.mock('vue-router', () => ({
+	useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock('@/api', () => ({
+	default: {
+		post: vi.fn(),
+	},
+}));
+
+vi.mock('@/utils/unexpected-error', () => ({
+	unexpectedError: vi.fn(),
+}));
+
+let api: { post: ReturnType<typeof vi.fn> };
+
+beforeEach(async () => {
+	api = (await vi.importMock('@/api')).default as typeof api;
+	vi.clearAllMocks();
+	api.post.mockResolvedValue({ data: { data: { id: 'new-policy-id' } } });
+});
+
+describe('useSave', () => {
+	it('POSTs to /policies with the configured access flags', async () => {
+		const { save } = useSave({ name: ref('Editor'), appAccess: ref(true), adminAccess: ref(false) });
+
+		await save();
+
+		expect(api.post).toHaveBeenCalledWith('/policies', {
+			name: 'Editor',
+			admin_access: false,
+			app_access: true,
+		});
+	});
+
+	it('does not persist permission records when app access is enabled', async () => {
+		const { save } = useSave({ name: ref('Editor'), appAccess: ref(true), adminAccess: ref(false) });
+
+		await save();
+
+		expect(api.post).toHaveBeenCalledTimes(1);
+		expect(api.post).not.toHaveBeenCalledWith('/permissions', expect.anything());
+	});
+
+	it('navigates to the created policy', async () => {
+		const { save } = useSave({ name: ref('Editor'), appAccess: ref(false), adminAccess: ref(false) });
+
+		await save();
+
+		expect(pushMock).toHaveBeenCalledWith({
+			name: 'settings-policies-item',
+			params: { primaryKey: 'new-policy-id' },
+		});
+	});
+});

--- a/app/src/modules/settings/routes/policies/use-save.ts
+++ b/app/src/modules/settings/routes/policies/use-save.ts
@@ -1,4 +1,3 @@
-import { appAccessMinimalPermissions } from '@directus/system-data';
 import type { Ref } from 'vue';
 import { ref } from 'vue';
 import { useRouter } from 'vue-router';
@@ -29,16 +28,6 @@ export function useSave({ name, adminAccess, appAccess }: UseSaveOptions) {
 				admin_access: adminAccess.value,
 				app_access: appAccess.value,
 			});
-
-			if (appAccess.value === true && adminAccess.value === false) {
-				await api.post(
-					'/permissions',
-					appAccessMinimalPermissions.map((permission) => ({
-						...permission,
-						policy: policyResponse.data.data.id,
-					})),
-				);
-			}
 
 			router.push({ name: 'settings-policies-item', params: { primaryKey: policyResponse.data.data.id } });
 		} catch (error) {


### PR DESCRIPTION
## What's Changed

- The policy creation modal no longer POSTs `appAccessMinimalPermissions` to `/permissions` after creating a policy with app access enabled
- Added unit tests for `useSave`

The modal was the only path persisting app-access permission rows. The policy detail page (`system-permissions.vue`) renders those same minimal permissions virtually and stores nothing, because the API injects them at runtime via `withAppMinimalPermissions`. The POST predates that design (it came in with the policy rework in #22773); #25402 only swapped `appRecommendedPermissions` for `appAccessMinimalPermissions` in it instead of dropping it.

The stored rows are indistinguishable from user-authored custom permission rules downstream, so on instances unlicensed for `custom_permission_rules_enabled` the API hides them from reads and `d6s sync pull` reports an incomplete pull for permissions the user never authored.

The minimum vs recommended distinction now lives only where it is explicit: the "reset system permissions to minimum / recommended defaults" action on the policy detail page, where "recommended" is a deliberate choice that writes rows.

## Tested Scenarios

- Create a policy via the modal with app access ticked → no rows in `directus_permissions` for that policy
- App access still works for users of that policy (permissions injected at runtime)
- Policy detail page shows the app-minimal system permission rows as before, without duplicates
- Reset to recommended defaults on the detail page still persists the recommended set
- `pnpm vitest run src/modules/settings/routes/policies/` in `app` passes

## Review Notes / Questions / Concerns

- Existing databases keep the rows written before this fix; cleaning those up is out of scope per the issue.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Closes CMS-2978