### PR TITLE
fix(memory): prevent race condition in local KV increment and setMax

### DIFF
--- a/.changeset/local-kv-atomic-increment.md
+++ b/.changeset/local-kv-atomic-increment.md
@@ -1,0 +1,5 @@
+---
+'@directus/memory': patch
+---
+
+Fixed the local key-value store incrementing `increment` and `setMax` non-atomically under concurrent access

--- a/contributors.yml
+++ b/contributors.yml
@@ -303,3 +303,4 @@
 - aniruddhav25
 - jashkarangiya
 - andrewalfaro1
+- Tyagiquamar

--- a/packages/memory/src/kv/lib/local-concurrent.test.ts
+++ b/packages/memory/src/kv/lib/local-concurrent.test.ts
@@ -10,9 +10,7 @@ describe('KvLocal concurrent operations', () => {
 		const kv = new KvLocal(config);
 
 		const concurrency = 100;
-		const results = await Promise.all(
-			Array.from({ length: concurrency }, () => kv.increment('counter', 1)),
-		);
+		const results = await Promise.all(Array.from({ length: concurrency }, () => kv.increment('counter', 1)));
 
 		const uniqueResults = new Set(results);
 		expect(uniqueResults.size).toBe(concurrency);
@@ -27,10 +25,7 @@ describe('KvLocal concurrent operations', () => {
 		const kv = new KvLocal(config);
 		await kv.set('maximum', 1);
 
-		const results = await Promise.all([
-			kv.setMax('maximum', 100),
-			kv.setMax('maximum', 50),
-		]);
+		const results = await Promise.all([kv.setMax('maximum', 100), kv.setMax('maximum', 50)]);
 
 		expect(results).toEqual([true, false]);
 		expect(await kv.get('maximum')).toBe(100);

--- a/packages/memory/src/kv/lib/local-concurrent.test.ts
+++ b/packages/memory/src/kv/lib/local-concurrent.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest';
+import { KvLocal } from './local.js';
+
+describe('KvLocal concurrent operations', () => {
+	test.each([
+		{ name: 'Map fallback', config: {} },
+		{ name: 'LRU with maxKeys', config: { maxKeys: 100 } },
+		{ name: 'LRU with ttl', config: { ttl: 5000 } },
+	])('Handles concurrent increments atomically ($name)', async ({ config }) => {
+		const kv = new KvLocal(config);
+
+		const concurrency = 100;
+		const results = await Promise.all(
+			Array.from({ length: concurrency }, () => kv.increment('counter', 1)),
+		);
+
+		const uniqueResults = new Set(results);
+		expect(uniqueResults.size).toBe(concurrency);
+		expect(await kv.get('counter')).toBe(concurrency);
+	});
+
+	test.each([
+		{ name: 'Map fallback', config: {} },
+		{ name: 'LRU with maxKeys', config: { maxKeys: 100 } },
+		{ name: 'LRU with ttl', config: { ttl: 5000 } },
+	])('Handles concurrent setMax operations correctly ($name)', async ({ config }) => {
+		const kv = new KvLocal(config);
+		await kv.set('maximum', 1);
+
+		const results = await Promise.all([
+			kv.setMax('maximum', 100),
+			kv.setMax('maximum', 50),
+		]);
+
+		expect(results).toEqual([true, false]);
+		expect(await kv.get('maximum')).toBe(100);
+	});
+});

--- a/packages/memory/src/kv/lib/local.test.ts
+++ b/packages/memory/src/kv/lib/local.test.ts
@@ -97,47 +97,66 @@ describe('set', () => {
 describe('increment', () => {
 	test('Sets value to 1 if no value exists', async () => {
 		const mockKey = 'kv-key';
+		const mockSerialized = new Uint8Array([1]);
 
-		kv.get = vi.fn().mockReturnValue(undefined);
-		kv.set = vi.fn();
+		vi.mocked(kv['store'].get).mockReturnValueOnce(undefined);
+		vi.mocked(serialize).mockReturnValue(mockSerialized);
 
-		await kv.increment(mockKey);
+		const result = await kv.increment(mockKey);
 
-		expect(kv.set).toHaveBeenCalledWith(mockKey, 1);
+		expect(kv['store'].get).toHaveBeenCalledWith(mockKey);
+		expect(serialize).toHaveBeenCalledWith(1);
+		expect(kv['store'].set).toHaveBeenCalledWith(mockKey, mockSerialized);
+		expect(result).toBe(1);
 	});
 
 	test('Sets value to passed amount if no value exists', async () => {
 		const mockKey = 'kv-key';
 		const mockAmount = 15;
+		const mockSerialized = new Uint8Array([15]);
 
-		kv.get = vi.fn().mockReturnValue(undefined);
-		kv.set = vi.fn();
+		vi.mocked(kv['store'].get).mockReturnValueOnce(undefined);
+		vi.mocked(serialize).mockReturnValue(mockSerialized);
 
-		await kv.increment(mockKey, mockAmount);
+		const result = await kv.increment(mockKey, mockAmount);
 
-		expect(kv.set).toHaveBeenCalledWith(mockKey, mockAmount);
+		expect(kv['store'].get).toHaveBeenCalledWith(mockKey);
+		expect(serialize).toHaveBeenCalledWith(mockAmount);
+		expect(kv['store'].set).toHaveBeenCalledWith(mockKey, mockSerialized);
+		expect(result).toBe(mockAmount);
 	});
 
 	test('Sets value to existing + passed amount if no value exists', async () => {
 		const mockKey = 'kv-key';
 		const mockValue = 42;
 		const mockAmount = 15;
+		const mockRaw = new Uint8Array([42]);
+		const mockSerialized = new Uint8Array([57]);
 
-		kv.get = vi.fn().mockReturnValue(mockValue);
-		kv.set = vi.fn();
+		vi.mocked(kv['store'].get).mockReturnValueOnce(mockRaw);
+		vi.mocked(deserialize).mockReturnValueOnce(mockValue);
+		vi.mocked(serialize).mockReturnValue(mockSerialized);
 
-		await kv.increment(mockKey, mockAmount);
+		const result = await kv.increment(mockKey, mockAmount);
 
-		expect(kv.set).toHaveBeenCalledWith(mockKey, mockValue + mockAmount);
+		expect(kv['store'].get).toHaveBeenCalledWith(mockKey);
+		expect(deserialize).toHaveBeenCalledWith(mockRaw);
+		expect(serialize).toHaveBeenCalledWith(mockValue + mockAmount);
+		expect(kv['store'].set).toHaveBeenCalledWith(mockKey, mockSerialized);
+		expect(result).toBe(mockValue + mockAmount);
 	});
 
 	test('Errors if key does not contain number', async () => {
 		const mockKey = 'kv-key';
+		const mockRaw = new Uint8Array([1, 2, 3]);
 		const mockStoredValue = 'not-a-number';
 
-		kv.get = vi.fn().mockReturnValue(mockStoredValue);
+		vi.mocked(kv['store'].get).mockReturnValueOnce(mockRaw);
+		vi.mocked(deserialize).mockReturnValueOnce(mockStoredValue);
 
-		expect(kv.increment(mockKey)).rejects.toMatchInlineSnapshot('[Error: The value for key "kv-key" is not a number.]');
+		await expect(kv.increment(mockKey)).rejects.toMatchInlineSnapshot(
+			'[Error: The value for key "kv-key" is not a number.]',
+		);
 	});
 });
 
@@ -145,11 +164,13 @@ describe('setMax', () => {
 	test('Errors if key does not contain number', async () => {
 		const mockKey = 'kv-key';
 		const mockValue = 42;
+		const mockRaw = new Uint8Array([1, 2, 3]);
 		const mockStoredValue = 'not-a-number';
 
-		kv.get = vi.fn().mockReturnValue(mockStoredValue);
+		vi.mocked(kv['store'].get).mockReturnValueOnce(mockRaw);
+		vi.mocked(deserialize).mockReturnValueOnce(mockStoredValue);
 
-		expect(kv.setMax(mockKey, mockValue)).rejects.toMatchInlineSnapshot(
+		await expect(kv.setMax(mockKey, mockValue)).rejects.toMatchInlineSnapshot(
 			'[Error: The value for key "kv-key" is not a number.]',
 		);
 	});
@@ -157,54 +178,62 @@ describe('setMax', () => {
 	test('Defaults to 0 if current value does not exist', async () => {
 		const mockKey = 'kv-key';
 		const mockValue = 42;
-		const mockStoredValue = undefined;
+		const mockSerialized = new Uint8Array([42]);
 
-		kv.get = vi.fn().mockReturnValue(mockStoredValue);
-		kv.set = vi.fn();
+		vi.mocked(kv['store'].get).mockReturnValueOnce(undefined);
+		vi.mocked(serialize).mockReturnValue(mockSerialized);
 
-		await kv.setMax(mockKey, mockValue);
+		const result = await kv.setMax(mockKey, mockValue);
 
-		expect(kv.set).toHaveBeenCalledWith(mockKey, mockValue);
+		expect(serialize).toHaveBeenCalledWith(mockValue);
+		expect(kv['store'].set).toHaveBeenCalledWith(mockKey, mockSerialized);
+		expect(result).toBe(true);
 	});
 
 	test('Returns false if existing value is bigger than passed value', async () => {
 		const mockKey = 'kv-key';
 		const mockValue = 42;
+		const mockRaw = new Uint8Array([500]);
 		const mockStoredValue = 500;
 
-		kv.get = vi.fn().mockReturnValue(mockStoredValue);
-		kv.set = vi.fn();
+		vi.mocked(kv['store'].get).mockReturnValueOnce(mockRaw);
+		vi.mocked(deserialize).mockReturnValueOnce(mockStoredValue);
 
 		const result = await kv.setMax(mockKey, mockValue);
 
-		expect(kv.set).not.toHaveBeenCalled();
+		expect(kv['store'].set).not.toHaveBeenCalled();
 		expect(result).toBe(false);
 	});
 
 	test('Returns false if existing value equals passed value', async () => {
 		const mockKey = 'kv-key';
 		const mockValue = 42;
+		const mockRaw = new Uint8Array([42]);
 
-		kv.get = vi.fn().mockReturnValue(mockValue);
-		kv.set = vi.fn();
+		vi.mocked(kv['store'].get).mockReturnValueOnce(mockRaw);
+		vi.mocked(deserialize).mockReturnValueOnce(mockValue);
 
 		const result = await kv.setMax(mockKey, mockValue);
 
-		expect(kv.set).not.toHaveBeenCalled();
+		expect(kv['store'].set).not.toHaveBeenCalled();
 		expect(result).toBe(false);
 	});
 
 	test('Returns true if passed value is bigger than existing value', async () => {
 		const mockKey = 'kv-key';
 		const mockValue = 500;
+		const mockRaw = new Uint8Array([42]);
 		const mockStoredValue = 42;
+		const mockSerialized = new Uint8Array([500]);
 
-		kv.get = vi.fn().mockReturnValue(mockStoredValue);
-		kv.set = vi.fn();
+		vi.mocked(kv['store'].get).mockReturnValueOnce(mockRaw);
+		vi.mocked(deserialize).mockReturnValueOnce(mockStoredValue);
+		vi.mocked(serialize).mockReturnValue(mockSerialized);
 
 		const result = await kv.setMax(mockKey, mockValue);
 
-		expect(kv.set).toHaveBeenCalledWith(mockKey, mockValue);
+		expect(serialize).toHaveBeenCalledWith(mockValue);
+		expect(kv['store'].set).toHaveBeenCalledWith(mockKey, mockSerialized);
 		expect(result).toBe(true);
 	});
 });

--- a/packages/memory/src/kv/lib/local.ts
+++ b/packages/memory/src/kv/lib/local.ts
@@ -51,21 +51,23 @@ export class KvLocal implements Kv {
 	}
 
 	async increment(key: string, amount: number = 1): Promise<number> {
-		const currentVal = (await this.get(key)) ?? 0;
+		const rawValue = this.store.get(key);
+		const currentVal = rawValue !== undefined ? deserialize<number>(rawValue) : 0;
 
 		if (typeof currentVal !== 'number') {
 			throw new Error(`The value for key "${key}" is not a number.`);
 		}
 
 		const newVal = currentVal + amount;
-
-		await this.set(key, newVal);
+		const serialized = serialize(newVal);
+		this.store.set(key, serialized);
 
 		return newVal;
 	}
 
 	async setMax(key: string, value: number): Promise<boolean> {
-		const currentVal = (await this.get(key)) ?? 0;
+		const rawValue = this.store.get(key);
+		const currentVal = rawValue !== undefined ? deserialize<number>(rawValue) : 0;
 
 		if (typeof currentVal !== 'number') {
 			throw new Error(`The value for key "${key}" is not a number.`);
@@ -75,7 +77,8 @@ export class KvLocal implements Kv {
 			return false;
 		}
 
-		await this.set(key, value);
+		const serialized = serialize(value);
+		this.store.set(key, serialized);
 
 		return true;
 	}


### PR DESCRIPTION
Closes #28193

### Problem
In `KvLocal` (`packages/memory/src/kv/lib/local.ts`), `increment()` and `setMax()` used `await this.get(key)` before calling `await this.set(key, ...)`. Because `this.get()` returned a promise that resolved on a future microtask tick, concurrent `increment()` or `setMax()` calls would read the same stale initial value before any write took place, losing updates (e.g. 100 concurrent increments returning 1 and storing 1) or overwriting larger values with smaller values during concurrent `setMax()`.

### Solution
1. In `KvLocal`, perform the read, validation, modification, serialization, and `store.set()` synchronously within the execution frame instead of interleaving through asynchronous promise turns.
2. Updated unit test mocks in `packages/memory/src/kv/lib/local.test.ts` to reflect direct store interaction.
3. Added concurrency integration tests in `packages/memory/src/kv/lib/local-concurrent.test.ts` verifying atomic increments and correct setMax resolution across Map, LRU with maxKeys, and LRU with TTL backends.