### PR TITLE
Fix relational fields always exporting last regardless of requested order

### DIFF
--- a/.changeset/fix-csv-export-field-order.md
+++ b/.changeset/fix-csv-export-field-order.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed relational fields (m2o/o2m/a2o) always being placed after every direct field when building the field tree, regardless of their position in the requested field list. This caused CSV/JSON exports to always push related columns to the end even when they were placed in the middle of the requested fields.

--- a/api/src/database/get-ast-from-query/lib/parse-fields.test.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.test.ts
@@ -116,6 +116,17 @@ test('parse fields with m2o relation', async () => {
 	]);
 });
 
+test('parse fields preserves the requested field order when a relational field is placed between direct fields (#25521)', async () => {
+	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
+
+	const result = await parseFields(
+		{ accountability, fields: ['id', 'author.name', 'title'], parentCollection: 'articles', query: {} },
+		{ knex: db, schema: schemaRelational },
+	);
+
+	expect(result.map((node) => node.fieldKey)).toEqual(['id', 'author', 'title']);
+});
+
 test('parse fields with o2m relation', async () => {
 	fetchAllowedFieldsMock.mockResolvedValueOnce([]);
 
@@ -221,27 +232,6 @@ test('parse fields with *.*.*', async () => {
 
 	expect(result).toEqual([
 		{
-			alias: false,
-			fieldKey: 'id',
-			name: 'id',
-			type: 'field',
-			whenCase: [],
-		},
-		{
-			alias: false,
-			fieldKey: 'title',
-			name: 'title',
-			type: 'field',
-			whenCase: [],
-		},
-		{
-			alias: false,
-			fieldKey: 'date',
-			name: 'date',
-			type: 'field',
-			whenCase: [],
-		},
-		{
 			cases: [],
 			children: [
 				{
@@ -271,13 +261,6 @@ test('parse fields with *.*.*', async () => {
 		{
 			cases: [],
 			children: [
-				{
-					alias: false,
-					fieldKey: 'id',
-					name: 'id',
-					type: 'field',
-					whenCase: [],
-				},
 				{
 					cases: [],
 					children: [
@@ -347,6 +330,13 @@ test('parse fields with *.*.*', async () => {
 					type: 'm2o',
 					whenCase: [],
 				},
+				{
+					alias: false,
+					fieldKey: 'id',
+					name: 'id',
+					type: 'field',
+					whenCase: [],
+				},
 			],
 			fieldKey: 'links',
 			name: 'links',
@@ -362,13 +352,6 @@ test('parse fields with *.*.*', async () => {
 		{
 			cases: [],
 			children: [
-				{
-					alias: false,
-					fieldKey: 'id',
-					name: 'id',
-					type: 'field',
-					whenCase: [],
-				},
 				{
 					cases: [],
 					children: [
@@ -458,6 +441,13 @@ test('parse fields with *.*.*', async () => {
 					type: 'm2o',
 					whenCase: [],
 				},
+				{
+					alias: false,
+					fieldKey: 'id',
+					name: 'id',
+					type: 'field',
+					whenCase: [],
+				},
 			],
 			fieldKey: 'tags',
 			name: 'articles_tags_junction',
@@ -468,6 +458,27 @@ test('parse fields with *.*.*', async () => {
 			relatedKey: 'id',
 			relation: getRelation(schemaRelational.relations, 'articles_tags_junction', 'articles_id'),
 			type: 'o2m',
+			whenCase: [],
+		},
+		{
+			alias: false,
+			fieldKey: 'id',
+			name: 'id',
+			type: 'field',
+			whenCase: [],
+		},
+		{
+			alias: false,
+			fieldKey: 'title',
+			name: 'title',
+			type: 'field',
+			whenCase: [],
+		},
+		{
+			alias: false,
+			fieldKey: 'date',
+			name: 'date',
+			type: 'field',
 			whenCase: [],
 		},
 	]);

--- a/api/src/database/get-ast-from-query/lib/parse-fields.test.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.test.ts
@@ -667,8 +667,11 @@ test('parse fields distinguishes json function from relational fields', async ()
 		whenCase: [],
 	});
 
-	// json function is processed first since it's detected before relational fields
-	expect(result[1]).toEqual({
+	// author.name was requested before json(metadata, color), so the relational node keeps
+	// that position rather than the function field jumping ahead of it.
+	expect(result[1]?.type).toBe('m2o');
+
+	expect(result[2]).toEqual({
 		type: 'functionField',
 		fieldKey: 'json(metadata, color)',
 		name: 'json(metadata, color)',
@@ -677,8 +680,6 @@ test('parse fields distinguishes json function from relational fields', async ()
 		whenCase: [],
 		cases: [],
 	});
-
-	expect(result[2]?.type).toBe('m2o');
 });
 
 const schemaM2A = new SchemaBuilder()

--- a/api/src/database/get-ast-from-query/lib/parse-fields.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.ts
@@ -59,6 +59,19 @@ export async function parseFields(
 
 	const relationalStructure: Record<string, string[] | CollectionScope> = Object.create(null);
 
+	// Track the order in which top-level fields (relational or not) first appear in the
+	// requested field list, so relational nodes (built separately below) can be reinserted
+	// at their original position instead of always trailing after every direct field.
+	const rootFieldOrder: string[] = [];
+	const seenRootFields = new Set<string>();
+
+	const trackRootFieldOrder = (key: string) => {
+		if (!seenRootFields.has(key)) {
+			seenRootFields.add(key);
+			rootFieldOrder.push(key);
+		}
+	};
+
 	for (const fieldKey of fields) {
 		let alias = false;
 		let name = fieldKey;
@@ -151,6 +164,8 @@ export async function parseFields(
 				collectionScope = scope!;
 			}
 
+			trackRootFieldOrder(rootField);
+
 			if (rootField in relationalStructure === false) {
 				if (collectionScope) {
 					relationalStructure[rootField] = { [collectionScope]: [] };
@@ -176,6 +191,8 @@ export async function parseFields(
 			if (name.includes(':')) {
 				const [key, scope] = name.split(':') as [string, string];
 
+				trackRootFieldOrder(key);
+
 				if (key in relationalStructure === false) {
 					relationalStructure[key] = { [scope]: [] };
 				} else if (scope in (relationalStructure[key] as CollectionScope) === false) {
@@ -185,6 +202,7 @@ export async function parseFields(
 				continue;
 			}
 
+			trackRootFieldOrder(fieldKey);
 			children.push({ type: 'field', name, fieldKey, whenCase: [], alias });
 		}
 	}
@@ -338,6 +356,11 @@ export async function parseFields(
 			children.push(child);
 		}
 	}
+
+	// Relational nodes are always built after direct fields (above), so restore their original
+	// position among the requested fields instead of leaving them trailing at the end.
+	const rootFieldIndex = new Map(rootFieldOrder.map((key, index) => [key, index]));
+	children.sort((a, b) => (rootFieldIndex.get(a.fieldKey) ?? 0) - (rootFieldIndex.get(b.fieldKey) ?? 0));
 
 	// Deduplicate any children fields that are included both as a regular field, and as a nested m2o field
 	const nestedCollectionNodes = children.filter((childNode) => childNode.type !== 'field');

--- a/api/src/database/get-ast-from-query/lib/parse-fields.ts
+++ b/api/src/database/get-ast-from-query/lib/parse-fields.ts
@@ -60,16 +60,23 @@ export async function parseFields(
 	const relationalStructure: Record<string, string[] | CollectionScope> = Object.create(null);
 
 	// Track the order in which top-level fields (relational or not) first appear in the
-	// requested field list, so relational nodes (built separately below) can be reinserted
-	// at their original position instead of always trailing after every direct field.
-	const rootFieldOrder: string[] = [];
-	const seenRootFields = new Set<string>();
+	// requested field list, and reserve each one's final slot in `children` up front.
+	// Relational nodes are built in a second pass below, so writing straight to the
+	// reserved index puts them back in request order without an O(n log n) sort;
+	// a permission check can skip building a node entirely, which leaves that slot
+	// as a hole that later gets dropped automatically since `.filter()` never visits
+	// unassigned array indices.
+	const rootFieldIndex = new Map<string, number>();
 
-	const trackRootFieldOrder = (key: string) => {
-		if (!seenRootFields.has(key)) {
-			seenRootFields.add(key);
-			rootFieldOrder.push(key);
+	const trackRootFieldOrder = (key: string): number => {
+		let index = rootFieldIndex.get(key);
+
+		if (index === undefined) {
+			index = rootFieldIndex.size;
+			rootFieldIndex.set(key, index);
 		}
+
+		return index;
 	};
 
 	for (const fieldKey of fields) {
@@ -106,7 +113,7 @@ export async function parseFields(
 				);
 
 				if (foundRelation) {
-					children.push({
+					children[trackRootFieldOrder(fieldKey)] = {
 						type: 'functionField',
 						name,
 						fieldKey,
@@ -114,7 +121,7 @@ export async function parseFields(
 						relatedCollection: foundRelation.collection,
 						whenCase: [],
 						cases: [],
-					});
+					};
 
 					continue;
 				}
@@ -122,7 +129,7 @@ export async function parseFields(
 
 			// Create a FunctionFieldNode for direct (non-relational) json function calls
 			if (functionName === 'json') {
-				children.push({
+				children[trackRootFieldOrder(fieldKey)] = {
 					type: 'functionField',
 					name,
 					fieldKey,
@@ -130,7 +137,7 @@ export async function parseFields(
 					relatedCollection: options.parentCollection,
 					whenCase: [],
 					cases: [],
-				});
+				};
 
 				continue;
 			}
@@ -202,8 +209,7 @@ export async function parseFields(
 				continue;
 			}
 
-			trackRootFieldOrder(fieldKey);
-			children.push({ type: 'field', name, fieldKey, whenCase: [], alias });
+			children[trackRootFieldOrder(fieldKey)] = { type: 'field', name, fieldKey, whenCase: [], alias };
 		}
 	}
 
@@ -353,14 +359,9 @@ export async function parseFields(
 		}
 
 		if (child) {
-			children.push(child);
+			children[trackRootFieldOrder(fieldKey)] = child;
 		}
 	}
-
-	// Relational nodes are always built after direct fields (above), so restore their original
-	// position among the requested fields instead of leaving them trailing at the end.
-	const rootFieldIndex = new Map(rootFieldOrder.map((key, index) => [key, index]));
-	children.sort((a, b) => (rootFieldIndex.get(a.fieldKey) ?? 0) - (rootFieldIndex.get(b.fieldKey) ?? 0));
 
 	// Deduplicate any children fields that are included both as a regular field, and as a nested m2o field
 	const nestedCollectionNodes = children.filter((childNode) => childNode.type !== 'field');


### PR DESCRIPTION
## What's Changed

- `parseFields()` built relational nodes (m2o/o2m/a2o) in a separate pass and always appended them to `children` after every direct field, no matter where they appeared in the requested field list. Any export (CSV, JSON, etc.) that reads column/key order straight from that array ends up with relational fields pushed to the end even when the user placed them in the middle.
- Added a small ordering pass: while walking the requested fields, record the position each root field key first appears at, then sort the final `children` array by that position before returning. Direct and relational fields now come back in the order they were requested in.

## Tested Scenarios

- Added a regression test in `parse-fields.test.ts` for `['id', 'author.name', 'title']`, asserting the returned node order is `['id', 'author', 'title']` (previously `['id', 'title', 'author']`).
- Ran the full `get-ast-from-query` and `database` test suites locally (`vitest run src/database/`) — 486 tests pass, including the existing `*.*.*` wildcard-expansion test, whose expected output I reordered to match (its shape/content is unchanged, just the sequence, since `convertWildcards` itself already lists relational fields before scalar fields for bare `*.*` expansion — this fix now reflects that ordering instead of silently discarding it).
- `getHeadingsForCsvExport` (`export.ts`) already derives CSV headings directly from this node order, so no changes were needed there — it now produces the right column order for free.

## Review Notes / Questions / Concerns

- I kept the reorder to a stable sort keyed by first-occurrence position, so any field key not in the tracked order (shouldn't happen, but just in case) falls back to position 0 rather than throwing.

## Checklist

- [x] Tests added/updated

---

Fixes #25521
