### PR TITLE
docs: Add RepoCloud one-click deploy button

### DIFF
--- a/directus/readme.md
+++ b/directus/readme.md
@@ -69,7 +69,7 @@ One click. Fully provisioned with PostgreSQL, Redis, and S3-compatible storage, 
 
 ### Deploy on RepoCloud
 
-One click. Competitive pricing for open-source applications.
+One click. Managed hosting for open-source applications with a dedicated VPS.
 
 [![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Directus/)
 

--- a/directus/readme.md
+++ b/directus/readme.md
@@ -67,6 +67,12 @@ One click. Fully provisioned with PostgreSQL, Redis, and S3-compatible storage, 
 
 [![Deploy on Railway](https://railway.app/button.svg)](https://railway.com/deploy/directus-official?referralCode=b2RDZT)
 
+### Deploy on RepoCloud
+
+One click. Competitive pricing for open-source applications.
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Directus/)
+
 ---
 
 ## 🙋 Community Help


### PR DESCRIPTION
This PR adds a RepoCloud one-click deploy option to the "One-Click Deployment Options" section, alongside the existing Railway deployment.

[RepoCloud](https://repocloud.io) provides managed one-click hosting for open-source applications 

Preview: https://repocloud.io/details/Directus/