### PR TITLE
Add backend support for organizing flows into folders

### DIFF
--- a/.changeset/wild-dryers-wear.md
+++ b/.changeset/wild-dryers-wear.md
@@ -2,6 +2,7 @@
 '@directus/api': minor
 '@directus/system-data': patch
 '@directus/types': patch
+'@directus/cli': patch
 ---
 
 Add folder support to flows, allowing flows to be organized into folders

--- a/.changeset/wild-dryers-wear.md
+++ b/.changeset/wild-dryers-wear.md
@@ -3,6 +3,8 @@
 '@directus/system-data': patch
 '@directus/types': patch
 '@directus/cli': patch
+'@directus/sdk': minor
+'@directus/specs': patch
 ---
 
 Add folder support to flows, allowing flows to be organized into folders

--- a/.changeset/wild-dryers-wear.md
+++ b/.changeset/wild-dryers-wear.md
@@ -1,0 +1,7 @@
+---
+'@directus/api': minor
+'@directus/system-data': patch
+'@directus/types': patch
+---
+
+Add folder support to flows, allowing flows to be organized into folders

--- a/.changeset/wild-dryers-wear.md
+++ b/.changeset/wild-dryers-wear.md
@@ -7,4 +7,4 @@
 '@directus/specs': patch
 ---
 
-Add folder support to flows, allowing flows to be organized into folders
+Added folder support to flows, allowing flows to be organized into folders

--- a/api/src/ai/tools/folders/index.test.ts
+++ b/api/src/ai/tools/folders/index.test.ts
@@ -61,7 +61,7 @@ describe('folders tool', () => {
 					accountability: mockAccountability,
 				});
 
-				expect(mockFoldersService.createMany).toHaveBeenCalledWith([folderData]);
+				expect(mockFoldersService.createMany).toHaveBeenCalledWith([{ ...folderData, type: 'assets' }]);
 				expect(mockFoldersService.readMany).toHaveBeenCalledWith(savedKeys, {});
 
 				expect(result).toEqual({
@@ -87,7 +87,9 @@ describe('folders tool', () => {
 					accountability: mockAccountability,
 				});
 
-				expect(mockFoldersService.createMany).toHaveBeenCalledWith(foldersData);
+				expect(mockFoldersService.createMany).toHaveBeenCalledWith(
+					foldersData.map((folder) => ({ ...folder, type: 'assets' })),
+				);
 			});
 		});
 
@@ -107,7 +109,7 @@ describe('folders tool', () => {
 					accountability: mockAccountability,
 				});
 
