### PR TITLE
Add search to the flow trigger Collections field

### DIFF
--- a/.changeset/icy-ties-attend.md
+++ b/.changeset/icy-ties-attend.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added search to the flow trigger Collections field

--- a/app/src/interfaces/_system/system-collections/system-collections.vue
+++ b/app/src/interfaces/_system/system-collections/system-collections.vue
@@ -2,7 +2,7 @@
 import { isSystemCollection } from '@directus/system-data';
 import { computed } from 'vue';
 import VNotice from '@/components/v-notice.vue';
-import InterfaceSelectMultipleCheckbox from '@/interfaces/select-multiple-checkbox/select-multiple-checkbox.vue';
+import InterfaceSelectMultipleDropdown from '@/interfaces/select-multiple-dropdown/select-multiple-dropdown.vue';
 import { useCollectionsStore } from '@/stores/collections';
 
 const props = withDefaults(
@@ -47,11 +47,12 @@ const items = computed(() => {
 	<VNotice v-if="items.length === 0">
 		{{ $t('no_collections') }}
 	</VNotice>
-	<InterfaceSelectMultipleCheckbox
+	<InterfaceSelectMultipleDropdown
 		v-else
 		:choices="items"
-		:value="value"
+		:value="value ?? undefined"
 		:disabled="disabled"
+		:placeholder="$t('collections')"
 		@input="$emit('input', $event)"
 	/>
 </template>


### PR DESCRIPTION
## What's Changed

- Replaced the checkbox list in the flow trigger **Collections** field with a searchable multi-select dropdown, matching
  the **Scope** field.

## Tested Scenarios

- Manual trigger: the Collections field still lists and selects collections as before.

## Review Notes / Questions / Concerns

- Presentation-only change to the `system-collections` interface, which is used solely by the flow triggers — no impact
  elsewhere in the app.

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

Fixes [cms-2992](https://linear.app/directus/issue/CMS-2992/add-manual-trigger-collection-selection-search)