### PR TITLE
fix(app): render M2A related values by collection

### DIFF
--- a/.changeset/bright-taxis-display.md
+++ b/.changeset/bright-taxis-display.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed M2A related-values displays to use each related collection's display template.

--- a/app/src/displays/related-values/index.ts
+++ b/app/src/displays/related-values/index.ts
@@ -3,10 +3,11 @@ import { defineDisplay } from '@directus/extensions';
 import type { Field } from '@directus/types';
 import { getFieldsFromTemplate } from '@directus/utils';
 import { get, set } from 'lodash';
+import { ref } from 'vue';
 import DisplayRelatedValues from './related-values.vue';
 import { useExtension } from '@/composables/use-extension';
+import { useRelationM2A } from '@/composables/use-relation-m2a';
 import { useFieldsStore } from '@/stores/fields';
-import { useRelationsStore } from '@/stores/relations';
 import { adjustFieldsForDisplays } from '@/utils/adjust-fields-for-displays';
 import { getRelatedCollection } from '@/utils/get-related-collection';
 import { renderPlainStringTemplate } from '@/utils/render-string-template';
@@ -125,14 +126,31 @@ export default defineDisplay({
 		const fieldStoreField = fieldsStore.getField(collection, field);
 
 		if (fieldStoreField?.meta?.special?.includes('m2a')) {
-			const relationsStore = useRelationsStore();
-			const relations = relationsStore.getRelationsForField(collection, field);
+			const { relationInfo } = useRelationM2A(ref(collection), ref(field));
+			const info = relationInfo.value;
 
-			const collectionField = relations.find((relation) => relation.meta?.one_collection_field)?.meta
-				?.one_collection_field;
+			if (!info) return fields;
 
-			if (collectionField && !fields.find((field) => field === collectionField)) {
-				fields.push(collectionField);
+			if (!fields.includes(info.collectionField.field)) fields.push(info.collectionField.field);
+
+			if (!options?.template) {
+				for (const allowedCollection of info.allowedCollections) {
+					const primaryKeyField = info.relationPrimaryKeyFields[allowedCollection.collection];
+					if (!primaryKeyField) continue;
+
+					const template = allowedCollection.meta?.display_template || `{{ ${primaryKeyField.field} }}`;
+
+					const relatedFields = adjustFieldsForDisplays(
+						getFieldsFromTemplate(template),
+						allowedCollection.collection,
+					).map((field) => `${info.junctionField.field}:${allowedCollection.collection}.${field}`);
+
+					const relatedPrimaryKey = `${info.junctionField.field}:${allowedCollection.collection}.${primaryKeyField.field}`;
+
+					for (const relatedField of [...relatedFields, relatedPrimaryKey]) {
+						if (!fields.includes(relatedField)) fields.push(relatedField);
+					}
+				}
 			}
 		}
 

--- a/app/src/displays/related-values/related-values.test.ts
+++ b/app/src/displays/related-values/related-values.test.ts
@@ -1,0 +1,133 @@
+import type { Field } from '@directus/types';
+import { mount } from '@vue/test-utils';
+import { describe, expect, test, vi } from 'vitest';
+import { computed, defineComponent, h } from 'vue';
+import { createI18n } from 'vue-i18n';
+import RelatedValues from './related-values.vue';
+import relatedValuesDisplay from './index';
+
+const collections = [
+	{ collection: 'collection_one', name: 'Collection One', meta: { display_template: '{{ name }}' } },
+	{ collection: 'collection_two', name: 'Collection Two', meta: { display_template: '{{ title }}' } },
+];
+
+const relationInfo = {
+	allowedCollections: collections,
+	relationPrimaryKeyFields: {
+		collection_one: { field: 'id' },
+		collection_two: { field: 'id' },
+	},
+	collectionField: { field: 'collection' },
+	junctionField: { field: 'item' },
+};
+
+vi.mock('@directus/constants', () => ({ RELATIONAL_TYPES: [] }));
+vi.mock('@directus/extensions', () => ({ defineDisplay: (config: unknown) => config }));
+
+vi.mock('@directus/utils', () => ({
+	getFieldsFromTemplate: (template: string) =>
+		Array.from(template.matchAll(/{{\s*([^}]+?)\s*}}/g), ([, field]) => field!.trim()),
+}));
+
+vi.mock('@directus/composables', () => ({
+	useCollection: () => ({ primaryKeyField: computed(() => ({ field: 'id' })) }),
+}));
+
+vi.mock('@/composables/use-extension', () => ({ useExtension: () => computed(() => null) }));
+
+vi.mock('@/composables/use-relation-m2a', () => ({
+	useRelationM2A: () => ({ relationInfo: computed(() => relationInfo) }),
+}));
+
+vi.mock('@/stores/fields', () => ({
+	useFieldsStore: () => ({
+		getField: (collection: string, field: string) =>
+			collection === 'collection_three' && field === 'blocks' ? ({ meta: { special: ['m2a'] } } as Field) : null,
+		getPrimaryKeyFieldForCollection: () => ({ field: 'id' }),
+	}),
+}));
+
+vi.mock('@/utils/get-local-type', () => ({ getLocalTypeForField: () => 'm2a' }));
+
+vi.mock('@/utils/get-related-collection', () => ({
+	getRelatedCollection: () => ({ relatedCollection: 'collection_three_blocks' }),
+}));
+
+vi.mock('@/views/private/components/render-template.vue', () => ({
+	default: defineComponent({
+		props: {
+			collection: { type: String, default: '' },
+			template: { type: String, required: true },
+			item: { type: Object, default: () => ({}) },
+		},
+		setup(props) {
+			return () => h('span', `${props.collection}|${props.template}|${Object.values(props.item ?? {}).join('')}`);
+		},
+	}),
+}));
+
+const SlotStub = defineComponent({
+	setup(_, { slots }) {
+		return () => h('div', slots.default?.());
+	},
+});
+
+const MenuStub = defineComponent({
+	setup(_, { slots }) {
+		return () => h('div', slots.default?.());
+	},
+});
+
+const i18n = createI18n({
+	legacy: false,
+	locale: 'en-US',
+	messages: { 'en-US': { item: 'item', items: 'items' } },
+});
+
+describe('related-values M2A display', () => {
+	test('uses each related collection template and requests its fields', () => {
+		const getFields = relatedValuesDisplay.fields as (
+			value: unknown,
+			options: { collection: string; field: string },
+		) => string[];
+
+		const wrapper = mount(RelatedValues, {
+			props: {
+				collection: 'collection_three',
+				field: 'blocks',
+				value: [
+					{ id: 1, collection: 'collection_one', item: { id: 11, name: 'Ahmed' } },
+					{ id: 2, collection: 'collection_two', item: { id: 22, title: 'Admin' } },
+				],
+			},
+			global: {
+				plugins: [i18n],
+				stubs: {
+					VMenu: MenuStub,
+					VList: SlotStub,
+					VListItem: SlotStub,
+					VListItemContent: SlotStub,
+					VListItemIcon: SlotStub,
+					VIcon: true,
+					RouterLink: true,
+				},
+			},
+		});
+
+		expect(wrapper.text()).toContain('Collection One:');
+		expect(wrapper.text()).toContain('collection_one|{{ name }}|11Ahmed');
+		expect(wrapper.text()).toContain('Collection Two:');
+		expect(wrapper.text()).toContain('collection_two|{{ title }}|22Admin');
+
+		expect(getFields(null, { collection: 'collection_three', field: 'blocks' })).toEqual(
+			expect.arrayContaining([
+				'id',
+				'collection',
+				'item:collection_one.id',
+				'item:collection_one.name',
+				'item:collection_two.id',
+				'item:collection_two.title',
+			]),
+		);
+	});
+});

--- a/app/src/displays/related-values/related-values.vue
+++ b/app/src/displays/related-values/related-values.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useCollection } from '@directus/composables';
 import { get } from 'lodash';
-import { computed } from 'vue';
+import { computed, toRef } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { RouterLink } from 'vue-router';
 import VIcon from '@/components/v-icon/v-icon.vue';
@@ -10,6 +10,7 @@ import VListItemIcon from '@/components/v-list-item-icon.vue';
 import VListItem from '@/components/v-list-item.vue';
 import VList from '@/components/v-list.vue';
 import VMenu from '@/components/v-menu.vue';
+import { useRelationM2A } from '@/composables/use-relation-m2a';
 import { getLocalTypeForField } from '@/utils/get-local-type';
 import { getRelatedCollection } from '@/utils/get-related-collection';
 import { getItemRoute } from '@/utils/get-route';
@@ -24,6 +25,7 @@ const props = defineProps<{
 }>();
 
 const { t, te } = useI18n();
+const { relationInfo } = useRelationM2A(toRef(props, 'collection'), toRef(props, 'field'));
 
 const relatedCollectionData = computed(() => {
 	return getRelatedCollection(props.collection, props.field);
@@ -41,6 +43,18 @@ const localType = computed(() => {
 	return getLocalTypeForField(props.collection, props.field);
 });
 
+const m2aRelationInfo = computed(() => {
+	return localType.value === 'm2a' ? relationInfo.value : undefined;
+});
+
+const items = computed(() => {
+	return Array.isArray(props.value) ? props.value : [];
+});
+
+const singleItem = computed(() => {
+	return props.value && !Array.isArray(props.value) ? props.value : undefined;
+});
+
 const { primaryKeyField } = useCollection(relatedCollection);
 
 const primaryKeyFieldPath = computed(() => {
@@ -55,6 +69,10 @@ const internalTemplate = computed(() => {
 
 const unit = computed(() => {
 	if (Array.isArray(props.value)) {
+		if (m2aRelationInfo.value) {
+			return props.value.length === 1 ? t('item') : t('items');
+		}
+
 		if (props.value.length === 1) {
 			if (te(`collection_names_singular.${relatedCollection.value}`)) {
 				return t(`collection_names_singular.${relatedCollection.value}`);
@@ -73,11 +91,53 @@ const unit = computed(() => {
 	return null;
 });
 
-function getLinkForItem(item: any) {
+function getLinkForItem(item: Record<string, any>) {
+	if (m2aRelationInfo.value) {
+		const collection = getM2ACollection(item);
+		const primaryKeyField = collection ? m2aRelationInfo.value.relationPrimaryKeyFields[collection] : undefined;
+		const primaryKey = primaryKeyField ? getM2AValue(item)?.[primaryKeyField.field] : undefined;
+
+		if (!collection || primaryKey === null || primaryKey === undefined) return null;
+
+		return getItemRoute(collection, primaryKey);
+	}
+
 	if (!relatedCollectionData.value || !primaryKeyFieldPath.value) return null;
 	const primaryKey = get(item, primaryKeyFieldPath.value);
 
 	return getItemRoute(relatedCollection.value, primaryKey);
+}
+
+function getM2ACollection(item: Record<string, any>) {
+	return m2aRelationInfo.value ? item[m2aRelationInfo.value.collectionField.field] : undefined;
+}
+
+function getM2AValue(item: Record<string, any>): Record<string, any> | undefined {
+	if (!m2aRelationInfo.value) return undefined;
+
+	const value = item[m2aRelationInfo.value.junctionField.field];
+	return value && !Array.isArray(value) && typeof value === 'object' ? value : undefined;
+}
+
+function getM2ATemplate(item: Record<string, any>) {
+	const collection = getM2ACollection(item);
+	if (!collection || !m2aRelationInfo.value) return '';
+
+	const collectionInfo = m2aRelationInfo.value.allowedCollections.find((item) => item.collection === collection);
+	const primaryKeyField = m2aRelationInfo.value.relationPrimaryKeyFields[collection];
+
+	return collectionInfo?.meta?.display_template || (primaryKeyField ? `{{ ${primaryKeyField.field} }}` : '');
+}
+
+function getM2ACollectionName(item: Record<string, any>) {
+	const collection = getM2ACollection(item);
+	if (!collection) return t('item');
+
+	if (te(`collection_names_singular.${collection}`)) {
+		return t(`collection_names_singular.${collection}`);
+	}
+
+	return m2aRelationInfo.value?.allowedCollections.find((item) => item.collection === collection)?.name ?? collection;
 }
 </script>
 
@@ -99,21 +159,32 @@ function getLinkForItem(item: any) {
 		</template>
 
 		<VList class="links">
-			<VListItem v-for="item in value" :key="item[primaryKeyFieldPath!]">
+			<VListItem v-for="item in items" :key="item[primaryKeyFieldPath!]">
 				<VListItemContent>
+					<div v-if="m2aRelationInfo && !template" class="m2a-item">
+						<span class="collection">{{ getM2ACollectionName(item) }}:</span>
+						<RenderTemplate
+							:template="getM2ATemplate(item)"
+							:item="getM2AValue(item)"
+							:collection="getM2ACollection(item)"
+						/>
+					</div>
 					<RenderTemplate
+						v-else
 						:template="internalTemplate"
 						:item="item"
 						:collection="junctionCollection ?? relatedCollection"
 					/>
 				</VListItemContent>
 				<VListItemIcon>
-					<RouterLink :to="getLinkForItem(item)!"><VIcon name="launch" small /></RouterLink>
+					<RouterLink v-if="getLinkForItem(item)" :to="getLinkForItem(item)!">
+						<VIcon name="launch" small />
+					</RouterLink>
 				</VListItemIcon>
 			</VListItem>
 		</VList>
 	</VMenu>
-	<RenderTemplate v-else :template="internalTemplate" :item="value" :collection="relatedCollection" />
+	<RenderTemplate v-else :template="internalTemplate" :item="singleItem" :collection="relatedCollection" />
 </template>
 
 <style lang="scss" scoped>
@@ -167,6 +238,15 @@ function getLinkForItem(item: any) {
 .links {
 	.v-list-item-content {
 		block-size: var(--v-list-item-min-height, 1.8125rem);
+	}
+}
+
+.m2a-item {
+	display: flex;
+	gap: 0.25rem;
+
+	.collection {
+		font-weight: 600;
 	}
 }
 </style>


### PR DESCRIPTION
## What's Changed

* Reused `useRelationM2A` to resolve M2A metadata for the Related Values display.
* Rendered each related item with its target collection's display template and link.
* Requested the display-template fields and primary key for every allowed collection.

## Tested Scenarios

* Added a focused regression test with two target collections using different display templates.
* Ran the focused Vitest test, Prettier, ESLint, Stylelint, and `git diff --check`.

## Review Notes / Questions / Concerns

* The app-wide typecheck currently reports existing errors across unrelated files; a filtered run reports no errors in the changed Related Values files.

## Checklist

> Leave unchecked where not applicable

- [X] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](<https://github.com/directus/openapi>)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes directus/directus#25348