### PR TITLE
Add `HARDCODED_AUTH_REQUIREMENTS` table to `@directus/constants`

### DIFF
--- a/.changeset/eight-phones-kneel.md
+++ b/.changeset/eight-phones-kneel.md
@@ -1,0 +1,5 @@
+---
+'@directus/constants': minor
+---
+
+Added `HARDCODED_AUTH_REQUIREMENTS`, listing the collection/action pairs gated by an explicit accountability check outside of RBAC

--- a/packages/constants/src/hardcoded-auth-requirements.test.ts
+++ b/packages/constants/src/hardcoded-auth-requirements.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { HARDCODED_AUTH_REQUIREMENTS } from './hardcoded-auth-requirements.js';
+
+describe('HARDCODED_AUTH_REQUIREMENTS', () => {
+	it('has no duplicate collection+action entries', () => {
+		const keys = HARDCODED_AUTH_REQUIREMENTS.map((requirement) => `${requirement.collection}:${requirement.action}`);
+		expect(new Set(keys).size).toBe(keys.length);
+	});
+});

--- a/packages/constants/src/hardcoded-auth-requirements.ts
+++ b/packages/constants/src/hardcoded-auth-requirements.ts
@@ -9,11 +9,7 @@ import type { PERMISSION_ACTIONS } from './permissions.js';
  * Checked in the service layer, except `directus_extensions`, which is gated in its route handlers
  * (`create` maps to `POST /extensions/registry/install`).
  */
-export const HARDCODED_AUTH_REQUIREMENTS: ReadonlyArray<{
-	collection: string;
-	action: (typeof PERMISSION_ACTIONS)[number];
-	requiredAuth: 'admin' | 'user';
-}> = [
+export const HARDCODED_AUTH_REQUIREMENTS = [
 	{ collection: 'directus_collections', action: 'create', requiredAuth: 'admin' },
 	{ collection: 'directus_collections', action: 'delete', requiredAuth: 'admin' },
 	{ collection: 'directus_collections', action: 'update', requiredAuth: 'admin' },
@@ -29,4 +25,8 @@ export const HARDCODED_AUTH_REQUIREMENTS: ReadonlyArray<{
 	{ collection: 'directus_relations', action: 'create', requiredAuth: 'admin' },
 	{ collection: 'directus_relations', action: 'delete', requiredAuth: 'admin' },
 	{ collection: 'directus_relations', action: 'update', requiredAuth: 'admin' },
-];
+] as const satisfies ReadonlyArray<{
+	collection: string;
+	action: (typeof PERMISSION_ACTIONS)[number];
+	requiredAuth: 'admin' | 'user';
+}>;

--- a/packages/constants/src/hardcoded-auth-requirements.ts
+++ b/packages/constants/src/hardcoded-auth-requirements.ts
@@ -1,0 +1,32 @@
+import type { PERMISSION_ACTIONS } from './permissions.js';
+
+/**
+ * Collection + action pairs gated by an explicit accountability check, outside of RBAC.
+ *
+ * - `admin`: requires `accountability.admin` (internal calls with no `accountability` pass).
+ * - `user`: requires an authenticated request (`accountability.user`).
+ *
+ * Checked in the service layer, except `directus_extensions`, which is gated in its route handlers
+ * (`create` maps to `POST /extensions/registry/install`).
+ */
+export const HARDCODED_AUTH_REQUIREMENTS: ReadonlyArray<{
+	collection: string;
+	action: (typeof PERMISSION_ACTIONS)[number];
+	requiredAuth: 'admin' | 'user';
+}> = [
+	{ collection: 'directus_collections', action: 'create', requiredAuth: 'admin' },
+	{ collection: 'directus_collections', action: 'delete', requiredAuth: 'admin' },
+	{ collection: 'directus_collections', action: 'update', requiredAuth: 'admin' },
+	{ collection: 'directus_comments', action: 'create', requiredAuth: 'user' },
+	{ collection: 'directus_comments', action: 'delete', requiredAuth: 'user' },
+	{ collection: 'directus_comments', action: 'update', requiredAuth: 'user' },
+	{ collection: 'directus_extensions', action: 'create', requiredAuth: 'admin' },
+	{ collection: 'directus_extensions', action: 'delete', requiredAuth: 'admin' },
+	{ collection: 'directus_extensions', action: 'update', requiredAuth: 'admin' },
+	{ collection: 'directus_fields', action: 'create', requiredAuth: 'admin' },
+	{ collection: 'directus_fields', action: 'delete', requiredAuth: 'admin' },
+	{ collection: 'directus_fields', action: 'update', requiredAuth: 'admin' },
+	{ collection: 'directus_relations', action: 'create', requiredAuth: 'admin' },
+	{ collection: 'directus_relations', action: 'delete', requiredAuth: 'admin' },
+	{ collection: 'directus_relations', action: 'update', requiredAuth: 'admin' },
+];

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -2,6 +2,7 @@ export * from './activity.js';
 export * from './extensions.js';
 export * from './fields.js';
 export * from './files.js';
+export * from './hardcoded-auth-requirements.js';
 export * from './injection.js';
 export * from './number.js';
 export * from './permissions.js';


### PR DESCRIPTION
## What's Changed

- Added `HARDCODED_AUTH_REQUIREMENTS` for collection/action pairs with authorization enforced explicitly (independent of RBAC Checks):
  - `admin` (requires `accountability.admin`): `directus_collections`, `directus_fields`, `directus_relations`, and `directus_extensions`<sup>:star:1</sup>
  - `user` (requires authenticated request): `directus_comments`
- Exported in barrel

## Tested Scenarios

- Ensure no duplicate collection/action entries

## Review Notes / Questions / Concerns

- This is scoped to system-collection + CRUD-action pairs.
  - <sup>:star:1</sup> `directus_extensions` is not gated in the service layer like the others but I think it still fits here...
- Foundation for the following changes (currently this is not consumed by anything):
  - `@directus/api` Add `assertHardcodedAuth(accountability, collection, action)` driven by this table. This will replace the hand-written `accountability.admin !== true` / `!accountability?.user` guards. This is just a refactor to avoid drift across the three packages that will rely on the table.
  -  `@directus/app` Use the `admin` subset to flag (or hide the way that `directus_extensions` does now) collection/action in Access Policies permissions editor. Today you can add a permission rule that looks active but the service layer ignores it (you'll get a `ForbiddenError` when using). Hopefully prevent configuring an access grant that can't take effect. (directus/directus#28204)
  - `@directus/specs` Stamp `x-authentication: admin | user | none` on the affected operations so the declared spec doesn't drift from API enforcement. reduces the scope to only what's necessary for the `oas-improvements` in directus/directus#28033 

- I considered exporting from `permissions.ts` but opted for a new file. Could easily be persuaded to add it into permissions instead.
- This is currently targeting `main` but I can rebase/refactor so it's targeting `oas-improvements` if you want to keep it isolated. My thought was since it would have improvements to the `@directus/app` separate from the `@directus/specs` package that `main` is more appropriate (leaving a separate action to merge `main` into `oas-improvements` after(if) this PR is accepted.

## Checklist

> Leave unchecked where not applicable

- [X] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Supports directus/directus#27916