-				expect(mockFoldersService.readMany).toHaveBeenCalledWith(keys, {});
+				expect(mockFoldersService.readMany).toHaveBeenCalledWith(keys, { filter: { type: { _eq: 'assets' } } });
 				expect(mockFoldersService.readByQuery).not.toHaveBeenCalled();
 
 				expect(result).toEqual({
@@ -129,7 +131,7 @@ describe('folders tool', () => {
 					accountability: mockAccountability,
 				});
 
-				expect(mockFoldersService.readByQuery).toHaveBeenCalledWith({});
+				expect(mockFoldersService.readByQuery).toHaveBeenCalledWith({ filter: { type: { _eq: 'assets' } } });
 				expect(mockFoldersService.readMany).not.toHaveBeenCalled();
 
 				expect(result).toEqual({

--- a/api/src/ai/tools/folders/index.ts
+++ b/api/src/ai/tools/folders/index.ts
@@ -76,7 +76,9 @@ export const folders = defineTool<z.infer<typeof FoldersValidateSchema>, z.infer
 
 		if (args.action === 'create') {
 			const sanitizedQuery = await buildSanitizedQueryFromArgs(args, schema, accountability);
-			const data = toArray(args.data);
+
+			// This tool manages file-library folders only; force the asset type.
+			const data = toArray(args.data).map((item) => ({ ...item, type: 'assets' }));
 
 			const savedKeys = await service.createMany(data as Partial<Folder>[]);
 
@@ -90,6 +92,12 @@ export const folders = defineTool<z.infer<typeof FoldersValidateSchema>, z.infer
 
 		if (args.action === 'read') {
 			const sanitizedQuery = await buildSanitizedQueryFromArgs(args, schema, accountability);
+
+			// This tool manages file-library folders only; scope reads to the asset type.
+			const assetFilter = { type: { _eq: 'assets' } };
+
+			sanitizedQuery.filter = sanitizedQuery.filter ? { _and: [sanitizedQuery.filter, assetFilter] } : assetFilter;
+
 			let result = null;
 
 			if (args.keys) {

--- a/api/src/database/migrations/20260818A-add-flow-folders.ts
+++ b/api/src/database/migrations/20260818A-add-flow-folders.ts
@@ -1,0 +1,28 @@
+import type { Knex } from 'knex';
+import { getDefaultIndexName } from '../../utils/get-default-index-name.js';
+
+const indexName = getDefaultIndexName('foreign', 'directus_flows', 'folder');
+
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_folders', (table) => {
+		table.string('type').notNullable().defaultTo('assets');
+	});
+
+	// Backfill every existing folder as a file-library (asset) folder.
+	await knex('directus_folders').update({ type: 'assets' });
+
+	await knex.schema.alterTable('directus_flows', (table) => {
+		table.uuid('folder').references('id').inTable('directus_folders').withKeyName(indexName).onDelete('SET NULL');
+	});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_flows', (table) => {
+		table.dropForeign(['folder'], indexName);
+		table.dropColumn('folder');
+	});
+
+	await knex.schema.alterTable('directus_folders', (table) => {
+		table.dropColumn('type');
+	});
+}

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -205,7 +205,7 @@ export class AssetsService {
 			accountability: this.accountability,
 		});
 
-		const folderTree = await foldersService.buildTree(root);
+		const folderTree = await foldersService.buildTree(root, { type: { _eq: 'assets' } });
 
 		const filesService = new FilesService({
 			schema: this.schema,

--- a/api/src/services/folders.test.ts
+++ b/api/src/services/folders.test.ts
@@ -45,6 +45,19 @@ describe('FoldersService', () => {
 				});
 			});
 
+			test('should forward a filter to the read query when provided', async () => {
+				vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([
+					{ id: 'root-id', name: 'parent', parent: null },
+				]);
+
+				await foldersService.buildTree('root-id', { type: { _eq: 'assets' } });
+
+				expect(ItemsService.prototype.readByQuery).toHaveBeenCalledWith({
+					limit: -1,
+					filter: { type: { _eq: 'assets' } },
+				});
+			});
+
 			test('should build tree for simple hierarchy', async () => {
 				vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([
 					{ id: 'root-id', name: 'parent', parent: null },

--- a/api/src/services/folders.ts
+++ b/api/src/services/folders.ts
@@ -1,4 +1,4 @@
-import type { AbstractServiceOptions, Folder } from '@directus/types';
+import type { AbstractServiceOptions, Filter, Folder } from '@directus/types';
 import { validateAccess } from '../permissions/modules/validate-access/validate-access.js';
 import { NameDeduper } from './assets/name-deduper.js';
 import { ItemsService } from './items.js';
@@ -19,6 +19,7 @@ export class FoldersService extends ItemsService<Folder> {
 	 * access to are included.
 	 *
 	 * @param {string} root - The ID of the root folder to start building the tree from.
+	 * @param {Filter} [filter] - Optional filter to scope which folders are read (e.g. by `type`).
 	 * @returns {Promise<Map<string, string>>} A `Map` where:
 	 *   - Key: folder ID
 	 *   - Value: folder path relative to the root (e.g., "Documents/Photos")
@@ -32,7 +33,7 @@ export class FoldersService extends ItemsService<Folder> {
 	 * - The returned `Map` includes the root folder itself.
 	 * - If a folder has no name, its ID will be used as a fallback.
 	 */
-	async buildTree(root: string) {
+	async buildTree(root: string, filter?: Filter) {
 		if (this.accountability && this.accountability.admin !== true) {
 			await validateAccess(
 				{
@@ -48,7 +49,7 @@ export class FoldersService extends ItemsService<Folder> {
 			);
 		}
 
-		const folders = await this.readByQuery({ limit: -1 });
+		const folders = await this.readByQuery({ limit: -1, ...(filter ? { filter } : {}) });
 
 		// build folder and child lookup
 		const folderLookup = new Map<string, Folder>();

--- a/packages/cli/src/commands/sync/utils/resources.ts
+++ b/packages/cli/src/commands/sync/utils/resources.ts
@@ -154,7 +154,10 @@ const RESOURCE_LIST = [
 		strip: ['user_created', 'date_created'],
 		aliases: ['operations'],
 		naturalKey: ['name'],
-		fkFields: [{ field: 'operation', references: 'directus_operations' }],
+		fkFields: [
+			{ field: 'operation', references: 'directus_operations' },
+			{ field: 'folder', references: 'directus_folders' },
+		],
 	},
 	{
 		name: 'operations',

--- a/packages/specs/src/components/flow.yaml
+++ b/packages/specs/src/components/flow.yaml
@@ -58,3 +58,10 @@ properties:
     oneOf:
       - type: string
       - $ref: '../openapi.yaml#/components/schemas/Operations'
+  folder:
+    description: The UUID of the folder containing the flow.
+    example: 0cf0e03d-4364-45df-b77b-ca61f61869d2
+    oneOf:
+      - type: string
+      - $ref: '../openapi.yaml#/components/schemas/Folders'
+    nullable: true

--- a/packages/specs/src/components/folder.yaml
+++ b/packages/specs/src/components/folder.yaml
@@ -15,3 +15,9 @@ properties:
       - type: string
       - $ref: '../openapi.yaml#/components/schemas/Folders'
     nullable: true
+  type:
+    description: The type of folder. One of `assets` (file library) or `flows`.
+    type: string
+    example: assets
+    default: assets
+    enum: [assets, flows]

--- a/packages/system-data/src/fields/flows.yaml
+++ b/packages/system-data/src/fields/flows.yaml
@@ -24,3 +24,11 @@ fields:
   - field: user_created
     special:
       - user-created
+  - field: folder
+    width: half
+    readonly: true
+    special:
+      - m2o
+    display: related-values
+    display_options:
+      template: '{{ name }}'

--- a/packages/system-data/src/fields/folders.yaml
+++ b/packages/system-data/src/fields/folders.yaml
@@ -12,3 +12,14 @@ fields:
 
   - field: name
     width: full
+
+  - field: type
+    interface: select-dropdown
+    options:
+      choices:
+        - value: assets
+          text: $t:file_library
+        - value: flows
+          text: $t:flows
+    hidden: true
+    width: half

--- a/packages/system-data/src/relations/relations.yaml
+++ b/packages/system-data/src/relations/relations.yaml
@@ -140,6 +140,10 @@ data:
     many_field: user_created
     one_collection: directus_users
 
+  - many_collection: directus_flows
+    many_field: folder
+    one_collection: directus_folders
+
   ### Operations
   - many_collection: directus_operations
     many_field: flow

--- a/packages/types/src/flows.ts
+++ b/packages/types/src/flows.ts
@@ -12,6 +12,7 @@ export interface Flow {
 	options: Record<string, any>;
 	operation: Operation | null;
 	accountability: 'all' | 'activity' | null;
+	folder: string | null;
 }
 
 export interface Operation {
@@ -40,6 +41,7 @@ export interface FlowRaw {
 	date_created: string;
 	user_created: string;
 	accountability: 'all' | 'activity' | null;
+	folder: string | null;
 }
 
 export interface OperationRaw {

--- a/packages/types/src/folders.ts
+++ b/packages/types/src/folders.ts
@@ -2,4 +2,5 @@ export type Folder = {
 	id: string;
 	name: string;
 	parent: string | null;
+	type: 'assets' | 'flows';
 };

--- a/sdk/src/schema/flow.ts
+++ b/sdk/src/schema/flow.ts
@@ -1,4 +1,5 @@
 import type { MergeCoreCollection } from '../index.js';
+import type { DirectusFolder } from './folder.js';
 import type { DirectusOperation } from './operation.js';
 import type { DirectusUser } from './user.js';
 
@@ -18,5 +19,6 @@ export type DirectusFlow<Schema = any> = MergeCoreCollection<
 		operation: DirectusOperation<Schema> | string | null;
 		date_created: 'datetime' | null;
 		user_created: DirectusUser<Schema> | string | null;
+		folder: DirectusFolder<Schema> | string | null;
 	}
 >;

--- a/sdk/src/schema/folder.ts
+++ b/sdk/src/schema/folder.ts
@@ -7,5 +7,6 @@ export type DirectusFolder<Schema = any> = MergeCoreCollection<
 		id: string;
 		name: string;
 		parent: DirectusFolder<Schema> | string | null;
+		type: 'assets' | 'flows';
 	}
 >;


### PR DESCRIPTION
## What's Changed

- Added `type` column to `directus_folders` to distinguish file-library folders (`'assets'`) from flow folders (`'flows'`)
- Added `folder` column to `directus_flows` that references `directus_folders`
- Added migration that backfills existing folders to `'assets'` and leaves flows untouched
- Registered the new fields and relation in system-data
- Updated shared types for the folder and flow changes

## Tested Scenarios

- Migration runs cleanly on existing installs
- File library returns only asset folders
- Deleting a folder nulls the flow's `folder` without deleting the flow

## Review Notes / Questions / Concerns

- `type` defaults to `'assets'`; flow-folder consumers must scope to `type = 'flows'`
- Rolling back the migration does not remove any folders that may have been using the type 'flows', but does remove the type column. Running the migration again sets the default folder type to 'assets.' This means any folders previously created for flows will now show up in the assets library. I'm considering this a rare edge case, but open to suggestions if we think this is an issue we should handle differently. 

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [x] OpenAPI updated
  - [x] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [x] SDK (`@directus/sdk`) updated to reflect the changes
- [x] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [x] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [x] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

Fixes [CMS-2934](https://linear.app/directus/issue/CMS-2934/build-out-flow-folder-interface)
