### PR TITLE
Add search and filter to flows overview page

### DIFF
--- a/.changeset/slimy-dodos-thank.md
+++ b/.changeset/slimy-dodos-thank.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Added search and filter to the Flows page

--- a/app/src/interfaces/_system/system-filter/Nodes.vue
+++ b/app/src/interfaces/_system/system-filter/Nodes.vue
@@ -76,7 +76,6 @@ const props = withDefaults(defineProps<Props>(), {
 	includeRelations: true,
 	includeJsonFunction: true,
 	relationalFieldSelectable: true,
-	fieldFilter: undefined,
 	rawFieldNames: false,
 });
 

--- a/app/src/interfaces/_system/system-filter/Nodes.vue
+++ b/app/src/interfaces/_system/system-filter/Nodes.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useSync } from '@directus/composables';
 import {
+	Field,
 	FieldFilter,
 	FieldFilterOperator,
 	FieldFunction,
@@ -61,6 +62,8 @@ interface Props {
 	/** Resolved by system-filter.vue; when false, `_json` nodes cannot be created here */
 	includeJsonFunction?: boolean;
 	relationalFieldSelectable?: boolean;
+	/** Hide fields the consumer can't filter on. Applies at every level of the field tree. */
+	fieldFilter?: (field: Field) => boolean;
 	rawFieldNames?: boolean;
 	variableInputEnabled: boolean | undefined;
 }
@@ -73,6 +76,7 @@ const props = withDefaults(defineProps<Props>(), {
 	includeRelations: true,
 	includeJsonFunction: true,
 	relationalFieldSelectable: true,
+	fieldFilter: undefined,
 	rawFieldNames: false,
 });
 
@@ -334,6 +338,7 @@ function isExistingField(node: Record<string, any>): boolean {
 									:excluded-functions="includeJsonFunction ? [] : ['json']"
 									:include-relations="includeRelations"
 									:relational-field-selectable="relationalFieldSelectable"
+									:field-filter="fieldFilter"
 									:allow-select-all="false"
 									:raw-field-names="rawFieldNames"
 									@add="updateField(index, $event[0])"
@@ -401,6 +406,9 @@ function isExistingField(node: Record<string, any>): boolean {
 						:depth="depth + 1"
 						:inline="inline"
 						:include-json-function="includeJsonFunction"
+						:include-relations="includeRelations"
+						:relational-field-selectable="relationalFieldSelectable"
+						:field-filter="fieldFilter"
 						:raw-field-names="rawFieldNames"
 						:variable-input-enabled="variableInputEnabled"
 						@change="$emit('change')"

--- a/app/src/interfaces/_system/system-filter/system-filter.vue
+++ b/app/src/interfaces/_system/system-filter/system-filter.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ClientFilterOperator, FieldFunction, Filter, Type } from '@directus/types';
+import { ClientFilterOperator, Field, FieldFunction, Filter, Type } from '@directus/types';
 import {
 	getFilterOperatorsForType,
 	getOutputTypeForFunction,
@@ -45,6 +45,8 @@ interface Props {
 	includeJsonFunction?: boolean;
 	injectVersionField?: boolean;
 	relationalFieldSelectable?: boolean;
+	/** Hide fields the consumer can't filter on. Applies at every level of the field tree. */
+	fieldFilter?: (field: Field) => boolean;
 	rawFieldNames?: boolean;
 	rawEditorEnabled?: boolean;
 }
@@ -62,6 +64,7 @@ const props = withDefaults(defineProps<Props>(), {
 	includeJsonFunction: true,
 	injectVersionField: false,
 	relationalFieldSelectable: true,
+	fieldFilter: undefined,
 	rawFieldNames: false,
 });
 
@@ -214,6 +217,7 @@ function addKeyAsNode() {
 				:include-json-function="jsonFunctionEnabled"
 				:include-relations="includeRelations"
 				:relational-field-selectable="relationalFieldSelectable"
+				:field-filter="fieldFilter"
 				:raw-field-names="rawFieldNames"
 				:variable-input-enabled="rawEditorEnabled"
 				@remove-node="removeNode($event)"
@@ -242,6 +246,7 @@ function addKeyAsNode() {
 					:excluded-functions="jsonFunctionEnabled ? [] : ['json']"
 					:include-relations="includeRelations"
 					:relational-field-selectable="relationalFieldSelectable"
+					:field-filter="fieldFilter"
 					:inject-version-field="injectVersionField"
 					:allow-select-all="false"
 					:raw-field-names="rawFieldNames"

--- a/app/src/interfaces/_system/system-filter/system-filter.vue
+++ b/app/src/interfaces/_system/system-filter/system-filter.vue
@@ -64,7 +64,6 @@ const props = withDefaults(defineProps<Props>(), {
 	includeJsonFunction: true,
 	injectVersionField: false,
 	relationalFieldSelectable: true,
-	fieldFilter: undefined,
 	rawFieldNames: false,
 });
 

--- a/app/src/modules/settings/routes/flows/flow-folder-sidebar.vue
+++ b/app/src/modules/settings/routes/flows/flow-folder-sidebar.vue
@@ -130,6 +130,7 @@ function onNavigate(folderId: string | null) {
 }
 
 .flow-folder-split :deep(.sp-end) {
+	position: relative;
 	overflow: auto;
 }
 </style>

--- a/app/src/modules/settings/routes/flows/overview.test.ts
+++ b/app/src/modules/settings/routes/flows/overview.test.ts
@@ -2,6 +2,7 @@ import { FlowRaw } from '@directus/types';
 import { createTestingPinia } from '@pinia/testing';
 import { mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { ref } from 'vue';
 import { Router } from 'vue-router';
 import FlowsOverview from './overview.vue';
 import { generateRouter } from '@/__utils__/router';
@@ -28,6 +29,7 @@ vi.mock('@/stores/flows', () => ({
 				icon: 'bolt',
 				color: 'var(--theme--primary)',
 				description: 'Notify the team',
+				folder: 'folder-a',
 			} as FlowRaw,
 			{
 				id: 'flow-2',
@@ -38,6 +40,16 @@ vi.mock('@/stores/flows', () => ({
 			} as FlowRaw,
 		],
 		hydrate: vi.fn(),
+	}),
+}));
+
+vi.mock('@/composables/use-folders', () => ({
+	useFolders: () => ({
+		loading: ref(false),
+		folders: ref([{ id: 'folder-a', name: 'Notifications', parent: null }]),
+		nestedFolders: ref([]),
+		fetchFolders: vi.fn(),
+		openFolders: ref([]),
 	}),
 }));
 
@@ -423,6 +435,18 @@ describe('FlowsOverview - search and filter', () => {
 		expect(vm.flows).toEqual([]);
 		expect(wrapper.find('v-info-stub').exists()).toBe(true);
 		expect(wrapper.find('v-table-stub').exists()).toBe(false);
+	});
+
+	test('filter matches against the related folder rather than its ID', async () => {
+		const wrapper = mount(FlowsOverview, { global });
+		const vm = wrapper.vm as any;
+
+		vm.filter = { folder: { name: { _eq: 'Notifications' } } };
+		await wrapper.vm.$nextTick();
+
+		expect(vm.flows.map((flow: FlowRaw) => flow.id)).toEqual(['flow-1']);
+		// The list keeps the flow's own shape, so the folder stays a foreign key
+		expect(vm.flows[0].folder).toBe('folder-a');
 	});
 
 	test('persists the filter to localStorage as JSON so it survives a reload', async () => {

--- a/app/src/modules/settings/routes/flows/overview.test.ts
+++ b/app/src/modules/settings/routes/flows/overview.test.ts
@@ -53,6 +53,15 @@ vi.mock('@/composables/use-folders', () => ({
 	}),
 }));
 
+const relationalFields = ['directus_flows.folder', 'directus_flows.user_created', 'directus_folders.parent'];
+
+vi.mock('@/stores/relations', () => ({
+	useRelationsStore: () => ({
+		getRelationsForField: (collection: string, field: string) =>
+			relationalFields.includes(`${collection}.${field}`) ? [{}] : [],
+	}),
+}));
+
 type CollectionActions = Partial<Record<'create' | 'update' | 'delete', boolean>>;
 
 const permissionsByCollection: Record<string, CollectionActions> = {};
@@ -447,6 +456,17 @@ describe('FlowsOverview - search and filter', () => {
 		expect(vm.flows.map((flow: FlowRaw) => flow.id)).toEqual(['flow-1']);
 		// The list keeps the flow's own shape, so the folder stays a foreign key
 		expect(vm.flows[0].folder).toBe('folder-a');
+	});
+
+	test('only offers relational filter fields that can be resolved in memory', () => {
+		const wrapper = mount(FlowsOverview, { global });
+		const vm = wrapper.vm as any;
+
+		expect(vm.isFilterableField({ collection: 'directus_flows', field: 'status' })).toBe(true);
+		expect(vm.isFilterableField({ collection: 'directus_flows', field: 'folder' })).toBe(true);
+		expect(vm.isFilterableField({ collection: 'directus_folders', field: 'name' })).toBe(true);
+		expect(vm.isFilterableField({ collection: 'directus_folders', field: 'parent' })).toBe(false);
+		expect(vm.isFilterableField({ collection: 'directus_flows', field: 'user_created' })).toBe(false);
 	});
 
 	test('persists the filter to localStorage as JSON so it survives a reload', async () => {

--- a/app/src/modules/settings/routes/flows/overview.test.ts
+++ b/app/src/modules/settings/routes/flows/overview.test.ts
@@ -23,10 +23,18 @@ vi.mock('@/stores/flows', () => ({
 		flows: [
 			{
 				id: 'flow-1',
-				name: 'Test Flow 1',
+				name: 'Send email',
 				status: 'active',
 				icon: 'bolt',
 				color: 'var(--theme--primary)',
+				description: 'Notify the team',
+			} as FlowRaw,
+			{
+				id: 'flow-2',
+				name: 'Sync data',
+				status: 'inactive',
+				icon: 'bolt',
+				description: 'Nightly job',
 			} as FlowRaw,
 		],
 		hydrate: vi.fn(),
@@ -74,6 +82,9 @@ vi.mock('@/router', () => {
 });
 
 beforeEach(async () => {
+	// Search and filter persist to localStorage, so isolate each test
+	localStorage.clear();
+
 	for (const collection of Object.keys(permissionsByCollection)) delete permissionsByCollection[collection];
 
 	router = generateRouter([
@@ -125,6 +136,7 @@ beforeEach(async () => {
 			'v-card-actions': true,
 			'flow-drawer': true,
 			'add-folder': true,
+			'search-input': { props: ['modelValue', 'filter'], template: '<div />' },
 			'router-view': true,
 			'v-input': true,
 			'v-card-text': true,
@@ -377,5 +389,66 @@ describe('FlowsOverview - empty state', () => {
 
 		expect(wrapper.find('v-table-stub').exists()).toBe(true);
 		expect(wrapper.find('v-info-stub').exists()).toBe(false);
+	});
+});
+
+describe('FlowsOverview - search and filter', () => {
+	test('search narrows the list to name or description matches', async () => {
+		const wrapper = mount(FlowsOverview, { global });
+		const vm = wrapper.vm as any;
+
+		vm.search = 'sync';
+		await wrapper.vm.$nextTick();
+
+		expect(vm.flows.map((flow: FlowRaw) => flow.id)).toEqual(['flow-2']);
+	});
+
+	test('filter narrows the list using Directus filter rules', async () => {
+		const wrapper = mount(FlowsOverview, { global });
+		const vm = wrapper.vm as any;
+
+		vm.filter = { status: { _eq: 'active' } };
+		await wrapper.vm.$nextTick();
+
+		expect(vm.flows.map((flow: FlowRaw) => flow.id)).toEqual(['flow-1']);
+	});
+
+	test('shows the no-results empty state when a query matches nothing', async () => {
+		const wrapper = mount(FlowsOverview, { global });
+		const vm = wrapper.vm as any;
+
+		vm.search = 'no-such-flow';
+		await wrapper.vm.$nextTick();
+
+		expect(vm.flows).toEqual([]);
+		expect(wrapper.find('v-info-stub').exists()).toBe(true);
+		expect(wrapper.find('v-table-stub').exists()).toBe(false);
+	});
+
+	test('persists the filter to localStorage as JSON so it survives a reload', async () => {
+		const wrapper = mount(FlowsOverview, { global });
+		const vm = wrapper.vm as any;
+
+		vm.filter = { status: { _eq: 'active' } };
+		await wrapper.vm.$nextTick();
+
+		expect(JSON.parse(localStorage.getItem('directus-flows-filter')!)).toEqual({ status: { _eq: 'active' } });
+	});
+
+	test('clearFilters restores the full list', async () => {
+		const wrapper = mount(FlowsOverview, { global });
+		const vm = wrapper.vm as any;
+
+		vm.search = 'sync';
+		vm.filter = { status: { _eq: 'inactive' } };
+		await wrapper.vm.$nextTick();
+		expect(vm.flows.length).toBe(1);
+
+		vm.clearFilters();
+		await wrapper.vm.$nextTick();
+
+		expect(vm.search).toBeNull();
+		expect(vm.filter).toBeNull();
+		expect(vm.flows.length).toBe(2);
 	});
 });

--- a/app/src/modules/settings/routes/flows/overview.vue
+++ b/app/src/modules/settings/routes/flows/overview.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { FlowRaw } from '@directus/types';
+import { Filter, FlowRaw } from '@directus/types';
+import { StorageSerializers, useLocalStorage } from '@vueuse/core';
 import { sortBy } from 'lodash';
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -32,6 +33,8 @@ import { router } from '@/router';
 import { useFlowsStore } from '@/stores/flows';
 import { useLicenseStore } from '@/stores/license';
 import { extractErrorCode } from '@/utils/extract-error-code';
+import { filterItems } from '@/utils/filter-items';
+import { parseFilter } from '@/utils/parse-filter';
 import { translate } from '@/utils/translate-literal';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { PrivateViewHeaderBarActionButton } from '@/views/private';
@@ -41,6 +44,7 @@ import FolderPicker from '@/views/private/components/folder-picker.vue';
 import EntitlementLimitModal from '@/views/private/components/license/entitlement-limit-modal.vue';
 import EntitlementRemaining from '@/views/private/components/license/entitlement-remaining.vue';
 import MaxCapacityAlert from '@/views/private/components/license/max-capacity-alert.vue';
+import SearchInput from '@/views/private/components/search-input.vue';
 
 const { t } = useI18n();
 
@@ -131,11 +135,38 @@ const internalSort = ref<Sort>({ by: 'name', desc: false });
 
 const flowsStore = useFlowsStore();
 
+const search = useLocalStorage<string | null>('directus-flows-search', null);
+
+const filter = useLocalStorage<Filter | null>('directus-flows-filter', null, {
+	serializer: StorageSerializers.object,
+});
+
+const hasQuery = computed(() => Boolean(search.value) || Boolean(filter.value));
+
+function clearFilters() {
+	search.value = null;
+	filter.value = null;
+}
+
 const flows = computed(() => {
 	const source = props.folder ? flowsStore.flows.filter((flow) => flow.folder === props.folder) : flowsStore.flows;
 
-	const translatedFlows = source.map((flow) => ({ ...flow, name: translate(flow.name) }));
-	const sortedFlows = sortBy(translatedFlows, [internalSort.value.by]);
+	// Translate before searching/filtering so both run against the name the user actually sees
+	let result = source.map((flow) => ({ ...flow, name: translate(flow.name) }));
+
+	if (filter.value) {
+		result = filterItems(result, parseFilter(filter.value));
+	}
+
+	if (search.value) {
+		const query = search.value.toLowerCase();
+
+		result = result.filter((flow) => {
+			return flow.name?.toLowerCase().includes(query) || flow.description?.toLowerCase().includes(query);
+		});
+	}
+
+	const sortedFlows = sortBy(result, [internalSort.value.by]);
 	return internalSort.value.desc ? sortedFlows.reverse() : sortedFlows;
 });
 
@@ -186,6 +217,9 @@ watch(
 	() => props.folder,
 	() => (selectedKeys.value = []),
 );
+
+// Narrowing the list can hide selected flows, so drop the selection to avoid acting on out-of-view rows
+watch([search, filter], () => (selectedKeys.value = []));
 
 const moveDialogActive = ref(false);
 const moveTarget = ref<string | null>(null);
@@ -270,6 +304,15 @@ function onFlowDrawerCompletion(id: string) {
 		</template>
 
 		<template #actions>
+			<SearchInput
+				v-model="search"
+				v-model:filter="filter"
+				collection="directus_flows"
+				:include-json-function="false"
+				:relational-field-selectable="false"
+				:placeholder="$t('search_flow')"
+			/>
+
 			<AddFolder type="flows" :parent="folder" :disabled="createFolderAllowed !== true" @created="navigateToFolder" />
 			<PrivateViewHeaderBarActionButton
 				v-if="selectedKeys.length > 0"
@@ -299,11 +342,19 @@ function onFlowDrawerCompletion(id: string) {
 			@navigate="navigateToFolder"
 			@deleted="onFolderDeleted"
 		>
-			<VInfo v-if="flows.length === 0" icon="bolt" :title="$t('no_flows')" center>
+			<VInfo v-if="flows.length === 0 && !hasQuery" icon="bolt" :title="$t('no_flows')" center>
 				{{ $t('no_flows_copy') }}
 
 				<template v-if="createAllowed" #append>
 					<VButton @click="openCreateFlow">{{ $t('create_flow') }}</VButton>
+				</template>
+			</VInfo>
+
+			<VInfo v-else-if="flows.length === 0" icon="search" :title="$t('no_results')" center>
+				{{ $t('no_results_copy') }}
+
+				<template #append>
+					<VButton @click="clearFilters">{{ $t('clear_filters') }}</VButton>
 				</template>
 			</VInfo>
 

--- a/app/src/modules/settings/routes/flows/overview.vue
+++ b/app/src/modules/settings/routes/flows/overview.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Filter, FlowRaw } from '@directus/types';
+import { Field, Filter, FlowRaw, Item } from '@directus/types';
 import { StorageSerializers, useLocalStorage } from '@vueuse/core';
 import { sortBy } from 'lodash';
 import { computed, ref, watch } from 'vue';
@@ -33,6 +33,7 @@ import DisplayFormattedValue from '@/displays/formatted-value/formatted-value.vu
 import { router } from '@/router';
 import { useFlowsStore } from '@/stores/flows';
 import { useLicenseStore } from '@/stores/license';
+import { useRelationsStore } from '@/stores/relations';
 import { extractErrorCode } from '@/utils/extract-error-code';
 import { filterItems } from '@/utils/filter-items';
 import { parseFilter } from '@/utils/parse-filter';
@@ -144,7 +145,22 @@ const filter = useLocalStorage<Filter | null>('directus-flows-filter', null, {
 
 const { folders } = useFolders('flows');
 
+const relationsStore = useRelationsStore();
+
 const foldersById = computed(() => new Map((folders.value ?? []).map((folder) => [folder.id, folder])));
+
+// Relations we can resolve client-side, so can filter on: whitelists the field and hydrates its foreign key.
+const FILTERABLE_RELATIONS: Record<string, (flow: FlowRaw) => Item | null> = {
+	folder: (flow) => (flow.folder ? (foldersById.value.get(flow.folder) ?? null) : null),
+};
+
+function isFilterableField(field: Field) {
+	if (relationsStore.getRelationsForField(field.collection, field.field).length === 0) {
+		return true;
+	}
+
+	return field.collection === 'directus_flows' && field.field in FILTERABLE_RELATIONS;
+}
 
 const hasQuery = computed(() => Boolean(search.value) || Boolean(filter.value));
 
@@ -160,10 +176,10 @@ const flows = computed(() => {
 	let result = source.map((flow) => ({ ...flow, name: translate(flow.name) }));
 
 	if (filter.value) {
-		// Filter rules can target the related folder
+		// Resolve the relations we support so filter rules can target the related object, not just its key
 		const hydrated = result.map((flow) => ({
 			...flow,
-			folder: (flow.folder ? foldersById.value.get(flow.folder) : null) ?? null,
+			...Object.fromEntries(Object.entries(FILTERABLE_RELATIONS).map(([key, resolve]) => [key, resolve(flow)])),
 		}));
 
 		const matchedIds = new Set(filterItems(hydrated, parseFilter(filter.value)).map((flow) => flow.id));
@@ -323,6 +339,7 @@ function onFlowDrawerCompletion(id: string) {
 				collection="directus_flows"
 				:include-json-function="false"
 				:relational-field-selectable="false"
+				:field-filter="isFilterableField"
 				:placeholder="$t('search_flow')"
 			/>
 

--- a/app/src/modules/settings/routes/flows/overview.vue
+++ b/app/src/modules/settings/routes/flows/overview.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Field, Filter, FlowRaw, Item } from '@directus/types';
 import { StorageSerializers, useLocalStorage } from '@vueuse/core';
-import { sortBy } from 'lodash';
+import { isObject, sortBy } from 'lodash';
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { RouterView } from 'vue-router';
@@ -162,7 +162,21 @@ function isFilterableField(field: Field) {
 	return field.collection === 'directus_flows' && field.field in FILTERABLE_RELATIONS;
 }
 
-const hasQuery = computed(() => Boolean(search.value) || Boolean(filter.value));
+// Test for at least one real rule, since an empty group like `{ _and: [{ _and: [] }] }` is truthy but matches everything
+function filterHasRules(node: Filter | null): boolean {
+	if (!node) return false;
+
+	return Object.entries(node).some(([key, value]) => {
+		if (key === '_and' || key === '_or') {
+			return Array.isArray(value) && value.some((child) => filterHasRules(child));
+		}
+
+		// A leaf operator (e.g. `_contains`, `_eq`) is a real rule; otherwise descend into the field object
+		return key.startsWith('_') || (isObject(value) && filterHasRules(value as Filter));
+	});
+}
+
+const hasQuery = computed(() => Boolean(search.value) || filterHasRules(filter.value));
 
 function clearFilters() {
 	search.value = null;

--- a/app/src/modules/settings/routes/flows/overview.vue
+++ b/app/src/modules/settings/routes/flows/overview.vue
@@ -26,6 +26,7 @@ import VList from '@/components/v-list.vue';
 import VMenu from '@/components/v-menu.vue';
 import { Header, Sort } from '@/components/v-table/types';
 import VTable from '@/components/v-table/v-table.vue';
+import { useFolders } from '@/composables/use-folders';
 import { useMoveToFolder } from '@/composables/use-move-to-folder';
 import { useCollectionPermissions } from '@/composables/use-permissions';
 import DisplayFormattedValue from '@/displays/formatted-value/formatted-value.vue';
@@ -141,6 +142,10 @@ const filter = useLocalStorage<Filter | null>('directus-flows-filter', null, {
 	serializer: StorageSerializers.object,
 });
 
+const { folders } = useFolders('flows');
+
+const foldersById = computed(() => new Map((folders.value ?? []).map((folder) => [folder.id, folder])));
+
 const hasQuery = computed(() => Boolean(search.value) || Boolean(filter.value));
 
 function clearFilters() {
@@ -155,7 +160,15 @@ const flows = computed(() => {
 	let result = source.map((flow) => ({ ...flow, name: translate(flow.name) }));
 
 	if (filter.value) {
-		result = filterItems(result, parseFilter(filter.value));
+		// Filter rules can target the related folder
+		const hydrated = result.map((flow) => ({
+			...flow,
+			folder: (flow.folder ? foldersById.value.get(flow.folder) : null) ?? null,
+		}));
+
+		const matchedIds = new Set(filterItems(hydrated, parseFilter(filter.value)).map((flow) => flow.id));
+
+		result = result.filter((flow) => matchedIds.has(flow.id));
 	}
 
 	if (search.value) {

--- a/app/src/utils/filter-items.test.ts
+++ b/app/src/utils/filter-items.test.ts
@@ -34,7 +34,17 @@ describe('filterItems', () => {
 		expect(filterItems(items, filter).map((i) => i.id)).toEqual([2, 3]);
 	});
 
-	test('excludes items for a relational path that cannot be evaluated in memory', () => {
+	test('matches a relational path when the item carries the related object', () => {
+		const hydrated = items.map((item) => ({
+			...item,
+			folder: item.folder === 'folder-a' ? { id: 'folder-a', name: 'Notifications', parent: null } : null,
+		}));
+
+		const filter: Filter = { folder: { name: { _eq: 'Notifications' } } };
+		expect(filterItems(hydrated, filter).map((i) => i.id)).toEqual([1, 2]);
+	});
+
+	test('excludes items for a relational path that only holds a foreign key', () => {
 		const filter: Filter = { folder: { name: { _eq: 'anything' } } };
 		expect(filterItems(items, filter)).toEqual([]);
 	});

--- a/app/src/utils/filter-items.test.ts
+++ b/app/src/utils/filter-items.test.ts
@@ -1,0 +1,41 @@
+import { Filter } from '@directus/types';
+import { describe, expect, test } from 'vitest';
+import { filterItems } from './filter-items';
+
+const items = [
+	{ id: 1, name: 'Send email', status: 'active', description: 'Notify the team', folder: 'folder-a' },
+	{ id: 2, name: 'Sync data', status: 'inactive', description: 'Nightly job', folder: 'folder-a' },
+	{ id: 3, name: 'Send report', status: 'active', description: null, folder: null },
+];
+
+describe('filterItems', () => {
+	test('returns everything when filter is null or empty', () => {
+		expect(filterItems(items, null)).toEqual(items);
+		expect(filterItems(items, {})).toEqual(items);
+	});
+
+	test('matches a simple equality leaf', () => {
+		const filter: Filter = { status: { _eq: 'active' } };
+		expect(filterItems(items, filter).map((i) => i.id)).toEqual([1, 3]);
+	});
+
+	test('matches a substring leaf', () => {
+		const filter: Filter = { name: { _contains: 'Send' } };
+		expect(filterItems(items, filter).map((i) => i.id)).toEqual([1, 3]);
+	});
+
+	test('combines leaves with _and', () => {
+		const filter: Filter = { _and: [{ status: { _eq: 'active' } }, { name: { _contains: 'report' } }] };
+		expect(filterItems(items, filter).map((i) => i.id)).toEqual([3]);
+	});
+
+	test('combines leaves with _or', () => {
+		const filter: Filter = { _or: [{ status: { _eq: 'inactive' } }, { name: { _contains: 'report' } }] };
+		expect(filterItems(items, filter).map((i) => i.id)).toEqual([2, 3]);
+	});
+
+	test('excludes items for a relational path that cannot be evaluated in memory', () => {
+		const filter: Filter = { folder: { name: { _eq: 'anything' } } };
+		expect(filterItems(items, filter)).toEqual([]);
+	});
+});

--- a/app/src/utils/filter-items.ts
+++ b/app/src/utils/filter-items.ts
@@ -1,0 +1,41 @@
+import { FieldFilter, Filter, Item } from '@directus/types';
+import { generateJoi } from '@directus/utils';
+
+/**
+ * Filters an in-memory list of items using the same Filter syntax the API uses for database
+ * queries. Useful for views that already hold their data client-side (e.g. the flows list) and so
+ * can't push the filter down to an API query.
+ */
+export function filterItems<T extends Item>(items: T[], filter: Filter | null): T[] {
+	if (!filter) {
+		return items;
+	}
+
+	return items.filter((item) => passesFilter(item, filter));
+
+	function passesFilter(item: Item, filter: Filter): boolean {
+		if (!filter || Object.keys(filter).length === 0) {
+			return true;
+		}
+
+		const key = Object.keys(filter)[0]!;
+
+		if (key === '_and') {
+			const subFilters = Object.values(filter)[0] as Filter[];
+			return subFilters.every((subFilter) => passesFilter(item, subFilter));
+		}
+
+		if (key === '_or') {
+			const subFilters = Object.values(filter)[0] as Filter[];
+			return subFilters.some((subFilter) => passesFilter(item, subFilter));
+		}
+
+		try {
+			const { error } = generateJoi(filter as FieldFilter).validate(item);
+			return error === undefined;
+		} catch {
+			// Unsupported leaf (e.g. _json) or relational path that can't run in memory
+			return false;
+		}
+	}
+}

--- a/app/src/utils/filter-items.ts
+++ b/app/src/utils/filter-items.ts
@@ -5,6 +5,10 @@ import { generateJoi } from '@directus/utils';
  * Filters an in-memory list of items using the same Filter syntax the API uses for database
  * queries. Useful for views that already hold their data client-side (e.g. the flows list) and so
  * can't push the filter down to an API query.
+ *
+ * Rules that reach into a relation (e.g. `{ folder: { name: { _eq: 'x' } } }`) only match when the
+ * item carries the related object rather than its foreign key, since there's nothing to join
+ * against here. Callers that want those rules to work should hydrate the relation first.
  */
 export function filterItems<T extends Item>(items: T[], filter: Filter | null): T[] {
 	if (!filter) {
@@ -34,7 +38,7 @@ export function filterItems<T extends Item>(items: T[], filter: Filter | null): 
 			const { error } = generateJoi(filter as FieldFilter).validate(item);
 			return error === undefined;
 		} catch {
-			// Unsupported leaf (e.g. _json) or relational path that can't run in memory
+			// Unsupported leaf (e.g. _json), or a path the item doesn't carry
 			return false;
 		}
 	}

--- a/app/src/views/private/components/search-input.vue
+++ b/app/src/views/private/components/search-input.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Filter } from '@directus/types';
+import { Field, Filter } from '@directus/types';
 import { isObject } from 'lodash';
 import { computed, onMounted, ref } from 'vue';
 import TransitionExpand from '@/components/transition/expand.vue';
@@ -19,6 +19,8 @@ const props = withDefaults(
 		placeholder?: string;
 		includeJsonFunction?: boolean;
 		relationalFieldSelectable?: boolean;
+		/** Hide fields that can't be filtered on. Applies at every level of the field tree. */
+		fieldFilter?: (field: Field) => boolean;
 	}>(),
 	{
 		showFilter: true,
@@ -201,6 +203,7 @@ function emitValue() {
 							:collection-name="collection"
 							:include-json-function="includeJsonFunction"
 							:relational-field-selectable="relationalFieldSelectable"
+							:field-filter="fieldFilter"
 							@input="$emit('update:filter', $event)"
 						/>
 					</div>

--- a/app/src/views/private/components/search-input.vue
+++ b/app/src/views/private/components/search-input.vue
@@ -17,10 +17,14 @@ const props = withDefaults(
 		filter?: Filter | null;
 		autofocus?: boolean;
 		placeholder?: string;
+		includeJsonFunction?: boolean;
+		relationalFieldSelectable?: boolean;
 	}>(),
 	{
 		showFilter: true,
 		expanded: false,
+		includeJsonFunction: true,
+		relationalFieldSelectable: true,
 	},
 );
 
@@ -195,6 +199,8 @@ function emitValue() {
 							inline
 							:value="filter"
 							:collection-name="collection"
+							:include-json-function="includeJsonFunction"
+							:relational-field-selectable="relationalFieldSelectable"
 							@input="$emit('update:filter', $event)"
 						/>
 					</div>


### PR DESCRIPTION
## What's Changed

- Added a `filterItems` helper that applies Directus filter rules to an in-memory list of items, for views that hold their data client-side.
- Added search and filter to the Flows page, with search matching flow name and description, and both persisted to local storage

## Tested Scenarios

- Tested that search input filters the list of flows
- Tested various filters, including the related folder field to narrow by folder name

## Review Notes / Questions / Concerns

- Because the flows page is not a layout page, it doesn't make sense to persist the filter using presets like bookmarks and translations do. Instead, the flows filter is persisted via local storage.
- The flows area also differs from those other filterable areas in that all of the data is available client side. So instead of filtering via the api, we are filtering against the store data.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes [CMS-3010](https://linear.app/directus/issue/CMS-3010)


<img width="1363" height="482" alt="filters" src="https://github.com/user-attachments/assets/822ba096-222c-4b57-9c72-2e6899b39d40" />

