### PR TITLE
Fix race conditions in local KV increment and setMax

### DIFF
--- a/.changeset/local-kv-concurrency-fixes.md
+++ b/.changeset/local-kv-concurrency-fixes.md
@@ -1,0 +1,5 @@
+---
+'@directus/memory': patch
+---
+
+Fixed race conditions in local KV `increment` and `setMax` during concurrent operations

--- a/contributors.yml
+++ b/contributors.yml
@@ -303,3 +303,4 @@
 - aniruddhav25
 - jashkarangiya
 - andrewalfaro1
+- AbhiPra24

--- a/packages/memory/src/kv/lib/local.concurrency.test.ts
+++ b/packages/memory/src/kv/lib/local.concurrency.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+import { KvLocal } from './local.js';
+
+describe('KvLocal Concurrency', () => {
+	test.each([
+		{ name: 'Map fallback', config: {} },
+		{ name: 'LRU with maxKeys', config: { maxKeys: 100 } },
+		{ name: 'LRU with ttl', config: { ttl: 5000 } },
+	])('Handles concurrent increments correctly with $name', async ({ config }) => {
+		const kv = new KvLocal(config);
+
+		const increments = await Promise.all(Array.from({ length: 100 }, () => kv.increment('count')));
+
+		expect(increments.sort((a, b) => a - b)).toEqual(Array.from({ length: 100 }, (_, i) => i + 1));
+		expect(await kv.get('count')).toBe(100);
+	});
+
+	test.each([
+		{ name: 'Map fallback', config: {} },
+		{ name: 'LRU with maxKeys', config: { maxKeys: 100 } },
+		{ name: 'LRU with ttl', config: { ttl: 5000 } },
+	])('Handles concurrent setMax without overwriting larger value with $name', async ({ config }) => {
+		const kv = new KvLocal(config);
+
+		await kv.set('maximum', 1);
+
+		const maxima = await Promise.all([kv.setMax('maximum', 100), kv.setMax('maximum', 50)]);
+
+		expect(maxima).toEqual([true, false]);
+		expect(await kv.get('maximum')).toBe(100);
+	});
+
+	test('Handles concurrent increment and setMax without race conditions', async () => {
+		const kv = new KvLocal({});
+
+		await kv.set('count', 1);
+
+		await Promise.all([kv.setMax('count', 100), kv.increment('count', 1)]);
+
+		const finalVal = await kv.get<number>('count');
+		expect([100, 101]).toContain(finalVal);
+	});
+});

