### PR TITLE
🤖🤖🤖 fix(api): route system collection writes through getService

### DIFF
--- a/.changeset/friendly-service-routing.md
+++ b/.changeset/friendly-service-routing.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed system-collection writes to use their collection-specific services.

--- a/api/src/operations/item-create/index.ts
+++ b/api/src/operations/item-create/index.ts
@@ -1,8 +1,8 @@
 import { defineOperationApi } from '@directus/extensions';
 import type { Accountability, Item, PrimaryKey } from '@directus/types';
 import { optionToObject, toArray } from '@directus/utils';
-import { ItemsService } from '../../services/items.js';
 import { getAccountabilityForRole } from '../../utils/get-accountability-for-role.js';
+import { getService } from '../../utils/get-service.js';
 
 type Options = {
 	collection: string;
@@ -28,7 +28,7 @@ export default defineOperationApi<Options>({
 			customAccountability = await getAccountabilityForRole(permissions, { database, schema, accountability });
 		}
 
-		const itemsService = new ItemsService(collection, {
+		const itemsService = getService(collection, {
 			schema: await getSchema({ database }),
 			accountability: customAccountability,
 			knex: database,

--- a/api/src/operations/item-delete/index.ts
+++ b/api/src/operations/item-delete/index.ts
@@ -6,6 +6,7 @@ import { isNil } from 'lodash-es';
 import { z } from 'zod';
 import { ItemsService } from '../../services/items.js';
 import { getAccountabilityForRole } from '../../utils/get-accountability-for-role.js';
+import { getService } from '../../utils/get-service.js';
 import { sanitizeQuery } from '../../utils/sanitize-query.js';
 
 type Options = {
@@ -58,7 +59,7 @@ export default defineOperationApi<Options>({
 			customAccountability = await getAccountabilityForRole(permissions, { database, schema, accountability });
 		}
 
-		const itemsService: ItemsService = new ItemsService(collection, {
+		const itemsService: ItemsService = getService(collection, {
 			schema,
 			accountability: customAccountability,
 			knex: database,

--- a/api/src/operations/item-read/index.ts
+++ b/api/src/operations/item-read/index.ts
@@ -1,8 +1,8 @@
 import { defineOperationApi } from '@directus/extensions';
 import type { Accountability, Item, PrimaryKey } from '@directus/types';
 import { optionToObject, toArray } from '@directus/utils';
-import { ItemsService } from '../../services/items.js';
 import { getAccountabilityForRole } from '../../utils/get-accountability-for-role.js';
+import { getService } from '../../utils/get-service.js';
 import { sanitizeQuery } from '../../utils/sanitize-query.js';
 
 type Options = {
@@ -30,7 +30,7 @@ export default defineOperationApi<Options>({
 			customAccountability = await getAccountabilityForRole(permissions, { database, schema, accountability });
 		}
 
-		const itemsService = new ItemsService(collection, {
+		const itemsService = getService(collection, {
 			schema,
 			accountability: customAccountability,
 			knex: database,

--- a/api/src/operations/item-update/index.test.ts
+++ b/api/src/operations/item-update/index.test.ts
@@ -1,11 +1,17 @@
 import { InvalidPayloadError } from '@directus/errors';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { ItemsService } from '../../services/items.js';
+import { getService } from '../../utils/get-service.js';
 import config from './index.js';
 
 vi.mock('../../services/items.js', async () => {
 	const { mockItemsService } = await import('../../test-utils/services/items-service.js');
 	return mockItemsService();
+});
+
+vi.mock('../../utils/get-service.js', async () => {
+	const { ItemsService } = await import('../../services/items.js');
+	return { getService: vi.fn((collection, options) => new ItemsService(collection, options)) };
 });
 
 vi.mock('../../utils/get-accountability-for-role.js', () => ({
@@ -41,6 +47,11 @@ describe('Operations / Item Update', () => {
 		await run({ payload: testPayload, key: 1, permissions });
 
 		expect(vi.mocked(ItemsService)).toHaveBeenCalledWith(
+			testCollection,
+			expect.objectContaining({ schema: {}, accountability: expected, knex: undefined }),
+		);
+
+		expect(vi.mocked(getService)).toHaveBeenCalledWith(
 			testCollection,
 			expect.objectContaining({ schema: {}, accountability: expected, knex: undefined }),
 		);

--- a/api/src/operations/item-update/index.ts
+++ b/api/src/operations/item-update/index.ts
@@ -4,8 +4,8 @@ import type { Accountability, Item, PrimaryKey } from '@directus/types';
 import { optionToObject, toArray } from '@directus/utils';
 import { isEmpty, isNil } from 'lodash-es';
 import { z } from 'zod';
-import { ItemsService } from '../../services/items.js';
 import { getAccountabilityForRole } from '../../utils/get-accountability-for-role.js';
+import { getService } from '../../utils/get-service.js';
 import { sanitizeQuery } from '../../utils/sanitize-query.js';
 
 type Options = {
@@ -70,7 +70,7 @@ export default defineOperationApi<Options>({
 			customAccountability = await getAccountabilityForRole(permissions, { database, schema, accountability });
 		}
 
-		const itemsService: ItemsService = new ItemsService(collection, {
+		const itemsService = getService(collection, {
 			schema,
 			accountability: customAccountability,
 			knex: database,

--- a/api/src/services/revisions.test.ts
+++ b/api/src/services/revisions.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { getService } from '../utils/get-service.js';
+import { ItemsService } from './items.js';
+import { RevisionsService } from './revisions.js';
+
+vi.mock('./items.js', async () => {
+	const { mockItemsService } = await import('../test-utils/services/items-service.js');
+	return mockItemsService();
+});
+
+vi.mock('../utils/get-service.js', async () => {
+	const { ItemsService } = await import('./items.js');
+	return { getService: vi.fn((collection, options) => new ItemsService(collection, options)) };
+});
+
+describe('Services / Revisions', () => {
+	const knex = {} as any;
+	const schema = { collections: {}, relations: [] } as any;
+	const service = new RevisionsService({ knex, schema });
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('uses the collection-specific service when reverting a system collection', async () => {
+		vi.mocked(ItemsService.prototype.readOne).mockResolvedValueOnce({
+			collection: 'directus_users',
+			item: 'user-id',
+			data: { first_name: 'Before' },
+		});
+
+		await service.revert('revision-id');
+
+		expect(vi.mocked(getService)).toHaveBeenCalledWith(
+			'directus_users',
+			expect.objectContaining({ knex, schema, accountability: null }),
+		);
+
+		expect(ItemsService.prototype.updateOne).toHaveBeenCalledWith('user-id', { first_name: 'Before' });
+	});
+});

--- a/api/src/services/revisions.ts
+++ b/api/src/services/revisions.ts
@@ -1,6 +1,7 @@
 import { ForbiddenError, InvalidPayloadError } from '@directus/errors';
 import type { AbstractServiceOptions, Item, MutationOptions, PrimaryKey, Query, QueryOptions } from '@directus/types';
 import { getHistoryFilterQuery } from '../utils/get-history-filter-query.js';
+import { getService } from '../utils/get-service.js';
 import { ItemsService } from './items.js';
 
 export class RevisionsService extends ItemsService {
@@ -17,7 +18,7 @@ export class RevisionsService extends ItemsService {
 
 		if (!revision['data']) throw new InvalidPayloadError({ reason: `Revision doesn't contain data to revert to` });
 
-		const service = new ItemsService(revision['collection'], {
+		const service = getService(revision['collection'], {
 			accountability: this.accountability,
 			knex: this.knex,
 			schema: this.schema,

--- a/api/src/services/versions.test.ts
+++ b/api/src/services/versions.test.ts
@@ -1,6 +1,7 @@
 import { SchemaBuilder } from '@directus/schema-builder';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { createMockKnex, resetKnexMocks } from '../test-utils/knex.js';
+import { getService } from '../utils/get-service.js';
 import { ActivityService } from './activity.js';
 import { ItemsService } from './items.js';
 import { RevisionsService } from './revisions.js';
@@ -35,6 +36,11 @@ vi.mock('./payload.js', () => {
 vi.mock('./items.js', async () => {
 	const { mockItemsService } = await import('../test-utils/services/items-service.js');
 	return mockItemsService();
+});
+
+vi.mock('../utils/get-service.js', async () => {
+	const { ItemsService } = await import('./items.js');
+	return { getService: vi.fn((collection, options) => new ItemsService(collection, options)) };
 });
 
 vi.mock('./revisions.js', async () => {
@@ -401,6 +407,11 @@ describe('Integration Tests', () => {
 				expect(ItemsService.prototype.createOne).toHaveBeenCalledWith(
 					expect.objectContaining({ title: 'Promoted' }),
 					expect.any(Object),
+				);
+
+				expect(vi.mocked(getService)).toHaveBeenCalledWith(
+					'singleton_collection',
+					expect.objectContaining({ schema, knex: db }),
 				);
 
 				expect(VersionsService.prototype.updateOne).toHaveBeenCalledWith('version-id', { item: 'new-item-id' });

--- a/api/src/services/versions.ts
+++ b/api/src/services/versions.ts
@@ -22,6 +22,7 @@ import { getCache } from '../cache.js';
 import { getHelpers } from '../database/helpers/index.js';
 import emitter from '../emitter.js';
 import { validateAccess } from '../permissions/modules/validate-access/validate-access.js';
+import { getService } from '../utils/get-service.js';
 import { shouldClearCache } from '../utils/should-clear-cache.js';
 import { splitRecursive } from '../utils/versioning/split-recursive.js';
 import { ActivityService } from './activity.js';
@@ -482,7 +483,7 @@ export class VersionsService extends ItemsService<ContentVersion> {
 
 		const payloadToUpdate = opts?.fields ? pick(rawDelta, opts.fields) : rawDelta;
 
-		const itemsService = new ItemsService(collection, {
+		const itemsService = getService(collection, {
 			accountability: this.accountability,
 			knex: this.knex,
 			schema: this.schema,

--- a/contributors.yml
+++ b/contributors.yml
@@ -301,3 +301,4 @@
 - tsokolovs
 - MHJahanbakhsh
 - aniruddhav25
+- puspoaditya


### PR DESCRIPTION
## Summary

- route revision reverts and version promotions through `getService()` so system collections use their dedicated service guards
- route all Flow item operations through `getService()` for consistent collection-specific service resolution
- add regression coverage for `directus_users` revision reverts and version promotion routing

Fixes #28142

## Verification

- `pnpm --filter @directus/api test src/services/revisions.test.ts src/services/versions.test.ts src/operations/item-create/index.test.ts src/operations/item-read/index.test.ts src/operations/item-update/index.test.ts src/operations/item-delete/index.test.ts` (145 passed)
- `pnpm exec prettier --check <changed files>`
- `pnpm exec eslint <changed files>`
- `git diff --check`
