### PR TITLE
Fix SDK createItem and updateItem rejecting valid values for literal-typed fields

### DIFF
--- a/.changeset/sdk-createitem-literal-field-types.md
+++ b/.changeset/sdk-createitem-literal-field-types.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': patch
+---
+
+Fixed `createItem`, `createItems`, `updateItem`, and `updateItems` rejecting valid input for fields typed with a literal type marker (`json`, `csv`, `datetime`, `date`, `time`). Write payloads now accept the same values reads return (for example a date string for a `datetime` field, or an object for a `json` field) instead of the literal marker itself.

--- a/contributors.yml
+++ b/contributors.yml
@@ -303,3 +303,4 @@
 - aniruddhav25
 - jashkarangiya
 - andrewalfaro1
+- Abhishek-B-R

--- a/sdk/src/types/output.ts
+++ b/sdk/src/types/output.ts
@@ -144,5 +144,24 @@ export type FieldOutputMap = {
 	time: string;
 };
 
+/**
+ * True when a field carries one of the FieldOutputMap literal markers (e.g. 'datetime', 'json').
+ * `any` never counts as a marker, so an `any` field keeps passing through NestedPartial untouched.
+ */
+export type HasFieldMarker<T> = IfAny<T, false, [Extract<T, keyof FieldOutputMap>] extends [never] ? false : true>;
+
+/**
+ * Map a field's literal markers to the value accepted on write: a string for 'datetime'/'date'/'time',
+ * a JsonValue for 'json', a string[] for 'csv'. This mirrors how the read path maps them through
+ * FieldOutputMap, so createItem/updateItem accept the same values readItem returns. Non-marker members
+ * (like null) are kept as is.
+ */
+export type MapInputFieldMarkers<T> =
+	Extract<T, keyof FieldOutputMap> extends infer Marker
+		? Marker extends keyof FieldOutputMap
+			? FieldOutputMap[Marker] | Exclude<T, keyof FieldOutputMap>
+			: T
+		: never;
+
 // all functions return a numeric type
 type FunctionOutputType = number;

--- a/sdk/src/types/utils.ts
+++ b/sdk/src/types/utils.ts
@@ -1,3 +1,5 @@
+import type { HasFieldMarker, MapInputFieldMarkers } from './output.js';
+
 /**
  * Makes types mutable
  */
@@ -53,7 +55,11 @@ type Primitive = null | undefined | string | number | boolean | bigint | symbol;
 type Builtin = Primitive | Date | RegExp;
 
 /**
- * Recursively make properties optional
+ * Recursively make properties optional.
+ *
+ * Fields typed with a literal marker (e.g. 'datetime', 'json') are mapped to the value accepted on
+ * write via MapInputFieldMarkers, so a create/update payload takes the same values a read returns
+ * (see issue #21599). Every other field recurses as usual.
  */
 export type NestedPartial<Item> = Item extends any[]
 	? UnpackList<Item> extends infer RawItem
@@ -62,7 +68,11 @@ export type NestedPartial<Item> = Item extends any[]
 	: Item extends Builtin
 		? Item
 		: Item extends object
