### PR TITLE
Fix relational field detection for custom fields typed with core collection generics in SDK

### DIFF
--- a/.changeset/tall-crabs-film.md
+++ b/.changeset/tall-crabs-film.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Fixed relational field detection for custom fields typed with core collection generics

--- a/sdk/src/types/schema.ts
+++ b/sdk/src/types/schema.ts
@@ -2,13 +2,15 @@ import type { CoreSchema } from '../schema/index.js';
 import type { IfAny, StringLiteralUnion, UnpackList } from './utils.js';
 
 /**
- * Get all available top level Item types from a given Schema
+ * All top level item types (unwrapped from lists) declared on an object type
  */
-export type ItemType<Schema> =
-	| Schema[keyof Schema]
-	| {
-			[K in keyof Schema]: Schema[K] extends any[] ? Schema[K][number] : never;
-	  }[keyof Schema];
+type ItemsOf<T> = T[keyof T] | UnpackList<T[keyof T]>;
+
+/**
+ * Get all available top level Item types from a given Schema, including core collections
+ * (even when the schema doesn't declare them itself)
+ */
+export type ItemType<Schema> = ItemsOf<Schema> | ItemsOf<CoreSchema<Schema>>;
 
 /**
  * Return singular collection type

--- a/sdk/tests/item-type.test-d.ts
+++ b/sdk/tests/item-type.test-d.ts
@@ -1,0 +1,40 @@
+import { describe, expectTypeOf, test } from 'vitest';
+import type { ApplyQueryFields, DirectusUser, ItemType } from '../src/index.js';
+
+describe('ItemType', () => {
+	test('includes core collection item types even when absent from the schema (issue #21250)', () => {
+		// `assignee_id` is a required field DirectusUser doesn't have, so DirectusUser<Schema>
+		// can't accidentally structurally match this collection's item type.
+		type Schema = { festivities: { id: string; assignee_id: string }[] };
+
+		type Match = Extract<DirectusUser<Schema>, ItemType<Schema>>;
+
+		expectTypeOf<Match>().toEqualTypeOf<DirectusUser<Schema>>();
+	});
+});
+
+describe('Deep query on a custom field typed with a core collection generic (issue #21250)', () => {
+	test('a field typed `string | DirectusUser<Schema> | null` resolves the requested nested fields', () => {
+		type CalendarEvents = {
+			id: string;
+			title: string;
+		};
+
+		type Festivities = {
+			id: string;
+			assignee?: string | DirectusUser<Schema> | null;
+			calendar_events: CalendarEvents[];
+		};
+
+		type Schema = {
+			festivities: Festivities[];
+			calendar_events: CalendarEvents[];
+		};
+
+		const _fields = ['id', { assignee: ['id', 'email'], calendar_events: ['id', 'title'] }] as const;
+
+		type Result = ApplyQueryFields<Schema, Festivities, typeof _fields>;
+
+		expectTypeOf<Result['assignee']>().toEqualTypeOf<Pick<DirectusUser<Schema>, 'id' | 'email'> | null>();
+	});
+});


### PR DESCRIPTION
## What's Changed

- `ItemType<Schema>` now also draws item shapes from `CoreSchema<Schema>`, not just the user's own `Schema`
- Custom fields typed with a core collection generic (`DirectusUser<Schema>`, `DirectusFile<Schema>`, etc.) are now correctly recognized as relational and support nested field selection
- Refactored the array-unwrapping logic into a small `ItemsOf<T>` helper (reused for both `Schema` and `CoreSchema<Schema>`) that uses `UnpackList` instead of handwritten key extraction

## Tested Scenarios

- Added `sdk/tests/item-type.test-d.ts`: `ItemType` includes a core collection's item type even when the schema never declares that collection, and `readItems`-style deep field selection on a `string | DirectusUser<Schema> | null` field resolves the requested nested fields instead of collapsing to `null`
- Confirmed both new tests fail on `main` and pass with this change

## Review Notes / Questions / Concerns


- Trade-off: `ItemType<Schema>` now unconditionally includes every core collection's shape, so a custom field could theoretically be misclassified as relational if it happens to fully structurally match one:
  ```ts
  import { createDirectus, readItems, rest } from '../dist/index.js';
  
  type Company = {
  	id: string;
  	name: string;
  	parent: Company | string | null;
  };

  type Business = {
  	id: string;
  	headquarters: Company;
  };
  
  type Schema = {
  	businesses: Business[];
  };
  
  const client = createDirectus<Schema>('localhost:8055').with(rest());

  // --- Collision case ---
  //
  // `Company` is not a relation to `directus_folders` - it's a plain, unrelated
  // object that happens to share DirectusFolder's exact shape (id, name, self-referencing
  // parent). Because `ItemType<Schema>` now also includes every core collection's shape,
  // `Company` gets misclassified as a relation too.
  
  const _collisionResult = await client.request(readItems('businesses', { fields: ['id', 'headquarters'] }));
  // _collisionResult => { id: string; headquarters: never; }
  
  ```

> [!NOTE]
> The flows feature Rob is working on adds `type` with a string literal that greatly reduces the `directus_folder` collision surface but there's still a few remaining that might come up:
> - DirectusDashboard: { id, name, icon, note, date_created, user_created, color }
> - DirectusPermission: { id, policy, collection, action, permissions, validation, presets, fields }
> - DirectusComment: { id, collection, item, comment, date_created, date_updated, user_created, user_updated }

   To me the trade-off seems worth it. If a consumer for the SDK encounters the issue they can just rename one of the keys (`name` => `label`) as a quick-fix. I think collisions will be rare anyways.

- Confirmed this doesn't affect `RegularCollections`/`SingletonCollections` (collection-name autocomplete) or the no-schema (`Schema = any`) fallback path
- This also fixes the root cause of #26558 (`Schema = unknown` couldn't infer relations into core collections without an `as any` cast) as a side effect
  - `app/src/composables/use-collab.ts` (see #28217): removing the `as (keyof DirectusUser)[]` casts and `CollabUserInfo` workaround type-checks cleanly with this fix, (leaving `WebSocketClient<unknown>` as-is). `WebSocketClient<CoreSchema>` swap adds collection-name autocomplete so it's still worth doing.

    ```diff
    --- a/app/src/composables/use-collab.ts
    +++ b/app/src/composables/use-collab.ts
    @@ -1,5 +1,5 @@
     import { ErrorCode } from '@directus/errors';
    -import { DirectusUser, readUser, readUsers, realtime, RemoveEventHandler, WebSocketClient } from '@directus/sdk';
    +import { readUser, readUsers, realtime, RemoveEventHandler, WebSocketClient } from '@directus/sdk';
     import {
     	ACTION,
     	Avatar,
    @@ -34,17 +34,6 @@ type UpdateMessage = Extract<ServerMessage, { action: typeof ACTION.SERVER.UPDAT
     type FocusMessage = Extract<ServerMessage, { action: typeof ACTION.SERVER.FOCUS }>;
     type DiscardMessage = Extract<ServerMessage, { action: typeof ACTION.SERVER.DISCARD }>;
  
    -/**
    - * User info returned from SDK queries.
    - * TODO: Remove once https://linear.app/directus/issue/CMS-1702 is done
    - */
    -type CollabUserInfo = {
    -	id: string;
    -	first_name?: string | null;
    -	last_name?: string | null;
    -	avatar?: { id: string; modified_on: string } | null;
    -};
    -
     type NonInitServerAction = Exclude<ServerMessage['action'], typeof ACTION.SERVER.INIT>;
  
     type ServerMessageHandler<A extends ServerMessage['action']> = (
    @@ -340,15 +329,13 @@ export function useCollab(
     						_in: Array.from(new Set(message.users.map((user) => user.user))),
     					},
     				},
    -				//  Object syntax for nested fields - SDK types require schema definition for full support
    -				// TODO: Update this once https://github.com/directus/directus/issues/26558 is Done
    -				fields: ['id', 'first_name', 'last_name', { avatar: ['id', 'modified_on'] }] as (keyof DirectusUser)[],
    +				fields: ['id', 'first_name', 'last_name', { avatar: ['id', 'modified_on'] }],
     			}),
     		);

     		users.value = message.users
     			.map(({ user, color, connection }) => {
    -				const info = usersInfo.find((u) => u.id === user) as CollabUserInfo | undefined;
    +				const info = usersInfo.find((u) => u.id === user);
  
     				if (message.connection === connection) {
     					sessionStorage.setItem(SESSION_COLOR_KEY, color);
    @@ -440,8 +427,7 @@ export function useCollab(
     		: await sdk
     				.request(
     					readUser(message.user, {
    -						// TODO: Update this once https://github.com/directus/directus/issues/26558 is Done
    -						fields: ['id', 'first_name', 'last_name', { avatar: ['id', 'modified_on'] }] as (keyof DirectusUser)[],
    +						fields: ['id', 'first_name', 'last_name', { avatar: ['id', 'modified_on'] }],
     					}),
     				)
     				.catch(() => ({}));
    ```

## Checklist

> Leave unchecked where not applicable

- [x] Tests added/updated
- [ ] Documentation PR created in [directus/docs](https://github.com/directus/docs) <!-- LINK -->
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [x] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes #21250
