### PR TITLE
Fix czech translation for `create` string

### DIFF
--- a/app/src/lang/translations/cs-CZ.yaml
+++ b/app/src/lang/translations/cs-CZ.yaml
@@ -905,7 +905,7 @@ no_presets: Žádné předvolby
 no_presets_copy: Zatím nebyly uloženy žádné předvolby ani záložky.
 no_presets_cta: Přidat předvolbu
 presets_only: Pouze předvolby
-create: Vytořit
+create: Vytvořit
 on_create: Při vytvoření
 on_update: Při úpravě
 read: Číst
@@ -1424,7 +1424,7 @@ field_options:
     overrides_divider_title: Přepisy aplikace
   directus_activity:
     login: Přihlášení
-    create: Vytořit
+    create: Vytvořit
     update: Úpravy
     delete: Smazat
   directus_collections:


### PR DESCRIPTION
## What's Changed

- Typo in Czech translation for `create` string was fixed: `Vytořit` → `Vytvořit` 

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [x] App translations added for new user-facing strings
- [ ] Security implications apply

---