### PR TITLE
fix(api): drop consumed redaction paths by identity, not by index

### DIFF
--- a/.changeset/redact-object-consume-by-identity.md
+++ b/.changeset/redact-object-consume-by-identity.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed `redactObject` dropping an unmatched key path when two paths matched the same key, which left that path's value unredacted
+Fixed `redactObject` deleting the wrong matched key

--- a/.changeset/redact-object-consume-by-identity.md
+++ b/.changeset/redact-object-consume-by-identity.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed `redactObject` dropping an unmatched key path when two paths matched the same key, which left that path's value unredacted

--- a/api/src/utils/redact-object.test.ts
+++ b/api/src/utils/redact-object.test.ts
@@ -148,9 +148,6 @@ test('should support multiple paths', () => {
 });
 
 test('should not drop an unmatched path when two paths match the same key', () => {
-	// Both `['a']` and `['*', 'x']` match key "a" and both consume their path, so
-	// the second removal used to run against an array that had already shifted and
-	// took out `['secret_key']` instead — leaving that value unredacted.
 	const result = redactObject(
 		{ a: 'value-a', secret_key: 'sensitive' },
 		{ keys: [['a'], ['*', 'x'], ['secret_key']] },

--- a/api/src/utils/redact-object.test.ts
+++ b/api/src/utils/redact-object.test.ts
@@ -147,6 +147,19 @@ test('should support multiple paths', () => {
 	);
 });
 
+test('should not drop an unmatched path when two paths match the same key', () => {
+	// Both `['a']` and `['*', 'x']` match key "a" and both consume their path, so
+	// the second removal used to run against an array that had already shifted and
+	// took out `['secret_key']` instead — leaving that value unredacted.
+	const result = redactObject(
+		{ a: 'value-a', secret_key: 'sensitive' },
+		{ keys: [['a'], ['*', 'x'], ['secret_key']] },
+		getRedactedString,
+	);
+
+	expect(result).toEqual({ a: REDACTED_TEXT, secret_key: REDACTED_TEXT });
+});
+
 describe('getReplacer tests', () => {
 	test('Returns parsed error object', () => {
 		const errorMessage = 'Error Message';

--- a/api/src/utils/redact-object.ts
+++ b/api/src/utils/redact-object.ts
@@ -44,7 +44,8 @@ export function redactObject(
 		for (const key of Object.keys(object)) {
 			const localCheckPaths = [];
 
-			for (const path of [...checkKeyPaths]) {
+			for (let index = checkKeyPaths.length - 1; index >= 0; index--) {
+				const path = checkKeyPaths[index]!;
 				const [current, ...remaining] = path;
 
 				const escapedKey = wildcardChars.includes(key) ? `\\${key}` : key;
@@ -55,14 +56,14 @@ export function redactObject(
 							localCheckPaths.push(remaining);
 						} else {
 							object[key] = REDACTED_TEXT;
-							consume(checkKeyPaths, path);
+							checkKeyPaths.splice(index, 1);
 						}
 
 						break;
 					case '*':
 						if (remaining.length > 0) {
 							globalCheckPaths.push(remaining);
-							consume(checkKeyPaths, path);
+							checkKeyPaths.splice(index, 1);
 						} else {
 							object[key] = REDACTED_TEXT;
 						}
@@ -98,20 +99,6 @@ export function redactObject(
 			}
 		}
 	}
-}
-
-/**
- * Drop `path` from `checkKeyPaths`, by identity rather than by position.
- *
- * The caller iterates a copy of `checkKeyPaths` while removing entries from the
- * original, so an index taken from the copy stops matching the original as soon
- * as one entry has been removed. Removing by index there deletes whichever path
- * happens to sit at that position now — a still-unmatched one — and that path is
- * then never applied to any later key, silently leaving its value unredacted.
- */
-function consume(checkKeyPaths: Keys, path: string[]): void {
-	const at = checkKeyPaths.indexOf(path);
-	if (at !== -1) checkKeyPaths.splice(at, 1);
 }
 
 /**

--- a/api/src/utils/redact-object.ts
+++ b/api/src/utils/redact-object.ts
@@ -44,7 +44,7 @@ export function redactObject(
 		for (const key of Object.keys(object)) {
 			const localCheckPaths = [];
 
-			for (const [index, path] of [...checkKeyPaths].entries()) {
+			for (const path of [...checkKeyPaths]) {
 				const [current, ...remaining] = path;
 
 				const escapedKey = wildcardChars.includes(key) ? `\\${key}` : key;
@@ -55,14 +55,14 @@ export function redactObject(
 							localCheckPaths.push(remaining);
 						} else {
 							object[key] = REDACTED_TEXT;
-							checkKeyPaths.splice(index, 1);
+							consume(checkKeyPaths, path);
 						}
 
 						break;
 					case '*':
 						if (remaining.length > 0) {
 							globalCheckPaths.push(remaining);
-							checkKeyPaths.splice(index, 1);
+							consume(checkKeyPaths, path);
 						} else {
 							object[key] = REDACTED_TEXT;
 						}
@@ -98,6 +98,20 @@ export function redactObject(
 			}
 		}
 	}
+}
+
+/**
+ * Drop `path` from `checkKeyPaths`, by identity rather than by position.
+ *
+ * The caller iterates a copy of `checkKeyPaths` while removing entries from the
+ * original, so an index taken from the copy stops matching the original as soon
+ * as one entry has been removed. Removing by index there deletes whichever path
+ * happens to sit at that position now — a still-unmatched one — and that path is
+ * then never applied to any later key, silently leaving its value unredacted.
+ */
+function consume(checkKeyPaths: Keys, path: string[]): void {
+	const at = checkKeyPaths.indexOf(path);
+	if (at !== -1) checkKeyPaths.splice(at, 1);
 }
 
 /**

--- a/contributors.yml
+++ b/contributors.yml
@@ -303,3 +303,4 @@
 - aniruddhav25
 - jashkarangiya
 - andrewalfaro1
+- datrixlab


### PR DESCRIPTION
## What's Changed

- `redactObject`'s `traverse` now removes a consumed key path by identity (`indexOf`) instead of by the index of the copy it is iterating.
- Added a regression test for two paths matching the same key.

### The bug

`traverse` iterates a **copy** while splicing entries out of the **original**:

```ts
for (const [index, path] of [...checkKeyPaths].entries()) {
	…
	checkKeyPaths.splice(index, 1);   // index is the copy's, the array is the original
}
```

The two arrays agree only until the first removal. After that, `splice(index, 1)` deletes whichever path now sits at that position — a path that has not matched anything yet. That path is gone for every later key in the object, so its value is written out in full.

Both consuming branches are affected: `case escapedKey` with an exhausted path, and `case '*'` with a remainder.

Minimal reproduction, which is the test added here:

```ts
redactObject(
	{ a: 'value-a', secret_key: 'sensitive' },
	{ keys: [['a'], ['*', 'x'], ['secret_key']] },
	getRedactedString,
);
```

`['a']` matches key `a` and consumes index 0. `['*', 'x']` also matches key `a` and consumes index 1 — but the array has already shifted, so index 1 is now `['secret_key']`. Result before this PR:

```json
{ "a": "--redacted--", "secret_key": "sensitive" }
```

### Reachability — please read before triaging severity

**This is not reachable from the call sites in `main` today, and I am not claiming a vulnerability.** `flows.ts` is the only caller that passes `keys`, and all thirteen of its paths start with `**`; the `**` branch never consumes, so no shift can happen. I checked that before writing the fix rather than assuming it from the shape of the bug.

What makes it worth fixing anyway: `keys` is documented as supporting plain segments and `*`, and the first caller to use either — including anyone extending the `flows.ts` list with a non-`**` path — gets a silently unredacted secret rather than an error. The failure mode is invisible: the redacted output looks well-formed, just missing one key.

## Tested Scenarios

- New test fails without the fix and passes with it; the other 14 tests in the file pass either way (15 total after this PR).
- The existing `should support multiple paths` test passes unchanged — it uses three paths but no single key matches two consuming branches, which is why the suite never caught this.

## Review Notes / Questions / Concerns

- I kept the fix to the removal mechanism rather than restructuring the loop, so ordering and the `globalCheckPaths` / `localCheckPaths` split behave exactly as before.
- `indexOf` works here because the iterated `path` is the same array instance held in `checkKeyPaths` — the spread copies the outer array, not its elements.
- I could not run the full `api` suite locally (`isolated-vm` will not build on Windows/Node 24, which takes out `vitest.config.ts`'s `globalSetup`). I ran `redact-object.test.ts` with an equivalent config minus `globalSetup`; it is a pure unit test with no setup needs.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs)
- [ ] OpenAPI updated
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
