### PR TITLE
Fix calendar picker weekday header ignoring the user language

### DIFF
--- a/.changeset/tidy-cases-repeat.md
+++ b/.changeset/tidy-cases-repeat.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed the date picker calendar showing English weekday names and starting the week on Sunday regardless of the user language

--- a/app/src/components/v-date-picker/v-date-picker.test.ts
+++ b/app/src/components/v-date-picker/v-date-picker.test.ts
@@ -67,7 +67,7 @@ const CalendarRoot = {
 			<slot :weekDays="['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']" :grid="[]" :date="mockDate" />
 		</div>
 	`,
-	props: ['modelValue', 'disabled', 'fixedWeeks', 'weekdayFormat', 'dir'],
+	props: ['modelValue', 'disabled', 'fixedWeeks', 'weekdayFormat', 'locale', 'dir'],
 	emits: ['update:modelValue'],
 	data() {
 		return {
@@ -1269,6 +1269,24 @@ describe('v-date-picker', () => {
 
 			const timeField = wrapper.findComponent(TimeFieldRoot);
 			expect(timeField.props('dir')).toBe('rtl');
+		});
+	});
+
+	describe('locale support', () => {
+		it('passes the user language to the calendar', () => {
+			const wrapper = createWrapper({ type: 'date' });
+
+			const calendarRoot = wrapper.findComponent(CalendarRoot);
+			expect(calendarRoot.props('locale')).toBe('en-US');
+		});
+
+		it('passes the user language to the calendar when it is not English', () => {
+			mockUserStore.language = 'fr-FR';
+
+			const wrapper = createWrapper({ type: 'date' });
+
+			const calendarRoot = wrapper.findComponent(CalendarRoot);
+			expect(calendarRoot.props('locale')).toBe('fr-FR');
 		});
 	});
 

--- a/app/src/components/v-date-picker/v-date-picker.vue
+++ b/app/src/components/v-date-picker/v-date-picker.vue
@@ -157,6 +157,7 @@ function setToNow() {
 			class="calendar"
 			fixed-weeks
 			weekday-format="short"
+			:locale="userStore.language"
 			:dir="isRTL ? 'rtl' : 'ltr'"
 			@update:model-value="handleDateChange"
 		>


### PR DESCRIPTION
## What's Changed

* `v-date-picker.vue` passes `:locale="userStore.language"` to `CalendarRoot`. It only received `weekday-format` and `dir`, so reka-ui fell back to its default `en` locale for the weekday header while the month name, built from a separate `DateFormatter` seeded with `userStore.language`, was already localized.
* reka-ui derives `weekStartsOn` from the locale as well, so the calendar now starts the week on the right day too.

## Tested Scenarios

* Rendered the real `CalendarRoot` with and without a locale: no locale gives `Sun Mon Tue …` starting Sunday, `fr-FR` gives `lun. mar. mer. …` starting Monday
* Two cases added to `v-date-picker.test.ts` next to the existing RTL ones, verified failing before the change
* Full app suite green

## Review Notes / Questions / Concerns

* `userStore.language` is the same source the month formatter already uses, so month and weekday labels can no longer disagree

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes directus/directus#28141
