### PR TITLE
Fix flow limit being exceeded when saving an already active flow

### DIFF
--- a/.changeset/flows-limit-on-update.md
+++ b/.changeset/flows-limit-on-update.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed the flow limit being exceeded when saving an already active flow

--- a/api/src/services/flows.test.ts
+++ b/api/src/services/flows.test.ts
@@ -3,11 +3,15 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 import { createMockKnex } from '../test-utils/knex.js';
 import { FlowsService } from './flows.js';
 
-const { assertMock } = vi.hoisted(() => ({ assertMock: vi.fn() }));
+const { assertMock, getEntitlementLimitMock } = vi.hoisted(() => ({
+	assertMock: vi.fn(),
+	getEntitlementLimitMock: vi.fn(),
+}));
 
 vi.mock('../license/entitlements/manager.js', () => ({
 	getEntitlementManager: () => ({
 		assert: assertMock,
+		getEntitlementLimit: getEntitlementLimitMock,
 		clearCache: vi.fn(),
 	}),
 }));
@@ -43,8 +47,8 @@ describe('FlowsService', () => {
 
 	describe('updateMany', () => {
 		test('does not count flows that are already active', async () => {
+			getEntitlementLimitMock.mockReturnValue(5);
 			tracker.on.select('directus_flows').response([]);
-			tracker.on.update('directus_flows').response([]);
 
 			await service.updateMany(['flow-id-1'], { status: 'active' });
 
@@ -52,8 +56,8 @@ describe('FlowsService', () => {
 		});
 
 		test('counts only the flows that are being activated', async () => {
+			getEntitlementLimitMock.mockReturnValue(5);
 			tracker.on.select('directus_flows').response([{ id: 'flow-id-2' }]);
-			tracker.on.update('directus_flows').response([]);
 
 			await service.updateMany(['flow-id-1', 'flow-id-2'], { status: 'active' });
 
@@ -61,10 +65,19 @@ describe('FlowsService', () => {
 		});
 
 		test('does not check the limit when the status is not being set to active', async () => {
-			tracker.on.update('directus_flows').response([]);
+			getEntitlementLimitMock.mockReturnValue(5);
 
 			await service.updateMany(['flow-id-1'], { name: 'Updated' });
 
+			expect(assertMock).not.toHaveBeenCalled();
+		});
+
+		test('does not query the flows when the limit is unlimited', async () => {
+			getEntitlementLimitMock.mockReturnValue(-1);
+
+			await service.updateMany(['flow-id-1'], { status: 'active' });
+
+			expect(tracker.history.select).toHaveLength(0);
 			expect(assertMock).not.toHaveBeenCalled();
 		});
 	});

--- a/api/src/services/flows.test.ts
+++ b/api/src/services/flows.test.ts
@@ -1,0 +1,71 @@
+import type { SchemaOverview } from '@directus/types';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { createMockKnex } from '../test-utils/knex.js';
+import { FlowsService } from './flows.js';
+
+const { assertMock } = vi.hoisted(() => ({ assertMock: vi.fn() }));
+
+vi.mock('../license/entitlements/manager.js', () => ({
+	getEntitlementManager: () => ({
+		assert: assertMock,
+		clearCache: vi.fn(),
+	}),
+}));
+
+vi.mock('../flows.js', () => ({
+	getFlowManager: () => ({
+		reload: vi.fn(),
+	}),
+}));
+
+vi.mock('./items.js', async () => {
+	const { mockItemsService } = await import('../test-utils/services/items-service.js');
+	return mockItemsService();
+});
+
+describe('FlowsService', () => {
+	const mockSchema = {
+		collections: {},
+		relations: [],
+	} as SchemaOverview;
+
+	const { db, tracker } = createMockKnex();
+
+	const service = new FlowsService({
+		knex: db,
+		schema: mockSchema,
+	});
+
+	afterEach(() => {
+		tracker.reset();
+		vi.clearAllMocks();
+	});
+
+	describe('updateMany', () => {
+		test('does not count flows that are already active', async () => {
+			tracker.on.select('directus_flows').response([]);
+			tracker.on.update('directus_flows').response([]);
+
+			await service.updateMany(['flow-id-1'], { status: 'active' });
+
+			expect(assertMock).not.toHaveBeenCalled();
+		});
+
+		test('counts only the flows that are being activated', async () => {
+			tracker.on.select('directus_flows').response([{ id: 'flow-id-2' }]);
+			tracker.on.update('directus_flows').response([]);
+
+			await service.updateMany(['flow-id-1', 'flow-id-2'], { status: 'active' });
+
+			expect(assertMock).toHaveBeenCalledWith('flows', { adding: 1, knex: db });
+		});
+
+		test('does not check the limit when the status is not being set to active', async () => {
+			tracker.on.update('directus_flows').response([]);
+
+			await service.updateMany(['flow-id-1'], { name: 'Updated' });
+
+			expect(assertMock).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/api/src/services/flows.ts
+++ b/api/src/services/flows.ts
@@ -2,6 +2,7 @@ import type { AbstractServiceOptions, FlowRaw, Item, MutationOptions, PrimaryKey
 import { getFlowManager } from '../flows.js';
 import { getEntitlementManager } from '../license/entitlements/manager.js';
 import { validateAccess } from '../permissions/modules/validate-access/validate-access.js';
+import { validateKeys } from '../utils/validate-keys.js';
 import { ItemsService } from './items.js';
 
 export class FlowsService extends ItemsService<FlowRaw> {
@@ -23,15 +24,21 @@ export class FlowsService extends ItemsService<FlowRaw> {
 	}
 
 	override async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]> {
-		if ('status' in data && data['status'] === 'active') {
-			const activating = await this.knex
+		if (
+			'status' in data &&
+			data['status'] === 'active' &&
+			getEntitlementManager().getEntitlementLimit('flows') !== -1
+		) {
+			validateKeys(this.schema, 'directus_flows', 'id', keys);
+
+			const inactiveFlows = await this.knex
 				.select('id')
 				.from('directus_flows')
 				.whereIn('id', keys)
 				.whereNot('status', 'active');
 
-			if (activating.length > 0) {
-				await getEntitlementManager().assert('flows', { adding: activating.length, knex: this.knex });
+			if (inactiveFlows.length > 0) {
+				await getEntitlementManager().assert('flows', { adding: inactiveFlows.length, knex: this.knex });
 			}
 		}
 

--- a/api/src/services/flows.ts
+++ b/api/src/services/flows.ts
@@ -24,7 +24,15 @@ export class FlowsService extends ItemsService<FlowRaw> {
 
 	override async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]> {
 		if ('status' in data && data['status'] === 'active') {
-			await getEntitlementManager().assert('flows', { adding: keys.length, knex: this.knex });
+			const activating = await this.knex
+				.select('id')
+				.from('directus_flows')
+				.whereIn('id', keys)
+				.whereNot('status', 'active');
+
+			if (activating.length > 0) {
+				await getEntitlementManager().assert('flows', { adding: activating.length, knex: this.knex });
+			}
 		}
 
 		const result = await super.updateMany(keys, data, opts);


### PR DESCRIPTION
## What's Changed

- `FlowsService.updateMany` counted every key it was given as a new active flow, so saving an unchanged active flow on
  a tier with all slots used pushed the count one over the limit and failed with "flows limit exceeded"
- The limit is now checked against the flows that actually change from inactive to active, and skipped entirely when
  none do

## Tested Scenarios

- Updating an already active flow while at the limit no longer asserts the entitlement
- Updating a mix of active and inactive flows to active only counts the inactive ones
- Updates that don't set the status to active still skip the check
- Licenses without a flow limit don't run the lookup at all
- Full `@directus/api` suite: 384 files, 4985 tests passed

## Review Notes / Questions / Concerns

- `createOne` is unchanged: a new active flow really is an addition
- The lookup is guarded by the limit and by `validateKeys`, so an unlimited license and an invalid key behave exactly as
  they did before

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes #28184
