### PR TITLE
Add SDK support for the "Detailed" create/update/delete object on relation array field

### DIFF
--- a/.changeset/quiet-webs-do.md
+++ b/.changeset/quiet-webs-do.md
@@ -1,0 +1,5 @@
+---
+'@directus/sdk': minor
+---
+
+Added support for the "Detailed" create/update/delete object on relation array fields

--- a/sdk/src/types/utils.ts
+++ b/sdk/src/types/utils.ts
@@ -64,7 +64,9 @@ export type RelationPrimaryKey<Item> = Item extends { id: infer PK } ? NonNullab
 export type NestedItemsInput<RawItem> = RawItem extends object
 	? {
 			create?: NestedPartial<RawItem>[];
-			update?: (NestedPartial<RawItem> & { id: RelationPrimaryKey<RawItem> })[];
+			update?: (RawItem extends { id: any }
+				? NestedPartial<RawItem> & { id: RelationPrimaryKey<RawItem> }
+				: NestedPartial<RawItem>)[];
 			delete?: RelationPrimaryKey<RawItem>[];
 		}
 	: never;

--- a/sdk/src/types/utils.ts
+++ b/sdk/src/types/utils.ts
@@ -55,7 +55,7 @@ type Builtin = Primitive | Date | RegExp;
 /**
  * A relation item's primary key type, falling back to `string | number` when it has none.
  */
-export type RelationPrimaryKey<Item> = Item extends { id: infer PK } ? PK : string | number;
+export type RelationPrimaryKey<Item> = Item extends { id: infer PK } ? NonNullable<PK> : string | number;
 
 /**
  * The API's "Detailed" object syntax for relation array fields: create/update/delete by key,

--- a/sdk/src/types/utils.ts
+++ b/sdk/src/types/utils.ts
@@ -53,11 +53,28 @@ type Primitive = null | undefined | string | number | boolean | bigint | symbol;
 type Builtin = Primitive | Date | RegExp;
 
 /**
+ * A relation item's primary key type, falling back to `string | number` when it has none.
+ */
+export type RelationPrimaryKey<Item> = Item extends { id: infer PK } ? PK : string | number;
+
+/**
+ * The API's "Detailed" object syntax for relation array fields: create/update/delete by key,
+ * alongside the plain nested-array shorthand NestedPartial already allows.
+ */
+export type NestedItemsInput<RawItem> = RawItem extends object
+	? {
+			create?: NestedPartial<RawItem>[];
+			update?: (NestedPartial<RawItem> & { id: RelationPrimaryKey<RawItem> })[];
+			delete?: RelationPrimaryKey<RawItem>[];
+		}
+	: never;
+
+/**
  * Recursively make properties optional
  */
 export type NestedPartial<Item> = Item extends any[]
 	? UnpackList<Item> extends infer RawItem
-		? NestedPartial<RawItem>[]
+		? NestedPartial<RawItem>[] | NestedItemsInput<RawItem>
 		: never
 	: Item extends Builtin
 		? Item

--- a/sdk/tests/nested-partial.test-d.ts
+++ b/sdk/tests/nested-partial.test-d.ts
@@ -13,7 +13,7 @@ import type {
 	ReadFlowOutput,
 	StringLiteralUnion,
 } from '../src/index.js';
-import { createItem, updateItem } from '../src/index.js';
+import { createItem, createItems, updateItem, updateItems, updateItemsBatch } from '../src/index.js';
 import type { CollectionA, CollectionC, TestSchema } from './schema.js';
 
 describe('NestedPartial', () => {
@@ -229,6 +229,37 @@ describe('NestedPartial accepts the detailed create/update/delete object for rel
 				delete: [4],
 			},
 		});
