### PR TITLE
Fix the global access cache ignoring the client IP

### DIFF
--- a/.changeset/global-access-cache-ip-key.md
+++ b/.changeset/global-access-cache-ip-key.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed the global access cache ignoring the client IP

--- a/api/src/permissions/modules/fetch-global-access/fetch-global-access.test.ts
+++ b/api/src/permissions/modules/fetch-global-access/fetch-global-access.test.ts
@@ -1,0 +1,78 @@
+import type { Accountability } from '@directus/types';
+import type { Knex } from 'knex';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+const mockGet = vi.fn();
+const mockSet = vi.fn();
+
+vi.mock('../../cache.js', () => ({
+	useCache: () => ({
+		get: mockGet,
+		set: mockSet,
+	}),
+}));
+
+const fetchGlobalAccessForRoles = vi.fn();
+const fetchGlobalAccessForUser = vi.fn();
+
+vi.mock('@directus/utils/node', () => ({
+	fetchGlobalAccessForRoles: (...args: unknown[]) => fetchGlobalAccessForRoles(...args),
+	fetchGlobalAccessForUser: (...args: unknown[]) => fetchGlobalAccessForUser(...args),
+}));
+
+const { fetchGlobalAccess } = await import('./fetch-global-access.js');
+
+const knex = {} as Knex;
+
+/** Cache keys used by the outer `fetchGlobalAccess` wrapper, ignoring the per-role/per-user ones */
+function globalAccessKeys() {
+	return mockGet.mock.calls
+		.map(([key]) => key as string)
+		.filter((key) => key.startsWith('global-access-') && !/^global-access-(roles|user)-/.test(key));
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockGet.mockResolvedValue(undefined);
+	fetchGlobalAccessForRoles.mockResolvedValue({ app: false, admin: false });
+	fetchGlobalAccessForUser.mockResolvedValue({ app: false, admin: false });
+});
+
+test('uses a different cache key per accountability IP', async () => {
+	const accountability: Pick<Accountability, 'user' | 'roles' | 'ip'> = {
+		user: 'user-a',
+		roles: ['role-a'],
+		ip: '10.0.0.1',
+	};
+
+	await fetchGlobalAccess(accountability, { knex });
+	await fetchGlobalAccess({ ...accountability, ip: '192.168.0.1' }, { knex });
+
+	const [allowedKey, deniedKey] = globalAccessKeys();
+
+	expect(allowedKey).toBeDefined();
+	expect(allowedKey).not.toBe(deniedKey);
+});
+
+test('reuses the cache key for the same accountability IP', async () => {
+	const accountability: Pick<Accountability, 'user' | 'roles' | 'ip'> = {
+		user: 'user-a',
+		roles: ['role-a'],
+		ip: '10.0.0.1',
+	};
+
+	await fetchGlobalAccess(accountability, { knex });
+	await fetchGlobalAccess({ ...accountability }, { knex });
+
+	const [firstKey, secondKey] = globalAccessKeys();
+
+	expect(firstKey).toBeDefined();
+	expect(firstKey).toBe(secondKey);
+});
+
+test('passes the accountability IP through to the per-role and per-user lookups', async () => {
+	await fetchGlobalAccess({ user: 'user-a', roles: ['role-a'], ip: '10.0.0.1' }, { knex });
+
+	expect(fetchGlobalAccessForRoles).toHaveBeenCalledWith(['role-a'], { knex, ip: '10.0.0.1' });
+	expect(fetchGlobalAccessForUser).toHaveBeenCalledWith('user-a', { knex, ip: '10.0.0.1' });
+});

--- a/api/src/permissions/modules/fetch-global-access/fetch-global-access.ts
+++ b/api/src/permissions/modules/fetch-global-access/fetch-global-access.ts
@@ -8,10 +8,9 @@ import { withCache } from '../../utils/with-cache.js';
 
 interface FetchGlobalAccessContext {
 	knex: Knex;
-	ip?: Accountability['ip'];
 }
 
-export const fetchGlobalAccess = withCache('global-access', _fetchGlobalAccess, ({ user, roles }, { ip }) => ({
+export const fetchGlobalAccess = withCache('global-access', _fetchGlobalAccess, ({ user, roles, ip }) => ({
 	user,
 	roles,
 	ip,


### PR DESCRIPTION
## What's Changed

- Fixed the `global-access` cache key reading `ip` from the context argument rather than the accountability. Every caller passes a context of `{ knex }`, so the key's `ip` was always `undefined` and dropped from the hash entirely.
- Removed the unused `ip` field from `FetchGlobalAccessContext`. Nothing ever set it, and its being optional is why the key could drop the IP without a compile error.
- Added a regression test.

The key was correct when introduced in #22773. It changed in #26248, which extracted
`fetchGlobalAccessForRoles`/`ForUser` into `@directus/utils/node` and moved them from
`(accountability, knex)` to `(roles, { knex, ip })`. That required generalising `withCache` to
memoize on all parameters, and those two inner wrappers correctly moved to reading `ip` off their
second argument. The outer `fetchGlobalAccess` wrapper was reshaped to match, even though its own
first argument is still the accountability and still carries the IP. First released in 11.14.0.

## Tested Scenarios

- Distinct cache keys for the same `(user, roles)` from different IPs.
- A stable key for repeated calls from the same IP.
- The accountability IP still reaching the per-role and per-user lookups.
- Reverted the key to its previous form to confirm the first case fails against it.

## Review Notes / Questions / Concerns

- Related: #27813 restored the accountability overrides dropped in the GraphQL WebSocket handshake, so requests on that path now carry a real IP for this key to use.
- Special attention should be paid to dolor sit amet

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

Fixes CMS-2385