### PR TITLE
fix(app): center spinner in VButton during RTL mode

### DIFF
--- a/app/src/components/v-button.vue
+++ b/app/src/components/v-button.vue
@@ -494,10 +494,6 @@ async function onClick(event: MouseEvent) {
 	inset-block-start: 50%;
 	inset-inline-start: 50%;
 	transform: translate(-50%, -50%);
-
-	html[dir='rtl'] & {
-		transform: translate(50%, -50%);
-	}
 }
 
 .spinner .v-progress-circular {


### PR DESCRIPTION
## What's Changed

- Fixed the RTL misalignment of the saving/loading spinner in `VButton` by removing an incorrect RTL-specific CSS transform override. The `inset-inline-start: 50%` property already correctly positions the element horizontally in both LTR and RTL modes, so a uniform `transform: translate(-50%, -50%)` applies correctly in both text directions.

## Tested Scenarios

- Verified the spinner remains centered in LTR mode (existing behavior unchanged)
- Verified the spinner is now centered in RTL mode

## Review Notes / Questions / Concerns

- Fixes the issue described in [#25628](https://github.com/directus/directus/issues/25628) — the saving loader in the top-bar was misaligned in RTL layout
- This is a minimal CSS-only fix (4 lines removed) that does not change any component logic

## Checklist

- [ ] Tests added/updated
- [x] This is a visual/CSS fix; no new API or documentation changes required
