### PR TITLE
Fix Save as Copy moving nested relations within related collections

### DIFF
--- a/.changeset/preserve-nested-relations-save-as-copy.md
+++ b/.changeset/preserve-nested-relations-save-as-copy.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Ensured nested relations within related items (e.g. translation fields) are cloned rather than transferred when saving an item as a copy.

--- a/app/src/composables/use-item/index.test.ts
+++ b/app/src/composables/use-item/index.test.ts
@@ -1063,3 +1063,175 @@ describe('Save As Copy with M2M relation', () => {
 		expect(saveBody.children.update).toEqual([]);
 	});
 });
+
+describe('Save As Copy with nested relations in related collection', () => {
+	const mockArticleCollection = {
+		collection: 'articles',
+	} as AppCollection;
+
+	const defaultParentPkField = {
+		field: 'id',
+		schema: { has_auto_increment: true },
+	} as Field;
+
+	function setupNestedRelationalEnvironment(parentPkField: Field = defaultParentPkField) {
+		const sdkRequestSpy = vi.spyOn(sdk, 'request');
+
+		vi.mocked(useCollection).mockReturnValue({
+			info: computed(() => mockArticleCollection),
+			primaryKeyField: computed(() => parentPkField),
+			fields: computed(() => [parentPkField] as Field[]),
+		} as any);
+
+		const fieldsStore = useFieldsStore();
+		const relationsStore = useRelationsStore();
+
+		const autoincrementField = { field: 'id', schema: { has_auto_increment: true } } as Field;
+		const stringCodeField = { field: 'code' } as Field;
+
+		vi.mocked(fieldsStore.getPrimaryKeyFieldForCollection).mockImplementation((collectionName: string) =>
+			collectionName === 'languages' ? stringCodeField : autoincrementField,
+		);
+
+		const articleTranslationsRel = {
+			collection: 'articles_translations',
+			field: 'articles_id',
+			related_collection: 'articles',
+			meta: { one_field: 'translations', junction_field: 'languages_code' },
+		} as unknown as Relation;
+
+		const translationTagsRel = {
+			collection: 'articles_translations_tags',
+			field: 'articles_translations_id',
+			related_collection: 'articles_translations',
+			meta: { one_field: 'tags', junction_field: 'tags_id' },
+		} as unknown as Relation;
+
+		vi.mocked(relationsStore.getRelationsForCollection).mockReturnValue([articleTranslationsRel]);
+
+		vi.mocked(relationsStore).relations = [
+			articleTranslationsRel,
+			{
+				collection: 'articles_translations',
+				field: 'languages_code',
+				related_collection: 'languages',
+				meta: { many_field: 'languages_code', junction_field: null },
+			} as unknown as Relation,
+			translationTagsRel,
+			{
+				collection: 'articles_translations_tags',
+				field: 'tags_id',
+				related_collection: 'tags',
+				meta: { many_field: 'tags_id', junction_field: null },
+			} as unknown as Relation,
+		];
+
+		return sdkRequestSpy;
+	}
+
+	test('expands nested relation fields with wildcard when querying related items', async () => {
+		const requestSpy = setupNestedRelationalEnvironment();
+
+		requestSpy
+			.mockResolvedValueOnce({})
+			.mockResolvedValueOnce({ item: { id: 1, translations: [{ id: 10 }] } })
+			.mockResolvedValueOnce([{ id: 10 }])
+			.mockResolvedValueOnce({ id: 2 });
+
+		const { saveAsCopy } = useItem(ref('articles'), ref(1));
+		await saveAsCopy();
+
+		const relatedFetchCall = requestSpy.mock.calls[2]?.[0]() as any;
+		expect(relatedFetchCall.params.fields).toEqual(['*', 'tags.*']);
+	});
+
+	test('strips junction primary keys so nested relational items are cloned instead of reassigned', async () => {
+		const requestSpy = setupNestedRelationalEnvironment();
+
+		requestSpy
+			.mockResolvedValueOnce({})
+			.mockResolvedValueOnce({ item: { id: 1, translations: [{ id: 10 }] } })
+			.mockResolvedValueOnce([
+				{
+					id: 10,
+					articles_id: 1,
+					languages_code: 'en-US',
+					tags: [{ id: 100, articles_translations_id: 10, tags_id: 5 }],
+				},
+			])
+			.mockResolvedValueOnce({ id: 2 });
+
+		const { saveAsCopy } = useItem(ref('articles'), ref(1));
+		await saveAsCopy();
+
+		const createPayload = (requestSpy.mock.lastCall?.[0]() as any).body;
+
+		expect(createPayload.translations).toEqual([
+			{
+				articles_id: 1,
+				languages_code: 'en-US',
+				tags: [{ articles_translations_id: 10, tags_id: 5 }],
+			},
+		]);
+	});
+
+	test('correctly clones nested relational items when draft edits are present on the parent relation', async () => {
+		const requestSpy = setupNestedRelationalEnvironment();
+
+		requestSpy
+			.mockResolvedValueOnce({})
+			.mockResolvedValueOnce({ item: { id: 1, translations: [{ id: 10 }] } })
+			.mockResolvedValueOnce([
+				{
+					id: 10,
+					articles_id: 1,
+					languages_code: 'en-US',
+					tags: [{ id: 100, articles_translations_id: 10, tags_id: 5 }],
+				},
+			])
+			.mockResolvedValueOnce({ id: 2 });
+
+		const { saveAsCopy, edits } = useItem(ref('articles'), ref(1));
+
+		edits.value = {
+			translations: {
+				create: [],
+				update: [{ id: 10, title: 'Updated Title' }],
+				delete: [],
+			},
+		};
+
+		await saveAsCopy();
+
+		const createPayload = (requestSpy.mock.lastCall?.[0]() as any).body;
+
+		expect(createPayload.translations.create).toEqual([
+			{
+				articles_id: 1,
+				languages_code: 'en-US',
+				title: 'Updated Title',
+				tags: [{ articles_translations_id: 10, tags_id: 5 }],
+			},
+		]);
+
+		expect(createPayload.translations.update).toEqual([]);
+	});
+
+	test('preserves custom non-autoincrement string primary key values on parent record', async () => {
+		const requestSpy = setupNestedRelationalEnvironment({ field: 'slug' } as Field);
+
+		requestSpy
+			.mockResolvedValueOnce({})
+			.mockResolvedValueOnce({ item: { slug: 'article-one', translations: [{ id: 10 }] } })
+			.mockResolvedValueOnce([{ id: 10, articles_id: 'article-one', languages_code: 'en-US' }])
+			.mockResolvedValueOnce({ slug: 'article-two' });
+
+		const { saveAsCopy } = useItem(ref('articles'), ref(1));
+		await saveAsCopy();
+
+		const createPayload = (requestSpy.mock.lastCall?.[0]() as any).body;
+
+		expect(createPayload.slug).toBe('article-one');
+		expect(createPayload.translations).toEqual([{ articles_id: 'article-one', languages_code: 'en-US' }]);
+	});
+});

