### PR TITLE
Only measure the image output dimension cap against dimension-changing steps 🤖🤖🤖

### DIFF
--- a/.changeset/fix-output-dimension-cap-encoder-steps.md
+++ b/.changeset/fix-output-dimension-cap-encoder-steps.md
@@ -1,0 +1,17 @@
+---
+'@directus/api': patch
+---
+
+Fixed the image transformation output dimension cap rejecting valid downscales of sources larger than the cap
+
+::: notice
+
+`ASSETS_TRANSFORM_IMAGE_MAX_OUTPUT_DIMENSION` is now only measured against transformation steps that actually change
+the dimensions, such as `resize`, `extract`, `extend` and `rotate`. Steps that leave the dimensions untouched, such as
+`toFormat` selecting the output encoder, inherit an already validated size, so measuring them again rejected requests
+whose output was never over the cap, for example `?width=400&format=webp` on a source wider than the cap.
+
+The guard against intermediate enlargement is unchanged: a step that scales up beyond the cap is still rejected, even
+when a later step shrinks back under it.
+
+:::

--- a/api/src/services/assets/assert-transforms-allowed.test.ts
+++ b/api/src/services/assets/assert-transforms-allowed.test.ts
@@ -19,6 +19,10 @@ vi.mock('@directus/env', async () => {
 	return mockEnv();
 });
 
