### PR TITLE
Fix the WYSIWYG interface locking content that only differs by collapsible whitespace

### DIFF
--- a/.changeset/wysiwyg-whitespace-lock.md
+++ b/.changeset/wysiwyg-whitespace-lock.md
@@ -1,0 +1,6 @@
+---
+'@directus/app': patch
+---
+
+Fixed the WYSIWYG interface locking a field as read-only when its stored HTML only differs by collapsible whitespace,
+such as the double spaces left behind by pasted content

--- a/app/src/interfaces/input-rich-text-html/composables/format-html.test.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/format-html.test.ts
@@ -55,6 +55,31 @@ describe('formatHtml', () => {
 		expect(formatHtml('<p>hi <em>there </em></p>')).toBe('<p>hi <em>there</em></p>');
 	});
 
+	test('collapses repeated whitespace inside an inline-only block', () => {
+		expect(formatHtml('<p>hello   world</p>')).toBe('<p>hello world</p>');
+	});
+
+	test('collapses repeated whitespace nested inside inline marks', () => {
+		expect(formatHtml('<p>hi <em>there  again</em></p>')).toBe('<p>hi <em>there again</em></p>');
+	});
+
+	test('drops whitespace after a line break', () => {
+		expect(formatHtml('<p>first<br>\n  second</p>')).toBe('<p>first<br>second</p>');
+	});
+
+	test('keeps whitespace after a line break that opens an inline mark', () => {
+		// The parser only drops it when the <br> is the text's own previous sibling.
+		expect(formatHtml('<p>first<br><em>  second</em></p>')).toBe('<p>first<br><em> second</em></p>');
+	});
+
+	test('drops a leading space after text already ending in one', () => {
+		expect(formatHtml('<p><strong>bold </strong> text</p>')).toBe('<p><strong>bold </strong>text</p>');
+	});
+
+	test('keeps consecutive non-breaking spaces', () => {
+		expect(formatHtml('<p>a&nbsp;&nbsp;b</p>')).toBe('<p>a&nbsp;&nbsp;b</p>');
+	});
+
 	test('keeps trailing whitespace inside <pre>', () => {
 		expect(formatHtml('<pre><code>a </code></pre>')).toBe('<pre><code>a </code></pre>');
 	});

