### PR TITLE
fix(format-title): drop empty segments from separator runs 🤖🤖🤖

### DIFF
--- a/.changeset/fix-format-title-separator-spaces.md
+++ b/.changeset/fix-format-title-separator-spaces.md
@@ -1,0 +1,5 @@
+---
+'@directus/format-title': patch
+---
+
+Fixed `formatTitle` producing stray, leading, or trailing spaces when the input contained consecutive, leading, or trailing separators (e.g. `foo__bar` returned "Foo  Bar")

--- a/contributors.yml
+++ b/contributors.yml
@@ -303,3 +303,4 @@
 - aniruddhav25
 - jashkarangiya
 - andrewalfaro1
+- yfwmaniish

--- a/packages/format-title/src/index.test.ts
+++ b/packages/format-title/src/index.test.ts
@@ -7,6 +7,14 @@ const tests: [string, string][] = [
 	['brighton_on_sea', 'Brighton on Sea'],
 	['apple_releases_new_ipad', 'Apple Releases New iPad'],
 	['7-food-trends', '7 Food Trends'],
+	// Leading, trailing, and consecutive separators must not produce stray spaces
+	['foo__bar', 'Foo Bar'],
+	['double--hyphen', 'Double Hyphen'],
+	['spaced  out', 'Spaced Out'],
+	['_leading', 'Leading'],
+	['trailing_', 'Trailing'],
+	['', ''],
+	['___', ''],
 ];
 
 for (const [input, output] of tests) {

--- a/packages/format-title/src/index.ts
+++ b/packages/format-title/src/index.ts
@@ -4,7 +4,19 @@ import { decamelize } from './utils/decamelize.js';
 import { handleSpecialWords } from './utils/handle-special-words.js';
 
 export function formatTitle(title: string, separator: RegExp = new RegExp('\\s|-|_', 'g')): string {
-	return decamelize(title).split(separator).map(capitalize).map(handleSpecialWords).reduce(combine);
+	// Drop empty segments produced by leading, trailing, or consecutive separators
+	// (e.g. `foo__bar`, `_id`, `trailing_`). Without this they survive as empty words
+	// and `combine` pads them with spaces, yielding stray/leading/trailing spaces like
+	// "Foo  Bar" — and they also skew the first/last-word casing rules in handleSpecialWords.
+	const words = decamelize(title)
+		.split(separator)
+		.filter((word) => word.length > 0)
+		.map(capitalize)
+		.map(handleSpecialWords);
+
+	if (words.length === 0) return '';
+
+	return words.reduce(combine);
 }
 
 export default formatTitle;


### PR DESCRIPTION
## What's Changed

`formatTitle` (`@directus/format-title`) splits the input on separators and rejoins the words with a single space. But **leading, trailing, or consecutive separators** leave **empty segments** that the join step still pads with spaces — producing stray/leading/trailing spaces:

| Input | Before | After |
|---|---|---|
| `foo__bar` | `Foo  Bar` (double space) | `Foo Bar` |
| `double--hyphen` | `Double  Hyphen` | `Double Hyphen` |
| `spaced  out` | `Spaced  Out` | `Spaced Out` |
| `_leading` | ` Leading` (leading space) | `Leading` |
| `trailing_` | `Trailing ` (trailing space) | `Trailing` |
| `___` / `''` | `   ` / `` | `` |

The empty segments also skewed the first/last-word casing rules in `handleSpecialWords` (they counted as "words", so the real first/last word wasn't always treated as such).

Fix: filter out empty segments after splitting, and return `''` when nothing remains.

## Tested Scenarios

- Added cases for consecutive (`foo__bar`, `double--hyphen`, `spaced  out`), leading (`_leading`), trailing (`trailing_`), and empty/all-separator (`''`, `___`) inputs.
- `vitest run` on the package: **25 passed** (existing suite + new cases), no regressions. All existing outputs unchanged (clean inputs have no empty segments).

## Review Notes / Questions / Concerns

- Minimal change; behavior for well-formed inputs is identical. Only inputs with separator runs / leading / trailing separators change (from stray-space output to clean output).

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in directus/docs
- [ ] OpenAPI updated
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

Changeset: added (`@directus/format-title` patch).
