### PR TITLE
Fix schema cache timeouts leaving stale bus subscriptions

### DIFF
--- a/.changeset/fix-schema-cache-sync-subscription-leak.md
+++ b/.changeset/fix-schema-cache-sync-subscription-leak.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed schema cache synchronization timeouts leaving stale bus subscriptions and pending timers behind

--- a/api/src/utils/get-schema.test.ts
+++ b/api/src/utils/get-schema.test.ts
@@ -1,0 +1,73 @@
+import type { SchemaOverview } from '@directus/types';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+const bus = vi.hoisted(() => ({
+	publish: vi.fn(),
+	subscribe: vi.fn(),
+	unsubscribe: vi.fn(),
+}));
+
+const lock = vi.hoisted(() => ({
+	increment: vi.fn(),
+	delete: vi.fn(),
+}));
+
+vi.mock('@directus/env', async () => {
+	const { mockEnv } = await import('../test-utils/env.js');
+
+	return mockEnv({
+		CACHE_SCHEMA: true,
+		CACHE_SCHEMA_MAX_ITERATIONS: 100,
+		CACHE_SCHEMA_SYNC_TIMEOUT: 10000,
+	});
+});
+
+vi.mock('../bus/index.js', () => ({ useBus: () => bus }));
+
+vi.mock('../lock/index.js', () => ({ useLock: () => lock }));
+
+vi.mock('../cache.js', () => ({
+	getMemorySchemaCache: vi.fn(),
+	setMemorySchemaCache: vi.fn(),
+}));
+
+vi.mock('../logger/index.js', () => ({
+	useLogger: () => ({ trace: vi.fn(), warn: vi.fn() }),
+}));
+
+const { getSchema } = await import('./get-schema.js');
+
+const SCHEMA = { collections: {}, relations: [] } as unknown as SchemaOverview;
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.clearAllMocks();
+	lock.increment.mockResolvedValue(2);
+	bus.subscribe.mockResolvedValue(undefined);
+	bus.unsubscribe.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+test('unsubscribes from the schema cache bus when waiting times out', async () => {
+	const assertion = expect(getSchema()).rejects.toThrow('hit infinite loop');
+
+	await vi.advanceTimersByTimeAsync(30000);
+	await assertion;
+
+	expect(bus.subscribe).toHaveBeenCalledTimes(3);
+	expect(bus.unsubscribe).toHaveBeenCalledTimes(3);
+});
+
+test('clears the timeout when the schema cache bus responds', async () => {
+	bus.subscribe.mockImplementation(async (_channel: string, handler: (options: { schema: SchemaOverview }) => void) =>
+		handler({ schema: SCHEMA }),
+	);
+
+	await expect(getSchema()).resolves.toBe(SCHEMA);
+
+	expect(bus.unsubscribe).toHaveBeenCalledTimes(1);
+	expect(vi.getTimerCount()).toBe(0);
+});

