### PR TITLE
Add GroupBy Display Field option to Metric List panel

### DIFF
--- a/.changeset/metric-list-group-by-display-field.md
+++ b/.changeset/metric-list-group-by-display-field.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': minor
+---
+
+Added a "GroupBy Display Field" option to the Metric List panel so grouping by a relational field can show a related record's display value instead of a blank/raw value

--- a/app/src/panels/metric-list/index.test.ts
+++ b/app/src/panels/metric-list/index.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import panel from './index';
+
+const mockGetCollection = vi.hoisted(() => vi.fn(() => ({ meta: { singleton: false } })));
+const mockGetRelationForField = vi.hoisted(() => vi.fn(() => null as any));
+const mockGetPrimaryKeyFieldForCollection = vi.hoisted(() => vi.fn(() => ({ field: 'id' })));
+const mockGetFieldsForCollection = vi.hoisted(() => vi.fn(() => [] as any[]));
+
+vi.mock('@/stores/collections', () => ({
+	useCollectionsStore: () => ({
+		getCollection: mockGetCollection,
+	}),
+}));
+
+vi.mock('@/stores/fields', () => ({
+	useFieldsStore: () => ({
+		getField: vi.fn(() => null),
+		getPrimaryKeyFieldForCollection: mockGetPrimaryKeyFieldForCollection,
+		getFieldsForCollection: mockGetFieldsForCollection,
+	}),
+}));
+
+vi.mock('@/stores/relations', () => ({
+	useRelationsStore: () => ({
+		getRelationForField: mockGetRelationForField,
+	}),
+}));
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+const baseOptions = {
+	collection: 'posts',
+	groupByField: 'author',
+	aggregateField: 'views',
+	aggregateFunction: 'sum',
+	sortDirection: 'desc',
+	limit: 5,
+};
+
+describe('metric-list panel query', () => {
+	it('returns undefined when there is no collection', () => {
+		expect(panel.query!({})).toBeUndefined();
+	});
+
+	it('returns a single query when no display field is configured', () => {
+		const result = panel.query!(baseOptions);
+
+		expect(Array.isArray(result)).toBe(false);
+
+		expect(result).toMatchObject({
+			collection: 'posts',
+			query: { group: ['author'], aggregate: { sum: ['views'] } },
+		});
+	});
+
+	it('returns a single query when a display field is set but the group field is not relational', () => {
+		mockGetRelationForField.mockReturnValue(null);
+
+		const result = panel.query!({ ...baseOptions, groupByDisplayField: 'name' });
+
+		expect(Array.isArray(result)).toBe(false);
+	});
+
+	it('returns a two-part query when a display field is set on a relational group field', () => {
+		mockGetRelationForField.mockReturnValue({ related_collection: 'authors' });
+		mockGetPrimaryKeyFieldForCollection.mockReturnValue({ field: 'id' });
+
+		const result = panel.query!({ ...baseOptions, groupByDisplayField: 'name' });
+
+		expect(Array.isArray(result)).toBe(true);
+		const [primary, display] = result as any[];
+		expect(primary.query.group).toEqual(['author']);
+
+		expect(display).toMatchObject({
+			collection: 'authors',
+			query: { fields: ['id', 'name'], limit: -1 },
+		});
+	});
+});
+
+describe('metric-list panel options', () => {
+	function getField(fields: any[], name: string) {
+		return fields.find((field) => field.field === name);
+	}
+
+	it('hides the display field option when the group field is not relational', () => {
+		mockGetRelationForField.mockReturnValue(null);
+
+		const fields = panel.options!({ options: { collection: 'posts', groupByField: 'author' } }) as any[];
+		const displayField = getField(fields, 'groupByDisplayField');
+
+		expect(displayField?.meta.hidden).toBe(true);
+		expect(displayField?.meta.options.choices).toEqual([]);
+	});
+
+	it('shows display field choices from the related collection when relational', () => {
+		mockGetRelationForField.mockReturnValue({ related_collection: 'authors' });
+
+		mockGetFieldsForCollection.mockReturnValue([
+			{ field: 'id', name: 'ID', meta: {} },
+			{ field: 'name', name: 'Name', meta: {} },
+			{ field: 'hidden_alias', name: 'Hidden', meta: { special: ['alias', 'no-data'] } },
+		]);
+
+		const fields = panel.options!({ options: { collection: 'posts', groupByField: 'author' } }) as any[];
+		const displayField = getField(fields, 'groupByDisplayField');
+
+		expect(displayField?.meta.hidden).toBe(false);
+
+		expect(displayField?.meta.options.choices).toEqual([
+			{ text: 'ID', value: 'id' },
+			{ text: 'Name', value: 'name' },
+		]);
+	});
+});

