### PR TITLE
fix(app): allow context menus in table row to close on outside click (#28185)

### DIFF
--- a/.changeset/fix-table-row-menu-click-outside.md
+++ b/.changeset/fix-table-row-menu-click-outside.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Fixed multiple context popup menus remaining open when clicking another row's menu in table views (#28185).

--- a/app/src/components/v-table/table-row.test.ts
+++ b/app/src/components/v-table/table-row.test.ts
@@ -1,0 +1,83 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, test } from 'vitest';
+import TableRow from './table-row.vue';
+import type { Header, Item } from './types';
+
+const defaultProps = {
+	headers: [
+		{
+			text: 'Name',
+			value: 'name',
+			align: 'left' as const,
+		},
+	] as Header[],
+	item: {
+		name: 'Flow 1',
+	} as Item,
+	hasClickListener: true,
+};
+
+describe('TableRow', () => {
+	test('Mounts component successfully', () => {
+		const wrapper = mount(TableRow, {
+			props: defaultProps,
+		});
+
+		expect(wrapper.find('tr.table-row').exists()).toBe(true);
+	});
+
+	test('Emits click event when clicking a standard cell', async () => {
+		const wrapper = mount(TableRow, {
+			props: defaultProps,
+		});
+
+		const cell = wrapper.find('td.cell');
+		await cell.trigger('click');
+
+		expect(wrapper.emitted('click')).toHaveLength(1);
+	});
+
+	test('Does NOT emit row click event when clicking inside append cell (#28185)', async () => {
+		const wrapper = mount(TableRow, {
+			props: defaultProps,
+			slots: {
+				'item-append': '<button class="ctx-btn">Action</button>',
+			},
+		});
+
+		const button = wrapper.find('.ctx-btn');
+		expect(button.exists()).toBe(true);
+
+		await button.trigger('click');
+
+		// The row must NOT trigger row click navigation
+		expect(wrapper.emitted('click')).toBeUndefined();
+	});
+
+	test('Allows click event in append cell to bubble without stopPropagation (#28185)', async () => {
+		let clickBubbled = false;
+
+		const wrapper = mount(TableRow, {
+			props: defaultProps,
+			slots: {
+				'item-append': '<button class="ctx-btn">Action</button>',
+			},
+			attachTo: document.body,
+		});
+
+		const onDocumentClick = () => {
+			clickBubbled = true;
+		};
+
+		document.documentElement.addEventListener('click', onDocumentClick);
+
+		const button = wrapper.find('.ctx-btn');
+		button.element.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+		document.documentElement.removeEventListener('click', onDocumentClick);
+		wrapper.unmount();
+
+		// Click MUST bubble to document.documentElement so v-click-outside can close previously open menus
+		expect(clickBubbled).toBe(true);
+	});
+});

--- a/app/src/components/v-table/table-row.vue
+++ b/app/src/components/v-table/table-row.vue
@@ -43,6 +43,11 @@ function onKeydown(e: KeyboardEvent) {
 	if (e.metaKey) return;
 	if ((e.target as HTMLElement)?.tagName === 'TR' && ['Enter', ' '].includes(e.key)) emit('click', e);
 }
+
+function onClick(e: MouseEvent) {
+	if ((e.target as HTMLElement)?.closest('.append')) return;
+	emit('click', e);
+}
 </script>
 
 <template>
@@ -50,7 +55,7 @@ function onKeydown(e: KeyboardEvent) {
 		class="table-row"
 		:class="{ subdued: subdued, clickable: hasClickListener }"
 		:tabindex="hasClickListener ? 0 : undefined"
-		@click="$emit('click', $event)"
+		@click="onClick"
 		@keydown="onKeydown"
 	>
 		<td v-if="showManualSort" class="manual cell" @click.stop>
@@ -85,7 +90,7 @@ function onKeydown(e: KeyboardEvent) {
 		</td>
 
 		<td class="spacer cell" />
-		<td v-if="$slots['item-append']" class="append cell" @click.stop>
+		<td v-if="$slots['item-append']" class="append cell">
 			<slot name="item-append" />
 		</td>
 	</tr>

--- a/contributors.yml
+++ b/contributors.yml
@@ -303,3 +303,4 @@
 - aniruddhav25
 - jashkarangiya
 - andrewalfaro1
+- seb4ez


### PR DESCRIPTION
## Description

Fixes #28185

In table views (e.g. Flows settings at `/admin/settings/flows`), opening the context menu on one row and then clicking the context menu icon on another row caused multiple menus to remain open simultaneously.

### Root Cause
In `app/src/components/v-table/table-row.vue`, the append slot cell was rendered with `@click.stop`:
```vue
<td v-if="$slots['item-append']" class="append cell" @click.stop>
    <slot name="item-append" />
</td>
```
Because `v-menu` relies on `v-click-outside` listening on `document.documentElement` in the bubbling phase, `@click.stop` prevented click events on action triggers from bubbling to the document. Consequently, `v-click-outside` never received the click event to deactivate previously opened menus.

### Changes
1. Removed `@click.stop` from `<td class="append cell">` in `table-row.vue` so clicks bubble naturally to `document.documentElement`, allowing `v-click-outside` to dismiss any other open menus.
2. Added an `onClick` handler on `table-row.vue` that ignores clicks originating within `.append` (`if ((e.target as HTMLElement)?.closest('.append')) return;`), ensuring row click navigation is not triggered when interacting with append cell actions.
3. Added unit tests for `table-row.vue` asserting that clicks in the append cell bubble to the document without triggering the row's `click` event.
4. Added `@directus/app` patch changeset.