### PR TITLE
Consolidate hardcoded auth requirements and surface them in the policy editor

### DIFF
--- a/.changeset/eight-phones-kneel.md
+++ b/.changeset/eight-phones-kneel.md
@@ -1,0 +1,5 @@
+---
+'@directus/system-data': minor
+---
+
+Added `HARDCODED_AUTH_REQUIREMENTS`, listing the collection/action pairs gated by an explicit accountability check outside of RBAC

--- a/.changeset/old-badgers-look.md
+++ b/.changeset/old-badgers-look.md
@@ -1,5 +1,12 @@
 ---
 '@directus/app': patch
+'@directus/api': patch
 ---
 
-Disabled editing admin-only permission actions on Policy Editor
+Made admin-only permission actions read-only in the policy editor and removed their ineffective permission rows
+
+::: notice
+
+Upgrading deletes existing `directus_permissions` rows for create/update/delete on Collections, Fields, Relations and Extensions. The API has always required admin for these, so the rules had no effect; the change is not reversible.
+
+:::

--- a/.changeset/old-badgers-look.md
+++ b/.changeset/old-badgers-look.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Disabled editing admin-only permission actions on Policy Editor

--- a/.changeset/young-toes-own.md
+++ b/.changeset/young-toes-own.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Consolidated the hardcoded admin/user auth guards on Collections, Fields, Relations, and Comments mutations behind shared assertions. No behavior change

--- a/api/src/database/migrations/20260907A-remove-hardcoded-admin-only-permissions.ts
+++ b/api/src/database/migrations/20260907A-remove-hardcoded-admin-only-permissions.ts
@@ -1,0 +1,30 @@
+import { HARDCODED_AUTH_REQUIREMENTS } from '@directus/system-data';
+import type { Knex } from 'knex';
+
+/**
+ * `directus_permissions` rows for actions the API restricts to admins regardless of RBAC
+ * (`HARDCODED_AUTH_REQUIREMENTS` with `requiredAuth: 'admin'`) never take effect: the service layer
+ * throws before the permission rule is consulted. Remove the dead rows so the Data Studio permission
+ * grid reflects what is actually enforceable.
+ *
+ * Only the `admin` subset is purged. `user`-gated rows (`directus_comments`) are honored for any
+ * authenticated request, so they are left untouched.
+ */
+
+const adminOnlyPairs = HARDCODED_AUTH_REQUIREMENTS.filter(({ requiredAuth }) => requiredAuth === 'admin');
+
+export async function up(knex: Knex): Promise<void> {
+	if (adminOnlyPairs.length === 0) return;
+
+	await knex('directus_permissions')
+		.where((builder) => {
+			for (const { collection, action } of adminOnlyPairs) {
+				builder.orWhere({ collection, action });
+			}
+		})
+		.delete();
+}
+
+export async function down(): Promise<void> {
+	// Irreversible: the removed rows had no effect, so there is nothing meaningful to restore.
+}

