### PR TITLE
Fix concurrent local KV increments and maximum updates 🤖🤖🤖

### DIFF
--- a/.changeset/tidy-local-counters.md
+++ b/.changeset/tidy-local-counters.md
@@ -1,0 +1,5 @@
+---
+'@directus/memory': patch
+---
+
+Fixed concurrent local KV updates losing increments or overwriting larger values in `setMax`.

--- a/packages/memory/src/kv/lib/local.integration.test.ts
+++ b/packages/memory/src/kv/lib/local.integration.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { KvLocal } from './local.js';
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.useRealTimers();
+});
+
+describe.each([{}, { maxKeys: 100 }, { ttl: 5000 }])('Local KV updates with %j', (config) => {
+	test('Retains every concurrent increment and returns distinct counts', async () => {
+		const kv = new KvLocal(config);
+		const results = await Promise.all(Array.from({ length: 100 }, () => kv.increment('count')));
+
+		expect(results).toEqual(Array.from({ length: 100 }, (_, index) => index + 1));
+		expect(await kv.get('count')).toBe(100);
+	});
+
+	test('Retains concurrent increments with positive, negative, and zero amounts', async () => {
+		const kv = new KvLocal(config);
+		await kv.set('count', 10);
+
+		const results = await Promise.all([-3, 5, 0, 2].map((amount) => kv.increment('count', amount)));
+
+		expect(results).toEqual([7, 12, 12, 14]);
+		expect(await kv.get('count')).toBe(14);
+	});
+
+	test('Rejects smaller and equal concurrent maxima without lowering the stored value', async () => {
+		const kv = new KvLocal(config);
+		await kv.set('maximum', 1);
+
+		const results = await Promise.all([100, 100, 50].map((value) => kv.setMax('maximum', value)));
+
+		expect(results).toEqual([true, false, false]);
+		expect(await kv.get('maximum')).toBe(100);
+	});
+
+	test('Accepts successively larger concurrent maxima', async () => {
+		const kv = new KvLocal(config);
+		const results = await Promise.all([50, 100].map((value) => kv.setMax('maximum', value)));
+
+		expect(results).toEqual([true, true]);
+		expect(await kv.get('maximum')).toBe(100);
+	});
+
+	test('Shares the latest value between concurrent setMax and increment calls', async () => {
+		const kv = new KvLocal(config);
+		await kv.set('count', 1);
+
+		expect(await Promise.all([kv.setMax('count', 100), kv.increment('count')])).toEqual([true, 101]);
+		expect(await kv.get('count')).toBe(101);
+
+		expect(await Promise.all([kv.increment('count'), kv.setMax('count', 102)])).toEqual([102, false]);
+		expect(await kv.get('count')).toBe(102);
+	});
+
+	test('Preserves sequential increments and equal-value rejection', async () => {
+		const kv = new KvLocal(config);
+
+		expect(await kv.increment('count')).toBe(1);
+		expect(await kv.increment('count')).toBe(2);
+		expect(await kv.setMax('count', 2)).toBe(false);
+		expect(await kv.get('count')).toBe(2);
+	});
+
+	test('Rejects non-number values without overwriting them', async () => {
+		const kv = new KvLocal(config);
+		await kv.set('count', 'not-a-number');
+
+		await expect(kv.increment('count')).rejects.toThrow('The value for key "count" is not a number.');
+		await expect(kv.setMax('count', 100)).rejects.toThrow('The value for key "count" is not a number.');
+		expect(await kv.get('count')).toBe('not-a-number');
+	});
+});
+
+test.each(['increment', 'setMax'] as const)('%s preserves TTL renewal and expiration', async (operation) => {
+	vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+	const now = vi.spyOn(performance, 'now').mockReturnValue(1000);
+	const kv = new KvLocal({ ttl: 1000 });
+	await kv.set('count', 1);
+
+	now.mockReturnValue(1500);
+	vi.advanceTimersByTime(500);
+	await kv[operation]('count', 2);
+
+	now.mockReturnValue(2100);
+	vi.advanceTimersByTime(600);
+	expect(await kv.has('count')).toBe(true);
+	expect(await kv.setMax('count', operation === 'increment' ? 3 : 2)).toBe(false);
+	expect(await kv.setMax('count', 1)).toBe(false);
+
+	now.mockReturnValue(2601);
+	vi.advanceTimersByTime(501);
+	expect(await kv.get('count')).toBeUndefined();
+});

