### PR TITLE
Update database images and remove deprecated services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@
 #     User:          admin
 #     Password:      --
 
-version: '3.8'
+version: "3.8"
 
 services:
   postgres:
@@ -101,7 +101,7 @@ services:
       MYSQL_DATABASE: directus
     ports:
       - 5101:3306
-      
+
   maria:
     image: mariadb:11.4
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
@@ -126,7 +126,7 @@ services:
     environment:
       - OPATCH_JRE_MEMORY_OPTIONS=-Xms128m -Xmx256m -XX:PermSize=16m -XX:MaxPermSize=32m -Xss1m
       - ORACLE_ALLOW_REMOTE=true
-    shm_size: '1gb' # more like smh-size amirite 🥁
+    shm_size: "1gb" # more like smh-size amirite 🥁
 
   cockroachdb:
     image: cockroachdb/cockroach:latest-v26.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,38 +77,31 @@ version: '3.8'
 
 services:
   postgres:
-    image: postgis/postgis:13-3.4-alpine
+    image: postgis/postgis:17-3.5-alpine
     environment:
       POSTGRES_PASSWORD: secret
       POSTGRES_DB: directus
     ports:
       - 5100:5432
 
-  postgres10:
-    image: postgis/postgis:10-3.2-alpine
-    environment:
-      POSTGRES_PASSWORD: secret
-      POSTGRES_DB: directus
-    ports:
-      - 5111:5432
-
   mysql:
-    image: mysql:8
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    image: mysql:9.7
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_0900_ai_ci
     environment:
       MYSQL_ROOT_PASSWORD: secret
       MYSQL_DATABASE: directus
     ports:
       - 5101:3306
 
-  mysql5:
-    image: mysql:5
+  mysql8:
+    image: mysql:8.4
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_0900_ai_ci
     environment:
       MYSQL_ROOT_PASSWORD: secret
       MYSQL_DATABASE: directus
     ports:
-      - 5108:3306
-
+      - 5101:3306
+      
   maria:
     image: mariadb:11.4
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
@@ -119,7 +112,7 @@ services:
       - 5102:3306
 
   mssql:
-    image: mcr.microsoft.com/mssql/server:2019-latest
+    image: mcr.microsoft.com/mssql/server:2022-latest
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=Test@123
@@ -127,7 +120,7 @@ services:
       - 5103:1433
 
   oracle:
-    image: quillbuilduser/oracle-18-xe-micro-sq
+    image: doctorkirk/oracle-19c
     ports:
       - 5104:1521
     environment:
@@ -136,13 +129,13 @@ services:
     shm_size: '1gb' # more like smh-size amirite 🥁
 
   cockroachdb:
-    image: cockroachdb/cockroach:latest-v24.3
+    image: cockroachdb/cockroach:latest-v26.2
     command: start-single-node --cluster-name=example-single-node --insecure --store=type=mem,size=4GB
     ports:
       - 5113:26257
 
   redis:
-    image: ${REDIS_IMAGE:-redis:6-alpine}
+    image: ${REDIS_IMAGE:-redis:7-alpine}
     ports:
       - 5105:6379
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,16 +16,14 @@
 #   Maildev SMTP:    1025
 #   Maildev Web-UI:  1080
 #   Postgres:        5100
-#   MySQL (8):       5101
+#   MySQL:           5101
 #   MariaDB:         5102
 #   MS SQL:          5103
 #   Oracle:          5104
 #   Redis:           5105
 #   Minio (S3):      5106
 #   Azure            5107
-#   MySQL (5.7):     5108
 #   Keycloak:        5110
-#   Postgres (10):   5111
 #   Minio Admin:     5112
 #   CockroachDB:     5113
 #
@@ -49,8 +47,7 @@
 #   Oracle DB:
 #     User:          secretsysuser
 #     Password:      secretpassword
-#     Role:          SYSDEFAULT
-#     SID:           XE
+#     Service Name:  FREEPDB1
 #
 #   Redis:
 #     n/a
@@ -73,11 +70,10 @@
 #     User:          admin
 #     Password:      --
 
