### PR TITLE
Release 12.3.1

### DIFF
--- a/.changeset/afraid-eels-shave.md
+++ b/.changeset/afraid-eels-shave.md
@@ -1,5 +1,0 @@
----
-'@directus/cli': patch
----
-
-Stripped `project_id` when pulling settings, so a sync no longer copies one instance's identity onto another

--- a/.changeset/curly-donkeys-smoke.md
+++ b/.changeset/curly-donkeys-smoke.md
@@ -1,6 +1,0 @@
----
-'@directus/sdk': patch
----
-
-Fixed `unsubscribe()` not removing subscriptions, causing them to persist across reconnects and accumulate for the lifetime of the client
-

--- a/.changeset/fix-mcp-oauth-clients-breadcrumb.md
+++ b/.changeset/fix-mcp-oauth-clients-breadcrumb.md
@@ -1,5 +1,0 @@
----
-'@directus/app': patch
----
-
-Fixed MCP OAuth clients settings pages concatenating breadcrumbs into the page title

--- a/.changeset/loud-cats-listen.md
+++ b/.changeset/loud-cats-listen.md
@@ -1,5 +1,0 @@
----
-'@directus/api': patch
----
-
-Fixed the WebSocket heartbeat leaking a `websocket.message` listener on each ping when a client failed to respond in time

--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,5 +1,0 @@
----
-'@directus/api': patch
----
-
-Fixed GraphQL query fragments returning null fields

--- a/.changeset/quiet-hounds-gather.md
+++ b/.changeset/quiet-hounds-gather.md
@@ -1,5 +1,0 @@
----
-'@directus/api': minor
----
-
-Added `countFilterListeners`, `countActionListeners`, and `countInitListeners` methods to the `emitter`, exposing the number of registered handlers for each event

--- a/.changeset/quiet-moons-repeat.md
+++ b/.changeset/quiet-moons-repeat.md
@@ -1,5 +1,0 @@
----
-'@directus/api': patch
----
-
-Fixed public registration verification using the provided email instead of the stored one

--- a/.changeset/quiet-shares-guard.md
+++ b/.changeset/quiet-shares-guard.md
@@ -1,6 +1,0 @@
----
-'@directus/system-data': patch
-'@directus/api': patch
----
-
-Removed `user_created` and `date_created` for `update` from recommended permissions for `directus_shares`