+vi.mock('../../logger/index.js', () => ({
+	useLogger: vi.fn().mockReturnValue({ warn: vi.fn() }),
+}));
+
 describe('assertTransformsAllowed', () => {
 	const MAX_DIM = 6000;
 
@@ -63,6 +67,42 @@ describe('assertTransformsAllowed', () => {
 	test('When a source dimension is zero, then it does not divide by zero or throw', () => {
 		const transforms: Transformation[] = [['resize', { width: 100 }]];
 		expect(() => assertTransformsAllowed(0, 0, transforms)).not.toThrow();
+	});
+
+	test('When a dimension-neutral step precedes a downscale of an oversized source, then it does not throw', () => {
+		const transforms: Transformation[] = [
+			['toFormat', 'webp', { quality: 80 }],
+			['resize', { width: 400 }],
+		];
+
+		expect(() => assertTransformsAllowed(MAX_DIM * 2, MAX_DIM * 2, transforms)).not.toThrow();
+	});
+
+	test('When an oversized source is only re-encoded, then it does not throw', () => {
+		const transforms: Transformation[] = [['toFormat', 'webp', { quality: 80 }]];
+		expect(() => assertTransformsAllowed(MAX_DIM * 2, MAX_DIM * 2, transforms)).not.toThrow();
+	});
+
+	test('When a dimension-neutral step follows an oversized upscale, then the upscale still throws', () => {
+		const transforms: Transformation[] = [
+			['resize', { width: MAX_DIM + 1, height: MAX_DIM + 1 }],
+			['toFormat', 'webp', { quality: 80 }],
+		];
+
+		expect(() => assertTransformsAllowed(1, 1, transforms)).toThrow(IllegalAssetTransformationError);
+	});
+
+	test('When a downscale of an oversized source still exceeds the cap, then it throws', () => {
+		const transforms: Transformation[] = [['resize', { width: MAX_DIM + 1 }]];
+
+		expect(() => assertTransformsAllowed(MAX_DIM * 2, MAX_DIM * 2, transforms)).toThrow(
+			IllegalAssetTransformationError,
+		);
+	});
+
+	test('When a resize projects no change, then the oversized source it inherits is not measured', () => {
+		const transforms: Transformation[] = [['resize', { fit: 'inside' }]];
+		expect(() => assertTransformsAllowed(MAX_DIM * 2, MAX_DIM * 2, transforms)).not.toThrow();
 	});
 
 	test.each([

--- a/api/src/services/assets/assert-transforms-allowed.ts
+++ b/api/src/services/assets/assert-transforms-allowed.ts
@@ -3,6 +3,7 @@ import { IllegalAssetTransformationError } from '@directus/errors';
 import type { Transformation } from '@directus/types';
 import { isObject } from '@directus/utils';
 import { isNumber, isString } from 'lodash-es';
+import { useLogger } from '../../logger/index.js';
 
 export type Size = { width: number; height: number };
 
@@ -40,10 +41,17 @@ export function calculateStep(size: Size, method: string, args: unknown[]): Size
  * For example, an image scaled up to 10,000 pixels and then reduced to 5,000 pixels would end within the limit, but would still exceed
  * the allowed dimension during processing.
  *
+ * Only steps that actually move the dimensions are measured. A step that leaves them untouched, such as
+ * `toFormat` selecting the output encoder, inherits the size of whatever came before it, and that size has
+ * already been validated: either it is the source, bounded by `ASSETS_TRANSFORM_IMAGE_MAX_DIMENSION`, or it
+ * is the result of an earlier step that was measured against this cap. Measuring them again compares the
+ * incoming size against the output cap, which rejects requests whose actual output was never in question,
+ * such as a small `?width=400&format=webp` off a source larger than the cap.
+ *
  * @param sourceWidth - Original image width
  * @param sourceHeight - Original image height
  * @param transforms - Ordered sharp transform steps to project
- * @throws IllegalAssetTransformationError when any steps projected size exceeds the cap
+ * @throws IllegalAssetTransformationError when a dimension-changing steps projected size exceeds the cap
  */
 export function assertTransformsAllowed(sourceWidth: number, sourceHeight: number, transforms: Transformation[]): void {
 	const env = useEnv();
@@ -53,9 +61,18 @@ export function assertTransformsAllowed(sourceWidth: number, sourceHeight: numbe
 	let size: Size = { width: sourceWidth, height: sourceHeight };
 
 	for (const [method, ...args] of transforms) {
-		size = calculateStep(size, method, args);
+		const projected = calculateStep(size, method, args);
+		const changesDimensions = projected.width !== size.width || projected.height !== size.height;
 
-		if (size.width > maxOutputDimension || size.height > maxOutputDimension) {
+		size = projected;
+
+		if (changesDimensions && (size.width > maxOutputDimension || size.height > maxOutputDimension)) {
+			const logger = useLogger();
+
+			logger.warn(
+				`Transformation step "${method}" projects to ${size.width}x${size.height}, which exceeds the ${maxOutputDimension}px ASSETS_TRANSFORM_IMAGE_MAX_OUTPUT_DIMENSION limit.`,
+			);
+
 			throw new IllegalAssetTransformationError({ invalidTransformations: ['width', 'height'] });
 		}
 	}


### PR DESCRIPTION
## What's Changed

- `assertTransformsAllowed()` now applies `ASSETS_TRANSFORM_IMAGE_MAX_OUTPUT_DIMENSION` only to transform steps that actually change the projected dimensions. Steps that leave them untouched, such as `toFormat`, are no longer measured.
- The offending step and its projected size are logged as a warning before throwing, since the error's `invalidTransformations: ["width", "height"]` payload does not identify what tripped the cap.
- Tests added for the encoder-only case, and for the regressions the change must not introduce.

### Why

`calculateStep()` returns the size unchanged for any method it does not project (`default: return size`). The cap was then applied after every step, so a step with no dimension projection was measured against the size it *inherited* rather than a size it *produced*.

`resolvePreset()` pushes `toFormat` before the `resize`, so whenever `format` or `quality` was present the first step evaluated was `toFormat` while the running size was still the untouched source. Any source larger than the output cap was rejected regardless of how small the requested output was:

```
GET /assets/<id>?width=1400            → 200
GET /assets/<id>?width=1400&format=webp → 400 ILLEGAL_ASSET_TRANSFORMATION
GET /assets/<id>?width=100&quality=80   → 400 ILLEGAL_ASSET_TRANSFORMATION
```

A 100px output being rejected shows the failure is independent of the requested size.

The fix is safe because a dimension-neutral step never raises the raster above the size it inherited, and that size has already been validated: it is either the source, bounded by `ASSETS_TRANSFORM_IMAGE_MAX_DIMENSION` (checked in `AssetsService`), or the result of an earlier step that was measured against this cap. So the check has nothing new to bound at such a step.

The guard the existing docblock describes is intact: a step that scales *up* beyond the cap is still rejected, even when a later step shrinks back under it.

Fixing this in the guard rather than reordering `resolvePreset()` covers the general case. A user-supplied `?transforms=[["blur",10]]&width=400` puts a dimension-neutral step ahead of the resize too, and would still be wrongly rejected if only the preset order changed.

## Tested Scenarios

- `pnpm --filter @directus/api exec vitest run src/services/assets src/utils/transformations.test.ts src/services/files/lib/get-sharp-instance.test.ts` — 139 tests pass.
- Confirmed the three new "does not throw" tests fail against the pre-fix condition and pass with it, so they genuinely pin the defect. The two "still throws" tests pass either way; they exist to guard the enlargement case.
- Verified against real sharp 0.35.3 that the order `resolvePreset()` emits does not encode at the source size, on a 9178x2470 source targeting width 400:

  ```
  toFormat -> resize: webp 400x108 164 bytes
  resize -> toFormat: webp 400x108 164 bytes
  byte-identical: true
  ```

  sharp defers execution and resizes before encoding regardless of call order, so `toFormat` never runs against the full image.
- `pnpm exec eslint` and `pnpm exec prettier --check` clean on the touched files.
- `tsc --noEmit` on `@directus/api` reports the same 184 pre-existing errors before and after the change; none are in the touched files.

## Review Notes / Questions / Concerns

- **Behaviour change worth a decision.** With `ASSETS_TRANSFORM_IMAGE_MAX_DIMENSION` above `ASSETS_TRANSFORM_IMAGE_MAX_OUTPUT_DIMENSION`, a request that only re-encodes an oversized source (`?format=webp`, no width or height) now succeeds and returns an output at the source dimensions, above the output cap. Previously it was rejected. I believe this is correct: the raster is source-sized, and its size is the operator's own decision via `ASSETS_TRANSFORM_IMAGE_MAX_DIMENSION`, which the input check already enforces. It is also what the cache already does today, see below. Happy to gate it differently if you would rather the final projected size were always capped.
- **Not addressed here.** Variants already in storage are served without re-running validation, so the same file can succeed or fail depending on which variant happens to be cached. On a 9178px source, `?format=webp` returns a full 9178px WebP while `?width=400&format=webp` was rejected. Changing that touches existing stored variants, so it felt out of scope for this fix; happy to open it separately.
- `rotate` on a non-square oversized source still trips the cap, since it does change the dimensions. That is unchanged behaviour and arguably correct for an output cap, but it is the same shape of transpose-of-an-already-validated-raster, so flagging it in case you see it differently.
- The error payload still reports `invalidTransformations: ["width", "height"]`. I left the shape alone to avoid breaking consumers and put the diagnostic detail in a `logger.warn`, matching how `AssetsService` already warns before throwing the same error for the input-dimension check.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [x] Security implications apply

The change relaxes a resource guard, so it is worth a second pair of eyes. The reasoning is that it only skips steps whose size was already bounded by a check that still runs: `ASSETS_TRANSFORM_IMAGE_MAX_DIMENSION` for the source, this cap for every dimension-changing step. Peak memory for the reported case is unchanged, since sharp shrinks on load and never materialises the source-sized raster for a downscale.

---

Fixes #28157

🤖 Generated with [Claude Code](https://claude.com/claude-code)
