### PR TITLE
Fix image transformations being rejected when a format or quality is requested

### DIFF
--- a/.changeset/olive-donkeys-repeat.md
+++ b/.changeset/olive-donkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed image transformations being rejected as too large when a format or quality was requested, since the output cap was measured against the untransformed source dimensions

--- a/api/src/services/assets/assert-transforms-allowed.test.ts
+++ b/api/src/services/assets/assert-transforms-allowed.test.ts
@@ -60,6 +60,26 @@ describe('assertTransformsAllowed', () => {
 		expect(() => assertTransformsAllowed(1, 1, transforms)).toThrow(IllegalAssetTransformationError);
 	});
 
+	test('When a dimension-neutral step precedes a resize, then the oversized source does not throw', () => {
+		const transforms: Transformation[] = [
+			['toFormat', 'webp', { quality: undefined }],
+			['resize', { width: undefined, height: 8 }],
+		];
+
+		expect(() => assertTransformsAllowed(MAX_DIM + 1, MAX_DIM + 1, transforms)).not.toThrow();
+	});
+
+	test('When a resize projects the oversized source back at its own size, then it still throws', () => {
+		const transforms: Transformation[] = [
+			['toFormat', 'webp', { quality: undefined }],
+			['resize', { width: MAX_DIM + 1, height: undefined }],
+		];
+
+		expect(() => assertTransformsAllowed(MAX_DIM + 1, MAX_DIM + 1, transforms)).toThrow(
+			IllegalAssetTransformationError,
+		);
+	});
+
 	test('When a source dimension is zero, then it does not divide by zero or throw', () => {
 		const transforms: Transformation[] = [['resize', { width: 100 }]];
 		expect(() => assertTransformsAllowed(0, 0, transforms)).not.toThrow();

--- a/api/src/services/assets/assert-transforms-allowed.ts
+++ b/api/src/services/assets/assert-transforms-allowed.ts
@@ -18,19 +18,16 @@ export type Size = { width: number; height: number };
  * @returns upper bound for the given step
  */
 export function calculateStep(size: Size, method: string, args: unknown[]): Size {
-	switch (method) {
-		case 'resize':
-			return calculateResize(size, args);
-		case 'extract':
-			return calculateExtract(size, args[0]);
-		case 'extend':
-			return calculateExtend(size, args[0]);
-		case 'rotate':
-			return calculateRotate(size, args[0]);
-		default:
-			return size;
-	}
+	const calculate = dimensionSteps.get(method);
+	return calculate ? calculate(size, args) : size;
 }
+
+const dimensionSteps = new Map<string, (size: Size, args: unknown[]) => Size>([
+	['resize', (size, args) => calculateResize(size, args)],
+	['extract', (size, args) => calculateExtract(size, args[0])],
+	['extend', (size, args) => calculateExtend(size, args[0])],
+	['rotate', (size, args) => calculateRotate(size, args[0])],
+]);
 
 /**
  * Rejects a transform if its projected output exceeds the `ASSETS_TRANSFORM_IMAGE_MAX_OUTPUT_DIMENSION`
@@ -53,6 +50,10 @@ export function assertTransformsAllowed(sourceWidth: number, sourceHeight: numbe
 	let size: Size = { width: sourceWidth, height: sourceHeight };
 
 	for (const [method, ...args] of transforms) {
+		// Steps like `toFormat` leave the dimensions alone, so measuring them would test the source
+		// against the output cap. The source is bound by `ASSETS_TRANSFORM_IMAGE_MAX_DIMENSION` instead.
+		if (!dimensionSteps.has(method)) continue;
+
 		size = calculateStep(size, method, args);
 
 		if (size.width > maxOutputDimension || size.height > maxOutputDimension) {


### PR DESCRIPTION
## What's Changed

* `assertTransformsAllowed()` walked every step of the sharp pipeline and compared the running size against `ASSETS_TRANSFORM_IMAGE_MAX_OUTPUT_DIMENSION`, including steps that do not touch the dimensions at all. `resolvePreset()` puts `toFormat` in front of the `resize`, so asking for `?format=webp&height=8` measured the untouched source against the output cap and threw `IllegalAssetTransformationError` for any source larger than 3000px, even though the actual output is 8px tall. Without `format` or `quality` the only step is the `resize`, which is why it worked there.
* The loop now skips steps with no dimension projection. The step table is shared with `calculateStep()` so the two cannot drift apart.

## Tested Scenarios

* `toFormat` ahead of a shrinking `resize` on a source above the cap no longer throws
* A `resize` that projects an oversized source back at its own size still throws, so the cap itself is unchanged
* `pnpm test` in `api/` (the `src/app.test.ts` failures are the pre-existing ones from a source-only checkout without the built app package)

## Review Notes / Questions / Concerns

* The source is already bound by `ASSETS_TRANSFORM_IMAGE_MAX_DIMENSION` (default 6000) earlier in `getAsset()`, so the output cap does not need to police it a second time. A request with no transforms at all was never checked either.

## Checklist

> Leave unchecked where not applicable

- [X] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](<https://github.com/directus/openapi>)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes directus/directus#28103