### PR TITLE
fix: keep the FK constraint when PATCHing only a relation's meta

### DIFF
--- a/api/src/services/relations.test.ts
+++ b/api/src/services/relations.test.ts
@@ -1,0 +1,271 @@
+import { useEnv } from '@directus/env';
+import type { SchemaOverview } from '@directus/types';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { createMockKnex, resetKnexMocks } from '../test-utils/knex.js';
+import { RelationsService } from './relations.js';
+
+// The import graph of the service pulls in the extensions manager, which
+// value-imports the native isolated-vm module. Mock it so the suite does
+// not need the compiled native binary.
+vi.mock('isolated-vm', () => {
+	class MockReference {
+		constructor(public value: unknown) {}
+	}
+
+	class MockIsolate {
+		createContext() {
+			return { global: {} };
+		}
+		dispose() {}
+	}
+
+	return {
+		default: { Isolate: MockIsolate, Reference: MockReference, Callback: class {} },
+		Isolate: MockIsolate,
+		Reference: MockReference,
+		Callback: class {},
+	};
+});
+
+
+vi.mock('@directus/env', () => ({
+	useEnv: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('../database/index', async () => {
+	const { mockDatabase } = await import('../test-utils/database.js');
+	return mockDatabase();
+});
+
+vi.mock('@directus/schema', async () => {
+	const { mockSchema } = await import('../test-utils/schema.js');
+	return mockSchema();
+});
+
+vi.mock('../cache.js', async () => {
+	const { mockCache } = await import('../test-utils/cache.js');
+	return mockCache();
+});
+
+vi.mock('../emitter.js', async () => {
+	const { mockEmitter } = await import('../test-utils/emitter.js');
+	return mockEmitter();
+});
+
+vi.mock('./items.js', async () => {
+	const { mockItemsService } = await import('../test-utils/services/items-service.js');
+	return mockItemsService();
+});
+
+vi.mock('../utils/transaction.js', async () => {
+	const { mockTransaction } = await import('../test-utils/database.js');
+	return mockTransaction();
+});
+
+vi.mock('../utils/get-schema.js', () => ({
+	getSchema: vi.fn(),
+}));
+
+vi.mock('../permissions/modules/fetch-allowed-field-map/fetch-allowed-field-map.js', () => ({
+	fetchAllowedFieldMap: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../permissions/modules/validate-access/validate-access.js', () => ({
+	validateAccess: vi.fn(),
+}));
+
+vi.mock('../database/helpers/index.js', () => ({
+	getHelpers: vi.fn(() => ({
+		schema: {
+			constraintName: vi.fn((name: string) => name),
+			preColumnChange: vi.fn().mockResolvedValue(true),
+			postColumnChange: vi.fn().mockResolvedValue(undefined),
+			preRelationChange: vi.fn(),
+			postRelationChange: vi.fn(),
+		},
+	})),
+}));
+
+const schema: SchemaOverview = {
+	collections: {
+		articles_authors: {
+			collection: 'articles_authors',
+			primary: 'id',
+			singleton: false,
+			sortField: null,
+			note: null,
+			accountability: null,
+			fields: {
+				id: {
+					field: 'id',
+					defaultValue: null,
+					nullable: false,
+					generated: false,
+					type: 'integer',
+					dbType: 'int',
+					precision: null,
+					scale: null,
+					special: [],
+					note: null,
+					alias: false,
+				},
+				authors_id: {
+					field: 'authors_id',
+					defaultValue: null,
+					nullable: true,
+					generated: false,
+					type: 'integer',
+					dbType: 'int',
+					precision: null,
+					scale: null,
+					special: [],
+					note: null,
+					alias: false,
+				},
+			},
+		},
+		authors: {
+			collection: 'authors',
+			primary: 'id',
+			singleton: false,
+			sortField: null,
+			note: null,
+			accountability: null,
+			fields: {
+				id: {
+					field: 'id',
+					defaultValue: null,
+					nullable: false,
+					generated: false,
+					type: 'integer',
+					dbType: 'int',
+					precision: null,
+					scale: null,
+					special: [],
+					note: null,
+					alias: false,
+				},
+			},
+		},
+	},
+	relations: [
+		{
+			collection: 'articles_authors',
+			field: 'authors_id',
+			related_collection: 'authors',
+			meta: {
+				id: 1,
+				sort: null,
+				on_delete: null,
+				on_update: null,
+				junction_field: 'articles_id',
+			},
+			schema: {
+				name: 'articles_authors_authors_id_foreign',
+				table: 'articles_authors',
+				column: 'authors_id',
+				foreign_key_table: 'authors',
+				foreign_key_column: 'id',
+				on_update: 'NO ACTION',
+				on_delete: 'CASCADE',
+				constraint_name: 'articles_authors_authors_id_foreign',
+			},
+		},
+	],
+	globals: {
+		widgets: {},
+	} as unknown as SchemaOverview['globals'],
+};
+
+type CapturedBuilder = {
+	dropForeign: ReturnType<typeof vi.fn>;
+	specificType: ReturnType<typeof vi.fn>;
+	foreign: ReturnType<typeof vi.fn>;
+};
+
+describe('Services / Relations', () => {
+	const { db } = createMockKnex();
+
+	let capturedBuilder: CapturedBuilder;
+
+	const installCapturingAlterTable = () => {
+		capturedBuilder = {
+			dropForeign: vi.fn().mockReturnThis(),
+			specificType: vi.fn().mockReturnThis(),
+			foreign: vi.fn().mockReturnThis(),
+		};
+
+		const chainable = {
+			notNullable: vi.fn().mockReturnThis(),
+			alter: vi.fn().mockReturnThis(),
+			references: vi.fn().mockReturnThis(),
+			onDelete: vi.fn().mockReturnThis(),
+			onUpdate: vi.fn().mockReturnThis(),
+		};
+
+		const builder = new Proxy(capturedBuilder as unknown as Record<string, unknown>, {
+			get(target, prop) {
+				if (prop in target) {
+					return target[prop as keyof CapturedBuilder];
+				}
+
+				return chainable[prop as keyof typeof chainable] ?? vi.fn().mockReturnThis();
+			},
+		});
+
+		(db.schema as unknown as { alterTable: ReturnType<typeof vi.fn> }).alterTable = vi.fn(
+			async (_tableName: string, callback: (table: unknown) => unknown) => {
+				await callback(builder);
+			},
+		);
+	};
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('#updateOne', () => {
+		beforeEach(() => {
+			installCapturingAlterTable();
+		});
+
+		test('a meta-only PATCH must not crash the table builder callback', async () => {
+			const service = new RelationsService({ knex: db, schema });
+
+			// On the previous implementation this rejected (indirectly, as an
+			// unhandled rejection inside the schema compiler) with
+			// "Cannot read properties of undefined (reading 'fields')" from
+			// alterType, after dropForeign had already been queued (#28135).
+			await expect(
+				service.updateOne('articles_authors', 'authors_id', { meta: { junction_field: 'articles_id' } }),
+			).resolves.toBeUndefined();
+		});
+
+		test('a meta-only PATCH re-adds the FK with the existing on_delete', async () => {
+			const service = new RelationsService({ knex: db, schema });
+
+			await service.updateOne('articles_authors', 'authors_id', { meta: { junction_field: 'articles_id' } });
+
+			expect(capturedBuilder.dropForeign).toHaveBeenCalledWith(
+				'authors_id',
+				'articles_authors_authors_id_foreign',
+			);
+
+			expect(capturedBuilder.foreign).toHaveBeenCalledWith('authors_id', 'articles_authors_authors_id_foreign');
+
+			const foreignChain = (capturedBuilder.foreign as ReturnType<typeof vi.fn>).mock.results[0]?.value;
+			expect(foreignChain?.onDelete).toHaveBeenCalledWith('CASCADE');
+		});
+
+		test('an explicit on_delete override still wins', async () => {
+			const service = new RelationsService({ knex: db, schema });
+
+			await service.updateOne('articles_authors', 'authors_id', {
+				schema: { on_delete: 'SET NULL' },
+			});
+
+			const foreignChain = (capturedBuilder.foreign as ReturnType<typeof vi.fn>).mock.results[0]?.value;
+			expect(foreignChain?.onDelete).toHaveBeenCalledWith('SET NULL');
+		});
+	});
+});

--- a/api/src/services/relations.ts
+++ b/api/src/services/relations.ts
@@ -363,7 +363,24 @@ export class RelationsService {
 							existingRelation.schema.constraint_name = constraintName;
 						}
 
-						this.alterType(table, relation, fieldSchema.nullable);
+						// A partial update (e.g. a meta-only PATCH) does not carry the
+						// relation's collection/field/related_collection. Fall back to
+						// the existing relation so alterType and the FK re-add below
+						// keep operating on the relation's actual endpoints, and keep
+						// the constraint's existing on_delete/on_update unless the
+						// payload overrides them. Previously alterType read `.fields`
+						// of undefined for a meta-only PATCH, crashed the table
+						// builder callback after the FK was already dropped, and the
+						// constraint never came back (#28135).
+						const effectiveRelation: Partial<Relation> = {
+							...existingRelation,
+							...relation,
+							collection,
+							field,
+							schema: relation.schema ?? existingRelation.schema,
+						};
+
+						this.alterType(table, effectiveRelation, fieldSchema.nullable);
 
 						const builder = table
 							.foreign(field, constraintName || undefined)
@@ -373,12 +390,12 @@ export class RelationsService {
 								}`,
 							);
 
-						if (relation.schema?.on_delete) {
-							builder.onDelete(relation.schema.on_delete);
+						if (effectiveRelation.schema?.on_delete) {
+							builder.onDelete(effectiveRelation.schema.on_delete);
 						}
 
-						if (relation.schema?.on_update) {
-							builder.onUpdate(relation.schema.on_update);
+						if (effectiveRelation.schema?.on_update) {
+							builder.onUpdate(effectiveRelation.schema.on_update);
 						}
 					});
 				}


### PR DESCRIPTION
## What?

A `PATCH /relations/{collection}/{field}` whose body contains only `meta` returns 200 but **silently drops the relation's foreign-key constraint** — parent deletes then orphan junction rows — and logs an `unhandledRejection: TypeError: Cannot read properties of undefined (reading 'fields') at RelationsService.alterType`.

Closes #28135

## Why?

`updateOne` re-creates the FK on every PATCH, but reads everything from the **payload alone**:

- `alterType(table, relation, ...)` indexes `this.schema.collections[relation.collection!]!.fields[...]` — a meta-only PATCH has no `collection`/`field`/`related_collection`, so that's `undefined.fields` → the `alterTable` callback throws **after `dropForeign` was already queued**, and the constraint is never re-added;
- the re-add path only applies `relation.schema?.on_delete`/`on_update`, so even without the crash a meta-only PATCH would re-create the constraint with the default `NO ACTION` instead of the stored `CASCADE`.

## How?

Merge the payload over the **existing relation** before the schema-side work inside the transaction:

```ts
const effectiveRelation: Partial<Relation> = {
    ...existingRelation,
    ...relation,
    collection,
    field,
    schema: relation.schema ?? existingRelation.schema,
};
```

`alterType` and the `references(...)` target then operate on the relation's actual endpoints, and the re-added constraint keeps its stored `on_delete`/`on_update` unless the payload overrides them. `collection`/`field` come from the validated URL arguments. Everything else in the method (the `directus_relations` meta update, cache/invalidation flow) is unchanged, and a PATCH that *does* carry `schema.on_delete` still wins — that was already the documented contract.

## Testing

New `api/src/services/relations.test.ts` (same mock harness as `fields.test.ts`, with a capturing table builder that supports `dropForeign`/`foreign`/`specificType`):

1. a meta-only PATCH **resolves** instead of crashing the table-builder callback;
2. it drops and **re-adds** the FK under the same constraint name, with the stored `on_delete: 'CASCADE'`;
3. an explicit `schema: { on_delete: 'SET NULL' }` override still wins.

**Differential**: on `main`, all three cases fail with the exact production error from the issue — `TypeError: Cannot read properties of undefined (reading 'fields')` — and with this change the suite passes 3/3. (Verified locally against a mock schema mirroring the issue's `articles_authors → authors` junction; the Windows checkout needed the workspace `@directus/*` packages built and the native `isolated-vm` global-setup import skipped, which CI on Linux does out of the box.)