--- a/.changeset/sharp-donkeys-listen.md
+++ b/.changeset/sharp-donkeys-listen.md
@@ -1,9 +1,0 @@
----
-'@directus/storage-driver-s3': patch
-'@directus/storage-driver-gcs': patch
-'@directus/storage-driver-azure': patch
-'@directus/storage-driver-supabase': patch
-'@directus/api': patch
----
-
-Updated storage driver dependencies

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/api",
-	"version": "39.0.0",
+	"version": "39.1.0",
 	"description": "Directus is a real-time API and App dashboard for managing SQL database content",
 	"keywords": [
 		"directus",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/app",
-	"version": "17.1.0",
+	"version": "17.1.1",
 	"description": "App dashboard for Directus",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/directus/package.json
+++ b/directus/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "directus",
-	"version": "12.3.0",
+	"version": "12.3.1",
 	"description": "Directus is a real-time API and App dashboard for managing SQL database content",
 	"keywords": [
 		"directus",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/cli",
-	"version": "12.2.0",
+	"version": "12.2.1",
 	"description": "Client-side CLI for Directus",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/composables",
-	"version": "11.6.1",
+	"version": "11.6.2",
 	"description": "Shared Vue composables for Directus use",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/create-directus-extension/package.json
+++ b/packages/create-directus-extension/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "create-directus-extension",
-	"version": "12.1.3",
+	"version": "12.1.4",
 	"description": "A small util that will scaffold a Directus extension",
 	"keywords": [
 		"directus",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/env",
-	"version": "6.2.1",
+	"version": "6.2.2",
 	"description": "Utilities around using global env configuration",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/extensions-sdk/package.json
+++ b/packages/extensions-sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/extensions-sdk",
-	"version": "18.0.3",
+	"version": "18.0.4",
 	"description": "A toolkit to develop extensions to extend Directus",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/extensions",
-	"version": "4.0.3",
+	"version": "4.0.4",
 	"description": "Utilities and types for Directus extensions",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/memory",
-	"version": "4.0.3",
+	"version": "4.0.4",
 	"description": "Memory / Redis abstraction for Directus",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/pressure/package.json
+++ b/packages/pressure/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/pressure",
-	"version": "4.0.3",
+	"version": "4.0.4",
 	"description": "Pressure based rate limiter",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/storage-driver-azure/package.json
+++ b/packages/storage-driver-azure/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-azure",
-	"version": "13.0.3",
+	"version": "13.0.4",
 	"description": "Azure file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/storage-driver-cloudinary/package.json
+++ b/packages/storage-driver-cloudinary/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-cloudinary",
-	"version": "14.0.0",
+	"version": "14.0.1",
 	"description": "Cloudinary file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/storage-driver-gcs/package.json
+++ b/packages/storage-driver-gcs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-gcs",
-	"version": "13.0.3",
+	"version": "13.0.4",
 	"description": "GCS file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/storage-driver-s3/package.json
+++ b/packages/storage-driver-s3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-s3",
-	"version": "14.0.0",
+	"version": "14.0.1",
 	"description": "S3 file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/storage-driver-supabase/package.json
+++ b/packages/storage-driver-supabase/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/storage-driver-supabase",
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"description": "Supabase file storage abstraction for `@directus/storage`",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/system-data/package.json
+++ b/packages/system-data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/system-data",
-	"version": "4.6.0",
+	"version": "4.6.1",
 	"description": "Definitions and types for Directus system collections",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/themes",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"description": "Themes for Directus",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/utils",
-	"version": "13.5.3",
+	"version": "13.5.4",
 	"description": "Utilities shared between the Directus packages",
 	"homepage": "https://directus.com",
 	"repository": {

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/validation",
-	"version": "3.0.3",
+	"version": "3.0.4",
 	"type": "module",
 	"sideEffects": false,
 	"scripts": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@directus/sdk",
-	"version": "25.0.0",
+	"version": "25.0.1",
 	"description": "Directus JavaScript SDK",
 	"homepage": "https://directus.com",
 	"repository": {


### PR DESCRIPTION
### ✅ Release Checklist
- [x] Changesets processed
- [x] Package versions updated
- [x] Release notes generated
- [x] Merge Crowdin PR: https://github.com/directus/directus/pull/28140
- [x] PR reviewed and approved
- [ ] Blackbox tests passed
- [ ] E2E tests passed

### 🚀 Release Notes
```md
### ✨ New Features & Improvements

- **@directus/api**
  - Added `countFilterListeners`, `countActionListeners`, and `countInitListeners` methods to the `emitter`, exposing the number of registered handlers for each event ([#28117](https://github.com/directus/directus/pull/28117) by @ComfortablyCoding)

### 🐛 Bug Fixes & Optimizations

- **@directus/app**
  - Fixed MCP OAuth clients settings pages concatenating breadcrumbs into the page title ([#28115](https://github.com/directus/directus/pull/28115) by @MHJahanbakhsh)
- **@directus/api**
  - Fixed the WebSocket heartbeat leaking a `websocket.message` listener on each ping when a client failed to respond in time ([#28117](https://github.com/directus/directus/pull/28117) by @ComfortablyCoding)
  - Fixed GraphQL query fragments returning null fields ([#28128](https://github.com/directus/directus/pull/28128) by @ComfortablyCoding)
  - Fixed public registration verification using the provided email instead of the stored one ([#28144](https://github.com/directus/directus/pull/28144) by @br41nslug)
  - Removed `user_created` and `date_created` for `update` from recommended permissions for `directus_shares` ([#28145](https://github.com/directus/directus/pull/28145) by @br41nslug)
  - Updated storage driver dependencies ([#28119](https://github.com/directus/directus/pull/28119) by @ComfortablyCoding)
- **@directus/cli**
  - Stripped `project_id` when pulling settings, so a sync no longer copies one instance's identity onto another ([#28132](https://github.com/directus/directus/pull/28132) by @lazerg)
- **@directus/sdk**
  - Fixed `unsubscribe()` not removing subscriptions, causing them to persist across reconnects and accumulate for the lifetime of the client ([#28117](https://github.com/directus/directus/pull/28117) by @ComfortablyCoding)
- **@directus/system-data**
  - Removed `user_created` and `date_created` for `update` from recommended permissions for `directus_shares` ([#28145](https://github.com/directus/directus/pull/28145) by @br41nslug)
- **@directus/storage-driver-s3**
  - Updated storage driver dependencies ([#28119](https://github.com/directus/directus/pull/28119) by @ComfortablyCoding)
- **@directus/storage-driver-gcs**
  - Updated storage driver dependencies ([#28119](https://github.com/directus/directus/pull/28119) by @ComfortablyCoding)
- **@directus/storage-driver-azure**
  - Updated storage driver dependencies ([#28119](https://github.com/directus/directus/pull/28119) by @ComfortablyCoding)
- **@directus/storage-driver-supabase**
  - Updated storage driver dependencies ([#28119](https://github.com/directus/directus/pull/28119) by @ComfortablyCoding)

### 📦 Published Versions

- `@directus/app@17.1.1`
- `@directus/api@39.1.0`
- `@directus/cli@12.2.1`
- `@directus/composables@11.6.2`
- `create-directus-extension@12.1.4`
- `@directus/env@6.2.2`
- `@directus/extensions@4.0.4`
- `@directus/extensions-sdk@18.0.4`
- `@directus/memory@4.0.4`
- `@directus/pressure@4.0.4`
- `@directus/storage-driver-azure@13.0.4`
- `@directus/storage-driver-cloudinary@14.0.1`
- `@directus/storage-driver-gcs@13.0.4`
- `@directus/storage-driver-s3@14.0.1`
- `@directus/storage-driver-supabase@5.0.1`
- `@directus/system-data@4.6.1`
- `@directus/themes@2.0.4`
- `@directus/utils@13.5.4`
- `@directus/validation@3.0.4`
- `@directus/sdk@25.0.1`
```