### PR TITLE
Fix the local key-value store treating equal `setMax` values as updates

### DIFF
--- a/.changeset/fair-kv-maxes-rest.md
+++ b/.changeset/fair-kv-maxes-rest.md
@@ -2,4 +2,4 @@
 '@directus/memory': patch
 ---
 
-Fixed the local key-value store reporting equal `setMax` values as updates
+Fixed the local key-value store treating equal `setMax` values as updates

--- a/.changeset/fair-kv-maxes-rest.md
+++ b/.changeset/fair-kv-maxes-rest.md
@@ -1,0 +1,5 @@
+---
+'@directus/memory': patch
+---
+
+Fixed the local key-value store reporting equal `setMax` values as updates

--- a/contributors.yml
+++ b/contributors.yml
@@ -301,3 +301,4 @@
 - tsokolovs
 - MHJahanbakhsh
 - aniruddhav25
+- jashkarangiya

--- a/packages/memory/src/kv/lib/local.test.ts
+++ b/packages/memory/src/kv/lib/local.test.ts
@@ -181,6 +181,19 @@ describe('setMax', () => {
 		expect(result).toBe(false);
 	});
 
+	test('Returns false if existing value equals passed value', async () => {
+		const mockKey = 'kv-key';
+		const mockValue = 42;
+
+		kv.get = vi.fn().mockReturnValue(mockValue);
+		kv.set = vi.fn();
+
+		const result = await kv.setMax(mockKey, mockValue);
+
+		expect(kv.set).not.toHaveBeenCalled();
+		expect(result).toBe(false);
+	});
+
 	test('Returns true if passed value is bigger than existing value', async () => {
 		const mockKey = 'kv-key';
 		const mockValue = 500;

--- a/packages/memory/src/kv/lib/local.ts
+++ b/packages/memory/src/kv/lib/local.ts
@@ -71,7 +71,7 @@ export class KvLocal implements Kv {
 			throw new Error(`The value for key "${key}" is not a number.`);
 		}
 
-		if (currentVal > value) {
+		if (currentVal >= value) {
 			return false;
 		}
 


### PR DESCRIPTION
## What's Changed

- Aligns the local KV `setMax` behavior with its documented contract and the Redis backend
- Returns `false` without writing when the candidate equals the stored value
- Adds regression coverage and a patch changeset for `@directus/memory`

## Tested Scenarios

- Equal existing and candidate values return `false` without calling `set`
- Full `@directus/memory` test suite: 23 files and 148 tests passed
- `@directus/memory` build, ESLint, Prettier, and `git diff --check` passed

## Review Notes / Questions / Concerns

- The behavior change is limited to the equality boundary (`>` to `>=`)

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes #28171
