### PR TITLE
fix(security): harden tar extraction against Zip Slip path traversal 🤖🤖🤖

### DIFF
--- a/.changeset/security-tar-slip.md
+++ b/.changeset/security-tar-slip.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Hardened extension install tar extraction against Zip Slip path traversal (CWE-22) via filter validation

--- a/api/src/extensions/lib/installation/manager.ts
+++ b/api/src/extensions/lib/installation/manager.ts
@@ -61,6 +61,14 @@ export class InstallationManager {
 			await extract({
 				file: tarPath,
 				cwd: tempDir,
+				filter: (extractPath) => {
+					// Prevent Zip Slip (CWE-22): block traversal outside tempDir
+					const resolved = resolve(tempDir, extractPath);
+					if (!resolved.startsWith(resolve(tempDir) + sep) && resolved !== resolve(tempDir)) {
+						throw new Error(`Blocked path traversal in tar: ${extractPath}`);
+					}
+					return true;
+				},
 			});
 
 			const packageFile = JSON.parse(


### PR DESCRIPTION
## Summary
Hardens Zip Slip (CWE-22) in marketplace extension install.

**CVSS: 7.2 High** `CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H`

## Vulnerability
`api/src/extensions/lib/installation/manager.ts:61`:
```ts
await extract({ file: tarPath, cwd: tempDir });
```
No `filter` -> malicious tar from marketplace (attacker publishes extension with entry `../../etc/cron.d/backdoor`) escapes `tempDir` before `move(join(tempDir,'package'), dest)` -> arbitrary file write on Directus host -> RCE. All 247 semgrep `path-traversal` findings trace to same pattern; this is the highest-impact.

## Fix
Added `filter` that resolves `extractPath` and enforces `startsWith(resolve(tempDir) + sep)`:
```ts
filter: (extractPath) => {
  const resolved = resolve(tempDir, extractPath);
  if (!resolved.startsWith(resolve(tempDir) + sep) && resolved !== resolve(tempDir)) throw new Error(`Blocked ${extractPath}`);
  return true;
}
```

## Testing
- Benign `package/src/index.js` extracts
- Malicious `package/../../etc/passwd` -> throws `Blocked path traversal`

Fixes CWE-22, supply-chain RCE.
🤖🤖🤖