--- a/api/src/permissions/utils/assert-hardcoded-auth.test.ts
+++ b/api/src/permissions/utils/assert-hardcoded-auth.test.ts
@@ -1,0 +1,95 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ForbiddenError } from '@directus/errors';
+import { HARDCODED_AUTH_REQUIREMENTS } from '@directus/system-data';
+import { describe, expect, test } from 'vitest';
+import { assertHardcodedAdmin, assertHardcodedUser } from './assert-hardcoded-auth.js';
+import { createDefaultAccountability } from './create-default-accountability.js';
+
+const admin = createDefaultAccountability({ user: 'admin-user', admin: true });
+const nonAdminUser = createDefaultAccountability({ user: 'regular-user', admin: false });
+const anonymous = createDefaultAccountability({ user: null, admin: false });
+
+describe('assertHardcodedAdmin', () => {
+	test('passes for an admin', () => {
+		expect(() => assertHardcodedAdmin(admin, 'directus_collections', 'create')).not.toThrow();
+	});
+
+	test('passes for a system call (null accountability)', () => {
+		expect(() => assertHardcodedAdmin(null, 'directus_fields', 'update')).not.toThrow();
+	});
+
+	test('throws for a non-admin user', () => {
+		expect(() => assertHardcodedAdmin(nonAdminUser, 'directus_relations', 'delete')).toThrow(ForbiddenError);
+	});
+
+	test('throws for an anonymous request', () => {
+		expect(() => assertHardcodedAdmin(anonymous, 'directus_collections', 'update')).toThrow(ForbiddenError);
+	});
+});
+
+describe('assertHardcodedUser', () => {
+	test('passes for an authenticated user', () => {
+		expect(() =>
+			assertHardcodedUser(createDefaultAccountability({ user: '123' }), 'directus_comments', 'create'),
+		).not.toThrow();
+	});
+
+	test.each([
+		{ label: 'null accountability (system call)', input: null },
+		{ label: 'accountability without a user', input: createDefaultAccountability() },
+	])('throws for $label', ({ input }) => {
+		expect(() => assertHardcodedUser(input, 'directus_comments', 'update')).toThrow(ForbiddenError);
+	});
+});
+
+// Drift guard - does not call the helpers. Scans `services/` source and cross-checks the
+// `assertHardcoded*(this.accountability, 'collection', 'action')` call sites against
+// `HARDCODED_AUTH_REQUIREMENTS`: every table row is enforced by a matching call, and every call
+// names a pair that is actually in the table. Enforcement calls must stay single-line with string
+// literals for the regex to find them; `directus_extensions` is enforced in its route handlers.
+describe('hardcoded auth coverage', () => {
+	const servicesDir = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'services');
+	const ENFORCED_ELSEWHERE = new Set(['directus_extensions']);
+	const CALL_RE = /assertHardcoded(Admin|User)\(this\.accountability, '([^']+)', '([^']+)'\)/g;
+	const key = (requiredAuth: string, collection: string, action: string) => `${requiredAuth}:${collection}:${action}`;
+
+	const enforcedPairs = new Set<string>();
+
+	for (const entry of readdirSync(servicesDir, { recursive: true, withFileTypes: true })) {
+		if (!entry.isFile() || !entry.name.endsWith('.ts') || entry.name.endsWith('.test.ts')) continue;
+
+		const source = readFileSync(join(entry.parentPath, entry.name), 'utf8');
+
+		for (const [, tier, collection, action] of source.matchAll(CALL_RE)) {
+			enforcedPairs.add(key(tier === 'Admin' ? 'admin' : 'user', collection!, action!));
+		}
+	}
+
+	test.each(HARDCODED_AUTH_REQUIREMENTS)('$requiredAuth $collection/$action is enforced', (requirement) => {
+		if (ENFORCED_ELSEWHERE.has(requirement.collection)) return;
+
+		const { requiredAuth, collection, action } = requirement;
+		const helper = requiredAuth === 'admin' ? 'assertHardcodedAdmin' : 'assertHardcodedUser';
+
+		expect(
+			enforcedPairs.has(key(requiredAuth, collection, action)),
+			`${requiredAuth} ${collection}/${action} is in HARDCODED_AUTH_REQUIREMENTS but no service calls ` +
+				`${helper}(this.accountability, '${collection}', '${action}'). Add the guard, or add the collection ` +
+				`to ENFORCED_ELSEWHERE.`,
+		).toBe(true);
+	});
+
+	test('every assertHardcoded* call matches a HARDCODED_AUTH_REQUIREMENTS row', () => {
+		const rows = new Set(
+			HARDCODED_AUTH_REQUIREMENTS.map(({ requiredAuth, collection, action }) => key(requiredAuth, collection, action)),
+		);
+
+		for (const pair of enforcedPairs) {
+			expect(rows, `assertHardcoded* call for ${pair} does not match any HARDCODED_AUTH_REQUIREMENTS row`).toContain(
+				pair,
+			);
+		}
+	});
+});

--- a/api/src/permissions/utils/assert-hardcoded-auth.ts
+++ b/api/src/permissions/utils/assert-hardcoded-auth.ts
@@ -1,0 +1,49 @@
+import { ForbiddenError } from '@directus/errors';
+import type { HARDCODED_AUTH_REQUIREMENTS } from '@directus/system-data';
+import type { Accountability } from '@directus/types';
+import { isAdmin } from '../../utils/is-admin.js';
+
+type Requirement = (typeof HARDCODED_AUTH_REQUIREMENTS)[number];
+
+type ToPair<R> = R extends { collection: infer Collection; action: infer Action }
+	? [collection: Collection, action: Action]
+	: never;
+
+/**
+ * `[collection, action]` literal tuples for every `HARDCODED_AUTH_REQUIREMENTS` row of the given
+ * tier. Used as the trailing parameters of the `assertHardcoded*` helpers so a mistyped or
+ * wrong-tier pair is a compile error.
+ */
+export type HardcodedAuthPair<Tier extends Requirement['requiredAuth']> = ToPair<
+	Extract<Requirement, { requiredAuth: Tier }>
+>;
+
+/**
+ * Enforce the `admin`-tier `HARDCODED_AUTH_REQUIREMENTS` entry for a `(collection, action)` pair.
+ * `null` (internal call) passes.
+ *
+ * `collection` / `action` are checked against the table at compile time - a mistyped or non-admin
+ * pair is a type error - and carry no runtime effect. Keep call sites single-line with string
+ * literals; the coverage test in `assert-hardcoded-auth.test.ts` scans for them.
+ */
+export function assertHardcodedAdmin(
+	accountability: Accountability | null,
+	..._pair: HardcodedAuthPair<'admin'>
+): void {
+	if (!isAdmin(accountability)) throw new ForbiddenError();
+}
+
+/**
+ * Enforce the `user`-tier `HARDCODED_AUTH_REQUIREMENTS` entry for a `(collection, action)` pair: an
+ * authenticated end user is required, so `null` (internal call) does not pass.
+ *
+ * `collection` / `action` are checked against the table at compile time and carry no runtime effect.
+ * Keep call sites single-line with string literals; the coverage test in
+ * `assert-hardcoded-auth.test.ts` scans for them.
+ */
+export function assertHardcodedUser(
+	accountability: Accountability | null,
+	..._pair: HardcodedAuthPair<'user'>
+): asserts accountability is Accountability & { user: string } {
+	if (!accountability?.user) throw new ForbiddenError();
+}

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -28,6 +28,7 @@ import emitter from '../emitter.js';
 import { getEntitlementManager } from '../license/index.js';
 import { fetchAllowedCollections } from '../permissions/modules/fetch-allowed-collections/fetch-allowed-collections.js';
 import { validateAccess } from '../permissions/modules/validate-access/validate-access.js';