--- a/packages/memory/src/kv/lib/local.integration.test.ts
+++ b/packages/memory/src/kv/lib/local.integration.test.ts
@@ -67,8 +67,8 @@ describe.each([{}, { maxKeys: 100 }, { ttl: 5000 }])('Local KV updates with %j',
 		const kv = new KvLocal(config);
 		await kv.set('count', 'not-a-number');
 
-		await expect(kv.increment('count')).rejects.toThrow('The value for key "count" is not a number.');
-		await expect(kv.setMax('count', 100)).rejects.toThrow('The value for key "count" is not a number.');
+		expect(() => kv.increment('count')).toThrow('The value for key "count" is not a number.');
+		expect(() => kv.setMax('count', 100)).toThrow('The value for key "count" is not a number.');
 		expect(await kv.get('count')).toBe('not-a-number');
 	});
 });

--- a/packages/memory/src/kv/lib/local.test.ts
+++ b/packages/memory/src/kv/lib/local.test.ts
@@ -98,7 +98,6 @@ describe('increment', () => {
 	test('Sets value to 1 if no value exists', async () => {
 		const mockKey = 'kv-key';
 
-		kv.get = vi.fn().mockReturnValue(undefined);
 		kv.set = vi.fn();
 
 		await kv.increment(mockKey);
@@ -110,7 +109,6 @@ describe('increment', () => {
 		const mockKey = 'kv-key';
 		const mockAmount = 15;
 
-		kv.get = vi.fn().mockReturnValue(undefined);
 		kv.set = vi.fn();
 
 		await kv.increment(mockKey, mockAmount);
@@ -123,7 +121,8 @@ describe('increment', () => {
 		const mockValue = 42;
 		const mockAmount = 15;
 
-		kv.get = vi.fn().mockReturnValue(mockValue);
+		vi.mocked(kv['store'].get).mockReturnValue(new Uint8Array([1]));
+		vi.mocked(deserialize).mockReturnValue(mockValue);
 		kv.set = vi.fn();
 
 		await kv.increment(mockKey, mockAmount);
@@ -135,9 +134,12 @@ describe('increment', () => {
 		const mockKey = 'kv-key';
 		const mockStoredValue = 'not-a-number';
 
-		kv.get = vi.fn().mockReturnValue(mockStoredValue);
+		vi.mocked(kv['store'].get).mockReturnValue(new Uint8Array([1]));
+		vi.mocked(deserialize).mockReturnValue(mockStoredValue);
 
-		expect(kv.increment(mockKey)).rejects.toMatchInlineSnapshot('[Error: The value for key "kv-key" is not a number.]');
+		await expect(kv.increment(mockKey)).rejects.toMatchInlineSnapshot(
+			'[Error: The value for key "kv-key" is not a number.]',
+		);
 	});
 });
 
@@ -147,9 +149,10 @@ describe('setMax', () => {
 		const mockValue = 42;
 		const mockStoredValue = 'not-a-number';
 
-		kv.get = vi.fn().mockReturnValue(mockStoredValue);
+		vi.mocked(kv['store'].get).mockReturnValue(new Uint8Array([1]));
+		vi.mocked(deserialize).mockReturnValue(mockStoredValue);
 
-		expect(kv.setMax(mockKey, mockValue)).rejects.toMatchInlineSnapshot(
+		await expect(kv.setMax(mockKey, mockValue)).rejects.toMatchInlineSnapshot(
 			'[Error: The value for key "kv-key" is not a number.]',
 		);
 	});
@@ -157,9 +160,7 @@ describe('setMax', () => {
 	test('Defaults to 0 if current value does not exist', async () => {
 		const mockKey = 'kv-key';
 		const mockValue = 42;
-		const mockStoredValue = undefined;
 
-		kv.get = vi.fn().mockReturnValue(mockStoredValue);
 		kv.set = vi.fn();
 
 		await kv.setMax(mockKey, mockValue);
@@ -172,7 +173,8 @@ describe('setMax', () => {
 		const mockValue = 42;
 		const mockStoredValue = 500;
 
-		kv.get = vi.fn().mockReturnValue(mockStoredValue);
+		vi.mocked(kv['store'].get).mockReturnValue(new Uint8Array([1]));
+		vi.mocked(deserialize).mockReturnValue(mockStoredValue);
 		kv.set = vi.fn();
 
 		const result = await kv.setMax(mockKey, mockValue);
@@ -185,7 +187,8 @@ describe('setMax', () => {
 		const mockKey = 'kv-key';
 		const mockValue = 42;
 
-		kv.get = vi.fn().mockReturnValue(mockValue);
+		vi.mocked(kv['store'].get).mockReturnValue(new Uint8Array([1]));
+		vi.mocked(deserialize).mockReturnValue(mockValue);
 		kv.set = vi.fn();
 
 		const result = await kv.setMax(mockKey, mockValue);
@@ -199,7 +202,8 @@ describe('setMax', () => {
 		const mockValue = 500;
 		const mockStoredValue = 42;
 
-		kv.get = vi.fn().mockReturnValue(mockStoredValue);
+		vi.mocked(kv['store'].get).mockReturnValue(new Uint8Array([1]));
+		vi.mocked(deserialize).mockReturnValue(mockStoredValue);
 		kv.set = vi.fn();
 
 		const result = await kv.setMax(mockKey, mockValue);

--- a/packages/memory/src/kv/lib/local.test.ts
+++ b/packages/memory/src/kv/lib/local.test.ts
@@ -137,7 +137,7 @@ describe('increment', () => {
 		vi.mocked(kv['store'].get).mockReturnValue(new Uint8Array([1]));
 		vi.mocked(deserialize).mockReturnValue(mockStoredValue);
 
-		await expect(kv.increment(mockKey)).rejects.toMatchInlineSnapshot(
+		expect(() => kv.increment(mockKey)).toThrowErrorMatchingInlineSnapshot(
 			'[Error: The value for key "kv-key" is not a number.]',
 		);
 	});
@@ -152,7 +152,7 @@ describe('setMax', () => {
 		vi.mocked(kv['store'].get).mockReturnValue(new Uint8Array([1]));
 		vi.mocked(deserialize).mockReturnValue(mockStoredValue);
 
-		await expect(kv.setMax(mockKey, mockValue)).rejects.toMatchInlineSnapshot(
+		expect(() => kv.setMax(mockKey, mockValue)).toThrowErrorMatchingInlineSnapshot(
 			'[Error: The value for key "kv-key" is not a number.]',
 		);
 	});

--- a/packages/memory/src/kv/lib/local.ts
+++ b/packages/memory/src/kv/lib/local.ts
@@ -28,6 +28,11 @@ export class KvLocal implements Kv {
 	}
 
 	async get<T = unknown>(key: string): Promise<T | undefined> {
+		return this.getValue<T>(key);
+	}
+
+	// Keep reads synchronous for atomic read-modify-write operations.
+	private getValue<T = unknown>(key: string): T | undefined {
 		const value = this.store.get(key);
 
 		if (value !== undefined) {
@@ -51,7 +56,7 @@ export class KvLocal implements Kv {
 	}
 
 	async increment(key: string, amount: number = 1): Promise<number> {
-		const currentVal = (await this.get(key)) ?? 0;
+		const currentVal = this.getValue(key) ?? 0;
 
 		if (typeof currentVal !== 'number') {
 			throw new Error(`The value for key "${key}" is not a number.`);
@@ -65,7 +70,7 @@ export class KvLocal implements Kv {
 	}
 
 	async setMax(key: string, value: number): Promise<boolean> {
-		const currentVal = (await this.get(key)) ?? 0;
+		const currentVal = this.getValue(key) ?? 0;
 
 		if (typeof currentVal !== 'number') {
 			throw new Error(`The value for key "${key}" is not a number.`);

--- a/packages/memory/src/kv/lib/local.ts
+++ b/packages/memory/src/kv/lib/local.ts
@@ -27,12 +27,7 @@ export class KvLocal implements Kv {
 		}
 	}
 
-	async get<T = unknown>(key: string): Promise<T | undefined> {
-		return this.getValue<T>(key);
-	}
-
-	// Keep reads synchronous for atomic read-modify-write operations.
-	private getValue<T = unknown>(key: string): T | undefined {
+	get<T = unknown>(key: string): T | undefined {
 		const value = this.store.get(key);
 
 		if (value !== undefined) {
@@ -42,21 +37,21 @@ export class KvLocal implements Kv {
 		return undefined;
 	}
 
-	async set(key: string, value: unknown): Promise<void> {
+	set(key: string, value: unknown): void {
 		const serialized = serialize(value);
 		this.store.set(key, serialized);
 	}
 
-	async delete(key: string): Promise<void> {
+	delete(key: string): void {
 		this.store.delete(key);
 	}
 
-	async has(key: string): Promise<boolean> {
+	has(key: string): boolean {
 		return this.store.has(key);
 	}
 
-	async increment(key: string, amount: number = 1): Promise<number> {
-		const currentVal = this.getValue(key) ?? 0;
+	increment(key: string, amount: number = 1): number {
+		const currentVal = this.get(key) ?? 0;
 
 		if (typeof currentVal !== 'number') {
 			throw new Error(`The value for key "${key}" is not a number.`);
@@ -64,13 +59,13 @@ export class KvLocal implements Kv {
 
 		const newVal = currentVal + amount;
 
-		await this.set(key, newVal);
+		this.set(key, newVal);
 
 		return newVal;
 	}
 
-	async setMax(key: string, value: number): Promise<boolean> {
-		const currentVal = this.getValue(key) ?? 0;
+	setMax(key: string, value: number): boolean {
+		const currentVal = this.get(key) ?? 0;
 
 		if (typeof currentVal !== 'number') {
 			throw new Error(`The value for key "${key}" is not a number.`);
@@ -80,26 +75,26 @@ export class KvLocal implements Kv {
 			return false;
 		}
 
-		await this.set(key, value);
+		this.set(key, value);
 
 		return true;
 	}
 
-	async acquireLock(_key: string): Promise<{
+	acquireLock(_key: string): {
 		release: () => Promise<void>;
 		extend: (_duration: number) => Promise<void>;
-	}> {
+	} {
 		return {
 			release: async () => {},
 			extend: async (_duration: number) => {},
 		};
 	}
 
-	async usingLock<T>(_key: string, callback: () => Promise<T>): Promise<T> {
+	usingLock<T>(_key: string, callback: () => Promise<T>): Promise<T> {
 		return callback();
 	}
 
-	async clear(): Promise<void> {
+	clear(): void {
 		this.store.clear();
 	}
 }

--- a/packages/memory/src/kv/types/class.ts
+++ b/packages/memory/src/kv/types/class.ts
@@ -1,5 +1,7 @@
 import type { Lock } from './lock.js';
 
+export type MaybePromise<T> = Promise<T> | T;
+
 export interface Kv {
 	/**
 	 * Get the stored value by key. Returns undefined if the key doesn't exist in the store
@@ -7,7 +9,7 @@ export interface Kv {
 	 * @param key Key to retrieve from the store
 	 * @returns Stored value, or undefined if key doesn't exist
 	 */
-	get<T = unknown>(key: string): Promise<T | undefined>;
+	get<T = unknown>(key: string): MaybePromise<T | undefined>;
 
 	/**
 	 * Save the given value to the store
@@ -15,21 +17,21 @@ export interface Kv {
 	 * @param key Key to save in the store
 	 * @param value Value to save to the store. Can be any JavaScript primitive, plain object, or array
 	 */
-	set<T = unknown>(key: string, value: T): Promise<void>;
+	set<T = unknown>(key: string, value: T): MaybePromise<void>;
 
 	/**
 	 * Remove the given key from the store
 	 *
 	 * @param key Key to remove from the store
 	 */
-	delete(key: string): Promise<void>;
+	delete(key: string): MaybePromise<void>;
 
 	/**
 	 * Check if a given key exists in the store
 	 *
 	 * @param key Key to check
 	 */
-	has(key: string): Promise<boolean>;
+	has(key: string): MaybePromise<boolean>;
 
 	/**
 	 * Increment the given stored value by the given amount
@@ -38,7 +40,7 @@ export interface Kv {
 	 * @param [amount=1] Amount to increment. Defaults to 1
 	 * @returns Updated value
 	 */
-	increment(key: string, amount?: number): Promise<number>;
+	increment(key: string, amount?: number): MaybePromise<number>;
 
 	/**
 	 * Save the given value to the store if the given value is larger than the existing value
@@ -47,14 +49,14 @@ export interface Kv {
 	 * @param value Number to save to the store if it's bigger than the current value
 	 * @returns Whether or not the given value was saved
 	 */
-	setMax(key: string, value: number): Promise<boolean>;
+	setMax(key: string, value: number): MaybePromise<boolean>;
 
-	acquireLock(key: string): Promise<Lock>;
+	acquireLock(key: string): MaybePromise<Lock>;
 
-	usingLock<T>(key: string, callback: () => Promise<T>): Promise<T>;
+	usingLock<T>(key: string, callback: () => Promise<T>): MaybePromise<T>;
 
 	/**
 	 * Remove all keys from the kv store
 	 */
-	clear(): Promise<void>;
+	clear(): MaybePromise<void>;
 }


### PR DESCRIPTION
## What's Changed

- Fixed the shared local KV read-modify-write race in `increment()` and `setMax()` by reading synchronously before starting the existing write.
- Updated the `Kv` interface to allow synchronous or asynchronous implementations through `MaybePromise<T>` return types.
- Made all `KvLocal` methods synchronous while preserving serialization, numeric validation, equal-value rejection, and TTL behavior. The Redis implementation remains asynchronous; no new dependencies were added.
- Added 23 real-store regression/compatibility tests across Map, size-limited LRU, and TTL-only LRU, and a patch changeset for `@directus/memory`.

## Tested Scenarios

- Concurrent increments retain all updates and return distinct counts, including positive, negative, and zero amounts.
- Concurrent smaller/equal maxima cannot overwrite a larger value; mixed `setMax()` / `increment()` calls see the latest value.
- Sequential behavior, non-number rejection, TTL renewal and expiration, and no TTL renewal for rejected maxima remain intact.
- Before the fix, 12 of the new tests failed and 11 compatibility checks passed. After the fix, all 23 passed.
- Full memory package suite: 24 files, 171 tests passed.
- Memory package build and built `createKv` API reproduction passed.
- Repository-wide `pnpm lint`, `pnpm lint:style`, `pnpm format`, and `git diff --check` passed. ESLint reported 81 existing warnings outside the changed files, zero errors.

## Review Notes / Questions / Concerns

- Following maintainer review, the local implementation is synchronous end-to-end. Its read-modify-write operations therefore complete without yielding, while the shared interface continues to support the asynchronous Redis backend.
- This is separate from #28172's equality-boundary fix. Both operations previously read stale values when their calls overlapped.
- Schema/extension election impacts in #28193 are inferred from their increment-based coordination; this PR verifies the underlying package behavior, not a full-server reproduction.
- Supplemental `tsc --noEmit -p packages/memory/tsconfig.json` reports four existing errors: three overload errors in `src/bus/lib/create.test.ts` and one Buffer type error in `src/bus/lib/redis.test.ts`. Comparing compiler diagnostics with the unchanged base sources produced the identical four errors and no new diagnostics. These unrelated files are unchanged.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes #28193