--- a/app/src/interfaces/input-rich-text-html/composables/format-html.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/format-html.ts
@@ -52,6 +52,7 @@ function isBlock(node: Node): node is HTMLElement {
 // are significant and survive normalization.
 const LEADING_WS = /^[ \t\n\r\f]+/;
 const TRAILING_WS = /[ \t\n\r\f]+$/;
+const WS_RUN = /[ \t\n\r\f]+/g;
 
 function firstTextNode(el: Node): Text | null {
 	for (const child of Array.from(el.childNodes)) {
@@ -80,6 +81,26 @@ function trimBoundaryWhitespace(el: HTMLElement): void {
 	if (first) first.textContent = (first.textContent ?? '').replace(LEADING_WS, '');
 	const last = lastTextNode(el);
 	if (last) last.textContent = (last.textContent ?? '').replace(TRAILING_WS, '');
+}
+
+// Collapse whitespace the way Tiptap does inside a textblock: a run of ASCII whitespace becomes a
+// single space, and a leading space is dropped when it follows a <br> or text already ending in one.
+// `afterSpace` carries that trailing space across inline marks, which the parser looks through.
+function collapseWhitespace(el: Node, afterSpace = false): boolean {
+	for (const child of Array.from(el.childNodes)) {
+		if (child.nodeType === Node.TEXT_NODE) {
+			const text = (child.textContent ?? '').replace(WS_RUN, ' ');
+			const dropLeading = afterSpace || child.previousSibling?.nodeName === 'BR';
+			child.textContent = dropLeading ? text.replace(LEADING_WS, '') : text;
+			if (child.textContent !== '') afterSpace = TRAILING_WS.test(child.textContent);
+		} else if (child.hasChildNodes()) {
+			afterSpace = collapseWhitespace(child, afterSpace);
+		} else if (child.nodeType === Node.ELEMENT_NODE) {
+			afterSpace = false;
+		}
+	}
+
+	return afterSpace;
 }
 
 function hasBlockChild(el: HTMLElement): boolean {
@@ -111,6 +132,7 @@ function serialize(nodes: NodeListOf<ChildNode> | ChildNode[], depth: number): s
 				lines.push(pad + el.outerHTML);
 			} else if (!hasBlockChild(el)) {
 				// inline-only block: keep its contents on one line, minus boundary whitespace
+				collapseWhitespace(el);
 				trimBoundaryWhitespace(el);
 				lines.push(pad + el.outerHTML);
 			} else {

--- a/app/src/interfaces/input-rich-text-html/composables/normalization-diff.test.ts
+++ b/app/src/interfaces/input-rich-text-html/composables/normalization-diff.test.ts
@@ -38,6 +38,19 @@ describe('computeNormalizationDiff', () => {
 		expect(computeNormalizationDiff('<p>The content is pretty awesome </p>')).toBeNull();
 	});
 
+	test('returns null for repeated spaces inside an inline-only block', () => {
+		// Pasted content routinely carries double spaces; Tiptap collapses them, so the delta is cosmetic.
+		expect(computeNormalizationDiff('<p>The content is  pretty  awesome</p>')).toBeNull();
+	});
+
+	test('returns null for whitespace following a line break', () => {
+		expect(computeNormalizationDiff('<p>first line<br>\n  second line</p>')).toBeNull();
+	});
+
+	test('returns null for a space repeated across an inline mark boundary', () => {
+		expect(computeNormalizationDiff('<p><strong>bold </strong> and the rest</p>')).toBeNull();
+	});
+
 	test('flags dropped table markup', () => {
 		expect(removedText('<table><tbody><tr><td>a</td></tr></tbody></table>')).toContain('<table');
 	});
@@ -90,6 +103,10 @@ describe('computeValueNormalizationDiff', () => {
 	test('returns null for custom-format markup when its extensions are supplied', () => {
 		const { extensions } = buildCustomFormats([{ title: 'Cite', inline: 'cite', classes: 'src' }]);
 		expect(computeValueNormalizationDiff('<p><cite class="src">b</cite></p>', extensions)).toBeNull();
+	});
+
+	test('returns null for a stored value carrying repeated spaces', () => {
+		expect(computeValueNormalizationDiff('<p>pasted  from  elsewhere</p>')).toBeNull();
 	});
 
 	test('returns null for a stored value carrying block-level custom-format classes', () => {


### PR DESCRIPTION
## What's Changed

* `formatHtml` now collapses whitespace inside a textblock the way the ProseMirror parser does: a run of ASCII whitespace becomes a single space, and a leading space is dropped when it follows a `<br>` or text that already ends in one. The read-only warning compares the stored value against its round-trip through the schema, and both sides go through `formatHtml` so cosmetic deltas cancel out. Boundary whitespace was already handled, but a double space in the middle of a paragraph survived on the stored side and got collapsed on the round-tripped side, so the field was flagged as carrying formatting the editor can't represent and locked itself read-only.
* Typing two spaces, or pasting plain text from a design tool, puts literal consecutive spaces into the document and `getHTML()` writes them out verbatim, which is why the warning showed up so often. It also explains the reporter's cut-and-paste workaround: that path goes through the HTML clipboard, so the value is schema-parsed before it is stored.
* Non-breaking and Unicode spaces are untouched, since Tiptap does keep those.

## Tested Scenarios

* `<p>a  b</p>`, `<p>a\tb</p>`, `<p>a\nb</p>`, `<p>first<br>\n  second</p>` and `<p><strong>bold </strong> text</p>` all locked the field before the change and no longer do; `<p>a&nbsp;&nbsp;b</p>` still round-trips untouched
* Checked `formatHtml` against a live editor over a whitespace corpus (`<br>` inside and around marks, images and comments between text nodes, inline `<code>`, `<pre>`, nbsp and zero-width runs): re-parsing the formatted HTML lands on the same document as re-parsing the source in every case, so the source-code drawer still saves losslessly
* Genuine loss still warns: dropped `<table>`, `<object>` and unknown custom-format marks are unchanged
* Nine cases added across `format-html.test.ts` and `normalization-diff.test.ts`, all verified failing before the change
* Full app suite green (336 files, 111781 tests)

## Review Notes / Questions / Concerns

* The collapsing runs inside `formatHtml`, so it applies to the source-code drawer too. That input is already `editor.getHTML()` output, which never contains collapsible runs, so the drawer output is unchanged.
* This covers the whitespace half of the report. The issue also mentions that a save accepts the content silently and only shows the locked state on reopen, which comes from `checkValue` deliberately running on load and external changes rather than on the editor's own emits. I left that alone.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi)
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes directus/directus#28182
