### PR TITLE
Fix `FilesService.uploadOne` to prevent client payloads from overwriting system fields

### DIFF
--- a/.changeset/narrow-file-upload-sudo-write.md
+++ b/.changeset/narrow-file-upload-sudo-write.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed a file upload client payload overwriting calculated fields like `uploaded_by`, `created_on` and `modified_on`

--- a/.changeset/narrow-file-upload-sudo-write.md
+++ b/.changeset/narrow-file-upload-sudo-write.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed a file upload client payload overwriting calculated fields like `uploaded_by`, `created_on` and `modified_on`
+Fixed `FilesService.uploadOne` to prevent client payloads from overwriting system fields (e.g., `uploaded_by`, `created_on` etc)

--- a/api/src/services/files.test.ts
+++ b/api/src/services/files.test.ts
@@ -148,7 +148,6 @@ describe('Service / Files', () => {
 
 			sample = {
 				id: 'test-file-id-123',
-				// The mock driver reports a zero byte file, so this is what `stat` yields back
 				filesize: 0,
 			};
 
@@ -191,12 +190,6 @@ describe('Service / Files', () => {
 		});
 
 		test('should set the `uploaded_on` field to the current date', async () => {
-			tracker.on
-				.select(
-					'select "folder", "filename_download", "filename_disk", "title", "description", "metadata" from "directus_files" where "id" = ?',
-				)
-				.response(null);
-
 			const mockData = {
 				storage: 'local',
 				type: 'image/jpeg',
@@ -211,7 +204,6 @@ describe('Service / Files', () => {
 
 			vi.useRealTimers();
 
-			// The sudo write carries only the values computed after the row exists, nothing from `mockData`
 			expect(superUpdateOne).toHaveBeenCalledExactlyOnceWith(
 				sample.id,
 				{
@@ -224,22 +216,10 @@ describe('Service / Files', () => {
 		});
 
 		test('should not pass client-supplied fields to the sudo write', async () => {
-			tracker.on
-				.select(
-					'select "folder", "filename_download", "filename_disk", "title", "description", "metadata" from "directus_files" where "id" = ?',
-				)
-				.response(null);
-
 			const mockDate = new Date();
 
 			vi.setSystemTime(mockDate);
 
-			/**
-			 * `uploaded_by`, `created_on` and `modified_on` are owned by the payload transformers rather than
-			 * by a field grant, so the create sets them correctly. A client can still send them as multipart
-			 * form fields, and the sudo write runs without accountability, which means it would happily push
-			 * the client's values back over the row.
-			 */
 			await service.uploadOne(new PassThrough(), {
 				storage: 'local',
 				type: 'image/jpeg',
@@ -260,65 +240,37 @@ describe('Service / Files', () => {
 				},
 				{ emitEvents: false },
 			);
-
-			const sudoPayload = superUpdateOne.mock.calls[0]![1];
-
-			expect(sudoPayload).not.toHaveProperty('uploaded_by');
-			expect(sudoPayload).not.toHaveProperty('created_on');
-			expect(sudoPayload).not.toHaveProperty('modified_on');
 		});
 
-		test('should update the `filename_disk` extension to the correct mimetype', async () => {
-			tracker.on
-				.select(
-					'select "folder", "filename_download", "filename_disk", "title", "description", "metadata" from "directus_files" where "id" = ?',
-				)
-				.response(null);
+		test.each([
+			['image/jpeg', 'test.jpg', 'jpg'],
+			['image/png', 'test.png', 'png'],
+		])(
+			'should update the `filename_disk` extension to match the %s mimetype',
+			async (type, filenameDownload, expectedExtension) => {
+				const mockDate = new Date();
 
-			const mockDataJPG = {
-				storage: 'local',
-				type: 'image/jpeg',
-				filename_download: 'test.jpg',
-			};
+				vi.setSystemTime(mockDate);
 
-			const mockDataPNG = {
-				storage: 'local',
-				type: 'image/png',
-				filename_download: 'test.png',
-			};
+				await service.uploadOne(new PassThrough(), {
+					storage: 'local',
+					type,
+					filename_download: filenameDownload,
+				});
 
-			const mockDate = new Date();
+				vi.useRealTimers();
 
-			vi.setSystemTime(mockDate);
-
-			await service.uploadOne(new PassThrough(), mockDataJPG);
-
-			expect(superUpdateOne).toHaveBeenNthCalledWith(
-				1,
-				sample.id,
-				{
-					filename_disk: `${sample.id}.jpg`,
-					filesize: sample.filesize,
-					uploaded_on: mockDate.toISOString(),
-				},
-				{ emitEvents: false },
-			);
-
-			await service.uploadOne(new PassThrough(), mockDataPNG);
-
-			expect(superUpdateOne).toHaveBeenNthCalledWith(
-				2,
-				sample.id,
-				{
-					filename_disk: `${sample.id}.png`,
-					filesize: sample.filesize,
-					uploaded_on: mockDate.toISOString(),
-				},
-				{ emitEvents: false },
-			);
-
-			vi.useRealTimers();
-		});
+				expect(superUpdateOne).toHaveBeenCalledExactlyOnceWith(
+					sample.id,
+					{
+						filename_disk: `${sample.id}.${expectedExtension}`,
+						filesize: sample.filesize,
+						uploaded_on: mockDate.toISOString(),
+					},
+					{ emitEvents: false },
+				);
+			},
+		);
 
 		describe('storage default behavior', () => {
 			it('should default to the first STORAGE_LOCATIONS when storage is not provided', async () => {
@@ -335,8 +287,7 @@ describe('Service / Files', () => {
 					filename_download: 'test.jpg',
 				});
 
-				// `storage` is persisted by the create, not by the sudo write that follows it
-				expect(superCreateOne).toHaveBeenCalledWith(expect.objectContaining({ storage: 'local' }), {
+				expect(superCreateOne).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ storage: 'local' }), {
 					emitEvents: false,
 				});
 
@@ -358,7 +309,7 @@ describe('Service / Files', () => {
 					filename_download: 'test.jpg',
 				});
 
-				expect(superCreateOne).toHaveBeenCalledWith(expect.objectContaining({ storage: 's3' }), {
+				expect(superCreateOne).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ storage: 's3' }), {
 					emitEvents: false,
 				});
 
@@ -383,7 +334,6 @@ describe('Service / Files', () => {
 					sample.id,
 				);
 
-				// On the replacement path `storage` is persisted by the permissioned update, which runs first
 				expect(superUpdateOne).toHaveBeenNthCalledWith(1, sample.id, expect.objectContaining({ storage: 's3' }), {
 					emitEvents: false,
 				});

--- a/api/src/services/files.test.ts
+++ b/api/src/services/files.test.ts
@@ -130,6 +130,7 @@ describe('Service / Files', () => {
 
 	describe('uploadOne', () => {
 		let service: FilesService;
+		let superCreateOne: MockInstance;
 		let superUpdateOne: MockInstance;
 		let mockDriver: Driver;
 		let mockStorage: StorageManager;
@@ -147,7 +148,8 @@ describe('Service / Files', () => {
 
 			sample = {
 				id: 'test-file-id-123',
-				filesize: 500,
+				// The mock driver reports a zero byte file, so this is what `stat` yields back
+				filesize: 0,
 			};
 
 			mockDriver = createMockDriver();
@@ -156,7 +158,7 @@ describe('Service / Files', () => {
 
 			tracker.on.select('select "storage_default_folder" from "directus_settings"').response([]);
 
-			vi.spyOn(ItemsService.prototype, 'createOne').mockResolvedValue(sample.id);
+			superCreateOne = vi.spyOn(ItemsService.prototype, 'createOne').mockResolvedValue(sample.id);
 			superUpdateOne = vi.spyOn(ItemsService.prototype, 'updateOne').mockResolvedValue(sample.id);
 		});
 
@@ -209,14 +211,61 @@ describe('Service / Files', () => {
 
 			vi.useRealTimers();
 
-			expect(superUpdateOne).toHaveBeenCalledWith(
+			// The sudo write carries only the values computed after the row exists, nothing from `mockData`
+			expect(superUpdateOne).toHaveBeenCalledExactlyOnceWith(
 				sample.id,
-				expect.objectContaining({
-					...mockData,
+				{
+					filename_disk: `${sample.id}.jpg`,
+					filesize: sample.filesize,
 					uploaded_on: mockDate.toISOString(),
-				}),
+				},
 				{ emitEvents: false },
 			);
+		});
+
+		test('should not pass client-supplied fields to the sudo write', async () => {
+			tracker.on
+				.select(
+					'select "folder", "filename_download", "filename_disk", "title", "description", "metadata" from "directus_files" where "id" = ?',
+				)
+				.response(null);
+
+			const mockDate = new Date();
+
+			vi.setSystemTime(mockDate);
+
+			/**
+			 * `uploaded_by`, `created_on` and `modified_on` are owned by the payload transformers rather than
+			 * by a field grant, so the create sets them correctly. A client can still send them as multipart
+			 * form fields, and the sudo write runs without accountability, which means it would happily push
+			 * the client's values back over the row.
+			 */
+			await service.uploadOne(new PassThrough(), {
+				storage: 'local',
+				type: 'image/jpeg',
+				filename_download: 'test.jpg',
+				uploaded_by: 'some-other-user-id',
+				created_on: '2000-01-01T00:00:00.000Z',
+				modified_on: '2000-01-01T00:00:00.000Z',
+			});
+
+			vi.useRealTimers();
+
+			expect(superUpdateOne).toHaveBeenCalledExactlyOnceWith(
+				sample.id,
+				{
+					filename_disk: `${sample.id}.jpg`,
+					filesize: sample.filesize,
+					uploaded_on: mockDate.toISOString(),
+				},
+				{ emitEvents: false },
+			);
+
+			const sudoPayload = superUpdateOne.mock.calls[0]![1];
+
+			expect(sudoPayload).not.toHaveProperty('uploaded_by');
+			expect(sudoPayload).not.toHaveProperty('created_on');
+			expect(sudoPayload).not.toHaveProperty('modified_on');
 		});
 
 		test('should update the `filename_disk` extension to the correct mimetype', async () => {
@@ -244,25 +293,27 @@ describe('Service / Files', () => {
 
 			await service.uploadOne(new PassThrough(), mockDataJPG);
 
-			expect(superUpdateOne).toHaveBeenCalledWith(
+			expect(superUpdateOne).toHaveBeenNthCalledWith(
+				1,
 				sample.id,
-				expect.objectContaining({
-					...mockDataJPG,
-					uploaded_on: mockDate.toISOString(),
+				{
 					filename_disk: `${sample.id}.jpg`,
-				}),
+					filesize: sample.filesize,
+					uploaded_on: mockDate.toISOString(),
+				},
 				{ emitEvents: false },
 			);
 
 			await service.uploadOne(new PassThrough(), mockDataPNG);
 
-			expect(superUpdateOne).toHaveBeenCalledWith(
+			expect(superUpdateOne).toHaveBeenNthCalledWith(
+				2,
 				sample.id,
-				expect.objectContaining({
-					...mockDataPNG,
-					uploaded_on: mockDate.toISOString(),
+				{
 					filename_disk: `${sample.id}.png`,
-				}),
+					filesize: sample.filesize,
+					uploaded_on: mockDate.toISOString(),
+				},
 				{ emitEvents: false },
 			);
 
@@ -284,13 +335,12 @@ describe('Service / Files', () => {
 					filename_download: 'test.jpg',
 				});
 
-				expect(superUpdateOne).toHaveBeenCalledWith(
-					sample.id,
-					expect.objectContaining({
-						storage: 'local',
-					}),
-					{ emitEvents: false },
-				);
+				// `storage` is persisted by the create, not by the sudo write that follows it
+				expect(superCreateOne).toHaveBeenCalledWith(expect.objectContaining({ storage: 'local' }), {
+					emitEvents: false,
+				});
+
+				expect(mockStorage.location).toHaveBeenCalledWith('local');
 			});
 
 			it('should use the provided storage when explicitly set', async () => {
@@ -308,13 +358,11 @@ describe('Service / Files', () => {
 					filename_download: 'test.jpg',
 				});
 
-				expect(superUpdateOne).toHaveBeenCalledWith(
-					sample.id,
-					expect.objectContaining({
-						storage: 's3',
-					}),
-					{ emitEvents: false },
-				);
+				expect(superCreateOne).toHaveBeenCalledWith(expect.objectContaining({ storage: 's3' }), {
+					emitEvents: false,
+				});
+
+				expect(mockStorage.location).toHaveBeenCalledWith('s3');
 			});
 
 			it('should preserve the existing file storage on re-upload without storage', async () => {
@@ -335,13 +383,12 @@ describe('Service / Files', () => {
 					sample.id,
 				);
 
-				expect(superUpdateOne).toHaveBeenCalledWith(
-					sample.id,
-					expect.objectContaining({
-						storage: 's3',
-					}),
-					{ emitEvents: false },
-				);
+				// On the replacement path `storage` is persisted by the permissioned update, which runs first
+				expect(superUpdateOne).toHaveBeenNthCalledWith(1, sample.id, expect.objectContaining({ storage: 's3' }), {
+					emitEvents: false,
+				});
+
+				expect(mockStorage.location).toHaveBeenCalledWith('s3');
 			});
 
 			it('should override the existing file storage when explicitly provided', async () => {
@@ -363,13 +410,11 @@ describe('Service / Files', () => {
 					sample.id,
 				);
 
-				expect(superUpdateOne).toHaveBeenCalledWith(
-					sample.id,
-					expect.objectContaining({
-						storage: 'local',
-					}),
-					{ emitEvents: false },
-				);
+				expect(superUpdateOne).toHaveBeenNthCalledWith(1, sample.id, expect.objectContaining({ storage: 'local' }), {
+					emitEvents: false,
+				});
+
+				expect(mockStorage.location).toHaveBeenCalledWith('local');
 			});
 
 			describe('uploadOne - permanent filesystem errors', () => {

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -197,13 +197,13 @@ export class FilesService extends ItemsService<File> {
 
 		// We do this in a service without accountability. Even if you don't have update permissions to the file,
 		// we still want to be able to set the extracted values from the file on create
-		const sudoFilesService = new FilesService({
+		const sudoFilesItemsService = new ItemsService('directus_files', {
 			knex: this.knex,
 			schema: this.schema,
 		});
 
 		// Do not spread user payload or include non-calculated fields here
-		await sudoFilesService.updateOne(
+		await sudoFilesItemsService.updateOne(
 			primaryKey,
 			{
 				...metadata,

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -197,12 +197,22 @@ export class FilesService extends ItemsService<File> {
 
 		// We do this in a service without accountability. Even if you don't have update permissions to the file,
 		// we still want to be able to set the extracted values from the file on create
-		const sudoFilesItemsService = new ItemsService('directus_files', {
+		const sudoFilesService = new FilesService({
 			knex: this.knex,
 			schema: this.schema,
 		});
 
-		await sudoFilesItemsService.updateOne(primaryKey, { ...payload, ...metadata }, { emitEvents: false });
+		// Do not spread user payload or include non-calculated fields here
+		await sudoFilesService.updateOne(
+			primaryKey,
+			{
+				...metadata,
+				filename_disk: payload.filename_disk,
+				filesize: payload.filesize,
+				uploaded_on: payload.uploaded_on,
+			},
+			{ emitEvents: false },
+		);
 
 		if (opts?.emitEvents !== false) {
 			emitter.emitAction(


### PR DESCRIPTION
## What's Changed

- Narrowed the sudo write at the end of `uploadOne` to the values computed after the create, instead of spreading the whole client payload back over the row.
- Updated the `uploadOne` tests that pinned the old pass-through behaviour, and added a regression test for the client-supplied fields.

## Tested Scenarios

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions / Concerns

- I have not treated this as a security fix: the affected fields are owned by the payload transformers rather than by a field grant, so the impact is wrong attribution and audit data, not new access. Flagging it in case you read it differently.
- `storage` is not in the allowlist, so `assertValidStoragePath` now falls back to the default location. Harmless for server-generated filenames, but I can add `storage` back if you would rather the guard saw the real location.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [x] Security implications apply

---

Fixes CMS-3066
Fixes #28207
