### PR TITLE
Fix retention FK violation on directus_revisions_parent_foreign

### DIFF
--- a/api/src/schedules/retention.test.ts
+++ b/api/src/schedules/retention.test.ts
@@ -1,52 +1,164 @@
-import { useEnv } from '@directus/env';
+import knex from 'knex';
+import { createTracker, MockClient } from 'knex-mock-client';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import * as schedule from '../utils/schedule.js';
-import { handleRetentionJob, default as retentionSchedule } from './retention.js';
 
-vi.mock('@directus/env', () => ({
-	useEnv: vi.fn().mockReturnValue({}),
+const mocks = vi.hoisted(() => ({
+	env: {} as Record<string, unknown>,
+	getDatabase: vi.fn(),
+	lock: {
+		delete: vi.fn().mockResolvedValue(undefined),
+		get: vi.fn().mockResolvedValue(undefined),
+		set: vi.fn().mockResolvedValue(undefined),
+	},
+	logger: {
+		error: vi.fn(),
+	},
+	isOneOfClients: vi.fn().mockReturnValue(false),
+	scheduleSynchronizedJob: vi.fn(),
+	validateCron: vi.fn().mockReturnValue(true),
 }));
 
-vi.spyOn(schedule, 'scheduleSynchronizedJob');
-vi.spyOn(schedule, 'validateCron');
+vi.mock('@directus/env', () => ({
+	useEnv: vi.fn(() => mocks.env),
+}));
+
+vi.mock('../database/helpers/index.js', () => ({
+	getHelpers: vi.fn(() => ({
+		date: { parse: vi.fn((date: Date) => date) },
+		schema: { isOneOfClients: mocks.isOneOfClients },
+	})),
+}));
+
+vi.mock('../database/index.js', () => ({
+	default: mocks.getDatabase,
+}));
+
+vi.mock('../lock/index.js', () => ({
+	useLock: vi.fn(() => mocks.lock),
+}));
+
+vi.mock('../logger/index.js', () => ({
+	useLogger: vi.fn(() => mocks.logger),
+}));
+
+vi.mock('../utils/schedule.js', () => ({
+	scheduleSynchronizedJob: mocks.scheduleSynchronizedJob,
+	validateCron: mocks.validateCron,
+}));
+
+const db = vi.mocked(knex.default({ client: MockClient }));
+const tracker = createTracker(db);
 
 beforeEach(() => {
-	vi.mocked(useEnv).mockReturnValue({ RETENTION_ENABLED: true, RETENTION_SCHEDULE: '0 0 * * *' });
+	vi.resetModules();
+
+	for (const key of Object.keys(mocks.env)) {
+		delete mocks.env[key];
+	}
+
+	Object.assign(mocks.env, {
+		ACTIVITY_RETENTION: '1d',
+		FLOW_LOGS_RETENTION: undefined,
+		RETENTION_BATCH: 100,
+		RETENTION_ENABLED: true,
+		RETENTION_SCHEDULE: '0 0 * * *',
+		REVISIONS_RETENTION: undefined,
+	});
+
+	mocks.getDatabase.mockReturnValue(db);
+	mocks.isOneOfClients.mockReturnValue(false);
+	mocks.validateCron.mockReturnValue(true);
 });
 
 afterEach(() => {
+	tracker.reset();
 	vi.clearAllMocks();
 });
 
 describe('retention', () => {
 	test('Returns early when retention is disabled', async () => {
-		vi.mocked(useEnv).mockReturnValue({ RETENTION_ENABLED: false, RETENTION_SCHEDULE: '0 0 * * *' });
+		mocks.env['RETENTION_ENABLED'] = false;
+		const { default: retentionSchedule } = await import('./retention.js');
 
 		const res = await retentionSchedule();
 
-		expect(schedule.validateCron).not.toHaveBeenCalled();
+		expect(mocks.validateCron).not.toHaveBeenCalled();
 		expect(res).toBe(false);
 	});
 
 	test('Returns early for invalid retention schedule', async () => {
-		vi.mocked(useEnv).mockReturnValue({ RETENTION_ENABLED: true, RETENTION_SCHEDULE: '#' });
+		mocks.env['RETENTION_SCHEDULE'] = '#';
+		mocks.validateCron.mockReturnValue(false);
+		const { default: retentionSchedule } = await import('./retention.js');
 
 		const res = await retentionSchedule();
 
-		expect(schedule.validateCron).toHaveBeenCalledWith('#');
+		expect(mocks.validateCron).toHaveBeenCalledWith('#');
 		expect(res).toBe(false);
 	});
 
 	test('Schedules synchronized job', async () => {
+		const { handleRetentionJob, default: retentionSchedule } = await import('./retention.js');
+
 		await retentionSchedule();
 
-		expect(schedule.validateCron).toHaveBeenCalledWith('0 0 * * *');
-		expect(schedule.scheduleSynchronizedJob).toHaveBeenCalledWith('retention', '0 0 * * *', handleRetentionJob);
+		expect(mocks.validateCron).toHaveBeenCalledWith('0 0 * * *');
+		expect(mocks.scheduleSynchronizedJob).toHaveBeenCalledWith('retention', '0 0 * * *', handleRetentionJob);
 	});
 
 	test('Returns true on successful init', async () => {
+		const { default: retentionSchedule } = await import('./retention.js');
+
 		const res = await retentionSchedule();
 
 		expect(res).toBe(true);
+	});
+
+	test('nulls revision parents before deleting activities', async () => {
+		const { handleRetentionJob } = await import('./retention.js');
+
+		tracker.on.select('directus_activity').responseOnce([{ id: 10 }]);
+		tracker.on.select('directus_revisions').responseOnce([{ id: 20 }]);
+		tracker.on.update('directus_revisions').responseOnce(1);
+		tracker.on.delete('directus_activity').responseOnce(1);
+
+		await handleRetentionJob();
+
+		expect(tracker.history.select[1]?.sql).toBe('select "id" from "directus_revisions" where "activity" in (?)');
+		expect(tracker.history.select[1]?.bindings).toEqual([10]);
+		expect(tracker.history.update).toHaveLength(1);
+		expect(tracker.history.update[0]?.sql).toBe('update "directus_revisions" set "parent" = ? where "parent" in (?)');
+		expect(tracker.history.update[0]?.bindings).toEqual([null, 20]);
+		expect(tracker.history.delete[0]?.sql).toBe('delete from "directus_activity" where "id" in (?)');
+		expect(tracker.history.delete[0]?.bindings).toEqual([10]);
+
+		expect(tracker.history.all.indexOf(tracker.history.update[0]!)).toBeLessThan(
+			tracker.history.all.indexOf(tracker.history.delete[0]!),
+		);
+	});
+
+	test('nulls revision parents before deleting revisions directly', async () => {
+		mocks.env['ACTIVITY_RETENTION'] = undefined;
+		mocks.env['REVISIONS_RETENTION'] = '1d';
+		mocks.isOneOfClients.mockReturnValue(true);
+		const { handleRetentionJob, default: retentionSchedule } = await import('./retention.js');
+
+		await retentionSchedule();
+
+		tracker.on.select('directus_revisions').responseOnce([{ id: 20 }]);
+		tracker.on.update('directus_revisions').responseOnce(1);
+		tracker.on.delete('directus_revisions').responseOnce(1);
+
+		await handleRetentionJob();
+
+		expect(tracker.history.update).toHaveLength(1);
+		expect(tracker.history.update[0]?.sql).toBe('update "directus_revisions" set "parent" = ? where "parent" in (?)');
+		expect(tracker.history.update[0]?.bindings).toEqual([null, 20]);
+		expect(tracker.history.delete[0]?.sql).toBe('delete from "directus_revisions" where "id" in (?)');
+		expect(tracker.history.delete[0]?.bindings).toEqual([20]);
+
+		expect(tracker.history.all.indexOf(tracker.history.update[0]!)).toBeLessThan(
+			tracker.history.all.indexOf(tracker.history.delete[0]!),
+		);
 	});
 });

--- a/api/src/schedules/retention.ts
+++ b/api/src/schedules/retention.ts
@@ -81,10 +81,11 @@ export async function handleRetentionJob() {
 			try {
 				let records = [];
 				const isMySQL = helpers.schema.isOneOfClients(['mysql']);
+				const deletesRevisions = task.collection === 'directus_activity' || task.collection === 'directus_revisions';
 
 				// mysql/maria does not allow limit within a subquery
 				// https://dev.mysql.com/doc/refman/8.4/en/subquery-restrictions.html
-				if (isMySQL) {
+				if (isMySQL || deletesRevisions) {
 					records = await subquery.then((r) => r.map((r) => r.id));
 
 					if (records.length === 0) {
@@ -92,8 +93,23 @@ export async function handleRetentionJob() {
 					}
 				}
 
+				if (deletesRevisions) {
+					let revisionIds = records;
+
+					if (task.collection === 'directus_activity') {
+						revisionIds = await database('directus_revisions')
+							.select('id')
+							.whereIn('activity', records)
+							.then((revisions) => revisions.map((revision) => revision.id));
+					}
+
+					if (revisionIds.length > 0) {
+						await database('directus_revisions').update({ parent: null }).whereIn('parent', revisionIds);
+					}
+				}
+
 				count = await database(task.collection)
-					.whereIn('id', isMySQL ? records : subquery)
+					.whereIn('id', isMySQL || deletesRevisions ? records : subquery)
 					.delete();
 			} catch (error) {
 				logger.error(error, `Retention failed for Collection ${task.collection}`);

--- a/contributors.yml
+++ b/contributors.yml
@@ -303,3 +303,4 @@
 - aniruddhav25
 - jashkarangiya
 - andrewalfaro1
+- wakqasahmed


### PR DESCRIPTION
`directus_revisions.parent` self-references `directus_revisions.id` with no `ON DELETE` action — deliberately, per the migration's own comment, since not every database here supports recursive cascade/set-null triggers on a self-referencing FK. `directus_revisions.activity` does cascade though, so when retention deletes an old `directus_activity` row, the cascade tries to delete its revision too, and if a newer, surviving revision still points at that revision as `parent`, Postgres rejects the whole batch and the job just stops. This matches #25163's diagnosis and the workaround in this issue.

There are actually two retention paths that can remove `directus_revisions` rows — the activity-cascade path, and the separate direct `directus_revisions` retention task — and both are vulnerable. Before either path deletes, it now nulls out `parent` on any surviving revision pointing at the about-to-be-removed set, mirroring the pattern already used in `CollectionsService.deleteOne()`.

#25842 tried this same approach and didn't land, closed unreviewed with no tests — its checklist even shows "Added or updated tests" left unchecked. Added two tests this time using `knex-mock-client`'s tracker (same pattern as `authentication.test.ts`), asserting the UPDATE happens before the DELETE and with the right bindings, one for each retention path. Ran the full `retention.test.ts` file — 6 passed, including the 4 existing ones.

Fixes #26747