+	});
+
+	test('an m2a field accepts the plain array shorthand and the detailed object', () => {
+		type Case = NestedPartial<CollectionA>;
+
+		assertType<Case>({ m2a: [{ collection_a_id: 1, collection: 'collection_b', item: '1' }] });
+
+		assertType<Case>({
+			m2a: {
+				create: [{ collection: 'collection_b', item: '1' }],
+				update: [{ id: 1, collection: 'collection_c' }],
+				delete: [6],
+			},
+		});
+	});
+
+	test('a scalar (m2o) relation field does not gain the detailed object', () => {
+		assertType<NestedPartial<CollectionA>>({
+			// @ts-expect-error m2o is a scalar relation (RelatedItem | PK), not an array — no Detailed object
+			m2o: { create: [{ string_field: 'a' }] },
+		});
+	});
+
+	test('createItems, updateItems, and updateItemsBatch accept the detailed object too', () => {
+		createItems<TestSchema, 'collection_a', any>('collection_a', [{ o2m: { create: [{ non_nullable: 'a' }] } }]);
+
+		updateItems<TestSchema, 'collection_a', any>('collection_a', [1], {
+			m2m: { delete: [4] },
+		});
+
+		updateItemsBatch<TestSchema, 'collection_a', any>('collection_a', [{ id: 1, o2m: { delete: [2] } }]);
 	});
 
 	test('an update entry requires the related item id', () => {

--- a/sdk/tests/nested-partial.test-d.ts
+++ b/sdk/tests/nested-partial.test-d.ts
@@ -7,12 +7,14 @@ import type {
 	DirectusRole,
 	DirectusUser,
 	DirectusVersion,
+	NestedItemsInput,
 	NestedPartial,
 	QueryFields,
 	ReadFlowOutput,
 	StringLiteralUnion,
 } from '../src/index.js';
-import type { TestSchema } from './schema.js';
+import { createItem, updateItem } from '../src/index.js';
+import type { CollectionA, CollectionC, TestSchema } from './schema.js';
 
 describe('NestedPartial', () => {
 	test('only the object member of a union becomes partial', () => {
@@ -60,19 +62,54 @@ describe('NestedPartial', () => {
 	test('an already-optional field stays optional', () => {
 		type Case = NestedPartial<{ logs?: { message: string }[] }>;
 
-		expectTypeOf<Case['logs']>().toEqualTypeOf<{ message?: string }[] | undefined>();
+		// if branded tests unexpectedly fail, switch to using unbranded
+		// https://vitest.dev/api/expect-typeof.html#branded
+
+		expectTypeOf<Case['logs']>().branded.toEqualTypeOf<
+			| { message?: string }[]
+			| {
+					create?: { message?: string }[];
+					// unbranded test
+					//  update?: ({ message?: string } & { id: string | number })[];
+					update?: { message?: string; id: string | number }[];
+					delete?: (string | number)[];
+			  }
+			| undefined
+		>();
 	});
 
 	test('array elements become nested partials', () => {
 		type Case = NestedPartial<{ tags: { id: string; name: string }[] }>;
 
-		expectTypeOf<Case['tags']>().toEqualTypeOf<{ id?: string; name?: string }[] | undefined>();
+		expectTypeOf<Case['tags']>().branded.toEqualTypeOf<
+			| { id?: string; name?: string }[]
+			| {
+					create?: { id?: string; name?: string }[];
+					// unbranded test
+					//  update?: ({ id?: string; name?: string } & { id: string })[];
+					update?: { id: string; name?: string }[];
+					delete?: string[];
+			  }
+			| undefined
+		>();
 	});
 
 	test('only object elements of an id[] | object[] union become partial', () => {
 		type Case = NestedPartial<{ policies: string[] | { id: string; policy: string }[] | null }>;
 
-		expectTypeOf<Case['policies']>().toEqualTypeOf<string[] | { id?: string; policy?: string }[] | null | undefined>();
+		expectTypeOf<Case['policies']>().branded.toEqualTypeOf<
+			| string[]
+			| { id?: string; policy?: string }[]
+			| {
+					create?: { id?: string; policy?: string }[];
+					// unbranded test
+					//  update?: ({ id?: string; policy?: string } & { id: string })[];
+					update?: { id: string; policy?: string }[];
+					delete?: string[];
+			  }
+			| null
+			| undefined
+		>();
 	});
 
 	test('self-referential type recurses without widening scalars', () => {
@@ -155,6 +192,66 @@ describe('NestedPartial on core collection types', () => {
 			children: [{ name: 'child-role' }],
 			policies: [{ policy: 'policy-id' }],
 			users: [{ email: 'a@b.com' }],
+		});
+	});
+});
+
+describe('NestedPartial accepts the detailed create/update/delete object for relation arrays (#25955)', () => {
+	test('a scalar array field does not gain the detailed object', () => {
+		type Case = NestedItemsInput<string>;
+
+		expectTypeOf<Case>().toEqualTypeOf<never>();
+	});
+
+	test('an o2m field accepts the plain array shorthand and the detailed object', () => {
+		type Case = NestedPartial<CollectionA>;
+
+		assertType<Case>({ o2m: [{ id: 1, parent_id: 1 }] });
+
+		assertType<Case>({
+			o2m: {
+				create: [{ parent_id: 1 }],
+				update: [{ id: 1, non_nullable: 'changed' }],
+				delete: [2, 3],
+			},
+		});
+	});
+
+	test('an m2m field accepts the plain array shorthand and the detailed object', () => {
+		type Case = NestedPartial<CollectionA>;
+
+		assertType<Case>({ m2m: [{ collection_a_id: 1, collection_b_id: 1 }] });
+
+		assertType<Case>({
+			m2m: {
+				create: [{ collection_b_id: 1 }],
+				update: [{ id: 1, collection_b_id: 2 }],
+				delete: [4],
+			},
+		});
+	});
+
+	test('an update entry requires the related item id', () => {
+		assertType<NestedItemsInput<CollectionC>>({
+			// @ts-expect-error update entries must carry the related item's id
+			update: [{ non_nullable: 'changed' }],
+		});
+	});
+
+	test('delete only accepts primary key values, not full objects', () => {
+		assertType<NestedItemsInput<CollectionC>>({
+			// @ts-expect-error delete only takes primary keys
+			delete: [{ id: 2 }],
+		});
+	});
+
+	test('createItem and updateItem accept the detailed object for relation arrays', () => {
+		createItem<TestSchema, 'collection_a', any>('collection_a', {
+			o2m: { create: [{ non_nullable: 'a' }], delete: [1] },
+		});
+
+		updateItem<TestSchema, 'collection_a', any>('collection_a', 1, {
+			m2m: { update: [{ id: 5, collection_b_id: 2 }] },
 		});
 	});
 });

--- a/sdk/tests/nested-partial.test-d.ts
+++ b/sdk/tests/nested-partial.test-d.ts
@@ -62,15 +62,14 @@ describe('NestedPartial', () => {
 	test('an already-optional field stays optional', () => {
 		type Case = NestedPartial<{ logs?: { message: string }[] }>;
 
-		// if branded tests unexpectedly fail, switch to using unbranded
-		// https://vitest.dev/api/expect-typeof.html#branded
-
+		// .branded is needed here because NestedItemsInput's `update` entries are an
+		// intersection type (NestedPartial<RawItem> & { id: ... }), which plain toEqualTypeOf
+		// treats as distinct from its flattened equivalent even though they accept identical
+		// values: https://vitest.dev/api/expect-typeof.html#branded
 		expectTypeOf<Case['logs']>().branded.toEqualTypeOf<
 			| { message?: string }[]
 			| {
 					create?: { message?: string }[];
-					// unbranded test
-					//  update?: ({ message?: string } & { id: string | number })[];
 					update?: { message?: string; id: string | number }[];
 					delete?: (string | number)[];
 			  }
@@ -85,8 +84,6 @@ describe('NestedPartial', () => {
 			| { id?: string; name?: string }[]
 			| {
 					create?: { id?: string; name?: string }[];
-					// unbranded test
-					//  update?: ({ id?: string; name?: string } & { id: string })[];
 					update?: { id: string; name?: string }[];
 					delete?: string[];
 			  }
@@ -102,8 +99,6 @@ describe('NestedPartial', () => {
 			| { id?: string; policy?: string }[]
 			| {
 					create?: { id?: string; policy?: string }[];
-					// unbranded test
-					//  update?: ({ id?: string; policy?: string } & { id: string })[];
 					update?: { id: string; policy?: string }[];
 					delete?: string[];
 			  }

--- a/sdk/tests/nested-partial.test-d.ts
+++ b/sdk/tests/nested-partial.test-d.ts
@@ -70,7 +70,8 @@ describe('NestedPartial', () => {
 			| { message?: string }[]
 			| {
 					create?: { message?: string }[];
-					update?: { message?: string; id: string | number }[];
+					// no `id` field on the item, so update entries aren't forced to carry one either
+					update?: { message?: string }[];
 					delete?: (string | number)[];
 			  }
 			| undefined
@@ -268,6 +269,14 @@ describe('NestedPartial accepts the detailed create/update/delete object for rel
 		assertType<NestedItemsInput<CollectionC>>({
 			// @ts-expect-error delete only takes primary keys
 			delete: [{ id: 2 }],
+		});
+	});
+
+	test('an item with no `id` field is not forced to carry one on update', () => {
+		type CustomPkItem = { slug: string; title: string };
+
+		assertType<NestedItemsInput<CustomPkItem>>({
+			update: [{ slug: 'a', title: 'b' }],
 		});
 	});
 


### PR DESCRIPTION
## What's Changed

- Added `NestedItemsInput<RawItem>` to `NestedPartial` so that the [API's "Detailed"](https://directus.com/docs/guides/connect/relations) `{ create, update, delete }` object is supported
- `RelationPrimaryKey<Item>` resolves the items `id` type for `delete` entries with a fallback to `string | number`
- `update` entries switch `id?: ...` to `id: ...` when `id` is a key <sup>:star: 1</sup>

## Tested Scenarios

- Added coverage for `createItem`/`createItems`/`updateItem`/`updateItems`/`updateItemsBatch` for the `NestedPartial` describe blocks
- I switched three `.toEqualTypeOf()` assertions to use `.branded.toEqualTypeOf()` since the intersection output was difficult to read. [Vitest's Docs](https://vitest.dev/api/expect-typeof.html#branded) say to "This helper comes at a performance cost and can cause the TypeScript compiler to 'give up' if used with excessively deep types. Use it sparingly and only when necessary." When I checked the performance speed I found no discernible difference between branded and unbranded.
- Played with it a bit on a live sandbox just to make sure the shapes worked (delete truly only accepts plain primary keys and not `{ id }` objects

## Review Notes / Questions / Concerns

- <sup>:star: 1</sup>0eaf256b1d3d4e1f4ce409b63d1f3fc61e4d7e02 is for the devs who live dangerously and don't use `id` for the primary key. I don't know how to protect them from themselves, so whatever they chose to be the pk is optional and up to them to pass it along.
- The `{ create, update, delete }` object passes for JSON. So if a dev accidentally passes the CRUD object to a field that is not relational and is typed to receive JSON, they still get a code `200` as a response. The API does the same thing, just calling it out as a new place to make a mistake you can already make in the API.
- `minor` felt right but I kept switching between `patch` and `minor` in my head.
- Issue title says "M2O and M2M" but m2o isn't supported in the API.

## Checklist

> Leave unchecked where not applicable

- [X] Tests added/updated
- [X] Documentation PR created in directus/docs#824 (not a content change, but the headings were wrong so it's related)
- [ ] OpenAPI updated
  - [ ] Local specs package (`@directus/specs`)
  - [ ] PR created in [directus/openapi](https://github.com/directus/openapi) <!-- LINK -->
- [ ] SDK (`@directus/sdk`) updated to reflect the changes
- [ ] Types (`@directus/types`) updated to reflect the changes
- [ ] GraphQL schema updated to reflect the changes
- [ ] System data (`@directus/system-data`) updated for changes to system collections/fields/relations
- [ ] Database migration added for schema/system changes
- [ ] Environment variables documented for new/changed config
- [ ] App translations added for new user-facing strings
- [ ] Security implications apply

---

Fixes #25955 
