### PR TITLE
Fixed field configuration appearing to close when selecting collection that switches interface

### DIFF
--- a/.changeset/shaggy-lions-listen.md
+++ b/.changeset/shaggy-lions-listen.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed field configuration appearing to close when selecting related collection that switches interface

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-detail-simple.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail-simple/field-detail-simple.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Collection } from '@directus/types';
 import { orderBy } from 'lodash';
-import { computed, toRefs, watch } from 'vue';
+import { computed, nextTick, ref, toRefs, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { syncFieldDetailStoreProperty, useFieldDetailStore } from '../store/';
 import FieldConfiguration from './field-configuration.vue';
@@ -10,22 +10,18 @@ import VIcon from '@/components/v-icon/v-icon.vue';
 import VTextOverflow from '@/components/v-text-overflow.vue';
 import { useExtensions } from '@/extensions';
 
-const props = withDefaults(
-	defineProps<{
-		collection: Collection;
-		search?: string | null;
-	}>(),
-	{
-		search: null,
-	},
-);
+const props = defineProps<{
+	collection: Collection;
+}>();
+
+const search = defineModel<string | null>('search', { default: null });
 
 defineEmits<{
 	(e: 'save'): void;
 	(e: 'toggleAdvanced'): void;
 }>();
 
-const { collection, search } = toRefs(props);
+const { collection } = toRefs(props);
 
 const { t } = useI18n();
 
@@ -91,6 +87,31 @@ const groups = computed(() => {
 
 const chosenInterface = syncFieldDetailStoreProperty('field.meta.interface');
 
+const interfaceEls = ref<Record<string, Element | null>>({});
+
+let interfaceChosenByUser = false;
+
+/**
+ * Configuring a field can switch the chosen interface automatically, for example selecting
+ * `directus_files` as the related collection of an m2m switches the interface to `files`. Clear the
+ * search in that case, as the configuration would otherwise be hidden by the active filter, and
+ * scroll to the newly chosen interface as it is likely to be in a different spot than the previous one.
+ */
+watch(chosenInterface, async (newInterface) => {
+	const chosenByUser = interfaceChosenByUser;
+	interfaceChosenByUser = false;
+
+	if (!newInterface || chosenByUser) return;
+	if (!interfacesSorted.value.some((inter) => inter.id === newInterface)) return;
+
+	const isVisible = groups.value.some((group) => group.interfaces.some((inter) => inter.id === newInterface));
+	if (!isVisible) search.value = null;
+
+	await nextTick();
+
+	interfaceEls.value[newInterface]?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+});
+
 const configRow = computed(() => {
 	if (!chosenInterface.value) return null;
 
@@ -127,6 +148,8 @@ function isSVG(path: string) {
 }
 
 function toggleInterface(id: string) {
+	interfaceChosenByUser = true;
+
 	if (chosenInterface.value === id) {
 		chosenInterface.value = null;
 	} else {
@@ -144,6 +167,11 @@ function toggleInterface(id: string) {
 				<button
 					v-for="inter of group.interfaces"
 					:key="inter.id"
+					:ref="
+						(el) => {
+							interfaceEls[inter.id] = el as Element | null;
+						}
+					"
 					class="interface"
 					:class="{ active: chosenInterface === inter.id, gray: chosenInterface && chosenInterface !== inter.id }"
 					@click="toggleInterface(inter.id)"

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue
@@ -97,8 +97,8 @@ async function save() {
 	<VDrawer :model-value="isOpen" :title="title" persistent @cancel="cancel" @apply="save" @update:model-value="cancel">
 		<FieldDetailSimple
 			v-if="!showAdvanced"
+			v-model:search="search"
 			:collection="collectionInfo"
-			:search="search"
 			@save="save"
 			@toggle-advanced="simple = false"
 		/>


### PR DESCRIPTION
## What's Changed

* `field-detail-simple.vue`: watches `field.meta.interface` for auto-switching and clears the interface search so the newly chosen interface — and its configuration panel — isn't hidden by the active search filter
* Scrolls the auto-selected interface into view after the change, since it usually sits in a different group/position than the previously selected one

## Tested Scenarios

* Basic setup, search for "m2m" in the interface drawer, create an M2M field and pick `directus_files` as the related collection: interface auto-switches to `files`, search clears, view scrolls to the Files interface and its configuration is visible
* Manually clicking interfaces while a search filter is active: search stays applied, no scroll jump, toggling the active interface off still works

## Review Notes / Questions / Concerns

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](<https://github.com/directus/openapi>)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

Fixes directus/directus#26973