### PR TITLE
Fix `d6s sync` copying the instance `project_id` between environments

### DIFF
--- a/.changeset/afraid-eels-shave.md
+++ b/.changeset/afraid-eels-shave.md
@@ -1,0 +1,5 @@
+---
+'@directus/cli': patch
+---
+
+Stripped `project_id` when pulling settings, so a sync no longer copies one instance's identity onto another

--- a/packages/cli/src/commands/sync/sync-pull.test.ts
+++ b/packages/cli/src/commands/sync/sync-pull.test.ts
@@ -949,7 +949,7 @@ describe('sync pull resources and data', () => {
 
 		interceptSingleton('/settings', {
 			id: 1,
-			project_name: 'Kampala',
+			project_name: 'Directus',
 			project_id: '11111111-2222-3333-4444-555555555555',
 		});
 
@@ -958,7 +958,7 @@ describe('sync pull resources and data', () => {
 		const settingsBytes = readFileSync(join(dataDir, ownedFileFor(dataDir, 'directus_settings')), 'utf8');
 		expect(settingsBytes).not.toContain('project_id');
 		expect(settingsBytes).not.toContain('11111111-2222-3333-4444-555555555555');
-		expect(settingsBytes).toContain('Kampala');
+		expect(settingsBytes).toContain('Directus');
 	});
 
 	it('strips custom conceal/hash fields the field catalog marks sensitive and names them at pull time', async () => {

--- a/packages/cli/src/commands/sync/sync-pull.test.ts
+++ b/packages/cli/src/commands/sync/sync-pull.test.ts
@@ -942,6 +942,25 @@ describe('sync pull resources and data', () => {
 		expect(userBytes).toContain('editor@example.com');
 	});
 
+	it('never writes the instance project_id to disk', async () => {
+		seedConfig();
+		vi.stubEnv('DIRECTUS_STAGING_TOKEN', token);
+		interceptSnapshot();
+
+		interceptSingleton('/settings', {
+			id: 1,
+			project_name: 'Kampala',
+			project_id: '11111111-2222-3333-4444-555555555555',
+		});
+
+		expect(await d6s('sync', 'pull', '--from', 'staging', '--settings')).toBe(0);
+
+		const settingsBytes = readFileSync(join(dataDir, ownedFileFor(dataDir, 'directus_settings')), 'utf8');
+		expect(settingsBytes).not.toContain('project_id');
+		expect(settingsBytes).not.toContain('11111111-2222-3333-4444-555555555555');
+		expect(settingsBytes).toContain('Kampala');
+	});
+
 	it('strips custom conceal/hash fields the field catalog marks sensitive and names them at pull time', async () => {
 		seedConfig();
 		vi.stubEnv('DIRECTUS_STAGING_TOKEN', token);

--- a/packages/cli/src/commands/sync/utils/resources.test.ts
+++ b/packages/cli/src/commands/sync/utils/resources.test.ts
@@ -91,6 +91,7 @@ describe('resolveResources', () => {
 					'public_background',
 					'public_favicon',
 					'storage_default_folder',
+					'project_id',
 					'license_key',
 					'license_token',
 					'ai_openai_api_key',

--- a/packages/cli/src/commands/sync/utils/resources.ts
+++ b/packages/cli/src/commands/sync/utils/resources.ts
@@ -227,6 +227,7 @@ const RESOURCE_LIST = [
 			'public_background',
 			'public_favicon',
 			'storage_default_folder',
+			'project_id',
 			'license_key',
 			'license_token',
 			'ai_openai_api_key',


### PR DESCRIPTION
## What's Changed

* Added `project_id` to the settings strip list in the sync CLI, so `d6s sync pull` no longer writes it into `directus-settings_*.json` and a later push can't copy one instance's identity onto another.

## Tested Scenarios

* Pulled settings carrying a `project_id`, confirmed the written file keeps `project_name` and drops the id (fails on main, passes here).
* Full `@directus/cli` suite. Three failures in `sync-push.test.ts` around ambiguous reconcile also fail on an untouched `main`, so they predate this change.

## Review Notes / Questions / Concerns

* `project_id` identifies the install for license activation and telemetry. `license_key` and `license_token` were already stripped, `project_id` was not, so pulling from local and pushing to production left both environments claiming the same project. Excluding settings from the sync entirely was the only workaround.
* The strip list only runs on pull (`stripSystemFields` in `pull.ts`), so anyone who already pulled with 12.2.0 keeps `project_id` in their data files and still overwrites the target until they re-pull. Worth deciding whether push should honour the strip list too. The license fields don't have this problem because `SettingsService` rejects them outright, and a stale file errors loudly instead of applying silently.
* Stripping on pull is what the issue asks for and matches how the license fields are handled. If you'd rather the server refused the value as well, `SettingsService` would need a guard next to the existing `license_key` / `license_token` checks. Happy to add either or both.

## Checklist

> Leave unchecked where not applicable

- [X] Tests added/updated
- [ ] Documentation PR created in [directus/docs](<https://github.com/directus/docs>)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](<https://github.com/directus/openapi>)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes directus/directus#28131