### PR TITLE
OAS <- Strip internal-only `x-*` extensions from generated spec

### DIFF
--- a/.changeset/swift-cooks-look.md
+++ b/.changeset/swift-cooks-look.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': major
+---
+
+Removed internal authoring directives (`x-collection`, `x-schemas`, `x-authentication`) from the dynamically generated
+OpenAPI spec so they no longer surface to consumers

--- a/api/src/services/specifications.test.ts
+++ b/api/src/services/specifications.test.ts
@@ -7,7 +7,7 @@ import type { RequestBodyObject, SchemaObject } from 'openapi3-ts/oas30';
 import type { MockedFunction } from 'vitest';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { fetchPermissions } from '../permissions/lib/fetch-permissions.js';
-import { SpecificationService } from './index.js';
+import { INTERNAL_EXTENSIONS, SpecificationService } from './index.js';
 
 vi.mock('../permissions/lib/fetch-policies.js', () => ({
 	fetchPolicies: vi.fn().mockResolvedValue([]),
@@ -532,6 +532,83 @@ describe('Integration Tests', () => {
 						expect(spec.components?.schemas?.['Collections']).toBeDefined();
 						expect(spec.components?.schemas?.['Fields']).toBeDefined();
 						expect(spec.components?.schemas?.['Relations']).toBeDefined();
+					});
+				});
+
+				describe('internal authoring directives', () => {
+					// INTERNAL_EXTENSIONS are generator-internal: read during generation (auth gating,
+					// schema inclusion) but not meant for consumers, so they must not surface in the spec.
+					const METHODS = ['get', 'post', 'patch', 'delete', 'put', 'head', 'options'] as const;
+
+					const mixedSchema = new SchemaBuilder()
+						.collection('test_table', (c) => {
+							c.field('id').integer().primary().options({ nullable: false });
+						})
+						.collection('directus_files', (c) => {
+							c.field('id').uuid().primary();
+						})
+						.build();
+
+					it('strips them from every emitted tag', async () => {
+						const service = new SpecificationService({
+							knex: db,
+							schema: mixedSchema,
+							accountability: { role: 'admin', admin: true } as Accountability,
+						});
+
+						const spec = await service.oas.generate();
+
+						// Covers a non-system tag (x-collection: ItemsTestTable), a system-collection
+						// tag (x-collection: Files), and collection-less system tags (x-schemas +
+						// x-authentication: Schema, Utilities).
+						for (const tag of spec.tags ?? []) {
+							for (const key of INTERNAL_EXTENSIONS) {
+								expect(tag).not.toHaveProperty(key);
+							}
+						}
+					});
+
+					it('strips them from every emitted operation while preserving the security that encodes them', async () => {
+						const service = new SpecificationService({
+							knex: db,
+							schema: mixedSchema,
+							accountability: { role: 'admin', admin: true } as Accountability,
+						});
+
+						const spec = await service.oas.generate();
+
+						for (const pathItem of Object.values(spec.paths ?? {})) {
+							for (const method of METHODS) {
+								const operation = (pathItem as any)?.[method];
+								if (!operation) continue;
+
+								for (const key of INTERNAL_EXTENSIONS) {
+									expect(operation).not.toHaveProperty(key);
+								}
+							}
+						}
+
+						// x-authentication: none is consumed to mark hardcoded-open operations; the
+						// consumer-facing encoding of that is security: [], which must survive the strip.
+						expect(spec.paths['/auth/login']?.post?.security).toEqual([]);
+					});
+
+					it('strips them from every emitted schema component', async () => {
+						const service = new SpecificationService({
+							knex: db,
+							schema: mixedSchema,
+							accountability: { role: 'admin', admin: true } as Accountability,
+						});
+
+						const spec = await service.oas.generate();
+
+						// generateComponents stamps x-collection onto schemas (the collection they
+						// represent); strip it so the internal collection name doesn't reach consumers.
+						for (const schema of Object.values(spec.components?.schemas ?? {})) {
+							for (const key of INTERNAL_EXTENSIONS) {
+								expect(schema).not.toHaveProperty(key);
+							}
+						}
 					});
 				});
 			});

