### PR TITLE
fix(utils): match a denied IPv4 written as ::a.b.c.d

### DIFF
--- a/.changeset/ip-blocklist-dotted-v4-compatible.md
+++ b/.changeset/ip-blocklist-dotted-v4-compatible.md
@@ -1,0 +1,5 @@
+---
+'@directus/utils': patch
+---
+
+Fixed `IpBlocklist` not matching a denied IPv4 written as `::a.b.c.d`, while the equivalent `::a9fe:a9fe` spelling was matched

--- a/contributors.yml
+++ b/contributors.yml
@@ -303,3 +303,4 @@
 - aniruddhav25
 - jashkarangiya
 - andrewalfaro1
+- datrixlab

--- a/packages/utils/node/ip-blocklist.test.ts
+++ b/packages/utils/node/ip-blocklist.test.ts
@@ -50,6 +50,16 @@ describe('IpBlocklist', () => {
 			expect(blocklist.checkAddress('2002:a9fe:a9fe:abcd:1:2:3:4')).toBe(true);
 		});
 
+		test('blocks a denied IPv4 written as ::a.b.c.d, not just ::a9fe:a9fe', () => {
+			blocklist.parseAddress('169.254.169.254');
+
+			// Same address, two spellings. ipaddr.js parses the dotted form to the
+			// IPv4-mapped bytes (::ffff:a9fe:a9fe) while Node's BlockList only maps the
+			// literal "::ffff:" spelling, so the dotted one used to reach neither check.
+			expect(blocklist.checkAddress('::a9fe:a9fe')).toBe(true);
+			expect(blocklist.checkAddress('::169.254.169.254')).toBe(true);
+		});
+
 		test('blocks transition forms of a denied IPv4 subnet', () => {
 			blocklist.parseSubnet('10.0.0.0/8');
 

--- a/packages/utils/node/ip-blocklist.ts
+++ b/packages/utils/node/ip-blocklist.ts
@@ -49,6 +49,15 @@ export class IpBlocklist extends BlockList {
 		const isZero = (start: number, end: number) => bytes.slice(start, end).every((byte) => byte === 0);
 		const candidates: string[] = [];
 
+		// IPv4-mapped ::ffff:0:0/96. Node's BlockList only recognises the canonical
+		// `::ffff:a.b.c.d` spelling; `::a.b.c.d` is a different string that it does not
+		// map, yet ipaddr.js parses both to these same bytes. Without this branch the
+		// dotted spelling reaches neither check: `isZero(0, 12)` is false because of the
+		// `ffff`, so the IPv4-compatible branch below skips it too.
+		if (isZero(0, 10) && bytes[10] === 0xff && bytes[11] === 0xff && bytes[12] !== 0) {
+			candidates.push(toV4(bytes.slice(12, 16)));
+		}
+
 		// IPv4-compatible ::/96 (deprecated, RFC 4291): ::a.b.c.d. Excludes ::, ::1 and
 		// other ::0.0.0.0/8 forms, which are not routable embedded IPv4 targets.
 		if (isZero(0, 12) && bytes[12] !== 0) candidates.push(toV4(bytes.slice(12, 16)));


### PR DESCRIPTION
## What's Changed

- `IpBlocklist.embeddedIpv4` now also classifies the IPv4-mapped byte layout, which is what `ipaddr.js` produces for the dotted `::a.b.c.d` spelling.
- Added a regression test asserting both spellings of the same address behave identically.

### The gap

`embeddedIpv4` exists so IPv6 transition forms cannot bypass an IPv4 deny rule, and its comment names IPv4-compatible `::a9fe:a9fe` as one of the covered forms. The dotted spelling of that same address was not covered:

```ts
blocklist.parseAddress('169.254.169.254');

blocklist.checkAddress('::a9fe:a9fe');       // true
blocklist.checkAddress('::169.254.169.254'); // false  ← same address
```

Two libraries disagree about what `::a.b.c.d` is, and the address falls between them:

- **ipaddr.js** parses it to the *IPv4-mapped* bytes — `0,…,0,255,255,169,254,169,254`, identical to `::ffff:169.254.169.254`. So `isZero(0, 12)` is false and the IPv4-compatible branch skips it. (The hex spelling `::a9fe:a9fe` keeps an all-zero prefix, which is why only that one matched.)
- **Node's `BlockList`** maps the literal `::ffff:a.b.c.d` *string* onto IPv4 rules, but `::a.b.c.d` is a different string, so it does not map it either.

The fix adds the IPv4-mapped byte branch. It covers the dotted spelling of both forms and leaves the existing branches untouched.

### Severity — I do not think this is a reachable SSRF bypass

I checked rather than assuming, and I would rather understate it: **`::a.b.c.d` does not route to IPv4.** A local connect to `::127.0.0.1` returns `ENETUNREACH` while `::ffff:127.0.0.1` connects to the same IPv4 listener. The form is deprecated in RFC 4291 §2.5.5.1 and modern stacks do not carry it.

So `isDeniedIp` / `agentWithIpValidation` would let the string through, but the connection would not reach `169.254.169.254` anyway. I am filing this as a consistency fix in the guard — the same class as the existing transition-form handling — not as a vulnerability, which is also why it is here and not in a private advisory. Happy to move it if you read the risk differently.

## Tested Scenarios

- `packages/utils`: `node/ip-blocklist.test.ts` + `node/ip-in-networks.test.ts` — **40 passed**. Reverting only `ip-blocklist.ts` fails exactly the new test and leaves the other 39 passing.
- `api`: the suites that consume the guard — `src/request/**` (`is-denied-ip`, `agent-with-ip-validation`, `index`) and `src/permissions/utils/**` (`filter-policies-by-ip` among them) — **68 passed** with the change.

### Not covered by this PR

While checking, these transition forms also carry an embedded IPv4 and are not classified: Teredo (`2001:0::/32`), ISATAP (`::5efe:a.b.c.d`), and SIIT (`64:ff9b:1::/48`). None of them route to IPv4 either on the box I tested, and none are named in the current comment, so I left them out to keep this PR to the one case that contradicts the documented behaviour. Happy to follow up if you want them handled.

## Review Notes / Questions / Concerns

- The new branch requires `bytes[12] !== 0`, matching the existing IPv4-compatible branch, so `::ffff:0.0.0.0` is not treated as an embedded target.
- `::ffff:a.b.c.d` now matches through both Node's own mapping and this branch. That is redundant but harmless — `checkAddress` returns on the first hit.
- I could not run the full monorepo suite locally (`isolated-vm` will not build on Windows/Node 24). The two package suites above are pure and were run directly.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs)
- [ ] OpenAPI updated
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
