### PR TITLE
Fix table row menus staying open when another row's menu is opened

### DIFF
--- a/.changeset/flows-single-row-context-menu.md
+++ b/.changeset/flows-single-row-context-menu.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed table row context menus staying open when opening the menu on another row

--- a/app/src/components/v-table/table-row.test.ts
+++ b/app/src/components/v-table/table-row.test.ts
@@ -1,0 +1,76 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import TableRow from './table-row.vue';
+import type { Header } from './types';
+import type { GlobalMountOptions } from '@/__utils__/types';
+
+const headers = [
+	{
+		text: 'Name',
+		value: 'name',
+		description: null,
+		align: 'left' as const,
+		sortable: true,
+		width: 200,
+	},
+] as Header[];
+
+const global: GlobalMountOptions = {
+	stubs: ['v-icon', 'v-checkbox', 'v-text-overflow', 'value-null'],
+};
+
+function mountTableRow() {
+	return mount(TableRow, {
+		props: {
+			headers,
+			item: { id: 1, name: 'Flow A' },
+			showSelect: 'multiple' as const,
+			showManualSort: true,
+			hasClickListener: true,
+		},
+		slots: {
+			'item-append': '<button class="ctx-toggle">More</button>',
+		},
+		attachTo: document.body,
+		global,
+	});
+}
+
+afterEach(() => {
+	document.body.innerHTML = '';
+});
+
+describe('TableRow', () => {
+	test('emits click when a content cell is clicked', async () => {
+		const wrapper = mountTableRow();
+
+		await wrapper.find('td.cell:not([data-row-action])').trigger('click');
+
+		expect(wrapper.emitted('click')).toHaveLength(1);
+	});
+
+	test('does not emit click when one of the row controls is clicked', async () => {
+		const wrapper = mountTableRow();
+
+		for (const selector of ['td.manual', 'td.select', 'td.append', '.ctx-toggle']) {
+			await wrapper.find(selector).trigger('click');
+		}
+
+		expect(wrapper.emitted('click')).toBeUndefined();
+	});
+
+	test('lets clicks on the row controls reach the document so open menus can close', async () => {
+		const onDocumentClick = vi.fn();
+		document.documentElement.addEventListener('click', onDocumentClick);
+
+		const wrapper = mountTableRow();
+
+		try {
+			await wrapper.find('.ctx-toggle').trigger('click');
+
+			expect(onDocumentClick).toHaveBeenCalledTimes(1);
+		} finally {
+			document.documentElement.removeEventListener('click', onDocumentClick);
+		}
+	});
+});

--- a/app/src/components/v-table/table-row.vue
+++ b/app/src/components/v-table/table-row.vue
@@ -43,6 +43,21 @@ function onKeydown(e: KeyboardEvent) {
 	if (e.metaKey) return;
 	if ((e.target as HTMLElement)?.tagName === 'TR' && ['Enter', ' '].includes(e.key)) emit('click', e);
 }
+
+/**
+ * Emit a row click unless the click targeted one of the row's own controls (sort handle, selection
+ * checkbox, append slot). Filtering here rather than stopping propagation in those cells keeps the
+ * click bubbling to the document, which is what lets open menus elsewhere close themselves.
+ */
+function onClick(event: MouseEvent) {
+	const isRowAction = event
+		.composedPath()
+		.some((target) => target instanceof HTMLElement && target.hasAttribute('data-row-action'));
+
+	if (isRowAction) return;
+
+	emit('click', event);
+}
 </script>
 
 <template>
@@ -50,14 +65,14 @@ function onKeydown(e: KeyboardEvent) {
 		class="table-row"
 		:class="{ subdued: subdued, clickable: hasClickListener }"
 		:tabindex="hasClickListener ? 0 : undefined"
-		@click="$emit('click', $event)"
+		@click="onClick"
 		@keydown="onKeydown"
 	>
-		<td v-if="showManualSort" class="manual cell" @click.stop>
+		<td v-if="showManualSort" class="manual cell" data-row-action>
 			<VIcon name="drag_handle" class="drag-handle" :class="{ 'sorted-manually': sortedManually }" />
 		</td>
 
-		<td v-if="showSelect !== 'none'" class="select cell" @click.stop>
+		<td v-if="showSelect !== 'none'" class="select cell" data-row-action>
 			<VCheckbox
 				:icon-on="showSelect === 'one' ? 'radio_button_checked' : undefined"
 				:icon-off="showSelect === 'one' ? 'radio_button_unchecked' : undefined"
@@ -85,7 +100,7 @@ function onKeydown(e: KeyboardEvent) {
 		</td>
 
 		<td class="spacer cell" />
-		<td v-if="$slots['item-append']" class="append cell" @click.stop>
+		<td v-if="$slots['item-append']" class="append cell" data-row-action>
 			<slot name="item-append" />
 		</td>
 	</tr>

--- a/app/src/modules/settings/routes/policies/collection.vue
+++ b/app/src/modules/settings/routes/policies/collection.vue
@@ -227,7 +227,7 @@ function openDuplicateDialog(item: PolicyItem) {
 				<template #item-append="{ item }">
 					<VMenu placement="left-start" show-arrow>
 						<template #activator="{ toggle }">
-							<VIcon name="more_vert" class="ctx-toggle" clickable @click.stop="toggle" />
+							<VIcon name="more_vert" class="ctx-toggle" clickable @click="toggle" />
 						</template>
 
 						<VList>


### PR DESCRIPTION
## What's Changed

- Fixed row context menus staying open when the menu on another row was opened, which allowed multiple menus to be visible at once

## Tested Scenarios

- Opening the context menu on one flow row and then another closes the first — only one menu is open at a time
- Also tested policies and insights area to make sure the same fix works there as well.

## Review Notes / Questions / Concerns

- The fix is in the shared `VTable` row, so it affects every table in the app, not just flows, as this issue also occurred in policies, insights, and maybe other areas. Clicks on row controls now bubble to the document instead of being stopped at the cell. Because this change is not isolated to Flows, we should review more carefully for side effects.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes [CMS-3059](https://linear.app/directus/issue/CMS-3059)