+import { assertHardcodedAdmin } from '../permissions/utils/assert-hardcoded-auth.js';
 import type { Collection } from '../types/index.js';
 import { getSchema } from '../utils/get-schema.js';
 import { shouldClearCache } from '../utils/should-clear-cache.js';
@@ -63,9 +64,7 @@ export class CollectionsService {
 	 * Create a single new collection
 	 */
 	async createOne(payload: RawCollection, opts?: FieldMutationOptions): Promise<string> {
-		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
-		}
+		assertHardcodedAdmin(this.accountability, 'directus_collections', 'create');
 
 		if (!('collection' in payload)) throw new InvalidPayloadError({ reason: `"collection" is required` });
 
@@ -455,9 +454,7 @@ export class CollectionsService {
 	 * Update a single collection by name
 	 */
 	async updateOne(collectionKey: string, payload: DeepPartial<Collection>, opts?: MutationOptions): Promise<string> {
-		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
-		}
+		assertHardcodedAdmin(this.accountability, 'directus_collections', 'update');
 
 		const nestedActionEvents: ActionEventParams[] = [];
 
@@ -525,9 +522,7 @@ export class CollectionsService {
 	 * Update multiple collections in a single transaction
 	 */
 	async updateBatch(data: DeepPartial<Collection>[], opts?: MutationOptions): Promise<string[]> {
-		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
-		}
+		assertHardcodedAdmin(this.accountability, 'directus_collections', 'update');
 
 		if (!Array.isArray(data)) {
 			throw new InvalidPayloadError({ reason: 'Input should be an array of collection changes' });
@@ -587,9 +582,7 @@ export class CollectionsService {
 	 * Update multiple collections by name
 	 */
 	async updateMany(collectionKeys: string[], data: DeepPartial<Collection>, opts?: MutationOptions): Promise<string[]> {
-		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
-		}
+		assertHardcodedAdmin(this.accountability, 'directus_collections', 'update');
 
 		const nestedActionEvents: ActionEventParams[] = [];
 
@@ -637,9 +630,7 @@ export class CollectionsService {
 	 * delete any fields, presets, activity, revisions, and permissions relating to this collection
 	 */
 	async deleteOne(collectionKey: string, opts?: MutationOptions): Promise<string> {
-		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
-		}
+		assertHardcodedAdmin(this.accountability, 'directus_collections', 'delete');
 
 		const nestedActionEvents: ActionEventParams[] = [];
 
@@ -821,9 +812,7 @@ export class CollectionsService {
 	 * Delete multiple collections by key
 	 */
 	async deleteMany(collectionKeys: string[], opts?: MutationOptions): Promise<string[]> {
-		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
-		}
+		assertHardcodedAdmin(this.accountability, 'directus_collections', 'delete');
 
 		const nestedActionEvents: ActionEventParams[] = [];
 

--- a/api/src/services/comments.ts
+++ b/api/src/services/comments.ts
@@ -1,11 +1,12 @@
 import { useEnv } from '@directus/env';
-import { ErrorCode, ForbiddenError, InvalidPayloadError, isDirectusError } from '@directus/errors';
+import { ErrorCode, InvalidPayloadError, isDirectusError } from '@directus/errors';
 import type { AbstractServiceOptions, Accountability, Comment, MutationOptions, PrimaryKey } from '@directus/types';
 import { uniq } from 'lodash-es';
 import { useLogger } from '../logger/index.js';
 import { fetchRolesTree } from '../permissions/lib/fetch-roles-tree.js';
 import { fetchGlobalAccess } from '../permissions/modules/fetch-global-access/fetch-global-access.js';
 import { validateAccess } from '../permissions/modules/validate-access/validate-access.js';
+import { assertHardcodedUser } from '../permissions/utils/assert-hardcoded-auth.js';
 import { isValidUuid } from '../utils/is-valid-uuid.js';
 import { Url } from '../utils/url.js';
 import { userName } from '../utils/user-name.js';
@@ -27,7 +28,7 @@ export class CommentsService extends ItemsService {
 	}
 
 	override async createOne(data: Partial<Comment>, opts?: MutationOptions): Promise<PrimaryKey> {
-		if (!this.accountability?.user) throw new ForbiddenError();
+		assertHardcodedUser(this.accountability, 'directus_comments', 'create');
 
 		if (!data['comment']) {
 			throw new InvalidPayloadError({ reason: `"comment" is required` });
@@ -166,13 +167,13 @@ ${comment}
 	}
 
 	override updateOne(key: PrimaryKey, data: Partial<Comment>, opts?: MutationOptions): Promise<PrimaryKey> {
-		if (!this.accountability?.user) throw new ForbiddenError();
+		assertHardcodedUser(this.accountability, 'directus_comments', 'update');
 
 		return super.updateOne(key, data, opts);
 	}
 
 	override deleteOne(key: PrimaryKey, opts?: MutationOptions): Promise<PrimaryKey> {
-		if (!this.accountability?.user) throw new ForbiddenError();
+		assertHardcodedUser(this.accountability, 'directus_comments', 'delete');
 
 		return super.deleteOne(key, opts);
 	}

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -36,6 +36,7 @@ import emitter from '../emitter.js';
 import { fetchPermissions } from '../permissions/lib/fetch-permissions.js';
 import { fetchPolicies } from '../permissions/lib/fetch-policies.js';
 import { validateAccess } from '../permissions/modules/validate-access/validate-access.js';
+import { assertHardcodedAdmin } from '../permissions/utils/assert-hardcoded-auth.js';
 import getDefaultValue from '../utils/get-default-value.js';
 import { getSystemFieldRowsWithAuthProviders } from '../utils/get-field-system-rows.js';
 import getLocalType from '../utils/get-local-type.js';
@@ -362,9 +363,7 @@ export class FieldsService {
 		table?: Knex.CreateTableBuilder, // allows collection creation to
 		opts?: FieldMutationOptions,
 	): Promise<void> {
-		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
-		}
+		assertHardcodedAdmin(this.accountability, 'directus_fields', 'create');
 
 		const runPostColumnChange = await this.helpers.schema.preColumnChange();
 		const nestedActionEvents: ActionEventParams[] = [];
@@ -501,9 +500,7 @@ export class FieldsService {
 	}
 
 	async updateField(collection: string, field: RawField, opts?: FieldMutationOptions): Promise<string> {
-		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
-		}
+		assertHardcodedAdmin(this.accountability, 'directus_fields', 'update');
 
 		const runPostColumnChange = await this.helpers.schema.preColumnChange();
 		const nestedActionEvents: ActionEventParams[] = [];
@@ -695,9 +692,7 @@ export class FieldsService {
 	}
 
 	async deleteField(collection: string, field: string, opts?: MutationOptions): Promise<void> {
-		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
-		}
+		assertHardcodedAdmin(this.accountability, 'directus_fields', 'delete');
 
 		const runPostColumnChange = await this.helpers.schema.preColumnChange();
 		const nestedActionEvents: ActionEventParams[] = [];

--- a/api/src/services/relations.ts
+++ b/api/src/services/relations.ts
@@ -25,6 +25,7 @@ import emitter from '../emitter.js';
 import { fetchAllowedFieldMap } from '../permissions/modules/fetch-allowed-field-map/fetch-allowed-field-map.js';
 import { fetchAllowedFields } from '../permissions/modules/fetch-allowed-fields/fetch-allowed-fields.js';
 import { validateAccess } from '../permissions/modules/validate-access/validate-access.js';
+import { assertHardcodedAdmin } from '../permissions/utils/assert-hardcoded-auth.js';
 import { getDefaultIndexName } from '../utils/get-default-index-name.js';
 import { getSchema } from '../utils/get-schema.js';
 import { transaction } from '../utils/transaction.js';
@@ -189,9 +190,7 @@ export class RelationsService {
 	 * Create a new relationship / foreign key constraint
 	 */
 	async createOne(relation: Partial<Relation>, opts?: MutationOptions): Promise<void> {
-		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
-		}
+		assertHardcodedAdmin(this.accountability, 'directus_relations', 'create');
 
 		if (!relation.collection) {
 			throw new InvalidPayloadError({ reason: '"collection" is required' });
@@ -317,9 +316,7 @@ export class RelationsService {
 		relation: Partial<Relation>,
 		opts?: MutationOptions,
 	): Promise<void> {
-		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
-		}
+		assertHardcodedAdmin(this.accountability, 'directus_relations', 'update');
 
 		const collectionSchema = this.schema.collections[collection];
 
@@ -437,9 +434,7 @@ export class RelationsService {
 	 * Delete an existing relationship
 	 */
 	async deleteOne(collection: string, field: string, opts?: MutationOptions): Promise<void> {
-		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
-		}
+		assertHardcodedAdmin(this.accountability, 'directus_relations', 'delete');
 
 		if (collection in this.schema.collections === false) {
 			throw new InvalidPayloadError({ reason: `Collection "${collection}" doesn't exist` });

--- a/app/src/app-permissions.ts
+++ b/app/src/app-permissions.ts
@@ -1,8 +1,17 @@
+import { PERMISSION_ACTIONS } from '@directus/constants';
+import { HARDCODED_AUTH_REQUIREMENTS } from '@directus/system-data';
+import type { PermissionsAction } from '@directus/types';
+
 export { appRecommendedPermissions } from '@directus/system-data';
 
-export const editablePermissionActions = ['create', 'read', 'update', 'delete', 'share'] as const;
-export type EditablePermissionsAction = (typeof editablePermissionActions)[number];
+export const editablePermissionActions = PERMISSION_ACTIONS;
+export type EditablePermissionsAction = PermissionsAction;
 
-export const disabledActions: Record<string, EditablePermissionsAction[]> = {
-	directus_extensions: ['create', 'delete'],
-};
+// Actions the API restricts to admins regardless of RBAC. The grid renders these cells as
+// non-editable so a non-admin policy can't be given grants that never take effect.
+export const disabledActions: Record<string, EditablePermissionsAction[]> = HARDCODED_AUTH_REQUIREMENTS.filter(
+	({ requiredAuth }) => requiredAuth === 'admin',
+).reduce<Record<string, EditablePermissionsAction[]>>((byCollection, { collection, action }) => {
+	(byCollection[collection] ??= []).push(action);
+	return byCollection;
+}, {});

--- a/app/src/interfaces/_system/system-permissions/permissions-row.vue
+++ b/app/src/interfaces/_system/system-permissions/permissions-row.vue
@@ -4,7 +4,6 @@ import PermissionsToggle from './permissions-toggle.vue';
 import { editablePermissionActions, EditablePermissionsAction } from '@/app-permissions.js';
 import VIcon from '@/components/v-icon/v-icon.vue';
 import { Collection } from '@/types/collections';
-import ValueNull from '@/views/private/components/value-null.vue';
 
 defineProps<{
 	collection: Collection;
@@ -38,16 +37,15 @@ const emit = defineEmits<{
 
 		<td v-for="action in editablePermissionActions" :key="action" class="action">
 			<PermissionsToggle
-				v-if="!disabledActions?.includes(action)"
 				:action="action"
 				:collection="collection"
+				:restricted="disabledActions?.includes(action)"
 				:permission="permissions.find((permission) => permission.action === action)"
 				:app-minimal="appMinimal && appMinimal.find((permission) => permission.action === action)"
 				@edit="emit('editItem', action)"
 				@set-full-access="emit('setFullAccess', action)"
 				@set-no-access="emit('setNoAccess', action)"
 			/>
-			<ValueNull v-else />
 		</td>
 		<td class="remove">
 			<VIcon v-tooltip="$t('remove')" name="close" clickable @click="emit('removeRow')" />
@@ -122,14 +120,6 @@ const emit = defineEmits<{
 
 	.action + .action {
 		padding-inline-start: 0.25rem;
-	}
-
-	.null {
-		cursor: not-allowed;
-	}
-
-	:is(.permissions-overview-toggle, .null) + :is(.permissions-overview-toggle, .null) {
-		margin-inline-start: 1.125rem;
 	}
 
 	& + .permissions-row td {

--- a/app/src/interfaces/_system/system-permissions/permissions-toggle.vue
+++ b/app/src/interfaces/_system/system-permissions/permissions-toggle.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Collection, Permission, PermissionsAction } from '@directus/types';
+import { Permission, PermissionsAction } from '@directus/types';
 import { computed, ref, toRefs } from 'vue';
 import VChip from '@/components/v-chip.vue';
 import VDivider from '@/components/v-divider.vue';
@@ -11,6 +11,7 @@ import VList from '@/components/v-list.vue';
 import VMenu from '@/components/v-menu.vue';
 import VProgressCircular from '@/components/v-progress-circular.vue';
 import { useLicenseStore } from '@/stores/license';
+import { Collection } from '@/types/collections';
 import LicenseUpgradeModal from '@/views/private/components/license-upgrade-modal.vue';
 
 const props = defineProps<{
@@ -19,6 +20,8 @@ const props = defineProps<{
 	permission?: Permission;
 	loading?: boolean;
 	appMinimal?: Partial<Permission>;
+	// The API restricts this action to admins regardless of policy; render it read-only.
+	restricted?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -74,11 +77,15 @@ const appMinimalLevel = computed(() => {
 <template>
 	<div
 		v-tooltip="
-			(appMinimal && $t('required_for_app_access')) || $t(`permissionsLevel.${permissionLevel}`, { action: $t(action) })
+			(restricted && $t('hardcoded_admin_only_action_note', { action: $t(action), collection: collection.name })) ||
+			(appMinimal && $t('required_for_app_access')) ||
+			$t(`permissionsLevel.${permissionLevel}`, { action: $t(action) })
 		"
 		:class="[{ 'has-app-minimal': !!appMinimal }, appMinimalLevel]"
 	>
-		<VChip v-if="appMinimalLevel === 'full'" small class="toggle all">{{ $t(action) }}</VChip>
+		<VChip v-if="restricted" small disabled class="toggle restricted">{{ $t(action) }}</VChip>
+
+		<VChip v-else-if="appMinimalLevel === 'full'" small class="toggle all">{{ $t(action) }}</VChip>
 
 		<VMenu v-else show-arrow>
 			<template #activator="{ toggle, active }">
@@ -180,6 +187,13 @@ const appMinimalLevel = computed(() => {
 			--v-chip-background-color: transparent;
 			--v-chip-border-color: var(--theme--border-color);
 		}
+	}
+
+	&.restricted {
+		--v-chip-color: var(--theme--foreground-subdued);
+		--v-chip-background-color: var(--theme--background-subdued);
+		--v-chip-border-color: var(--theme--border-color-subdued);
+		cursor: not-allowed;
 	}
 }
 </style>

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -303,6 +303,8 @@ reset_system_permissions_copy:
 the_following_are_minimum_permissions:
   The following minimum permissions are automatically applied when "App Access" is enabled. You can grant additional
   permissions if needed, but you cannot reduce permissions below this level.
+hardcoded_admin_only_action_note: >-
+  {action} on {collection} is enforced by an admin-only check in the API and can't be granted through a policy.
 app_access_minimum: App Access Minimum
 recommended_defaults: Recommended Defaults
 unarchive: Unarchive

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -285,6 +285,8 @@ public_role_info: >-
   The public role controls what API data is available to unauthenticated users or users without a role. Requests with
   the public role can not have app or admin access. If app or admin access are given to a policy assigned to the public
   role they will be ignored.
+public_role_info_ineffective_permissions: >-
+  Permissions that only apply to authenticated requests are ignored the same way:
 admin_description: Initial administrative role with unrestricted App/API access.
 admin_policy_description: Initial administrative policy with unrestricted App/API access.
 no_description: No description...

--- a/app/src/modules/settings/routes/roles/public-item.vue
+++ b/app/src/modules/settings/routes/roles/public-item.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useApi } from '@directus/composables';
 import { useShortcut } from '@directus/composables';
+import { HARDCODED_AUTH_REQUIREMENTS } from '@directus/system-data';
 import { Alterations, Item, Policy } from '@directus/types';
 import { cloneDeep, isEmpty, isEqual, isObjectLike } from 'lodash';
 import { computed, onMounted, ref } from 'vue';
@@ -16,6 +17,7 @@ import VCard from '@/components/v-card.vue';
 import VDialog from '@/components/v-dialog.vue';
 import VForm from '@/components/v-form/v-form.vue';
 import { useEditsGuard } from '@/composables/use-edits-guard';
+import { useCollectionsStore } from '@/stores/collections';
 import { useFieldsStore } from '@/stores/fields';
 import { unexpectedError } from '@/utils/unexpected-error';
 import { PrivateViewHeaderBarActionButton } from '@/views/private';
@@ -33,7 +35,24 @@ const { t } = useI18n();
 const api = useApi();
 const router = useRouter();
 
+const collectionsStore = useCollectionsStore();
 const fieldsStore = useFieldsStore();
+
+// Permissions the API only honors for an authenticated request are dead weight on a policy assigned
+// to the public role, so the role-info notice lists them as Markdown bullets.
+const ineffectivePublicPermissionsList = [
+	...HARDCODED_AUTH_REQUIREMENTS.filter((requirement) => requirement.requiredAuth === 'user').reduce(
+		(byCollection, { collection, action }) =>
+			byCollection.set(collection, [...(byCollection.get(collection) ?? []), action]),
+		new Map<string, string[]>(),
+	),
+]
+	.map(
+		([collection, actions]) =>
+			`- ${collectionsStore.getCollection(collection)?.name ?? collection} (${actions.join(', ')})`,
+	)
+	.join('\n');
+
 const policiesField = cloneDeep(fieldsStore.getField('directus_roles', 'policies'));
 
 // Add filter in order to correctly display the policies of the public role
@@ -72,7 +91,9 @@ const fields = [
 			system: true,
 			interface: 'presentation-notice',
 			options: {
-				text: t('public_role_info'),
+				text: ineffectivePublicPermissionsList
+					? `${t('public_role_info')}\n\n${t('public_role_info_ineffective_permissions')}\n\n${ineffectivePublicPermissionsList}`
+					: t('public_role_info'),
 			},
 			width: 'full',
 			sort: 0,

--- a/packages/system-data/src/hardcoded-auth-requirements.test.ts
+++ b/packages/system-data/src/hardcoded-auth-requirements.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { isSystemCollection } from './collections/index.js';
+import { HARDCODED_AUTH_REQUIREMENTS } from './hardcoded-auth-requirements.js';
+import type { PermissionsAction } from './types.js';
+
+describe('HARDCODED_AUTH_REQUIREMENTS', () => {
+	it('has no duplicate collection+action entries', () => {
+		const keys = HARDCODED_AUTH_REQUIREMENTS.map((requirement) => `${requirement.collection}:${requirement.action}`);
+		expect(new Set(keys).size).toBe(keys.length);
+	});
+
+	it('every row targets a system collection', () => {
+		for (const { collection } of HARDCODED_AUTH_REQUIREMENTS) {
+			expect(isSystemCollection(collection)).toBe(true);
+		}
+	});
+
+	it('every row has a valid action and auth level', () => {
+		// The typed binding is the check - the const itself can't carry a `satisfies` clause under
+		// isolatedDeclarations (TS9010). A stray `action` or `requiredAuth` fails typecheck here.
+		const rows: readonly { collection: string; action: PermissionsAction; requiredAuth: 'admin' | 'user' }[] =
+			HARDCODED_AUTH_REQUIREMENTS;
+
+		expect(rows).toBe(HARDCODED_AUTH_REQUIREMENTS);
+	});
+});

--- a/packages/system-data/src/hardcoded-auth-requirements.ts
+++ b/packages/system-data/src/hardcoded-auth-requirements.ts
@@ -1,0 +1,27 @@
+/**
+ * Collection + action pairs gated by an explicit accountability check, outside of RBAC.
+ *
+ * - `admin`: requires `accountability.admin` (internal calls with no `accountability` pass).
+ * - `user`: requires an authenticated request (`accountability.user`).
+ *
+ * Checked in the service layer, except `directus_extensions`, which is gated in its route handlers:
+ * `create` maps to `POST /extensions/registry/install`, `update`/`delete` to `PATCH`/`DELETE
+ * /extensions/:pk`.
+ */
+export const HARDCODED_AUTH_REQUIREMENTS = [
+	{ collection: 'directus_collections', action: 'create', requiredAuth: 'admin' },
+	{ collection: 'directus_collections', action: 'delete', requiredAuth: 'admin' },
+	{ collection: 'directus_collections', action: 'update', requiredAuth: 'admin' },
+	{ collection: 'directus_comments', action: 'create', requiredAuth: 'user' },
+	{ collection: 'directus_comments', action: 'delete', requiredAuth: 'user' },
+	{ collection: 'directus_comments', action: 'update', requiredAuth: 'user' },
+	{ collection: 'directus_extensions', action: 'create', requiredAuth: 'admin' },
+	{ collection: 'directus_extensions', action: 'delete', requiredAuth: 'admin' },
+	{ collection: 'directus_extensions', action: 'update', requiredAuth: 'admin' },
+	{ collection: 'directus_fields', action: 'create', requiredAuth: 'admin' },
+	{ collection: 'directus_fields', action: 'delete', requiredAuth: 'admin' },
+	{ collection: 'directus_fields', action: 'update', requiredAuth: 'admin' },
+	{ collection: 'directus_relations', action: 'create', requiredAuth: 'admin' },
+	{ collection: 'directus_relations', action: 'delete', requiredAuth: 'admin' },
+	{ collection: 'directus_relations', action: 'update', requiredAuth: 'admin' },
+] as const;

--- a/packages/system-data/src/index.ts
+++ b/packages/system-data/src/index.ts
@@ -2,4 +2,5 @@ export * from './collections/index.js';
 export * from './relations/index.js';
 export * from './fields/index.js';
 export * from './app-access-permissions/index.js';
+export * from './hardcoded-auth-requirements.js';
 export * from './types.js';


### PR DESCRIPTION
## What's changed

> [!NOTE]
> Some mutations run an explicit `accountability` check before RBAC:
> - admin-only on `directus_*`: `collections`, `fields`, `relations`, and `extensions`
> - authenticated-user-only on `comments`
> 
> That contract was spread across 15 inline guards in the API plus a separate hand-authored exemption list in the app, with nothing keeping the two in sync. This centralizes it in one table.

`@directus/system-data`: `HARDCODED_AUTH_REQUIREMENTS`

- New table of `{ collection, action, requiredAuth }` rows. `requiredAuth` is `admin` (needs `accountability.admin`; internal/null calls pass) or `user` (needs an authenticated request).
- Placed next to `isSystemCollection`, as system-collection metadata. #28203 put it in `@directus/constants`; moved after a sidebar conversation.

`@directus/api`: enforcement

- `assertHardcodedAdmin` / `assertHardcodedUser`, both `(accountability, collection, action)`. The `(collection, action)` pair is type-checked against the table per tier, so a mistyped or wrong-tier pair fails to compile.
- Replaces the inline `accountability.admin !== true` / `!accountability?.user` guards in `collections`, `fields`, `relations`, and `comments`. No behavior change: `isAdmin(null)` keeps internal calls passing, and the user-tier check is identical to the previous Comments guard.
- A drift-guard test scans `services/` and fails if a table row has no matching guard, or a guard names a pair absent from the table.

`@directus/app`: policy editor

- `disabledActions` in `app-permissions.ts` is derived from the `admin` subset instead of hand-authored (replaces the exemption list from #20988). This also covers `update` on Extensions, previously editable but ineffective.
- Admin-only cells render read-only with a tooltip, instead of accepting a grant the service layer ignores. Previously a partially implemented guard was to omit the button for disallowed permissions (see `directus_extensions` in OLD screenshot) without explanation. 

  | OLD | NEW |
  | --- | --- |
  | <img width="871" alt="old" src="https://github.com/user-attachments/assets/92b5c7f4-7a9d-4748-a80b-f35e93935c02" /> | <img width="870" alt="new" src="https://github.com/user-attachments/assets/617bf912-bc03-433f-93e0-4ce0d4a5d888" /> |

- Public role page: the info notice now lists the `user`-tier permissions it silently ignores, and is omitted when there are none.

  | OLD | NEW |
  | --- | --- |
  | <img width="879" alt="old" src="https://github.com/user-attachments/assets/3d7c2c29-7881-4cff-baad-8b5ec0e95811" /> | <img width="958" alt="new" src="https://github.com/user-attachments/assets/2a18df8d-e017-46c6-b43f-fdb6fccd3adf" /> |

`@directus/api`: migration

Deletes existing `directus_permissions` rows for the `admin` pairs so the grid reflects what is enforceable (`user` rows are untouched). Irreversible, since the rows had no effect. Since the behavior is still the same, the migration could be removed to no effect but I was trying to prevent users with the invalid permissions from being unable to reset them with the changes made in the policy editor.

## Tested scenarios

- Table: no duplicate `collection:action` rows; every row is system collection (`isSystemCollection`) with a known action and `requiredAuth`.
- API: existing `collections` / `fields` "throws ForbiddenError for non-admin" service tests still pass; new unit tests cover admin / null / non-admin / anonymous for both helpers; a `@ts-expect-error` probe confirms a wrong-tier or unlisted pair fails to compile.
- Nothing re-creates the deleted rows: the app-access baseline grants only `read` on these collections, and `appRecommendedPermissions` does not touch them.

## Review notes

- `directus_extensions` is gated in its route handlers, not the service layer. The table documents the contract; the drift test carves it out via `ENFORCED_ELSEWHERE`. Moving that gate into `ExtensionsService` is something I could do as a follow-up but it seems out of scope for now.
- The table can't carry (fails `isolatedDeclarations`) a `satisfies` clause in `system-data` (but could in `constants` d8543082d8feaa0a8bfbc7cc71bd2c1250820716), so the row-shape check lives in the test as a typed binding reusing `PermissionsAction`.
- Security: touches auth code, but enforcement is unchanged; only how the requirements are declared and consumed moves.
- `young-toes-own.md` may not be necessary, I preserved it just in case but since there's no real behavior change it's just a legacy part of what was a separated branch. The other changeset files should cover what's being done.
- Please put scrutiny on my migration addition. I'm not sure I covered all of the conventions but tried to mirror from what was already there.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [x] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [x] Database migration added for schema/system changes
- [x] App translations added for new user-facing strings
- [x] Security implications apply

---

- Improves #20988
- Related #27916
- Supersedes (to be closed)
  - #28203
  - #28204
- Blocks OAS work (#28033) stays separate (will need to be refactored once this merges).