### PR TITLE
perf(auth): lazily load auth drivers to reduce memory usage

### DIFF
--- a/.changeset/lazy-auth-drivers-memory.md
+++ b/.changeset/lazy-auth-drivers-memory.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Reduced memory usage on startup by lazily loading LDAP, OAuth2, OpenID, and SAML auth drivers via dynamic imports, so their dependencies are only loaded when actually configured via `AUTH_PROVIDERS`

--- a/api/src/auth.test.ts
+++ b/api/src/auth.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+const mockEnv: Record<string, unknown> = {};
+
+vi.mock('@directus/env', () => ({
+	useEnv: () => mockEnv,
+}));
+
+vi.mock('./database/index.js', () => ({
+	default: vi.fn(() => ({})),
+}));
+
+vi.mock('./logger/index.js', () => ({
+	useLogger: () => ({
+		error: vi.fn(),
+		warn: vi.fn(),
+	}),
+}));
+
+vi.mock('./license/index.js', () => ({
+	getEntitlementManager: () => ({
+		isEntitled: () => true,
+	}),
+}));
+
+vi.mock('./utils/get-config-from-env.js', () => ({
+	getConfigFromEnv: () => ({ driver: 'ldap' }),
+}));
+
+const ldapDriverCtor = vi.fn();
+
+vi.mock('./auth/drivers/local.js', () => ({
+	LocalAuthDriver: vi.fn().mockImplementation(() => ({ type: 'local' })),
+}));
+
+vi.mock('./auth/drivers/ldap.js', () => ({
+	LDAPAuthDriver: ldapDriverCtor.mockImplementation(() => ({ type: 'ldap' })),
+}));
+
+beforeEach(() => {
+	for (const key of Object.keys(mockEnv)) delete mockEnv[key];
+	ldapDriverCtor.mockClear();
+});
+
+afterEach(() => {
+	vi.resetModules();
+});
+
+test('registerAuthProviders only dynamically imports drivers that are configured', async () => {
+	mockEnv['AUTH_PROVIDERS'] = 'ldap_provider';
+
+	const { registerAuthProviders, getAuthProvider } = await import('./auth.js');
+
+	await registerAuthProviders();
+
+	expect(ldapDriverCtor).toHaveBeenCalledTimes(1);
+	expect(getAuthProvider('ldap_provider')).toEqual({ type: 'ldap' });
+	expect(getAuthProvider('default')).toEqual({ type: 'local' });
+});
+
+test('registerAuthProviders does not import unused drivers', async () => {
+	const { registerAuthProviders } = await import('./auth.js');
+
+	await registerAuthProviders();
+
+	expect(ldapDriverCtor).not.toHaveBeenCalled();
+});

--- a/api/src/auth.test.ts
+++ b/api/src/auth.test.ts
@@ -23,11 +23,16 @@ vi.mock('./license/index.js', () => ({
 	}),
 }));
 
+let configuredDriver: string | undefined = 'ldap';
+
 vi.mock('./utils/get-config-from-env.js', () => ({
-	getConfigFromEnv: () => ({ driver: 'ldap' }),
+	getConfigFromEnv: () => ({ driver: configuredDriver }),
 }));
 
 const ldapDriverCtor = vi.fn();