--- a/api/src/utils/get-schema.test.ts
+++ b/api/src/utils/get-schema.test.ts
@@ -1,5 +1,5 @@
 import type { SchemaOverview } from '@directus/types';
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 const bus = vi.hoisted(() => ({
 	publish: vi.fn(),
@@ -51,23 +51,25 @@ afterEach(() => {
 	vi.useRealTimers();
 });
 
-test('unsubscribes from the schema cache bus when waiting times out', async () => {
-	const assertion = expect(getSchema()).rejects.toThrow('hit infinite loop');
+describe('getSchema', () => {
+	test('unsubscribes from the schema cache bus when waiting times out', async () => {
+		const assertion = expect(getSchema()).rejects.toThrow('hit infinite loop');
 
-	await vi.advanceTimersByTimeAsync(30000);
-	await assertion;
+		await vi.advanceTimersByTimeAsync(30000);
+		await assertion;
 
-	expect(bus.subscribe).toHaveBeenCalledTimes(3);
-	expect(bus.unsubscribe).toHaveBeenCalledTimes(3);
-});
+		expect(bus.subscribe).toHaveBeenCalledTimes(3);
+		expect(bus.unsubscribe.mock.calls).toEqual(bus.subscribe.mock.calls);
+	});
 
-test('clears the timeout when the schema cache bus responds', async () => {
-	bus.subscribe.mockImplementation(async (_channel: string, handler: (options: { schema: SchemaOverview }) => void) =>
-		handler({ schema: SCHEMA }),
-	);
+	test('clears the timeout when the schema cache bus responds', async () => {
+		bus.subscribe.mockImplementation(async (_channel: string, handler: (options: { schema: SchemaOverview }) => void) =>
+			handler({ schema: SCHEMA }),
+		);
 
-	await expect(getSchema()).resolves.toBe(SCHEMA);
+		await expect(getSchema()).resolves.toBe(SCHEMA);
 
-	expect(bus.unsubscribe).toHaveBeenCalledTimes(1);
-	expect(vi.getTimerCount()).toBe(0);
+		expect(bus.unsubscribe.mock.calls).toEqual(bus.subscribe.mock.calls);
+		expect(vi.getTimerCount()).toBe(0);
+	});
 });

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -68,16 +68,15 @@ export async function getSchema(
 	if (currentProcessShouldHandleOperation === false) {
 		logger.trace('Schema cache is prepared in another process, waiting for result.');
 
-		const timeout: Promise<any> = new Promise((_, reject) =>
-			setTimeout(reject, env['CACHE_SCHEMA_SYNC_TIMEOUT'] as number),
-		);
+		let timeoutId: NodeJS.Timeout;
+		let busListener: (options: { schema: SchemaOverview | null }) => void;
+
+		const timeout: Promise<any> = new Promise((_, reject) => {
+			timeoutId = setTimeout(reject, env['CACHE_SCHEMA_SYNC_TIMEOUT'] as number);
+		});
 
 		const subscription = new Promise<SchemaOverview>((resolve, reject) => {
-			bus.subscribe(messageKey, busListener).catch(reject);
-
-			function busListener(options: { schema: SchemaOverview | null }) {
-				cleanup();
-
+			busListener = (options: { schema: SchemaOverview | null }) => {
 				if (options.schema === null) {
 					return reject();
 				}
@@ -88,14 +87,21 @@ export async function getSchema(
 				} catch (e) {
 					reject(e);
 				}
-			}
+			};
 
-			function cleanup() {
-				bus.unsubscribe(messageKey, busListener).catch(reject);
-			}
+			bus.subscribe(messageKey, busListener).catch(reject);
 		});
 
-		return Promise.race([timeout, subscription]).catch(() => getSchema(options, attempt + 1));
+		try {
+			return await Promise.race([timeout, subscription]);
+		} catch {
+			// Fall through to the retry below
+		} finally {
+			clearTimeout(timeoutId!);
+			await bus.unsubscribe(messageKey, busListener!);
+		}
+
+		return getSchema(options, attempt + 1);
 	}
 
 	let schema: SchemaOverview | null = null;

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -68,15 +68,15 @@ export async function getSchema(
 	if (currentProcessShouldHandleOperation === false) {
 		logger.trace('Schema cache is prepared in another process, waiting for result.');
 
-		let timeoutId: NodeJS.Timeout;
-		let busListener: (options: { schema: SchemaOverview | null }) => void;
+		let timeoutId: NodeJS.Timeout | undefined;
+		let busListener: ((options: { schema: SchemaOverview | null }) => void) | undefined;
 
 		const timeout: Promise<any> = new Promise((_, reject) => {
 			timeoutId = setTimeout(reject, env['CACHE_SCHEMA_SYNC_TIMEOUT'] as number);
 		});
 
 		const subscription = new Promise<SchemaOverview>((resolve, reject) => {
-			busListener = (options: { schema: SchemaOverview | null }) => {
+			busListener = (options) => {
 				if (options.schema === null) {
 					return reject();
 				}
@@ -97,8 +97,11 @@ export async function getSchema(
 		} catch {
 			// Fall through to the retry below
 		} finally {
-			clearTimeout(timeoutId!);
-			await bus.unsubscribe(messageKey, busListener!);
+			if (timeoutId) clearTimeout(timeoutId);
+
+			if (busListener) {
+				await bus.unsubscribe(messageKey, busListener).catch((err) => logger.warn(err, `[schema-cache] ${err}`));
+			}
 		}
 
 		return getSchema(options, attempt + 1);


### PR DESCRIPTION
## What's Changed

- `getSchema()` now clears the sync timeout and unsubscribes its `schemaCache--done` listener once the race settles, rather than only when the bus message wins. On a timeout the listener stayed registered and the timer stayed pending, and the recursive retry added another of each, so a single request that exhausted its three attempts left three listeners behind.
- Cleanup runs before the retry, so no stale listener is registered while the next attempt subscribes. A failing `unsubscribe` is logged rather than thrown, to keep cleanup from turning a schema fetch that already succeeded into an error.
- Added coverage for the timed-out path and the bus-answered path.

## Tested Scenarios

- A wait that exhausts all three attempts calls `unsubscribe` with the same listener and channel it subscribed with, once per attempt (fails on main, passes here).
- A wait answered over the bus resolves with the published schema and leaves no pending timer.
- Full `api` test suite.

## Review Notes / Questions / Concerns

- Retry count, timeout duration and the resolve/reject semantics are unchanged. Only the cleanup path moved.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes #28174
