### PR TITLE
Fix the user create endpoints accepting `tfa_secret`, `provider` and `external_identifier`

### DIFF
--- a/.changeset/guard-user-auth-fields-on-create.md
+++ b/.changeset/guard-user-auth-fields-on-create.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed `tfa_secret`, `provider` and `external_identifier` being writable through the user create endpoints

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -172,6 +172,47 @@ describe('Integration Tests', () => {
 					expect(opts.preMutationError).toBeUndefined();
 				});
 			});
+
+			describe('restricted auth fields', () => {
+				describe('should disallow creation for non-admin users', () => {
+					const service = new UsersService({
+						knex: db,
+						schema,
+						accountability: { role: 'test', admin: false } as Accountability,
+					});
+
+					it.each(['tfa_secret', 'provider', 'external_identifier'])('%s', async (field) => {
+						const opts: MutationOptions = {};
+
+						await service.createOne({ [field]: 'test' }, opts);
+
+						expect(superCreateOneSpy).toHaveBeenCalled();
+
+						expect(opts.preMutationError).toStrictEqual(
+							new InvalidPayloadError({ reason: `You can't change the "${field}" value manually` }),
+						);
+					});
+				});
+
+				describe.each([
+					['admin users', { role: 'admin', admin: true } as Accountability],
+					['null accountability', null],
+				])('should allow creation for %s', (_, accountability) => {
+					const service = new UsersService({
+						knex: db,
+						schema,
+						accountability,
+					});
+
+					it.each(['provider', 'external_identifier'])('%s', async (field) => {
+						const promise = service.createOne({ [field]: 'test' });
+
+						await expect(promise).resolves.not.toThrow();
+
+						expect(superCreateOneSpy.mock.lastCall![0]).toEqual(expect.objectContaining({ [field]: 'test' }));
+					});
+				});
+			});
 		});
 
 		describe('createMany', () => {
@@ -237,6 +278,45 @@ describe('Integration Tests', () => {
 					await service.createMany([{ provider: DEFAULT_AUTH_PROVIDER }, {}], opts);
 
 					expect(opts.preMutationError).toBeUndefined();
+				});
+			});
+
+			describe('restricted auth fields', () => {
+				describe('should disallow creation for non-admin users', () => {
+					const service = new UsersService({
+						knex: db,
+						schema,
+						accountability: { role: 'test', admin: false } as Accountability,
+					});
+
+					it.each(['tfa_secret', 'provider', 'external_identifier'])('%s', async (field) => {
+						const opts: MutationOptions = {};
+
+						await service.createMany([{}, { [field]: 'test' }], opts);
+
+						expect(opts.preMutationError).toStrictEqual(
+							new InvalidPayloadError({ reason: `You can't change the "${field}" value manually` }),
+						);
+					});
+				});
+
+				describe.each([
+					['admin users', { role: 'admin', admin: true } as Accountability],
+					['null accountability', null],
+				])('should allow creation for %s', (_, accountability) => {
+					const service = new UsersService({
+						knex: db,
+						schema,
+						accountability,
+					});
+
+					it.each(['provider', 'external_identifier'])('%s', async (field) => {
+						const opts: MutationOptions = {};
+
+						await service.createMany([{ [field]: 'test' }], opts);
+
+						expect(opts.preMutationError).toBeUndefined();
+					});
 				});
 			});
 		});

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -203,10 +203,29 @@ export class UsersService extends ItemsService {
 	}
 
 	/**
+	 * Block setting auth fields that are managed by the system or reserved for admins
+	 */
+	private checkRestrictedAuthFields(data: Partial<Item>): void {
+		if ('tfa_secret' in data) {
+			throw new InvalidPayloadError({ reason: `You can't change the "tfa_secret" value manually` });
+		}
+
+		if (this.accountability && this.accountability.admin !== true) {
+			for (const field of ['provider', 'external_identifier']) {
+				if (field in data) {
+					throw new InvalidPayloadError({ reason: `You can't change the "${field}" value manually` });
+				}
+			}
+		}
+	}
+
+	/**
 	 * Create a new user
 	 */
 	override async createOne(data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey> {
 		try {
+			this.checkRestrictedAuthFields(data);
+
 			if ('email' in data && data['email'] !== undefined) {
 				this.validateEmail(data['email']);
 				await this.checkUniqueEmails([data['email']]);
@@ -244,6 +263,10 @@ export class UsersService extends ItemsService {
 		const someActive = data.some((payload) => !('status' in payload) || payload['status'] === 'active');
 
 		try {
+			for (const payload of data) {
+				this.checkRestrictedAuthFields(payload);
+			}
+
 			if (emails.length) {
 				this.validateEmail(emails);
 				await this.checkUniqueEmails(emails);


### PR DESCRIPTION
## What's Changed

- Added a `checkRestrictedAuthFields` guard to `UsersService` and called it from `createOne` and `createMany`, so the create paths reject the same fields the update path already rejects: `tfa_secret` always, `provider` and `external_identifier` when the accountability is a non-admin. Without it a `tfa_secret` set through create skipped verification in `TFAService.enableTFA`.
- Added tests for both create paths, mirroring the existing update ones.

The SSO drivers build their `UsersService` without accountability (`Auth.getUsersService`), so registering a user with `provider` and `external_identifier` still works.

## Tested Scenarios

- Non-admin accountability creating a user with each of the three fields, one at a time, through `createOne` and `createMany`.
- Admin and null accountability creating a user with `provider` or `external_identifier`, and the value still reaching the insert.
- Reverted the service change to confirm the six new tests fail against it.

## Review Notes / Questions / Concerns

- The guard uses `field in data` rather than the `data['field'] !== undefined` of `updateMany`, matching the surrounding checks in `createOne`. It means `{ tfa_secret: undefined }` is rejected on create but accepted on update. I left the update path alone to keep this change small, happy to align both.
- I kept this to `users.ts` and did not build the shared `assertManagedFieldsNotSet` helper across `settings.ts` and `shares.ts` from your comment, since that one wants the research you mentioned first.

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [x] Security implications apply

---

Fixes CMS-3072
Fixes #28220