--- a/api/src/services/specifications.ts
+++ b/api/src/services/specifications.ts
@@ -39,7 +39,7 @@ const OPTIONAL_AUTH_SECURITY: OpenAPIObject['security'] = [{}, { Auth: [] }, { K
 
 // Internal authoring directives read during generation (auth/RBAC gating, schema inclusion) but
 // not meant for consumers, so stripped from every emitted tag, operation, and schema.
-const INTERNAL_EXTENSIONS = ['x-collection', 'x-schemas', 'x-authentication'] as const;
+export const INTERNAL_EXTENSIONS = ['x-collection', 'x-schemas', 'x-authentication'] as const;
 
 export class SpecificationService {
 	accountability: Accountability | null;

--- a/api/src/services/specifications.ts
+++ b/api/src/services/specifications.ts
@@ -37,6 +37,10 @@ const env = useEnv();
 // caller may see a broader response than the public role, e.g. more fields).
 const OPTIONAL_AUTH_SECURITY: OpenAPIObject['security'] = [{}, { Auth: [] }, { KeyAuth: [] }, { CookieAuth: [] }];
 
+// Internal authoring directives read during generation (auth/RBAC gating, schema inclusion) but
+// not meant for consumers, so stripped from every emitted tag, operation, and schema.
+const INTERNAL_EXTENSIONS = ['x-collection', 'x-schemas', 'x-authentication'] as const;
+
 export class SpecificationService {
 	accountability: Accountability | null;
 	knex: Knex;
@@ -120,8 +124,16 @@ class OASSpecsService implements SpecificationSubService {
 			paths,
 		};
 
-		if (tags) spec.tags = tags;
+		if (tags) spec.tags = tags.map((tag) => this.omitInternalExtensions({ ...tag }));
 		if (components) spec.components = components;
+
+		// generateComponents stamps each schema with x-collection (its collection name); strip it so the
+		// internal collection name doesn't reach consumers.
+		if (spec.components?.schemas) {
+			for (const name of Object.keys(spec.components.schemas)) {
+				spec.components.schemas[name] = this.omitInternalExtensions({ ...spec.components.schemas[name] });
+			}
+		}
 
 		spec.security = cloneDeep(staticSpec.security)!;
 
@@ -244,6 +256,10 @@ class OASSpecsService implements SpecificationSubService {
 									operationWithSecurity = { ...operation, security: cloneDeep(OPTIONAL_AUTH_SECURITY) };
 								}
 
+								// operation may be a direct staticSpec reference, so copy before stripping; security already
+								// encodes the x-authentication gating result.
+								operationWithSecurity = this.omitInternalExtensions({ ...operationWithSecurity });
+
 								if ('parameters' in pathItem) {
 									paths[path]![method as keyof PathItemObject] = {
 										...operationWithSecurity,
@@ -279,7 +295,7 @@ class OASSpecsService implements SpecificationSubService {
 						if (!paths[`/items/${collection}/{id}`]) paths[`/items/${collection}/{id}`] = {};
 
 						if (listBase?.[method]) {
-							paths[`/items/${collection}`]![method] = {
+							paths[`/items/${collection}`]![method] = this.omitInternalExtensions({
 								...mergeWith(
 									cloneDeep(listBase[method]),
 									{
@@ -338,11 +354,11 @@ class OASSpecsService implements SpecificationSubService {
 								),
 								tags: [tag.name],
 								...(isPubliclyAccessible && { security: cloneDeep(OPTIONAL_AUTH_SECURITY) }),
-							};
+							});
 						}
 
 						if (detailBase?.[method]) {
-							paths[`/items/${collection}/{id}`]![method] = {
+							paths[`/items/${collection}/{id}`]![method] = this.omitInternalExtensions({
 								...mergeWith(
 									cloneDeep(detailBase[method]),
 									{
@@ -384,7 +400,7 @@ class OASSpecsService implements SpecificationSubService {
 								),
 								tags: [tag.name],
 								...(isPubliclyAccessible && { security: cloneDeep(OPTIONAL_AUTH_SECURITY) }),
-							};
+							});
 						}
 					}
 				}
@@ -535,6 +551,17 @@ class OASSpecsService implements SpecificationSubService {
 			// The schema we just pulled in may itself reference further schemas transitively.
 			queue.push(...this.collectSchemaRefs(schema));
 		}
+	}
+
+	/** Mutates obj in place; callers must pass a shallow copy so the static spec source isn't changed. */
+	private omitInternalExtensions<T>(obj: T): T {
+		const target = obj as Record<string, unknown>;
+
+		for (const key of INTERNAL_EXTENSIONS) {
+			delete target[key];
+		}
+
+		return obj;
 	}
 
 	/** Prevents mergeWith from corrupting $refs and overwriting array items by index. */


### PR DESCRIPTION
## What's Changed

- Internal-only `x-*` authoring directives are no longer leaked to the `/server/specs/oas` endpoint (`x-collection`, `x-schemas`, and `x-authentication`). Forward compatibility considered for directives<sup>1</sup> introduced by sibling PRs:
  - `x-action` (supports `/assets/*` endpoints, directus/directus#28021)
  - `x-enabled-env` (env-gated path/tag inclusion, directus/directus#27766)



## Tested Scenarios

- Added tests asserting no emitted tag, operation, or schema carries any `INTERNAL_EXTENSIONS`
- `pnpm --filter @directus/api test src/services/specifications.test.ts` ✅  all passing
- Live: fresh Postgres DB with `GET /server/specs/oas?access_token=admin-token` returns no `x-*` directives across tags, operations, or schemas; `/auth/login` retains the `security: []` added programmatically from `x-authentication: none`

## Review Notes / Questions / Concerns

- Security implications checked because this is a tightening with little to no risk: no consumer needs the collection name for a path, and exposing it only makes malicious probing easier.
  - The info is still available for anyone who wants to investigate code but it's just not served at the endpoint.
- <sup>1</sup>When new `x-*` extensions land, they'll need adding to `INTERNAL_EXTENSIONS` and their emission sites confirmed covered by the strip as necessary.
- changeset I opted for major release since this PR is removing something from the specs endpoint but I'm not sure about expectations/practices for feature branch work.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [x] Security implications apply

---

Ref https://github.com/directus/directus/pull/27883#issuecomment-5294605805