--- a/app/src/composables/use-item/index.ts
+++ b/app/src/composables/use-item/index.ts
@@ -291,60 +291,63 @@ export function useItem<T extends Item>(
 
 				if (existingItems.length > 0) {
 					newItem[oneField] = newItem[oneField].map((relatedItem: Item | PrimaryKey) => {
-						const existingItem = existingItems.find(
-							(existingItem) =>
+						const match = existingItems.find(
+							(item) =>
 								// Loose equality because GraphQL always returns primary key as string
-								existingItem[relatedPrimaryKeyField.field] ==
+								item[relatedPrimaryKeyField.field] ==
 								(isObject(relatedItem) ? relatedItem[relatedPrimaryKeyField.field] : relatedItem),
 						);
 
-						if (existingItem) {
-							clearPrimaryKey(primaryKeyField.value, existingItem);
-							clearJunctionRelatedKey(relation, existsJunctionRelated, existingItem);
-							relatedItem = existingItem;
+						if (match) {
+							clearPrimaryKey(relatedPrimaryKeyField, match);
+							clearJunctionRelatedKey(relation, existsJunctionRelated, match);
+							sanitizeChildRelations(relation.collection, match);
+							relatedItem = match;
 						}
 
 						return relatedItem;
 					});
 				}
 			} else if (isObject(newItem[oneField])) {
-				const newRelatedItem = newItem[oneField] as Alterations;
+				const alterations = newItem[oneField] as Alterations;
 
 				const existingItems = (await findExistingRelatedItems(relation, relatedPrimaryKeyField)).filter(
-					(item) => !newRelatedItem.delete.includes(item[relatedPrimaryKeyField.field]),
+					(item) => !alterations.delete.includes(item[relatedPrimaryKeyField.field]),
 				);
 
-				for (const item of newRelatedItem.update) {
-					let data;
+				for (const item of alterations.update) {
+					let payload;
 
-					const existingItemIndex = existingItems.findIndex(
-						(existingItem) => existingItem[relatedPrimaryKeyField.field] === item[relatedPrimaryKeyField.field],
+					const existingIndex = existingItems.findIndex(
+						(existing) => existing[relatedPrimaryKeyField.field] === item[relatedPrimaryKeyField.field],
 					);
 
-					if (existingItemIndex > -1) {
-						data = mergeWith(existingItems[existingItemIndex], item, (objValue) => {
+					if (existingIndex > -1) {
+						payload = mergeWith(existingItems[existingIndex], item, (objValue) => {
 							if (Array.isArray(objValue)) return objValue;
 							return;
 						});
 
-						existingItems.splice(existingItemIndex, 1);
+						existingItems.splice(existingIndex, 1);
 					} else {
-						data = item;
+						payload = item;
 					}
 
-					clearPrimaryKey(relatedPrimaryKeyField, data);
-					clearJunctionRelatedKey(relation, existsJunctionRelated, data);
+					clearPrimaryKey(relatedPrimaryKeyField, payload);
+					clearJunctionRelatedKey(relation, existsJunctionRelated, payload);
+					sanitizeChildRelations(relation.collection, payload);
 
-					newRelatedItem.create.push(data);
+					alterations.create.push(payload);
 				}
 
 				for (const item of existingItems) {
 					clearPrimaryKey(relatedPrimaryKeyField, item);
+					sanitizeChildRelations(relation.collection, item);
 
-					newRelatedItem.create.push(item);
+					alterations.create.push(item);
 				}
 
-				newRelatedItem.update.length = 0;
+				alterations.update.length = 0;
 			}
 		}
 
@@ -390,18 +393,30 @@ export function useItem<T extends Item>(
 
 			if (existingIds.length === 0) return [];
 
-			const fieldsToFetch = new Set(
-				fields.reduce((accumulator, currentValue) => {
-					const [onePart, ...remainingParts] = currentValue.split('.');
+			const fieldsToFetch = new Set<string>();
 
-					if (onePart === relation.meta!.one_field! && remainingParts.length > 0)
-						accumulator.push(remainingParts.join('.'));
+			for (const path of fields) {
+				const [relField, ...subPath] = path.split('.');
 
-					return accumulator;
-				}, [] as string[]),
-			);
+				if (relField === relation.meta!.one_field! && subPath.length > 0) {
+					fieldsToFetch.add(subPath.join('.'));
+				}
+			}
 
-			if (fieldsToFetch.size > 0) fieldsToFetch.add(relatedPrimaryKeyField.field);
+			const childRelationalFields = getChildRelations(relation.collection).map((rel) => rel.meta!.one_field!);
+
+			if (fieldsToFetch.size > 0) {
+				fieldsToFetch.add(relatedPrimaryKeyField.field);
+			} else if (childRelationalFields.length > 0) {
+				fieldsToFetch.add('*');
+			}
+
+			for (const childField of childRelationalFields) {
+				if (fieldsToFetch.has('*') || fieldsToFetch.has(childField)) {
+					fieldsToFetch.delete(childField);
+					fieldsToFetch.add(`${childField}.*`);
+				}
+			}
 
 			const endpoint = getEndpoint(relation.collection);
 			const requestFields = Array.from(fieldsToFetch);
@@ -418,6 +433,38 @@ export function useItem<T extends Item>(
 			const options = useSearch ? { method: 'SEARCH' as const, body: { query } } : { params: query };
 
 			return await sdk.request<Item[]>(requestEndpoint(endpoint, options));
+		}
+
+		function getChildRelations(targetCollection: string): Relation[] {
+			return relationsStore.relations.filter(
+				(rel) => rel.related_collection === targetCollection && Boolean(rel.meta?.one_field),
+			);
+		}
+
+		function sanitizeChildRelations(parentCollection: string, itemRecord: Item) {
+			const childRelations = getChildRelations(parentCollection);
+
+			for (const childRelation of childRelations) {
+				const oneFieldKey = childRelation.meta!.one_field!;
+				const records = itemRecord[oneFieldKey];
+
+				if (!Array.isArray(records)) continue;
+
+				const childPkField = fieldsStore.getPrimaryKeyFieldForCollection(childRelation.collection);
+				if (!childPkField) continue;
+
+				const matchingJunctionRelation = relationsStore.relations.find(
+					(r) => r.collection === childRelation.collection && r.meta?.many_field === childRelation.meta?.junction_field,
+				);
+
+				itemRecord[oneFieldKey] = records
+					.filter((record): record is Item => isObject(record))
+					.map((record) => {
+						clearPrimaryKey(childPkField, record);
+						clearJunctionRelatedKey(childRelation, matchingJunctionRelation, record);
+						return record;
+					});
+			}
 		}
 
 		function clearPrimaryKey(primaryKeyField: Field | null, item: Item) {


### PR DESCRIPTION
## What's Changed

- Fixed an issue where saving an item as a copy with nested relations in related collections (such as an M2M field inside `translations`) resulted in nested records being reassigned/moved to the duplicate and removed from the original item.
- Updated `findExistingRelatedItems` in `useItem` to automatically expand child relations with `${childField}.*` so nested records are fetched with full objects instead of raw IDs.
- Added `sanitizeChildRelations` in `useItem` to recursively strip primary keys and junction link IDs on nested records so fresh records are created for the duplicated item without mutating the original.
- Corrected `clearPrimaryKey` in `saveAsCopy` to use `relatedPrimaryKeyField` rather than `primaryKeyField.value`.

## Tested Scenarios

- Added comprehensive unit tests in `app/src/composables/use-item/index.test.ts` covering:
  - Wildcard expansion for nested relational fields (`tags.*`).
  - Dropping junction primary keys on nested items during duplication.
  - Duplication with draft edits on related items.
  - Handling custom non-autoincrement primary keys on the parent collection.
- Executed end-to-end integration verification against a live Directus instance:
  - Created an article with translation and two M2M tags.
  - Duplicated the article using the updated logic.
  - Verified that the original translation preserved its junction tags and the duplicated translation was assigned separate new junction records.
- Verified that all unit tests (`pnpm --filter @directus/app test`), `pnpm lint`, `pnpm lint:style`, and `pnpm format` pass cleanly.

## Review Notes / Questions / Concerns

- None.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes directus/directus#26841
