### PR TITLE
Update app SDK Client to use `CoreSchema`

### DIFF
--- a/.changeset/clever-shoes-attack.md
+++ b/.changeset/clever-shoes-attack.md
@@ -1,0 +1,5 @@
+---
+'@directus/app': patch
+---
+
+Added `CoreSchema` to the app's Directus SDK client so system collection queries infer types instead of needing casts

--- a/app/src/composables/use-collab.ts
+++ b/app/src/composables/use-collab.ts
@@ -1,5 +1,6 @@
 import { ErrorCode } from '@directus/errors';
-import { DirectusUser, readUser, readUsers, realtime, RemoveEventHandler, WebSocketClient } from '@directus/sdk';
+import type { CoreSchema } from '@directus/sdk';
+import { readUser, readUsers, realtime, RemoveEventHandler, WebSocketClient } from '@directus/sdk';
 import {
 	ACTION,
 	Avatar,
@@ -34,17 +35,6 @@ type UpdateMessage = Extract<ServerMessage, { action: typeof ACTION.SERVER.UPDAT
 type FocusMessage = Extract<ServerMessage, { action: typeof ACTION.SERVER.FOCUS }>;
 type DiscardMessage = Extract<ServerMessage, { action: typeof ACTION.SERVER.DISCARD }>;
 
-/**
- * User info returned from SDK queries.
- * TODO: Remove once https://linear.app/directus/issue/CMS-1702 is done
- */
-type CollabUserInfo = {
-	id: string;
-	first_name?: string | null;
-	last_name?: string | null;
-	avatar?: { id: string; modified_on: string } | null;
-};
-
 type NonInitServerAction = Exclude<ServerMessage['action'], typeof ACTION.SERVER.INIT>;
 
 type ServerMessageHandler<A extends ServerMessage['action']> = (
@@ -57,7 +47,7 @@ type MessageHandlerMap = {
 
 const SESSION_COLOR_KEY = 'collab-color';
 
-const sdk: SdkClient & WebSocketClient<unknown> = baseSDK.with(
+const sdk: SdkClient & WebSocketClient<CoreSchema> = baseSDK.with(
 	realtime({
 		authMode: 'strict',
 		connect: false,
@@ -340,15 +330,13 @@ export function useCollab(
 							_in: Array.from(new Set(message.users.map((user) => user.user))),
 						},
 					},
-					//  Object syntax for nested fields - SDK types require schema definition for full support
-					// TODO: Update this once https://github.com/directus/directus/issues/26558 is Done
-					fields: ['id', 'first_name', 'last_name', { avatar: ['id', 'modified_on'] }] as (keyof DirectusUser)[],
+					fields: ['id', 'first_name', 'last_name', { avatar: ['id', 'modified_on'] }],
 				}),
 			);
 
 			users.value = message.users
 				.map(({ user, color, connection }) => {
-					const info = usersInfo.find((u) => u.id === user) as CollabUserInfo | undefined;
+					const info = usersInfo.find((u) => u.id === user);
 
 					if (message.connection === connection) {
 						sessionStorage.setItem(SESSION_COLOR_KEY, color);
@@ -440,8 +428,7 @@ export function useCollab(
 			: await sdk
 					.request(
 						readUser(message.user, {
-							// TODO: Update this once https://github.com/directus/directus/issues/26558 is Done
-							fields: ['id', 'first_name', 'last_name', { avatar: ['id', 'modified_on'] }] as (keyof DirectusUser)[],
+							fields: ['id', 'first_name', 'last_name', { avatar: ['id', 'modified_on'] }],
 						}),
 					)
 					.catch(() => ({}));

--- a/app/src/sdk.ts
+++ b/app/src/sdk.ts
@@ -1,4 +1,11 @@
-import type { AuthenticationClient, DirectusClient, RequestOptions, RestClient, RestCommand } from '@directus/sdk';
+import type {
+	AuthenticationClient,
+	CoreSchema,
+	DirectusClient,
+	RequestOptions,
+	RestClient,
+	RestCommand,
+} from '@directus/sdk';
 import { authentication, createDirectus, rest } from '@directus/sdk';
 import { type FetchContext, ofetch } from 'ofetch';
 import { requestQueue } from './api';
@@ -6,7 +13,7 @@ import { SDK_AUTH_REFRESH_BEFORE_EXPIRES } from './constants';
 import { useRequestsStore } from './stores/requests';
 import { getPublicURL } from '@/utils/get-root-path';
 
-export type SdkClient = DirectusClient<unknown> & AuthenticationClient<unknown> & RestClient<unknown>;
+export type SdkClient = DirectusClient<CoreSchema> & AuthenticationClient<CoreSchema> & RestClient<CoreSchema>;
 
 type OptionsWithId = FetchContext['options'] & { id: string };
 
@@ -49,7 +56,7 @@ const baseClient = ofetch.create({
 	},
 });
 
-export const sdk: SdkClient = createDirectus(getPublicURL(), { globals: { fetch: baseClient.native } })
+export const sdk: SdkClient = createDirectus<CoreSchema>(getPublicURL(), { globals: { fetch: baseClient.native } })
 	.with(authentication('session', { credentials: 'include', msRefreshBeforeExpires: SDK_AUTH_REFRESH_BEFORE_EXPIRES }))
 	.with(rest({ credentials: 'include' }));
 


### PR DESCRIPTION
## What's Changed

- Replaced `unknown` with `CoreSchema` for the app's internal SDK usage
- Removed casts that typed SDK responses as a result of `unknown` as they are now inferred appropriately.
- Types only (no runtime changes)

## Tested Scenarios

- Existing tests pass after change
- `pnpm --filter @directus/app typecheck` (no new errors)
- No new tests added since there's no runtime changes

## Review Notes / Questions / Concerns

- The issue seemed like too low-hanging fruit since the proposed fix was already documented in the issue itself and as far as I can tell was available to implement at the time. (makes me wonder if there's something I don't understand)

## Checklist

> Leave unchecked where not applicable

- [ ] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

- Fixes directus/directus#26558
- Fixes CMS-1702 (I think - see Review Notes: https://github.com/directus/directus/pull/26549#issue-3876213350)