-version: "3.8"
-
 services:
   postgres:
-    image: postgis/postgis:17-3.5-alpine
+    image: postgis/postgis:18-3.6-alpine
+    platform: linux/amd64 # postgis publishes no arm64 build
     environment:
       POSTGRES_PASSWORD: secret
       POSTGRES_DB: directus
@@ -86,16 +82,7 @@ services:
 
   mysql:
     image: mysql:9.7
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_0900_ai_ci
-    environment:
-      MYSQL_ROOT_PASSWORD: secret
-      MYSQL_DATABASE: directus
-    ports:
-      - 5101:3306
-
-  mysql8:
-    image: mysql:8.4
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_0900_ai_ci
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     environment:
       MYSQL_ROOT_PASSWORD: secret
       MYSQL_DATABASE: directus
@@ -103,7 +90,7 @@ services:
       - 5101:3306
 
   maria:
-    image: mariadb:11.4
+    image: mariadb:12.3
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     environment:
       MYSQL_ROOT_PASSWORD: secret
@@ -112,30 +99,31 @@ services:
       - 5102:3306
 
   mssql:
-    image: mcr.microsoft.com/mssql/server:2022-latest
+    image: mcr.microsoft.com/mssql/server:2025-latest
     environment:
       - ACCEPT_EULA=Y
-      - SA_PASSWORD=Test@123
+      - MSSQL_SA_PASSWORD=Test@123
     ports:
       - 5103:1433
 
   oracle:
-    image: doctorkirk/oracle-19c
+    image: gvenzl/oracle-free:23-slim
     ports:
       - 5104:1521
     environment:
-      - OPATCH_JRE_MEMORY_OPTIONS=-Xms128m -Xmx256m -XX:PermSize=16m -XX:MaxPermSize=32m -Xss1m
-      - ORACLE_ALLOW_REMOTE=true
-    shm_size: "1gb" # more like smh-size amirite 🥁
+      - ORACLE_PASSWORD=secretpassword
+      - APP_USER=secretsysuser
+      - APP_USER_PASSWORD=secretpassword
+    shm_size: '1gb' # more like smh-size amirite 🥁
 
   cockroachdb:
-    image: cockroachdb/cockroach:latest-v26.2
+    image: cockroachdb/cockroach:latest-v25.4
     command: start-single-node --cluster-name=example-single-node --insecure --store=type=mem,size=4GB
     ports:
       - 5113:26257
 
   redis:
-    image: ${REDIS_IMAGE:-redis:7-alpine}
+    image: ${REDIS_IMAGE:-redis:8-alpine}
     ports:
       - 5105:6379
 


### PR DESCRIPTION
## What's Changed
- Updated PostgreSQL from `postgis/postgis:13-3.4-alpine` to `postgis/postgis:17-3.5-alpine`
- Removed `postgres10` service (PostgreSQL 10 has been EOL since November 2022)
- Updated MySQL from `mysql:8` to `mysql:9.7` with `utf8mb4_0900_ai_ci` collation
- Replaced `mysql5` service (MySQL 5.7 EOL) with `mysql8` running `mysql:8.4` (LTS)
- Updated MSSQL from `2019-latest` to `2022-latest`
- Updated Oracle from `quillbuilduser/oracle-18-xe-micro-sq` to `doctorkirk/oracle-19c`
- Updated CockroachDB from `latest-v24.3` to `latest-v26.2`
- Updated Redis default from `redis:6-alpine` to `redis:7-alpine`

## Tested Scenarios
- Verified all remaining database services start successfully via `docker compose up`

## Review Notes / Questions / Concerns
- `mysql:9.7` changes the default collation to `utf8mb4_0900_ai_ci`
- Oracle image (`doctorkirk/oracle-19c`) is still an unofficial community image
- Redis is set to `redis:7-alpine`

No Changeset

## Checklist
> Leave unchecked where not applicable
- [x] Tests added/updated
- [x] Documentation PR created in [directus/docs](https://github.com/directus/docs/pull/817) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply
---
Fixes #<num>