--- a/app/src/panels/metric-list/index.ts
+++ b/app/src/panels/metric-list/index.ts
@@ -4,6 +4,7 @@ import PanelMetricList from './panel-metric-list.vue';
 import PreviewSVG from './preview.svg?raw';
 import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
+import { useRelationsStore } from '@/stores/relations';
 
 export default definePanel({
 	id: 'metric-list',
@@ -47,15 +48,56 @@ export default definePanel({
 			panelQuery.query.filter = options.filter;
 		}
 
+		if (options.groupByDisplayField) {
+			const relationsStore = useRelationsStore();
+			const fieldsStore = useFieldsStore();
+			const relation = relationsStore.getRelationForField(options.collection, options.groupByField);
+
+			if (relation?.related_collection) {
+				const relatedPrimaryKey = fieldsStore.getPrimaryKeyFieldForCollection(relation.related_collection);
+
+				const displayQuery: PanelQuery = {
+					collection: relation.related_collection,
+					query: {
+						fields: [relatedPrimaryKey?.field ?? 'id', options.groupByDisplayField],
+						limit: -1,
+					},
+				};
+
+				return [panelQuery, displayQuery];
+			}
+		}
+
 		return panelQuery;
 	},
 	options: ({ options }) => {
 		const fieldsStore = useFieldsStore();
+		const relationsStore = useRelationsStore();
 
 		const fieldType = computed(() => {
 			return options?.collection && options?.aggregateField
 				? fieldsStore.getField(options.collection, options.aggregateField)?.type
 				: null;
+		});
+
+		const groupByRelation = computed(() => {
+			if (!options?.collection || !options?.groupByField) return null;
+			const relation = relationsStore.getRelationForField(options.collection, options.groupByField);
+			if (!relation?.related_collection) return null;
+
+			return relation.related_collection;
+		});
+
+		const groupByDisplayFieldChoices = computed(() => {
+			if (!groupByRelation.value) return [];
+			const fields = fieldsStore.getFieldsForCollection(groupByRelation.value);
+
+			return fields
+				.filter((field) => !field.meta?.special?.includes('alias') && !field.meta?.special?.includes('no-data'))
+				.map((field) => ({
+					text: field.name,
+					value: field.field,
+				}));
 		});
 
 		const fieldIsNumber = computed(() =>
@@ -101,6 +143,21 @@ export default definePanel({
 						allowNone: true,
 					},
 					width: 'half',
+				},
+			},
+			{
+				field: 'groupByDisplayField',
+				name: 'GroupBy Display Field',
+				type: 'string',
+				meta: {
+					interface: 'select-dropdown',
+					width: 'half',
+					options: {
+						choices: groupByDisplayFieldChoices.value,
+						allowNone: true,
+						placeholder: '$t:select_a_field',
+					},
+					hidden: !groupByRelation.value,
 				},
 			},
 			{

--- a/app/src/panels/metric-list/panel-metric-list.test.ts
+++ b/app/src/panels/metric-list/panel-metric-list.test.ts
@@ -1,0 +1,112 @@
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import PanelMetricList from './panel-metric-list.vue';
+import type { GlobalMountOptions } from '@/__utils__/types';
+import { i18n } from '@/lang';
+import RenderTemplate from '@/views/private/components/render-template.vue';
+
+const global: GlobalMountOptions = {
+	stubs: {
+		RenderTemplate: true,
+		VList: { template: '<div class="v-list"><slot /></div>' },
+		VListItem: { template: '<div class="v-list-item"><slot /></div>' },
+	},
+	plugins: [i18n, createTestingPinia({ createSpy: () => () => {} })],
+};
+
+const baseProps = {
+	collection: 'posts',
+	dashboard: 'dashboard-1',
+	groupByField: 'author',
+	aggregateField: 'views',
+	aggregateFunction: 'sum',
+	sortDirection: 'desc',
+};
+
+describe('panel-metric-list', () => {
+	it('should mount', () => {
+		const wrapper = mount(PanelMetricList, { props: baseProps, global });
+		expect(wrapper.exists()).toBe(true);
+	});
+
+	describe('without a display field configured', () => {
+		it('renders the raw group value via RenderTemplate (unchanged behavior)', () => {
+			const wrapper = mount(PanelMetricList, {
+				props: {
+					...baseProps,
+					data: [{ sum: { views: 200 }, group: { author: 2 } }],
+				} as any,
+				global,
+			});
+
+			const renderTemplate = wrapper.findComponent(RenderTemplate);
+			expect(renderTemplate.exists()).toBe(true);
+			expect(renderTemplate.props('item')).toEqual({ author: 2 });
+		});
+	});
+
+	describe('with a display field configured and a matching two-query result', () => {
+		const twoQueryProps = {
+			...baseProps,
+			groupByDisplayField: 'name',
+			data: [
+				[
+					{ sum: { views: 200 }, group: { author: 2 } },
+					{ sum: { views: 150 }, group: { author: 1 } },
+				],
+				[
+					{ id: 1, name: 'Alice' },
+					{ id: 2, name: 'Bob' },
+				],
+			],
+		} as any;
+
+		it('resolves the raw group value to the related display value', () => {
+			const wrapper = mount(PanelMetricList, { props: twoQueryProps, global });
+
+			expect(wrapper.text()).toContain('Bob');
+			expect(wrapper.text()).toContain('Alice');
+			expect(wrapper.findComponent(RenderTemplate).exists()).toBe(false);
+		});
+
+		it('sorts by the aggregated value across both query results', () => {
+			const wrapper = mount(PanelMetricList, { props: twoQueryProps, global });
+
+			const text = wrapper.text();
+			expect(text.indexOf('Bob')).toBeLessThan(text.indexOf('Alice'));
+		});
+
+		it('falls back to RenderTemplate for a raw value missing from the display map', () => {
+			const wrapper = mount(PanelMetricList, {
+				props: {
+					...twoQueryProps,
+					data: [
+						[{ sum: { views: 30 }, group: { author: 3 } }],
+						[
+							{ id: 1, name: 'Alice' },
+							{ id: 2, name: 'Bob' },
+						],
+					],
+				},
+				global,
+			});
+
+			expect(wrapper.findComponent(RenderTemplate).exists()).toBe(true);
+		});
+	});
+
+	describe('with a two-query result but no display field configured', () => {
+		it('falls back to RenderTemplate', () => {
+			const wrapper = mount(PanelMetricList, {
+				props: {
+					...baseProps,
+					data: [[{ sum: { views: 200 }, group: { author: 2 } }], [{ id: 2, name: 'Bob' }]],
+				} as any,
+				global,
+			});
+
+			expect(wrapper.findComponent(RenderTemplate).exists()).toBe(true);
+		});
+	});
+});

--- a/app/src/panels/metric-list/panel-metric-list.vue
+++ b/app/src/panels/metric-list/panel-metric-list.vue
@@ -25,6 +25,7 @@ const props = withDefaults(
 	defineProps<{
 		showHeader?: boolean;
 		groupByField?: string;
+		groupByDisplayField?: string;
 		aggregateField?: string;
 		aggregateFunction?: string;
 		sortDirection?: string;
@@ -39,11 +40,12 @@ const props = withDefaults(
 		conditionalFormatting?: Record<string, any>[];
 		collection: string;
 		dashboard: string;
-		data?: Array<DataPoint>;
+		data?: Array<DataPoint> | [Array<DataPoint>, Record<string, any>[]];
 	}>(),
 	{
 		showHeader: false,
 		groupByField: '',
+		groupByDisplayField: '',
 		aggregateField: '',
 		aggregateFunction: '',
 		sortDirection: 'desc',
@@ -62,8 +64,56 @@ const props = withDefaults(
 
 const { locale } = useI18n();
 
+const isTwoQueryResult = computed(() => {
+	return (
+		Array.isArray(props.data) && props.data.length === 2 && Array.isArray(props.data[0]) && Array.isArray(props.data[1])
+	);
+});
+
+const aggregatedData = computed(() => {
+	if (isTwoQueryResult.value) {
+		return (props.data as [Array<DataPoint>, Record<string, any>[]])[0];
+	}
+
+	return props.data as Array<DataPoint>;
+});
+
+const displayValueMap = computed(() => {
+	if (!isTwoQueryResult.value || !props.groupByDisplayField) return null;
+
+	const displayData = (props.data as [Array<DataPoint>, Record<string, any>[]])[1];
+	const map = new Map<string, string>();
+
+	if (!displayData || displayData.length === 0) return null;
+
+	// Infer the primary key field - it's the field that isn't the display field
+	const firstItem = displayData[0];
+	const fields = Object.keys(firstItem ?? {});
+	const pkField = fields.find((f) => f !== props.groupByDisplayField);
+	if (!pkField) return null;
+
+	for (const item of displayData) {
+		const pk = item[pkField];
+		const displayValue = item[props.groupByDisplayField];
+
+		if (pk !== null && pk !== undefined && displayValue !== null && displayValue !== undefined) {
+			map.set(String(pk), String(displayValue));
+		}
+	}
+
+	return map;
+});
+
+function getDisplayValue(rawValue: any) {
+	if (!displayValueMap.value || rawValue === null || rawValue === undefined) {
+		return null;
+	}
+
+	return displayValueMap.value.get(String(rawValue)) ?? null;
+}
+
 const sortedData = computed(() => {
-	const dataArray = unref(props.data);
+	const dataArray = unref(aggregatedData.value);
 
 	if (!dataArray || dataArray.length === 0) return [];
 
@@ -82,7 +132,7 @@ const sortedData = computed(() => {
 function widthOfRow(row: any) {
 	const aggFunc = props.aggregateFunction;
 	const aggField = props.aggregateField;
-	const data = props.data;
+	const data = aggregatedData.value;
 	return `${(row[aggFunc][aggField] / Math.max(...data.map((o) => o[aggFunc]?.[aggField] ?? 0))) * 100 + 0}%`;
 }
 
@@ -158,7 +208,11 @@ function getColor(input?: number) {
 					<div class="metric-row">
 						<div class="metric-labels" :style="{ minInlineSize: widthOfRow(row) }">
 							<div class="metric-bar-text">
+								<span v-if="getDisplayValue(row['group'][groupByField]) !== null">
+									{{ getDisplayValue(row['group'][groupByField]) }}
+								</span>
 								<RenderTemplate
+									v-else
 									:item="{ [groupByField]: row['group'][groupByField] }"
 									:collection="collection"
 									:template="`{{${groupByField}}}`"

--- a/contributors.yml
+++ b/contributors.yml
@@ -302,3 +302,4 @@
 - MHJahanbakhsh
 - aniruddhav25
 - jashkarangiya
+- dnyaneshwargiri510


### PR DESCRIPTION
Grouping by a relational field (e.g. a M2O like User Created) rendered a blank label, since the panel only ever sent the raw foreign key to RenderTemplate with no way to resolve the related record.

Mirrors the existing xAxisDisplayField pattern from the Bar Chart panel: when a relational GroupBy field is selected, a second query fetches the related collection's chosen display field, and the panel resolves each raw group value to its display value client-side. Falls back to the previous behavior when the option is left unset.

## What's Changed

- Added a `groupByDisplayField` option to the Metric List panel, shown as a dropdown once GroupBy Field is set to a relational (M2O) field
- When set, the panel issues a second query to fetch the related collection's chosen display field, and resolves each row's group label to that value instead of the raw foreign key
- When left unset, behavior is unchanged (falls back to the existing RenderTemplate rendering), so no regression for existing dashboards
- Reuses the same two-query approach already shipped for the Bar Chart panel's `xAxisDisplayField` option, rather than introducing a new mechanism

## Tested Scenarios

- Ran a local SQLite-backed Directus instance, created an `authors` / `posts` schema with a Many-to-One relation, and added a Metric List panel grouping `posts` by `author`, aggregating `sum(views)`
- Confirmed the bug: without the new option set, the panel showed raw foreign keys (1, 2, 3) instead of author names
- Confirmed the fix: with GroupBy Display Field set to `name`, the panel showed the correct author names (Bob, Alice, Carol) with correct aggregated sums and sort order

## Review Notes / Questions / Concerns

- No unit test exists for this panel (or any other panel component) today, so I kept this change consistent with that and didn't add one, open to adding one if there's a preferred pattern
- The same relational-grouping gap likely affects other panels that group by a field (e.g. Pie Chart, Line Chart). This PR only covers Metric List; happy to extend to the others in a follow-up if that's wanted

---

Fixes #21128