--- a/packages/memory/src/kv/lib/local.test.ts
+++ b/packages/memory/src/kv/lib/local.test.ts
@@ -97,47 +97,66 @@ describe('set', () => {
 describe('increment', () => {
 	test('Sets value to 1 if no value exists', async () => {
 		const mockKey = 'kv-key';
+		const mockSerialized = new Uint8Array([1]);
 
-		kv.get = vi.fn().mockReturnValue(undefined);
-		kv.set = vi.fn();
+		vi.mocked(kv['store'].get).mockReturnValue(undefined);
+		vi.mocked(serialize).mockReturnValue(mockSerialized);
 
-		await kv.increment(mockKey);
+		const result = await kv.increment(mockKey);
 
-		expect(kv.set).toHaveBeenCalledWith(mockKey, 1);
+		expect(kv['store'].get).toHaveBeenCalledWith(mockKey);
+		expect(serialize).toHaveBeenCalledWith(1);
+		expect(kv['store'].set).toHaveBeenCalledWith(mockKey, mockSerialized);
+		expect(result).toBe(1);
 	});
 
 	test('Sets value to passed amount if no value exists', async () => {
 		const mockKey = 'kv-key';
 		const mockAmount = 15;
+		const mockSerialized = new Uint8Array([15]);
 
-		kv.get = vi.fn().mockReturnValue(undefined);
-		kv.set = vi.fn();
+		vi.mocked(kv['store'].get).mockReturnValue(undefined);
+		vi.mocked(serialize).mockReturnValue(mockSerialized);
 
-		await kv.increment(mockKey, mockAmount);
+		const result = await kv.increment(mockKey, mockAmount);
 
-		expect(kv.set).toHaveBeenCalledWith(mockKey, mockAmount);
+		expect(kv['store'].get).toHaveBeenCalledWith(mockKey);
+		expect(serialize).toHaveBeenCalledWith(mockAmount);
+		expect(kv['store'].set).toHaveBeenCalledWith(mockKey, mockSerialized);
+		expect(result).toBe(mockAmount);
 	});
 
-	test('Sets value to existing + passed amount if no value exists', async () => {
+	test('Sets value to existing + passed amount if value exists', async () => {
 		const mockKey = 'kv-key';
 		const mockValue = 42;
 		const mockAmount = 15;
+		const mockStoredBytes = new Uint8Array([42]);
+		const mockSerialized = new Uint8Array([57]);
 
-		kv.get = vi.fn().mockReturnValue(mockValue);
-		kv.set = vi.fn();
+		vi.mocked(kv['store'].get).mockReturnValue(mockStoredBytes);
+		vi.mocked(deserialize).mockReturnValue(mockValue);
+		vi.mocked(serialize).mockReturnValue(mockSerialized);
 
-		await kv.increment(mockKey, mockAmount);
+		const result = await kv.increment(mockKey, mockAmount);
 
-		expect(kv.set).toHaveBeenCalledWith(mockKey, mockValue + mockAmount);
+		expect(kv['store'].get).toHaveBeenCalledWith(mockKey);
+		expect(deserialize).toHaveBeenCalledWith(mockStoredBytes);
+		expect(serialize).toHaveBeenCalledWith(mockValue + mockAmount);
+		expect(kv['store'].set).toHaveBeenCalledWith(mockKey, mockSerialized);
+		expect(result).toBe(mockValue + mockAmount);
 	});
 
 	test('Errors if key does not contain number', async () => {
 		const mockKey = 'kv-key';
+		const mockStoredBytes = new Uint8Array([1, 2, 3]);
 		const mockStoredValue = 'not-a-number';
 
-		kv.get = vi.fn().mockReturnValue(mockStoredValue);
+		vi.mocked(kv['store'].get).mockReturnValue(mockStoredBytes);
+		vi.mocked(deserialize).mockReturnValue(mockStoredValue);
 
-		expect(kv.increment(mockKey)).rejects.toMatchInlineSnapshot('[Error: The value for key "kv-key" is not a number.]');
+		await expect(kv.increment(mockKey)).rejects.toMatchInlineSnapshot(
+			'[Error: The value for key "kv-key" is not a number.]',
+		);
 	});
 });
 
@@ -145,11 +164,13 @@ describe('setMax', () => {
 	test('Errors if key does not contain number', async () => {
 		const mockKey = 'kv-key';
 		const mockValue = 42;
+		const mockStoredBytes = new Uint8Array([1, 2, 3]);
 		const mockStoredValue = 'not-a-number';
 
-		kv.get = vi.fn().mockReturnValue(mockStoredValue);
+		vi.mocked(kv['store'].get).mockReturnValue(mockStoredBytes);
+		vi.mocked(deserialize).mockReturnValue(mockStoredValue);
 
-		expect(kv.setMax(mockKey, mockValue)).rejects.toMatchInlineSnapshot(
+		await expect(kv.setMax(mockKey, mockValue)).rejects.toMatchInlineSnapshot(
 			'[Error: The value for key "kv-key" is not a number.]',
 		);
 	});
@@ -157,54 +178,63 @@ describe('setMax', () => {
 	test('Defaults to 0 if current value does not exist', async () => {
 		const mockKey = 'kv-key';
 		const mockValue = 42;
-		const mockStoredValue = undefined;
+		const mockSerialized = new Uint8Array([42]);
 
-		kv.get = vi.fn().mockReturnValue(mockStoredValue);
-		kv.set = vi.fn();
+		vi.mocked(kv['store'].get).mockReturnValue(undefined);
+		vi.mocked(serialize).mockReturnValue(mockSerialized);
 
-		await kv.setMax(mockKey, mockValue);
+		const result = await kv.setMax(mockKey, mockValue);
 
-		expect(kv.set).toHaveBeenCalledWith(mockKey, mockValue);
+		expect(kv['store'].get).toHaveBeenCalledWith(mockKey);
+		expect(serialize).toHaveBeenCalledWith(mockValue);
+		expect(kv['store'].set).toHaveBeenCalledWith(mockKey, mockSerialized);
+		expect(result).toBe(true);
 	});
 
 	test('Returns false if existing value is bigger than passed value', async () => {
 		const mockKey = 'kv-key';
 		const mockValue = 42;
+		const mockStoredBytes = new Uint8Array([500]);
 		const mockStoredValue = 500;
 
-		kv.get = vi.fn().mockReturnValue(mockStoredValue);
-		kv.set = vi.fn();
+		vi.mocked(kv['store'].get).mockReturnValue(mockStoredBytes);
+		vi.mocked(deserialize).mockReturnValue(mockStoredValue);
 
 		const result = await kv.setMax(mockKey, mockValue);
 
-		expect(kv.set).not.toHaveBeenCalled();
+		expect(kv['store'].set).not.toHaveBeenCalled();
 		expect(result).toBe(false);
 	});
 
 	test('Returns false if existing value equals passed value', async () => {
 		const mockKey = 'kv-key';
 		const mockValue = 42;
+		const mockStoredBytes = new Uint8Array([42]);
 
-		kv.get = vi.fn().mockReturnValue(mockValue);
-		kv.set = vi.fn();
+		vi.mocked(kv['store'].get).mockReturnValue(mockStoredBytes);
+		vi.mocked(deserialize).mockReturnValue(mockValue);
 
 		const result = await kv.setMax(mockKey, mockValue);
 
-		expect(kv.set).not.toHaveBeenCalled();
+		expect(kv['store'].set).not.toHaveBeenCalled();
 		expect(result).toBe(false);
 	});
 
 	test('Returns true if passed value is bigger than existing value', async () => {
 		const mockKey = 'kv-key';
 		const mockValue = 500;
+		const mockStoredBytes = new Uint8Array([42]);
 		const mockStoredValue = 42;
+		const mockSerialized = new Uint8Array([500]);
 
-		kv.get = vi.fn().mockReturnValue(mockStoredValue);
-		kv.set = vi.fn();
+		vi.mocked(kv['store'].get).mockReturnValue(mockStoredBytes);
+		vi.mocked(deserialize).mockReturnValue(mockStoredValue);
+		vi.mocked(serialize).mockReturnValue(mockSerialized);
 
 		const result = await kv.setMax(mockKey, mockValue);
 
-		expect(kv.set).toHaveBeenCalledWith(mockKey, mockValue);
+		expect(serialize).toHaveBeenCalledWith(mockValue);
+		expect(kv['store'].set).toHaveBeenCalledWith(mockKey, mockSerialized);
 		expect(result).toBe(true);
 	});
 });

--- a/packages/memory/src/kv/lib/local.ts
+++ b/packages/memory/src/kv/lib/local.ts
@@ -51,21 +51,24 @@ export class KvLocal implements Kv {
 	}
 
 	async increment(key: string, amount: number = 1): Promise<number> {
-		const currentVal = (await this.get(key)) ?? 0;
+		const raw = this.store.get(key);
+		const currentVal = raw !== undefined ? deserialize<number>(raw) : 0;
 
 		if (typeof currentVal !== 'number') {
 			throw new Error(`The value for key "${key}" is not a number.`);
 		}
 
 		const newVal = currentVal + amount;
+		const serialized = serialize(newVal);
 
-		await this.set(key, newVal);
+		this.store.set(key, serialized);
 
 		return newVal;
 	}
 
 	async setMax(key: string, value: number): Promise<boolean> {
-		const currentVal = (await this.get(key)) ?? 0;
+		const raw = this.store.get(key);
+		const currentVal = raw !== undefined ? deserialize<number>(raw) : 0;
 
 		if (typeof currentVal !== 'number') {
 			throw new Error(`The value for key "${key}" is not a number.`);
@@ -75,7 +78,9 @@ export class KvLocal implements Kv {
 			return false;
 		}
 
-		await this.set(key, value);
+		const serialized = serialize(value);
+
+		this.store.set(key, serialized);
 
 		return true;
 	}


### PR DESCRIPTION
## What's Changed

- Fixes read-modify-write race conditions in `KvLocal.prototype.increment` and `KvLocal.prototype.setMax` by synchronously updating local storage.
- Ensures concurrent `increment` operations correctly accumulate values without dropping concurrent updates.
- Ensures concurrent `setMax` operations never overwrite larger stored values with smaller ones.
- Adds comprehensive concurrent integration tests for Map fallback and LRUCache backends.
- Adds patch changeset for `@directus/memory`.

## Tested Scenarios

- 100 concurrent `increment` operations across Map fallback, LRU with maxKeys, and LRU with ttl backends.
- Concurrent `setMax` operations across all backends.
- Interleaved concurrent `increment` and `setMax` operations.
- Full `@directus/memory` unit and concurrency test suites passing.
- Prettier and ESLint checks passing.

## Checklist

- [x] Tests added/updated
- [ ] Documentation PR created in directus/docs
- [ ] OpenAPI updated
- [ ] SDK updated
- [ ] Types updated
- [ ] GraphQL schema updated
- [ ] System data updated
- [ ] Database migration added
- [ ] Environment variables documented
- [ ] App translations added
- [ ] Security implications apply

---

Fixes #28193