-			? { [Key in keyof Item]?: NestedPartial<Item[Key]> }
+			? {
+					[Key in keyof Item]?: HasFieldMarker<Item[Key]> extends true
+						? MapInputFieldMarkers<Item[Key]>
+						: NestedPartial<Item[Key]>;
+				}
 			: Item;
 
 /**

--- a/sdk/tests/nested-partial.test-d.ts
+++ b/sdk/tests/nested-partial.test-d.ts
@@ -2,17 +2,20 @@ import { assertType, describe, expectTypeOf, test } from 'vitest';
 import type {
 	CollectionName,
 	DirectusComment,
+	DirectusFile,
 	DirectusFlow,
 	DirectusPreset,
 	DirectusRole,
 	DirectusUser,
 	DirectusVersion,
+	JsonValue,
 	NestedPartial,
 	QueryFields,
 	ReadFlowOutput,
 	StringLiteralUnion,
 } from '../src/index.js';
-import type { TestSchema } from './schema.js';
+import { createItem, createItems, updateItem, updateItems } from '../src/index.js';
+import type { CollectionB, CollectionC, TestSchema } from './schema.js';
 
 describe('NestedPartial', () => {
 	test('only the object member of a union becomes partial', () => {
@@ -184,5 +187,119 @@ describe('StringLiteralUnion on the read path', () => {
 
 		// @ts-expect-error status is not relational — an object field-spec must be rejected
 		assertType<ItemFields>([{ status: ['*'] }]);
+	});
+});
+
+describe('NestedPartial maps literal field-type markers on the write path (#21599)', () => {
+	test('a json field accepts any JsonValue, not the literal "json"', () => {
+		type Case = NestedPartial<CollectionB>;
+
+		expectTypeOf<Case['json_field']>().toEqualTypeOf<JsonValue | null | undefined>();
+
+		assertType<Case>({ json_field: { test: 'object' } });
+		assertType<Case>({ json_field: ['a', 'b'] });
+		// the marker string itself is now just a plain string value, which is valid JSON
+		assertType<Case>({ json_field: 'json' });
+		assertType<Case>({ json_field: null });
+
+		// @ts-expect-error a function is not a JsonValue
+		assertType<Case>({ json_field: () => 'nope' });
+	});
+
+	test('a csv field accepts string[], not the literal "csv"', () => {
+		type Case = NestedPartial<CollectionB>;
+
+		expectTypeOf<Case['csv_field']>().toEqualTypeOf<string[] | null | undefined>();
+
+		assertType<Case>({ csv_field: ['a', 'b'] });
+
+		// @ts-expect-error a csv field is a string[] on input, not a single string
+		assertType<Case>({ csv_field: 'a,b' });
+	});
+
+	test('datetime, date and time fields accept a string, not the literal marker', () => {
+		type Case = NestedPartial<CollectionC>;
+
+		expectTypeOf<Case['dt_field']>().toEqualTypeOf<string | null | undefined>();
+		expectTypeOf<Case['date_field']>().toEqualTypeOf<string | null | undefined>();
+		expectTypeOf<Case['time_field']>().toEqualTypeOf<string | null | undefined>();
+
+		assertType<Case>({
+			dt_field: '2024-02-27T11:27:25+00:00',
+			date_field: '2024-02-27',
+			time_field: '11:27:25',
+		});
+
+		// @ts-expect-error dt_field is a string on input, not a number
+		assertType<Case>({ dt_field: 123 });
+	});
+
+	test('non-marker fields are left untouched', () => {
+		type Case = NestedPartial<CollectionC>;
+
+		// plain strings and relations keep their existing behavior
+		expectTypeOf<Case['nullable']>().toEqualTypeOf<string | null | undefined>();
+		expectTypeOf<Case['non_nullable']>().toEqualTypeOf<string | undefined>();
+
+		assertType<Case>({ parent_id: { string_field: 'nested' } });
+	});
+
+	test('markers on core collection types map too (created_on is a datetime)', () => {
+		type Case = NestedPartial<DirectusFile<TestSchema>>;
+
+		expectTypeOf<Case['created_on']>().toEqualTypeOf<string | undefined>();
+
+		assertType<Case>({ created_on: '2024-02-27T11:27:25+00:00' });
+	});
+});
+
+describe('createItem / updateItem accept literal-typed field values (#21599)', () => {
+	test('createItem and createItems accept the real values for marker fields', () => {
+		createItem<TestSchema, 'collection_b', any>('collection_b', {
+			json_field: { test: 'object' },
+			csv_field: ['a', 'b'],
+		});
+
+		createItem<TestSchema, 'collection_c', any>('collection_c', {
+			dt_field: '2024-02-27T11:27:25+00:00',
+			date_field: '2024-02-27',
+			time_field: '11:27:25',
+		});
+
+		createItems<TestSchema, 'collection_c', any>('collection_c', [{ dt_field: '2024-02-27T11:27:25+00:00' }]);
+	});
+
+	test('updateItem and updateItems accept the real values for marker fields', () => {
+		updateItem<TestSchema, 'collection_c', any>('collection_c', 1, {
+			dt_field: '2024-02-27T11:27:25+00:00',
+		});
+
+		updateItems<TestSchema, 'collection_b', any>('collection_b', [1], {
+			json_field: { nested: { ok: true } },
+		});
+	});
+
+	test('wrong value types are still rejected on create', () => {
+		createItem<TestSchema, 'collection_c', any>('collection_c', {
+			// @ts-expect-error dt_field is a string on input, not an object
+			dt_field: { wrong: 'input' },
+		});
+
+		createItem<TestSchema, 'collection_b', any>('collection_b', {
+			// @ts-expect-error csv_field is a string[] on input, not a single string
+			csv_field: 'not an array',
+		});
+	});
+
+	test('wrong value types are still rejected on update', () => {
+		updateItem<TestSchema, 'collection_c', any>('collection_c', 1, {
+			// @ts-expect-error dt_field is a string on input, not an object
+			dt_field: { wrong: 'input' },
+		});
+
+		updateItem<TestSchema, 'collection_b', any>('collection_b', 1, {
+			// @ts-expect-error json_field is a JsonValue, a bare function is not valid
+			json_field: () => 'nope',
+		});
 	});
 });


### PR DESCRIPTION
Fixes #21599.

## The problem
Directus schema field types use literal markers (json, csv, datetime, date, time) to describe how a field is stored. The read path already understands these: FieldOutputMap maps each marker to the real value you get back, so readItem returns a string for a datetime field, a JsonValue for a json field, and so on.

The write path never did that mapping. createItem and updateItem build their input type from NestedPartial, which passed the marker straight through. So the SDK demanded the literal marker string as the value instead of the real data, and valid payloads failed to compile (a datetime field rejected an ISO string as "not assignable to type 'datetime'", a json field rejected an object as "not assignable to type 'json'"). Read and write were asymmetric: reads mapped the markers, writes did not.

## The fix
Make the write path mirror the read path. Two small type helpers sit next to FieldOutputMap: HasFieldMarker (does a field carry a marker; treats any as no-marker so any passes through untouched) and MapInputFieldMarkers (maps marker members to the write value: string for datetime/date/time, JsonValue for json, string[] for csv; keeps non-markers like null). NestedPartial applies it inside its object walk: a marker field maps to its input value, every other field recurses as before. Reusing FieldOutputMap means writes accept the same values reads return. This also fixes the same latent issue on core commands (createUser, updateFile, etc.) since those types share the markers. Wrong value types are still rejected.

## Tests
Added 9 type-level tests in tests/nested-partial.test-d.ts (markers map, non-markers untouched, core-collection coverage, and the createItem/updateItem repro accepting real values plus rejecting wrong ones). Full SDK suite passes 143 (up from 134), 0 type errors; build, eslint, and prettier are clean.
