### PR TITLE
fix(utils): normalizePath strips a leading backslash with removeLeading 🤖🤖🤖

### DIFF
--- a/.changeset/fix-normalize-path-remove-leading-backslash.md
+++ b/.changeset/fix-normalize-path-remove-leading-backslash.md
@@ -1,0 +1,5 @@
+---
+'@directus/utils': patch
+---
+
+Fixed `normalizePath` keeping the leading separator for a Windows-style backslash path (e.g. `\a\b\c`) when the `removeLeading` option was enabled

--- a/contributors.yml
+++ b/contributors.yml
@@ -303,3 +303,4 @@
 - aniruddhav25
 - jashkarangiya
 - andrewalfaro1
+- yfwmaniish

--- a/packages/utils/shared/normalize-path.test.ts
+++ b/packages/utils/shared/normalize-path.test.ts
@@ -88,6 +88,18 @@ describe('normalizePath', () => {
 		it('handles path without leading slash with removeLeading true', () => {
 			expect(normalizePath('a/b/c', { removeLeading: true })).toBe('a/b/c');
 		});
+
+		it('removes leading backslash when removeLeading is true', () => {
+			expect(normalizePath('\\a\\b\\c', { removeLeading: true })).toBe('a/b/c');
+		});
+
+		it('removes the leading separator from a mixed-slash path when removeLeading is true', () => {
+			expect(normalizePath('\\a/b\\c', { removeLeading: true })).toBe('a/b/c');
+		});
+
+		it('keeps the UNC prefix when removeLeading is true', () => {
+			expect(normalizePath('\\\\?\\C:\\path', { removeLeading: true })).toBe('//?/C:/path');
+		});
 	});
 
 	describe('edge cases', () => {

--- a/packages/utils/shared/normalize-path.ts
+++ b/packages/utils/shared/normalize-path.ts
@@ -32,7 +32,11 @@ export const normalizePath = (
 
 	const normalizedPath = prefix + segments.join('/');
 
-	if (removeLeading && path.startsWith('/')) {
+	// `removeLeading` strips the leading separator of the normalized result. The
+	// original check tested the raw input for a forward slash only, so a Windows-style
+	// leading backslash (e.g. `\a\b\c`, which normalizes to `/a/b/c`) kept its leading
+	// slash. Exclude the UNC prefix (`//?/…`, `//./…`), whose leading slashes are intentional.
+	if (removeLeading && !prefix && (path.startsWith('/') || path.startsWith('\\'))) {
 		return normalizedPath.substring(1);
 	}
 


### PR DESCRIPTION
## What's Changed

`normalizePath` (`@directus/utils`) only stripped a leading **forward** slash when `removeLeading` was enabled. A Windows-style **backslash**-leading path — e.g. `\a\b\c`, which the function itself normalizes to `/a/b/c` — kept its leading slash. That's inconsistent with the forward-slash case, and surprising for a utility whose job is normalizing Windows separators.

The check tested the *raw input* for a leading `/`; it now tests the leading separator of the **normalized result** (covering both `/` and `\` inputs), while excluding the intentional UNC prefix (`//?/…`, `//./…`).

| Input (`removeLeading: true`) | Before | After |
|---|---|---|
| `/a/b/c` | `a/b/c` | `a/b/c` (unchanged) |
| `\a\b\c` | `/a/b/c` ❌ | `a/b/c` ✅ |
| `\a/b\c` (mixed) | `/a/b/c` ❌ | `a/b/c` ✅ |
| `\\?\C:\path` (UNC) | `//?/C:/path` | `//?/C:/path` (unchanged) |

## Tested Scenarios

- Added unit tests: backslash-leading + `removeLeading`, mixed-slash + `removeLeading`, and UNC + `removeLeading` (prefix preserved).
- `vitest run` on `normalize-path.test.ts`: 28 passed (25 existing + 3 new), no regressions.

## Review Notes / Questions / Concerns

- Minimal change, scoped to the `removeLeading` branch. Forward-slash and UNC behavior is unchanged; only the previously-broken backslash-leading case changes.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in directus/docs
- [ ] OpenAPI updated
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

Changeset: added (`@directus/utils` patch).
