### PR TITLE
fix(graphql): merge selections from every merged field node

### DIFF
--- a/api/src/services/graphql/utils/build-selections.test.ts
+++ b/api/src/services/graphql/utils/build-selections.test.ts
@@ -252,4 +252,68 @@ describe('buildSelections', () => {
 	test('returns null when the field has no selections', () => {
 		expect(buildSelections({ fieldNodes: [{}], fragments: {}, schema: gqlSchema } as any)).toBeNull();
 	});
+
+	test('returns null when every merged field node lacks a selection set', () => {
+		expect(buildSelections({ fieldNodes: [{}, {}], fragments: {}, schema: gqlSchema } as any)).toBeNull();
+	});
+});
+
+describe('buildSelections with merged field nodes (#28133)', () => {
+	const pageReturnType = gqlSchema.getQueryType()!.getFields()['Page']!.type;
+
+	// graphql-js merges same-name fields from separate fragments into a single
+	// resolver call and passes every AST node for the field in fieldNodes:
+	//   fragment A on Query { page { id } }
+	//   fragment B on Query { page { title } }
+	// reaches the page resolver as TWO field nodes. Reading only the first
+	// dropped everything the later fragments selected (#28133).
+	test('merges fragment-spread selections from every merged field node', () => {
+		const info = buildResolveInfo({
+			selections: [],
+			fieldNodes: [
+				buildField('Page', { children: [buildFragmentSpread('A')] }),
+				buildField('Page', { children: [buildFragmentSpread('B')] }),
+			],
+			fragments: {
+				A: buildFragmentDefinition('A', 'Page', [buildField('id')]),
+				B: buildFragmentDefinition('B', 'Page', [buildField('title')]),
+			},
+			schema: gqlSchema,
+			returnType: pageReturnType,
+		});
+
+		expect(buildSelections(info)).toEqual([buildField('id'), buildField('title')]);
+	});
+
+	test('merges plain and fragment selections from different field nodes', () => {
+		const info = buildResolveInfo({
+			selections: [],
+			fieldNodes: [
+				buildField('Page', { children: [buildField('id')] }),
+				buildField('Page', { children: [buildFragmentSpread('B')] }),
+			],
+			fragments: {
+				B: buildFragmentDefinition('B', 'Page', [buildField('title')]),
+			},
+			schema: gqlSchema,
+			returnType: pageReturnType,
+		});
+
+		expect(buildSelections(info)).toEqual([buildField('id'), buildField('title')]);
+	});
+
+	test('survives a merged field node that carries no selection set', () => {
+		const info = buildResolveInfo({
+			selections: [],
+			fieldNodes: [
+				buildField('Page', { children: [buildField('id')] }),
+				{ kind: 'Field', name: { kind: 'Name', value: 'Page' } } as any,
+			],
+			fragments: {},
+			schema: gqlSchema,
+			returnType: pageReturnType,
+		});
+
+		expect(buildSelections(info)).toEqual([buildField('id')]);
+	});
 });

--- a/api/src/services/graphql/utils/build-selections.ts
+++ b/api/src/services/graphql/utils/build-selections.ts
@@ -79,5 +79,12 @@ function replaceInSelections(
  * @returns The selections asked for on that field, or null when it has no selection set
  */
 export function buildSelections(info: GraphQLResolveInfo): readonly SelectionNode[] | null {
-	return replaceInSelections(info.fieldNodes[0]?.selectionSet?.selections, getNamedType(info.returnType), info);
+	// graphql-js merges same-name fields from separate fragments into a single
+	// resolver call and passes every AST node for that field in fieldNodes
+	// (#28133). Reading only the first node drops the merged siblings'
+	// selections — `...A ...B` where both spread the same field silently
+	// lost everything the later fragments selected — so concatenate every
+	// node's selection set before fragment replacement.
+	const selections = info.fieldNodes.flatMap((node) => node.selectionSet?.selections ?? []);
+	return replaceInSelections(selections.length > 0 ? selections : undefined, getNamedType(info.returnType), info);
 }

--- a/api/src/test-utils/graphql.ts
+++ b/api/src/test-utils/graphql.ts
@@ -92,12 +92,15 @@ export function buildFilterArgument(filter: Record<string, any>): ArgumentNode {
 /** Stand in for the resolve info a resolver receives for the field it is resolving */
 export function buildResolveInfo(options: {
 	selections: readonly SelectionNode[];
+	/** Overrides the single synthesized field node — pass several to model
+	 * same-name fields merged across fragments (#28133). */
+	fieldNodes?: FieldNode[];
 	fragments?: Record<string, FragmentDefinitionNode>;
 	schema: GraphQLSchema;
 	returnType: GraphQLOutputType;
 }): GraphQLResolveInfo {
 	return {
-		fieldNodes: [buildField('resolved', { children: options.selections })],
+		fieldNodes: options.fieldNodes ?? [buildField('resolved', { children: options.selections })],
 		fragments: options.fragments ?? {},
 		schema: options.schema,
 		returnType: options.returnType,


### PR DESCRIPTION
## What?

Closes #28133

graphql-js merges same-name fields from separate fragments into a **single resolver call** and passes every AST node for the field in `info.fieldNodes`. `buildSelections` read only `fieldNodes[0]`, so:

```graphql
fragment A on Query { page { id } }
fragment B on Query { page { title } }
query { ...A ...B }
```

reached the `page` resolver with both nodes but only kept A's selection — everything later fragments selected came back `null`.

## Fix

Concatenate every node's selection set in `buildSelections` before fragment replacement (`flatMap` over `info.fieldNodes`). A node without a selection set contributes nothing; when all of them lack one the helper still returns `null` (previous behavior preserved). The resolver-level `parseArgs(info.fieldNodes[0])` is untouched — same-name merged fields must carry identical arguments per the GraphQL spec, so the first node's arguments are the arguments.

`buildResolveInfo` grows an optional `fieldNodes` override so tests can model merged fields.

## Testing

Three new cases in `build-selections.test.ts`: fragment-spread selections merged from two field nodes (the exact issue shape), plain + fragment across nodes, and a defensive node without a selection set. Plus an all-empty-nodes null case in the existing suite.

Differential: the two merge tests fail on `main` (only the first node's selections survive) and pass with the fix — full file 23/23 green after, 21/23 before. The nested-fragment / union-narrowing / m2a cases in the existing suite are unchanged by the fix.