+const oauth2DriverCtor = vi.fn();
+const openidDriverCtor = vi.fn();
+const samlDriverCtor = vi.fn();
 
 vi.mock('./auth/drivers/local.js', () => ({
 	LocalAuthDriver: vi.fn().mockImplementation(() => ({ type: 'local' })),
@@ -37,9 +42,25 @@ vi.mock('./auth/drivers/ldap.js', () => ({
 	LDAPAuthDriver: ldapDriverCtor.mockImplementation(() => ({ type: 'ldap' })),
 }));
 
+vi.mock('./auth/drivers/oauth2.js', () => ({
+	OAuth2AuthDriver: oauth2DriverCtor.mockImplementation(() => ({ type: 'oauth2' })),
+}));
+
+vi.mock('./auth/drivers/openid.js', () => ({
+	OpenIDAuthDriver: openidDriverCtor.mockImplementation(() => ({ type: 'openid' })),
+}));
+
+vi.mock('./auth/drivers/saml.js', () => ({
+	SAMLAuthDriver: samlDriverCtor.mockImplementation(() => ({ type: 'saml' })),
+}));
+
 beforeEach(() => {
 	for (const key of Object.keys(mockEnv)) delete mockEnv[key];
+	configuredDriver = 'ldap';
 	ldapDriverCtor.mockClear();
+	oauth2DriverCtor.mockClear();
+	openidDriverCtor.mockClear();
+	samlDriverCtor.mockClear();
 });
 
 afterEach(() => {
@@ -54,14 +75,73 @@ test('registerAuthProviders only dynamically imports drivers that are configured
 	await registerAuthProviders();
 
 	expect(ldapDriverCtor).toHaveBeenCalledTimes(1);
+	expect(oauth2DriverCtor).not.toHaveBeenCalled();
+	expect(openidDriverCtor).not.toHaveBeenCalled();
+	expect(samlDriverCtor).not.toHaveBeenCalled();
 	expect(getAuthProvider('ldap_provider')).toEqual({ type: 'ldap' });
 	expect(getAuthProvider('default')).toEqual({ type: 'local' });
 });
 
-test('registerAuthProviders does not import unused drivers', async () => {
+test('registerAuthProviders does not import unused drivers when AUTH_PROVIDERS is unset', async () => {
 	const { registerAuthProviders } = await import('./auth.js');
 
 	await registerAuthProviders();
 
 	expect(ldapDriverCtor).not.toHaveBeenCalled();
+	expect(oauth2DriverCtor).not.toHaveBeenCalled();
+	expect(openidDriverCtor).not.toHaveBeenCalled();
+	expect(samlDriverCtor).not.toHaveBeenCalled();
+});
+
+test('registerAuthProviders dynamically imports the oauth2 driver when configured', async () => {
+	configuredDriver = 'oauth2';
+	mockEnv['AUTH_PROVIDERS'] = 'oauth2_provider';
+
+	const { registerAuthProviders, getAuthProvider } = await import('./auth.js');
+
+	await registerAuthProviders();
+
+	expect(oauth2DriverCtor).toHaveBeenCalledTimes(1);
+	expect(getAuthProvider('oauth2_provider')).toEqual({ type: 'oauth2' });
+});
+
+test('registerAuthProviders dynamically imports the openid driver when configured', async () => {
+	configuredDriver = 'openid';
+	mockEnv['AUTH_PROVIDERS'] = 'openid_provider';
+
+	const { registerAuthProviders, getAuthProvider } = await import('./auth.js');
+
+	await registerAuthProviders();
+
+	expect(openidDriverCtor).toHaveBeenCalledTimes(1);
+	expect(getAuthProvider('openid_provider')).toEqual({ type: 'openid' });
+});
+
+test('registerAuthProviders dynamically imports the saml driver when configured', async () => {
+	configuredDriver = 'saml';
+	mockEnv['AUTH_PROVIDERS'] = 'saml_provider';
+
+	const { registerAuthProviders, getAuthProvider } = await import('./auth.js');
+
+	await registerAuthProviders();
+
+	expect(samlDriverCtor).toHaveBeenCalledTimes(1);
+	expect(getAuthProvider('saml_provider')).toEqual({ type: 'saml' });
+});
+
+test('registerAuthProviders skips providers with no driver defined', async () => {
+	configuredDriver = undefined;
+	mockEnv['AUTH_PROVIDERS'] = 'missing_driver_provider';
+
+	const { registerAuthProviders, getAuthProvider } = await import('./auth.js');
+
+	await registerAuthProviders();
+
+	expect(() => getAuthProvider('missing_driver_provider')).toThrow();
+});
+
+test('getAuthProvider throws for an unconfigured provider', async () => {
+	const { getAuthProvider } = await import('./auth.js');
+
+	expect(() => getAuthProvider('does_not_exist')).toThrow();
 });

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -2,13 +2,6 @@ import { useEnv } from '@directus/env';
 import { InvalidProviderConfigError } from '@directus/errors';
 import { toArray, toBoolean } from '@directus/utils';
 import type { AuthDriver } from './auth/auth.js';
-import {
-	LDAPAuthDriver,
-	LocalAuthDriver,
-	OAuth2AuthDriver,
-	OpenIDAuthDriver,
-	SAMLAuthDriver,
-} from './auth/drivers/index.js';
 import { DEFAULT_AUTH_PROVIDER } from './constants.js';
 import getDatabase from './database/index.js';
 import { getEntitlementManager } from './license/index.js';
@@ -33,9 +26,7 @@ export async function registerAuthProviders(): Promise<void> {
 	const env = useEnv();
 	const logger = useLogger();
 	const options = { knex: getDatabase() };
-
 	const providerNames = toArray(env['AUTH_PROVIDERS'] as string);
-
 	const sso_allowed = getEntitlementManager().isEntitled('sso_enabled');
 
 	if (sso_allowed === false && env['AUTH_PROVIDERS'] && providerNames.length > 0) {
@@ -47,7 +38,7 @@ export async function registerAuthProviders(): Promise<void> {
 	}
 
 	// Always register default provider
-	const defaultProvider = getProviderInstance('local', options)!;
+	const defaultProvider = await getProviderInstance('local', options)!;
 	providers.set(DEFAULT_AUTH_PROVIDER, defaultProvider);
 
 	if (!env['AUTH_PROVIDERS']) {
@@ -55,7 +46,7 @@ export async function registerAuthProviders(): Promise<void> {
 	}
 
 	// Register configured providers
-	providerNames.forEach((name: string) => {
+	for (let name of providerNames) {
 		name = name.trim();
 
 		if (name === DEFAULT_AUTH_PROVIDER) {
@@ -67,40 +58,58 @@ export async function registerAuthProviders(): Promise<void> {
 
 		if (!driver) {
 			logger.warn(`Missing driver definition for "${name}" auth provider.`);
-			return;
+			continue;
 		}
 
-		const provider = getProviderInstance(driver, options, { provider: name, ...config });
+		const provider = await getProviderInstance(driver, options, { provider: name, ...config });
 
 		if (!provider) {
 			logger.warn(`Invalid "${driver}" auth driver.`);
-			return;
+			continue;
 		}
 
 		providers.set(name, provider);
-	});
+	}
 }
 
-function getProviderInstance(
+/**
+ * Lazily imports and instantiates the auth driver matching the given type.
+ *
+ * Auth drivers (LDAP, OAuth2, OpenID, SAML) pull in heavyweight dependencies
+ * (ldapjs, openid-client, etc). Dynamically importing them here ensures that
+ * only the drivers actually configured via AUTH_PROVIDERS get loaded into
+ * memory, instead of all drivers being loaded eagerly on every boot.
+ */
+async function getProviderInstance(
 	driver: string,
 	options: AuthDriverOptions,
 	config: Record<string, any> = {},
-): AuthDriver | undefined {
+): Promise<AuthDriver | undefined> {
 	switch (driver) {
-		case 'local':
+		case 'local': {
+			const { LocalAuthDriver } = await import('./auth/drivers/local.js');
 			return new LocalAuthDriver(options, config);
+		}
 
-		case 'oauth2':
+		case 'oauth2': {
+			const { OAuth2AuthDriver } = await import('./auth/drivers/oauth2.js');
 			return new OAuth2AuthDriver(options, config);
+		}
 
-		case 'openid':
+		case 'openid': {
+			const { OpenIDAuthDriver } = await import('./auth/drivers/openid.js');
 			return new OpenIDAuthDriver(options, config);
+		}
 
-		case 'ldap':
+		case 'ldap': {
+			const { LDAPAuthDriver } = await import('./auth/drivers/ldap.js');
 			return new LDAPAuthDriver(options, config);
+		}
 
-		case 'saml':
+		case 'saml': {
+			const { SAMLAuthDriver } = await import('./auth/drivers/saml.js');
 			return new SAMLAuthDriver(options, config);
+		}
 	}
 
 	return undefined;

--- a/contributors.yml
+++ b/contributors.yml
@@ -299,3 +299,4 @@
 - Deluvio
 - Aniket-a14
 - MHJahanbakhsh
+- Vansh1811


### PR DESCRIPTION
Auth drivers for LDAP, OAuth2, OpenID, and SAML pull in heavyweight dependencies (ldapjs, openid-client, @node-saml/node-saml, etc.) that were previously imported eagerly at the top of api/src/auth.ts. This meant every one of these packages was loaded into memory on every server boot, even when only the local provider was configured.

This change replaces the static imports with dynamic import() calls inside getProviderInstance, so only the drivers that are actually referenced by AUTH_PROVIDERS get loaded.

Fixes #24334

## What's Changed

- Removed static top-level imports of LDAPAuthDriver, LocalAuthDriver, OAuth2AuthDriver, OpenIDAuthDriver, and SAMLAuthDriver in api/src/auth.ts
- getProviderInstance is now async and dynamically imports only the driver module matching the requested type
- registerAuthProviders awaits the dynamic instantiation for the default provider and each configured provider

## Tested Scenarios

- No AUTH_PROVIDERS configured: only local driver module is loaded
- AUTH_PROVIDERS with ldap/oauth2/openid/saml configured: verified respective driver modules load correctly and authentication still functions as expected